### PR TITLE
Fix sprite frame ordering by reading .yy metadata files

### DIFF
--- a/Languages/de.json
+++ b/Languages/de.json
@@ -69,6 +69,7 @@
 "Console_Convertor_Sprites_Stopped" : "Sprite-Konvertierung gestoppt.",
 "Console_Convertor_Sprites_Converted" : "Konvertiert: {relative_path} -> sprites/{sprite_name}/{new_filename}",
 "Console_Convertor_Sprites_Error_NotFound" : "Keine Sprite-Bilder im GameMaker-Projekt gefunden.",
+"Console_Convertor_Sprites_YYParseFailed" : "Warnung: {yy_path} konnte nicht gelesen werden, Fallback-Reihenfolge wird fuer {sprite_name} verwendet.",
 
 "Console_Convertor_Fonts" : "Schriftarten werden konvertiert...",
 "Console_Convertor_Fonts_Complete" : "Schriftarten-Konvertierung abgeschlossen.",

--- a/Languages/eng.json
+++ b/Languages/eng.json
@@ -69,6 +69,7 @@
 "Console_Convertor_Sprites_Stopped" : "Sprite conversion stopped.",
 "Console_Convertor_Sprites_Converted" : "Converted: {relative_path} -> sprites/{sprite_name}/{new_filename}",
 "Console_Convertor_Sprites_Error_NotFound" : "No sprite images found in the GameMaker project.",
+"Console_Convertor_Sprites_YYParseFailed" : "Warning: Could not parse {yy_path}, using fallback frame ordering for {sprite_name}.",
 
 "Console_Convertor_Fonts" : "Converting fonts...",
 "Console_Convertor_Fonts_Complete" : "Font conversion completed.",

--- a/Languages/template/template.json
+++ b/Languages/template/template.json
@@ -69,6 +69,7 @@
 "Console_Convertor_Sprites_Stopped" : "Sprite conversion stopped.",
 "Console_Convertor_Sprites_Converted" : "Converted: {relative_path} -> sprites/{sprite_name}/{new_filename}",
 "Console_Convertor_Sprites_Error_NotFound" : "No sprite images found in the GameMaker project.",
+"Console_Convertor_Sprites_YYParseFailed" : "Warning: Could not parse {yy_path}, using fallback frame ordering for {sprite_name}.",
 
 "Console_Convertor_Fonts" : "Converting fonts...",
 "Console_Convertor_Fonts_Complete" : "Font conversion completed.",

--- a/src/conversion/sprites.py
+++ b/src/conversion/sprites.py
@@ -1,4 +1,6 @@
 import os
+import re
+import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from PIL import Image
 from collections import defaultdict
@@ -14,7 +16,7 @@ class SpriteConverter(BaseConverter):
                          update_log_callback, compact_logging, max_workers=max_workers)
         self.godot_sprites_path = os.path.join(self.godot_project_path, 'sprites')
 
-    def find_sprite_images(self):
+    def _find_all_sprite_images(self):
         sprite_folder = os.path.join(self.gm_project_path, 'sprites')
         image_files = defaultdict(list)
         for root, _, files in os.walk(sprite_folder):
@@ -26,6 +28,57 @@ class SpriteConverter(BaseConverter):
                     if file.lower().endswith(('.png', '.jpg', '.jpeg'))
                 )
         return image_files
+
+    def _parse_sprite_yy(self, sprite_name):
+        yy_path = os.path.join(self.gm_project_path, 'sprites', sprite_name, sprite_name + '.yy')
+        try:
+            with open(yy_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+            cleaned = re.sub(r',\s*([}\]])', r'\1', content)
+            data = json.loads(cleaned)
+
+            frame_guids = [frame['name'] for frame in data['frames']]
+
+            primary_layer_guid = None
+            for layer in data.get('layers', []):
+                if layer.get('visible', True):
+                    primary_layer_guid = layer['name']
+                    break
+            if primary_layer_guid is None and data.get('layers'):
+                primary_layer_guid = data['layers'][0]['name']
+
+            return (frame_guids, primary_layer_guid)
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, IndexError):
+            self._safe_log(get_localized("Console_Convertor_Sprites_YYParseFailed").format(
+                yy_path=yy_path, sprite_name=sprite_name))
+            return None
+
+    def _build_ordered_frame_list(self, sprite_name, all_image_paths):
+        result = self._parse_sprite_yy(sprite_name)
+        if result is None:
+            return sorted(all_image_paths)
+
+        frame_guids, primary_layer_guid = result
+
+        path_index = {}
+        for path in all_image_paths:
+            parts = path.replace('\\', '/').split('/')
+            frame_guid = parts[-2]
+            filename = parts[-1]
+            path_index.setdefault(frame_guid, {})[filename] = path
+
+        ordered = []
+        layer_filename = primary_layer_guid + '.png' if primary_layer_guid else None
+        for guid in frame_guids:
+            frame_files = path_index.get(guid, {})
+            if not frame_files:
+                continue
+            if layer_filename and layer_filename in frame_files:
+                ordered.append(frame_files[layer_filename])
+            else:
+                ordered.append(next(iter(frame_files.values())))
+
+        return ordered if ordered else sorted(all_image_paths)
 
     def _process_sprite(self, sprite_name, index, gm_sprite_path, images_count):
         if not self.conversion_running():
@@ -42,7 +95,7 @@ class SpriteConverter(BaseConverter):
     def convert_sprites(self):
         os.makedirs(self.godot_sprites_path, exist_ok=True)
 
-        sprite_images = self.find_sprite_images()
+        sprite_images = self._find_all_sprite_images()
         if not sprite_images:
             self.log_callback(get_localized("Console_Convertor_Sprites_Error_NotFound"))
             return
@@ -54,9 +107,9 @@ class SpriteConverter(BaseConverter):
         # Flatten all work items
         work_items = []
         for sprite_name, images in sprite_images.items():
-            sorted_images = sorted(images)
-            for index, gm_sprite_path in enumerate(sorted_images, start=1):
-                work_items.append((sprite_name, index, gm_sprite_path, len(sorted_images)))
+            ordered_images = self._build_ordered_frame_list(sprite_name, images)
+            for index, gm_sprite_path in enumerate(ordered_images, start=1):
+                work_items.append((sprite_name, index, gm_sprite_path, len(ordered_images)))
 
         total_images = len(work_items)
         processed_images = 0

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.1.0"
+VERSION = "0.1.1"
 
 def get_version():
     return VERSION

--- a/tests/test_sprites.py
+++ b/tests/test_sprites.py
@@ -165,5 +165,235 @@ class TestSpriteConverterEmpty(unittest.TestCase):
                         "Expected at least one log message for empty sprites folder")
 
 
+# Helper to create a minimal .yy file with trailing commas (like real GameMaker files)
+def _make_yy_content(sprite_name, frame_guids, layer_guids, layer_visible=None):
+    """Build a .yy file string with the given frames and layers."""
+    if layer_visible is None:
+        layer_visible = [True] * len(layer_guids)
+    frames_json = ",\n    ".join(
+        '{{"$GMSpriteFrame":"v1","%Name":"{g}","name":"{g}","resourceType":"GMSpriteFrame","resourceVersion":"2.0",}}'.format(g=g)
+        for g in frame_guids
+    )
+    layers_json = ",\n    ".join(
+        '{{"$GMImageLayer":"","name":"{g}","displayName":"Layer {i}","opacity":100.0,"visible":{v},"resourceType":"GMImageLayer","resourceVersion":"2.0",}}'.format(
+            g=g, i=i, v="true" if v else "false")
+        for i, (g, v) in enumerate(zip(layer_guids, layer_visible))
+    )
+    return '''{{\n  "frames":[\n    {frames}\n  ],\n  "layers":[\n    {layers}\n  ],\n  "name":"{name}",\n  "resourceType":"GMSprite",\n  "resourceVersion":"2.0",\n}}'''.format(
+        frames=frames_json, layers=layers_json, name=sprite_name)
+
+
+class TestSpriteConverterFrameOrdering(unittest.TestCase):
+    """Test that sprite frames are ordered according to the .yy file."""
+
+    # GUIDs chosen so alphabetical order (aa, bb, cc) differs from .yy order (cc, aa, bb)
+    FRAME_GUIDS = [
+        "cccccccc-0000-0000-0000-000000000000",
+        "aaaaaaaa-0000-0000-0000-000000000000",
+        "bbbbbbbb-0000-0000-0000-000000000000",
+    ]
+    LAYER_GUID = "11111111-0000-0000-0000-000000000000"
+    FRAME_COLORS = ["red", "green", "blue"]
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+
+        sprite_dir = os.path.join(self.gm_dir, "sprites", "ordered_sprite")
+        os.makedirs(sprite_dir)
+
+        # Write .yy file
+        yy_content = _make_yy_content("ordered_sprite", self.FRAME_GUIDS,
+                                       [self.LAYER_GUID])
+        with open(os.path.join(sprite_dir, "ordered_sprite.yy"), "w") as f:
+            f.write(yy_content)
+
+        # Create frame directories with distinct colors
+        for guid, color in zip(self.FRAME_GUIDS, self.FRAME_COLORS):
+            frame_dir = os.path.join(sprite_dir, "layers", guid)
+            os.makedirs(frame_dir)
+            img = Image.new("RGBA", (2, 2), color)
+            img.save(os.path.join(frame_dir, self.LAYER_GUID + ".png"), "PNG")
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def _make_converter(self):
+        return SpriteConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+
+    def test_frame_order_matches_yy_file(self):
+        converter = self._make_converter()
+        converter.convert_all()
+
+        godot_dir = os.path.join(self.godot_dir, "sprites", "ordered_sprite")
+        # Frame 1 should be red (cc), frame 2 green (aa), frame 3 blue (bb)
+        for idx, expected_color in enumerate(self.FRAME_COLORS, start=1):
+            path = os.path.join(godot_dir, f"ordered_sprite_{idx}.png")
+            self.assertTrue(os.path.exists(path), f"Missing {path}")
+            with Image.open(path) as img:
+                pixel = img.getpixel((0, 0))[:3]
+            expected_rgb = Image.new("RGBA", (1, 1), expected_color).getpixel((0, 0))[:3]
+            self.assertEqual(pixel, expected_rgb,
+                             f"Frame {idx} has wrong color: {pixel} != {expected_rgb}")
+
+    def test_correct_frame_count(self):
+        converter = self._make_converter()
+        converter.convert_all()
+
+        godot_dir = os.path.join(self.godot_dir, "sprites", "ordered_sprite")
+        png_files = [f for f in os.listdir(godot_dir) if f.endswith(".png")]
+        self.assertEqual(len(png_files), 3)
+
+    def test_fallback_when_yy_missing(self):
+        # Remove the .yy file
+        yy_path = os.path.join(self.gm_dir, "sprites", "ordered_sprite",
+                               "ordered_sprite.yy")
+        os.remove(yy_path)
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        godot_dir = os.path.join(self.godot_dir, "sprites", "ordered_sprite")
+        png_files = [f for f in os.listdir(godot_dir) if f.endswith(".png")]
+        self.assertEqual(len(png_files), 3)
+
+    def test_fallback_when_yy_malformed(self):
+        yy_path = os.path.join(self.gm_dir, "sprites", "ordered_sprite",
+                               "ordered_sprite.yy")
+        with open(yy_path, "w") as f:
+            f.write("{this is not valid json at all")
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        godot_dir = os.path.join(self.godot_dir, "sprites", "ordered_sprite")
+        png_files = [f for f in os.listdir(godot_dir) if f.endswith(".png")]
+        self.assertEqual(len(png_files), 3)
+
+
+class TestSpriteConverterMultiLayer(unittest.TestCase):
+    """Test that multi-layer sprites pick the first visible layer."""
+
+    FRAME_GUID = "aaaaaaaa-0000-0000-0000-000000000000"
+    LAYER_VISIBLE = "22222222-0000-0000-0000-000000000000"
+    LAYER_HIDDEN = "11111111-0000-0000-0000-000000000000"
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+
+        sprite_dir = os.path.join(self.gm_dir, "sprites", "multi_layer")
+        os.makedirs(sprite_dir)
+
+        # Hidden layer listed first, visible layer second
+        yy_content = _make_yy_content(
+            "multi_layer", [self.FRAME_GUID],
+            [self.LAYER_HIDDEN, self.LAYER_VISIBLE],
+            layer_visible=[False, True])
+        with open(os.path.join(sprite_dir, "multi_layer.yy"), "w") as f:
+            f.write(yy_content)
+
+        frame_dir = os.path.join(sprite_dir, "layers", self.FRAME_GUID)
+        os.makedirs(frame_dir)
+        # Hidden layer: red
+        img = Image.new("RGBA", (2, 2), "red")
+        img.save(os.path.join(frame_dir, self.LAYER_HIDDEN + ".png"), "PNG")
+        # Visible layer: green
+        img = Image.new("RGBA", (2, 2), "green")
+        img.save(os.path.join(frame_dir, self.LAYER_VISIBLE + ".png"), "PNG")
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def test_picks_first_visible_layer(self):
+        converter = SpriteConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+        converter.convert_all()
+
+        godot_dir = os.path.join(self.godot_dir, "sprites", "multi_layer")
+        png_files = [f for f in os.listdir(godot_dir) if f.endswith(".png")]
+        self.assertEqual(len(png_files), 1, "Should output 1 file, not 1 per layer")
+
+        with Image.open(os.path.join(godot_dir, png_files[0])) as img:
+            pixel = img.getpixel((0, 0))[:3]
+        self.assertEqual(pixel, (0, 128, 0),
+                         "Should use the visible layer (green), not hidden (red)")
+
+
+class TestParseSpriteYY(unittest.TestCase):
+    """Test _parse_sprite_yy directly."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.converter = SpriteConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: None,
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def _write_yy(self, sprite_name, content):
+        sprite_dir = os.path.join(self.gm_dir, "sprites", sprite_name)
+        os.makedirs(sprite_dir, exist_ok=True)
+        with open(os.path.join(sprite_dir, sprite_name + ".yy"), "w") as f:
+            f.write(content)
+
+    def test_parses_frames_in_order(self):
+        guids = ["cc-guid", "aa-guid", "bb-guid"]
+        self._write_yy("test_spr", _make_yy_content("test_spr", guids, ["layer1"]))
+
+        result = self.converter._parse_sprite_yy("test_spr")
+        self.assertIsNotNone(result)
+        frame_guids, layer_guid = result
+        self.assertEqual(frame_guids, guids)
+        self.assertEqual(layer_guid, "layer1")
+
+    def test_trailing_commas_handled(self):
+        # Write content with trailing commas (as real .yy files have)
+        content = '{"frames":[{"name":"frame1",},],"layers":[{"name":"layer1","visible":true,},],"name":"tc",}'
+        self._write_yy("tc", content)
+
+        result = self.converter._parse_sprite_yy("tc")
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], ["frame1"])
+
+    def test_returns_none_for_missing_file(self):
+        result = self.converter._parse_sprite_yy("nonexistent_sprite")
+        self.assertIsNone(result)
+
+    def test_returns_none_for_invalid_json(self):
+        self._write_yy("bad", "not json at all {{{")
+        result = self.converter._parse_sprite_yy("bad")
+        self.assertIsNone(result)
+
+    def test_selects_first_visible_layer(self):
+        guids = ["frame1"]
+        layers = ["hidden_layer", "visible_layer"]
+        self._write_yy("vis", _make_yy_content("vis", guids, layers,
+                                                 layer_visible=[False, True]))
+        result = self.converter._parse_sprite_yy("vis")
+        self.assertIsNotNone(result)
+        _, layer_guid = result
+        self.assertEqual(layer_guid, "visible_layer")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Parses each sprite's `.yy` metadata file to extract the correct frame playback order (instead of lexicographic sorting of GUID directory names)
- For multi-layer sprites, selects the first visible layer per frame (instead of outputting one file per layer)
- Falls back gracefully to sorted order when `.yy` file is missing or unparsable
- Bumps version to 0.1.1

Closes #4

## Test plan
- [x] All 15 sprite tests pass (5 existing + 10 new)
- [x] Full test suite passes (75 tests, 0 failures)
- [x] Manual test: convert a GameMaker project with multi-frame sprites and verify frame order matches GameMaker's `.yy` definitions