### PR TITLE
Add option to change platform-specific Gamemaker settings

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import webbrowser
 from functools import partial
 import requests
 import markdown2
+import platform
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk, font as tkfont
 from tkhtmlview import HTMLLabel
@@ -149,7 +150,13 @@ class ConverterGUI:
         self.conversion_settings["notes"].set(False)
         self.conversion_settings["objects"].set(False)
 
-        self.gm_platform_settings = "windows"
+        match(platform.system()):  
+            case "Linux":
+                self.gm_platform_settings = "linux"
+            case "Darwin":
+                self.gm_platform_settings = "macos"
+            case _:
+                self.gm_platform_settings = "windows"
 
     def update_platform_settings(self, event):
         self.gm_platform_settings = self.platform_combobox.get()


### PR DESCRIPTION
Add option to change where platform-specific Gamemaker settings are derived from.

Currently, settings are derived from Windows only. Add combobox in settings menu where user can choose between Windows (default), MacOS, and Linux, to derive settings from.

Platform-optional settings:
>> Icon,
 + add support for .png icons (for MacOS/Linux),
>> "option_x_version",
>> "option_x_vsync",
 + add "option_x_sync" variation for Linux,
>> "option_x_resize_window",
>> "option_x_interpolate_pixels",
>> "option_x_start_fullscreen",

Windows-specific options (because only Windows support them):
>> "option_windows_description_info",
>> "option_windows_use_splash",
>> "option_windows_borderless",