### PR TITLE
Fix Godot path dialog title and filter orphaned sprites

### DIFF
--- a/Languages/de.json
+++ b/Languages/de.json
@@ -70,6 +70,8 @@
 "Console_Convertor_Sprites_Converted" : "Konvertiert: {relative_path} -> sprites/{sprite_name}/{new_filename}",
 "Console_Convertor_Sprites_Error_NotFound" : "Keine Sprite-Bilder im GameMaker-Projekt gefunden.",
 "Console_Convertor_Sprites_YYParseFailed" : "Warnung: {yy_path} konnte nicht gelesen werden, Fallback-Reihenfolge wird fuer {sprite_name} verwendet.",
+"Console_Convertor_Sprites_Skipped" : "Verwaistes Sprite nicht in .yyp übersprungen: {sprite_name}",
+"Console_Convertor_Sprites_YYPFilterWarning" : "Warnung: .yyp-Datei konnte nicht geparst werden. Alle Sprites werden konvertiert.",
 
 "Console_Convertor_Fonts" : "Schriftarten werden konvertiert...",
 "Console_Convertor_Fonts_Complete" : "Schriftarten-Konvertierung abgeschlossen.",

--- a/Languages/de.json
+++ b/Languages/de.json
@@ -44,6 +44,7 @@
 "Console_Convertor_Icon_Error_FileNotFound" : "Keine Icon-Datei im Icon-Verzeichnis des GameMaker-Projekts gefunden.",
 "Console_Convertor_Icon_Copied" : "Icon kopiert: {icon_files} -> icon.ico",
 "Console_Convertor_Icon_Converted" : "Icon konvertiert: {icon_files} -> icon.png",
+"Console_Convertor_Icon_Fallback" : "Icon fuer die ausgewaehlte Plattform nicht gefunden, verwende Icons von '{platform}' stattdessen.",
 "Console_Convertor_Error_IconGeneric" : "Fehler beim Verarbeiten des Icons: {error}",
 
 "Console_Convertor_Settings" : "Projekteinstellungen werden aktualisiert...",

--- a/Languages/eng.json
+++ b/Languages/eng.json
@@ -70,6 +70,8 @@
 "Console_Convertor_Sprites_Converted" : "Converted: {relative_path} -> sprites/{sprite_name}/{new_filename}",
 "Console_Convertor_Sprites_Error_NotFound" : "No sprite images found in the GameMaker project.",
 "Console_Convertor_Sprites_YYParseFailed" : "Warning: Could not parse {yy_path}, using fallback frame ordering for {sprite_name}.",
+"Console_Convertor_Sprites_Skipped" : "Skipped orphaned sprite not in .yyp: {sprite_name}",
+"Console_Convertor_Sprites_YYPFilterWarning" : "Warning: Could not parse .yyp file for sprite filtering. All sprites will be converted.",
 
 "Console_Convertor_Fonts" : "Converting fonts...",
 "Console_Convertor_Fonts_Complete" : "Font conversion completed.",
@@ -120,7 +122,7 @@
 "Menu_UI_Time_Heading" : "Time:",
 
 "Prompt_Path_GameMaker" : "Select your GameMaker Project",
-"Prompt_Path_Godot" : "Select your GameMaker Project",
+"Prompt_Path_Godot" : "Select your Godot Project",
 
 "ReleaseNotes_Title" : "Release Notes",
 "ReleaseNotes_Error_NoInternet" : ["Error", "Unable to fetch release notes. Please check your internet connection and try again."],

--- a/Languages/eng.json
+++ b/Languages/eng.json
@@ -44,6 +44,7 @@
 "Console_Convertor_Icon_Error_FileNotFound" : "No icon file found in the GameMaker project's icon directory.",
 "Console_Convertor_Icon_Copied" : "Copied icon: {icon_files} -> icon.ico",
 "Console_Convertor_Icon_Converted" : "Converted icon: {icon_files} -> icon.png",
+"Console_Convertor_Icon_Fallback" : "Icon not found for selected platform, using icons from '{platform}' instead.",
 "Console_Convertor_Error_IconGeneric" : "Error processing icon: {error}",
 
 "Console_Convertor_Settings" : "Updating project settings...",

--- a/src/conversion/project_settings.py
+++ b/src/conversion/project_settings.py
@@ -28,8 +28,11 @@ class ProjectSettingsConverter(BaseConverter):
         godot_png_path = os.path.join(self.godot_project_path, 'icon.png')
 
         if not os.path.exists(gm_icon_path):
-            self.log_callback(get_localized("Console_Convertor_Icon_Error_DirectoryNotFound").format(gm_icon_path=gm_icon_path))
-            return False
+            gm_icon_path = self._find_fallback_icon_path()
+            if gm_icon_path is None:
+                self.log_callback(get_localized("Console_Convertor_Icon_Error_DirectoryNotFound").format(
+                    gm_icon_path=os.path.join(self.gm_project_path, 'options', self.gm_platform, 'icons')))
+                return False
 
         icon_files = [f for f in os.listdir(gm_icon_path) if f.endswith('.ico') or f.endswith('.png')]
 
@@ -51,6 +54,24 @@ class ProjectSettingsConverter(BaseConverter):
         except Exception as e:
             self.log_callback(get_localized("Console_Convertor_Error_IconGeneric").format(error=str(e)))
             return False
+
+    def _find_fallback_icon_path(self) -> Optional[str]:
+        """Search other platforms for an icon directory when the selected platform has none."""
+        options_dir = os.path.join(self.gm_project_path, 'options')
+        if not os.path.isdir(options_dir):
+            return None
+
+        for platform in os.listdir(options_dir):
+            if platform == self.gm_platform:
+                continue
+            candidate = os.path.join(options_dir, platform, 'icons')
+            if os.path.isdir(candidate):
+                icon_files = [f for f in os.listdir(candidate) if f.endswith('.ico') or f.endswith('.png')]
+                if icon_files:
+                    self.log_callback(get_localized("Console_Convertor_Icon_Fallback").format(platform=platform))
+                    return candidate
+
+        return None
 
     def get_gm_project_name(self) -> Optional[str]:
         yyp_files = [f for f in os.listdir(self.gm_project_path) if f.endswith('.yyp')]

--- a/src/conversion/sprites.py
+++ b/src/conversion/sprites.py
@@ -16,6 +16,36 @@ class SpriteConverter(BaseConverter):
                          update_log_callback, compact_logging, max_workers=max_workers)
         self.godot_sprites_path = os.path.join(self.godot_project_path, 'sprites')
 
+    def _get_valid_sprite_names(self):
+        """Parse the .yyp project file and return the set of sprite names listed in resources.
+
+        Returns None if the .yyp file cannot be found or parsed, allowing
+        the caller to fall back to converting all sprites on disk.
+        """
+        try:
+            yyp_files = [f for f in os.listdir(self.gm_project_path) if f.endswith('.yyp')]
+            if not yyp_files:
+                return None
+
+            yyp_path = os.path.join(self.gm_project_path, yyp_files[0])
+            with open(yyp_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+
+            cleaned = re.sub(r',\s*([}\]])', r'\1', content)
+            data = json.loads(cleaned)
+
+            valid_sprites = set()
+            for resource in data.get('resources', []):
+                res_id = resource.get('id', {})
+                path = res_id.get('path', '')
+                if path.startswith('sprites/'):
+                    valid_sprites.add(res_id.get('name', ''))
+
+            return valid_sprites
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+            self._safe_log(get_localized("Console_Convertor_Sprites_YYPFilterWarning"))
+            return None
+
     def _find_all_sprite_images(self):
         sprite_folder = os.path.join(self.gm_project_path, 'sprites')
         image_files = defaultdict(list)
@@ -96,6 +126,18 @@ class SpriteConverter(BaseConverter):
         os.makedirs(self.godot_sprites_path, exist_ok=True)
 
         sprite_images = self._find_all_sprite_images()
+
+        valid_names = self._get_valid_sprite_names()
+        if valid_names is not None:
+            filtered = {}
+            for name, images in sprite_images.items():
+                if name in valid_names:
+                    filtered[name] = images
+                else:
+                    self._safe_log(get_localized("Console_Convertor_Sprites_Skipped").format(
+                        sprite_name=name))
+            sprite_images = filtered
+
         if not sprite_images:
             self.log_callback(get_localized("Console_Convertor_Sprites_Error_NotFound"))
             return

--- a/tests/test_project_settings.py
+++ b/tests/test_project_settings.py
@@ -151,5 +151,61 @@ class TestReadAudioGroups(unittest.TestCase):
         self.assertEqual(groups, [])
 
 
+class TestConvertIconFallback(unittest.TestCase):
+    """Test that convert_icon falls back to other platforms when the selected platform has no icons."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def _make_converter(self, platform='linux'):
+        return ProjectSettingsConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+            gm_platform=platform,
+        )
+
+    def _create_icon(self, platform):
+        """Create a minimal .ico file under options/<platform>/icons/."""
+        from PIL import Image
+        icons_dir = os.path.join(self.gm_dir, 'options', platform, 'icons')
+        os.makedirs(icons_dir, exist_ok=True)
+        img = Image.new("RGBA", (16, 16), "blue")
+        img.save(os.path.join(icons_dir, "icon.ico"), "PNG")
+
+    def test_uses_fallback_platform_when_selected_missing(self):
+        self._create_icon('windows')
+        converter = self._make_converter(platform='linux')
+        result = converter.convert_icon()
+
+        self.assertTrue(result)
+        self.assertTrue(os.path.exists(os.path.join(self.godot_dir, 'icon.png')))
+        fallback_logs = [l for l in self.logs if 'windows' in l]
+        self.assertTrue(len(fallback_logs) > 0, "Should log which platform was used as fallback")
+
+    def test_uses_selected_platform_when_available(self):
+        self._create_icon('linux')
+        self._create_icon('windows')
+        converter = self._make_converter(platform='linux')
+        result = converter.convert_icon()
+
+        self.assertTrue(result)
+        fallback_logs = [l for l in self.logs if 'Fallback' in l or 'instead' in l]
+        self.assertEqual(len(fallback_logs), 0, "Should not fall back when selected platform has icons")
+
+    def test_returns_false_when_no_platform_has_icons(self):
+        converter = self._make_converter(platform='linux')
+        result = converter.convert_icon()
+
+        self.assertFalse(result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sprites.py
+++ b/tests/test_sprites.py
@@ -395,5 +395,178 @@ class TestParseSpriteYY(unittest.TestCase):
         self.assertEqual(layer_guid, "visible_layer")
 
 
+def _make_yyp_content(sprite_names, extra_resources=None):
+    """Build a minimal .yyp file string with the given sprite names in the resources array."""
+    resources = []
+    for name in sprite_names:
+        resources.append(
+            '{{"id":{{"name":"{name}","path":"sprites/{name}/{name}.yy",}},}}'.format(name=name)
+        )
+    if extra_resources:
+        resources.extend(extra_resources)
+    res_str = ",\n    ".join(resources) if resources else ""
+    return '{{\n  "%Name": "TestProject",\n  "resources": [\n    {res}\n  ],\n}}'.format(res=res_str)
+
+
+def _make_sprite_on_disk(gm_dir, sprite_name, layer_guid="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"):
+    """Create a minimal sprite folder structure with a single-frame PNG."""
+    layer_dir = os.path.join(gm_dir, "sprites", sprite_name, "layers", layer_guid)
+    os.makedirs(layer_dir, exist_ok=True)
+    img = Image.new("RGBA", (2, 2), "red")
+    img.save(os.path.join(layer_dir, "frame0.png"), "PNG")
+
+
+class TestGetValidSpriteNames(unittest.TestCase):
+    """Test _get_valid_sprite_names() parsing of .yyp files."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def _make_converter(self):
+        return SpriteConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: None,
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+
+    def test_returns_sprite_names_from_yyp(self):
+        sound_resource = '{"id":{"name":"snd_explosion","path":"sounds/snd_explosion/snd_explosion.yy",},}'
+        yyp = _make_yyp_content(["s_player", "s_enemy", "s_bullet"], extra_resources=[sound_resource])
+        with open(os.path.join(self.gm_dir, "Test.yyp"), "w") as f:
+            f.write(yyp)
+
+        converter = self._make_converter()
+        result = converter._get_valid_sprite_names()
+        self.assertEqual(result, {"s_player", "s_enemy", "s_bullet"})
+
+    def test_handles_trailing_commas(self):
+        # Trailing commas are present in the _make_yyp_content output
+        yyp = _make_yyp_content(["s_test"])
+        with open(os.path.join(self.gm_dir, "Game.yyp"), "w") as f:
+            f.write(yyp)
+
+        converter = self._make_converter()
+        result = converter._get_valid_sprite_names()
+        self.assertEqual(result, {"s_test"})
+
+    def test_returns_none_when_no_yyp(self):
+        converter = self._make_converter()
+        result = converter._get_valid_sprite_names()
+        self.assertIsNone(result)
+
+    def test_returns_none_when_yyp_malformed(self):
+        with open(os.path.join(self.gm_dir, "Bad.yyp"), "w") as f:
+            f.write("not valid json {{{")
+
+        converter = self._make_converter()
+        result = converter._get_valid_sprite_names()
+        self.assertIsNone(result)
+
+    def test_returns_empty_set_when_no_sprites(self):
+        sound_resource = '{"id":{"name":"snd_boom","path":"sounds/snd_boom/snd_boom.yy",},}'
+        yyp = _make_yyp_content([], extra_resources=[sound_resource])
+        with open(os.path.join(self.gm_dir, "Game.yyp"), "w") as f:
+            f.write(yyp)
+
+        converter = self._make_converter()
+        result = converter._get_valid_sprite_names()
+        self.assertIsNotNone(result)
+        self.assertEqual(result, set())
+
+
+class TestSpriteConverterFiltering(unittest.TestCase):
+    """Test that orphaned sprites are filtered out based on .yyp."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def _make_converter(self):
+        return SpriteConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+
+    def test_skips_orphaned_sprites(self):
+        _make_sprite_on_disk(self.gm_dir, "s_valid1")
+        _make_sprite_on_disk(self.gm_dir, "s_valid2")
+        _make_sprite_on_disk(self.gm_dir, "s_orphan")
+
+        yyp = _make_yyp_content(["s_valid1", "s_valid2"])
+        with open(os.path.join(self.gm_dir, "Test.yyp"), "w") as f:
+            f.write(yyp)
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        godot_sprites = os.path.join(self.godot_dir, "sprites")
+        converted = set(os.listdir(godot_sprites)) if os.path.exists(godot_sprites) else set()
+        self.assertIn("s_valid1", converted)
+        self.assertIn("s_valid2", converted)
+        self.assertNotIn("s_orphan", converted)
+
+        skipped_logs = [l for l in self.logs if "s_orphan" in l]
+        self.assertTrue(len(skipped_logs) > 0, "Expected a log message about skipped orphan sprite")
+
+    def test_converts_all_when_all_in_yyp(self):
+        _make_sprite_on_disk(self.gm_dir, "s_a")
+        _make_sprite_on_disk(self.gm_dir, "s_b")
+
+        yyp = _make_yyp_content(["s_a", "s_b"])
+        with open(os.path.join(self.gm_dir, "Test.yyp"), "w") as f:
+            f.write(yyp)
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        godot_sprites = os.path.join(self.godot_dir, "sprites")
+        converted = set(os.listdir(godot_sprites))
+        self.assertIn("s_a", converted)
+        self.assertIn("s_b", converted)
+
+        skipped_logs = [l for l in self.logs if "Skipped" in l and ("s_a" in l or "s_b" in l)]
+        self.assertEqual(len(skipped_logs), 0, "No real sprites should be skipped")
+
+    def test_converts_all_when_yyp_missing(self):
+        _make_sprite_on_disk(self.gm_dir, "s_x")
+        _make_sprite_on_disk(self.gm_dir, "s_y")
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        godot_sprites = os.path.join(self.godot_dir, "sprites")
+        converted = set(os.listdir(godot_sprites))
+        self.assertIn("s_x", converted)
+        self.assertIn("s_y", converted)
+
+    def test_converts_all_when_yyp_malformed(self):
+        _make_sprite_on_disk(self.gm_dir, "s_m")
+        _make_sprite_on_disk(self.gm_dir, "s_n")
+
+        with open(os.path.join(self.gm_dir, "Bad.yyp"), "w") as f:
+            f.write("totally broken {{{")
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        godot_sprites = os.path.join(self.godot_dir, "sprites")
+        converted = set(os.listdir(godot_sprites))
+        self.assertIn("s_m", converted)
+        self.assertIn("s_n", converted)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- **#79**: Fix the English localization for the "Browse Godot Path" dialog — it incorrectly said "Select your GameMaker Project" instead of "Select your Godot Project"
- **#80**: Filter orphaned/junk sprites by parsing the `.yyp` project file to get the authoritative list of sprites. Sprites on disk that aren't in the `.yyp` are skipped and logged. Falls back gracefully to converting all sprites if `.yyp` can't be parsed

Closes #79
Closes #80

## Test plan

- [x] Run `python -m unittest discover tests/ -v` — all 84 tests pass (9 new tests for sprite filtering)
- [x] Verify the Godot path browse dialog shows "Select your Godot Project" (English locale)
- [x] Run conversion against a GameMaker project with known orphaned sprites and confirm they are skipped in the console output