### PR TITLE
Implement font converter (closes #25)

### DIFF
--- a/Languages/de.json
+++ b/Languages/de.json
@@ -76,8 +76,14 @@
 
 "Console_Convertor_Fonts" : "Schriftarten werden konvertiert...",
 "Console_Convertor_Fonts_Complete" : "Schriftarten-Konvertierung abgeschlossen.",
-"Console_Convertor_Fonts_NotImplemented" : "Schriftarten-Konvertierung ist noch nicht implementiert.",
 "Console_Convertor_Fonts_Error_NotFound" : "Schriftarten-Ordner nicht in {gm_project_path} gefunden",
+"Console_Convertor_Fonts_Converted" : "Schriftart konvertiert: {name} -> fonts/{output_file}",
+"Console_Convertor_Fonts_CopiedTTF" : "TTF kopiert: {name} -> fonts/{output_file}",
+"Console_Convertor_Fonts_Stopped" : "Schriftarten-Konvertierung gestoppt.",
+"Console_Convertor_Fonts_SizeNote" : "  Hinweis: {name} Groesse {size}px muss auf der Node-/Theme-Ebene in Godot gesetzt werden.",
+"Console_Convertor_Fonts_ParseError" : "Warnung: {yy_path} konnte nicht gelesen werden, Schriftart wird uebersprungen.",
+"Console_Convertor_Fonts_TTFMissing" : "Warnung: {name} hat includeTTF=true, aber TTF-Datei '{ttf_name}' nicht gefunden. Fallback auf SystemFont.",
+"Console_Convertor_Fonts_SystemFontFallback" : "Warnung: Schriftart '{font_name}' fuer {name} nicht auf dem System gefunden. SystemFont-Referenz erstellt. Installieren Sie die Schriftart und fuehren Sie erneut aus, oder fuegen Sie die Schriftartdatei manuell zu fonts/ hinzu.",
 
 "Console_Convertor_Tilesets" : "Tilesets werden konvertiert...",
 "Console_Convertor_Tilesets_Complete" : "Tileset-Konvertierung abgeschlossen.",

--- a/Languages/eng.json
+++ b/Languages/eng.json
@@ -76,8 +76,14 @@
 
 "Console_Convertor_Fonts" : "Converting fonts...",
 "Console_Convertor_Fonts_Complete" : "Font conversion completed.",
-"Console_Convertor_Fonts_NotImplemented" : "Font conversion is not yet implemented.",
 "Console_Convertor_Fonts_Error_NotFound" : "Font folder not found in {gm_project_path}",
+"Console_Convertor_Fonts_Converted" : "Converted font: {name} -> fonts/{output_file}",
+"Console_Convertor_Fonts_CopiedTTF" : "Copied TTF: {name} -> fonts/{output_file}",
+"Console_Convertor_Fonts_Stopped" : "Font conversion stopped.",
+"Console_Convertor_Fonts_SizeNote" : "  Note: {name} size {size}px must be set at the node/theme level in Godot.",
+"Console_Convertor_Fonts_ParseError" : "Warning: Could not parse {yy_path}, skipping font.",
+"Console_Convertor_Fonts_TTFMissing" : "Warning: {name} has includeTTF=true but TTF file '{ttf_name}' not found. Falling back to SystemFont.",
+"Console_Convertor_Fonts_SystemFontFallback" : "Warning: Font '{font_name}' for {name} not found on system. Created SystemFont reference. Install the font and re-run, or manually add the font file to fonts/.",
 
 "Console_Convertor_Tilesets" : "Converting tilesets...",
 "Console_Convertor_Tilesets_Complete" : "Tileset conversion completed.",

--- a/src/conversion/converter.py
+++ b/src/conversion/converter.py
@@ -51,6 +51,8 @@ class Converter:
             ("fonts", lambda: FontConverter(
                 gm_path, godot_path, self.log_callback,
                 self.progress_callback, self.conversion_running.is_set,
+                update_log_callback=self.update_log_callback,
+                compact_logging=self.compact_logging,
                 max_workers=self.max_workers,
             ).convert_all(), "Console_Convertor_Fonts"),
             ("tilesets", lambda: TileSetConverter(

--- a/src/conversion/fonts.py
+++ b/src/conversion/fonts.py
@@ -1,31 +1,207 @@
+import json
 import os
+import platform
+import re
+import shutil
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
-# Import localization manager
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
 
-# WORK IN PROGRESS
+FONT_EXTENSIONS = ('.ttf', '.otf', '.ttc', '.otc', '.woff', '.woff2')
+
+
+def _get_system_font_dirs():
+    """Return a list of system font directories for the current OS."""
+    system = platform.system()
+    dirs = []
+    if system == 'Windows':
+        windir = os.environ.get('WINDIR', r'C:\Windows')
+        dirs.append(os.path.join(windir, 'Fonts'))
+        local_app = os.environ.get('LOCALAPPDATA', '')
+        if local_app:
+            dirs.append(os.path.join(local_app, 'Microsoft', 'Windows', 'Fonts'))
+    elif system == 'Darwin':
+        dirs.extend([
+            '/Library/Fonts',
+            '/System/Library/Fonts',
+            os.path.expanduser('~/Library/Fonts'),
+        ])
+    else:
+        dirs.extend([
+            '/usr/share/fonts',
+            '/usr/local/share/fonts',
+            os.path.expanduser('~/.local/share/fonts'),
+            os.path.expanduser('~/.fonts'),
+        ])
+    return [d for d in dirs if os.path.isdir(d)]
+
+
+def _find_system_font(font_name):
+    """Search system font directories for a font file matching the given name.
+
+    Returns the path to the font file if found, None otherwise.
+    """
+    font_name_lower = font_name.lower().replace(' ', '')
+    for font_dir in _get_system_font_dirs():
+        for root, _, files in os.walk(font_dir):
+            for filename in files:
+                if not filename.lower().endswith(FONT_EXTENSIONS):
+                    continue
+                name_without_ext = os.path.splitext(filename)[0].lower().replace(' ', '')
+                if name_without_ext == font_name_lower:
+                    return os.path.join(root, filename)
+                # Also match with common suffixes stripped (e.g. "Arial-Regular" -> "Arial")
+                for suffix in ('-regular', '-normal', '_regular', '_normal'):
+                    if name_without_ext.endswith(suffix):
+                        base = name_without_ext[:-len(suffix)]
+                        if base == font_name_lower:
+                            return os.path.join(root, filename)
+    return None
+
 
 class FontConverter(BaseConverter):
     def __init__(self, gm_project_path, godot_project_path, log_callback=print, progress_callback=None, conversion_running=None,
-                 max_workers=None):
+                 update_log_callback=None, compact_logging=False, max_workers=None):
         super().__init__(gm_project_path, godot_project_path, log_callback, progress_callback, conversion_running,
-                         max_workers=max_workers)
+                         update_log_callback, compact_logging, max_workers=max_workers)
         self.godot_fonts_path = os.path.join(self.godot_project_path, 'fonts')
 
+    def find_font_files(self):
+        font_folder = os.path.join(self.gm_project_path, 'fonts')
+        font_files = []
+        for root, _, files in os.walk(font_folder):
+            font_files.extend(
+                os.path.join(root, file)
+                for file in files
+                if file.lower().endswith('.yy') and not file.lower().endswith('.old.yy')
+            )
+        return font_files
+
+    def _parse_font_yy(self, yy_path):
+        try:
+            with open(yy_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+            cleaned = re.sub(r',\s*([}\]])', r'\1', content)
+            data = json.loads(cleaned)
+            return {
+                'fontName': data['fontName'],
+                'name': data['name'],
+                'size': data.get('size', 12.0),
+                'bold': data.get('bold', False),
+                'italic': data.get('italic', False),
+                'AntiAlias': data.get('AntiAlias', 0),
+                'includeTTF': data.get('includeTTF', False),
+                'TTFName': data.get('TTFName', ''),
+            }
+        except (OSError, json.JSONDecodeError, KeyError, TypeError):
+            self._safe_log(get_localized("Console_Convertor_Fonts_ParseError").format(yy_path=yy_path))
+            return None
+
+    def _generate_system_font_tres(self, font_data):
+        font_name = font_data['fontName']
+        italic = "true" if font_data['italic'] else "false"
+        weight = 700 if font_data['bold'] else 400
+        antialiasing = 1 if font_data['AntiAlias'] else 0
+
+        return (
+            '[gd_resource type="SystemFont" format=3]\n'
+            '\n'
+            '[resource]\n'
+            f'font_names = PackedStringArray("{font_name}")\n'
+            f'font_italic = {italic}\n'
+            f'font_weight = {weight}\n'
+            f'antialiasing = {antialiasing}\n'
+        )
+
+    def _process_font(self, yy_path):
+        if not self.conversion_running():
+            return None
+
+        font_data = self._parse_font_yy(yy_path)
+        if font_data is None:
+            return False
+
+        font_name = font_data['name']
+        system_font_name = font_data['fontName']
+        output_file = None
+
+        # 1. Try bundled TTF from GameMaker project
+        if font_data['includeTTF'] and font_data['TTFName']:
+            ttf_path = os.path.join(os.path.dirname(yy_path), font_data['TTFName'])
+            if os.path.isfile(ttf_path):
+                output_file = font_data['TTFName']
+                shutil.copy2(ttf_path, os.path.join(self.godot_fonts_path, output_file))
+                if not self.compact_logging:
+                    self._safe_log(get_localized("Console_Convertor_Fonts_CopiedTTF").format(
+                        name=font_name, output_file=output_file))
+            else:
+                self._safe_log(get_localized("Console_Convertor_Fonts_TTFMissing").format(
+                    name=font_name, ttf_name=font_data['TTFName']))
+
+        # 2. Try finding the font on the system
+        if output_file is None:
+            system_path = _find_system_font(system_font_name)
+            if system_path:
+                output_file = font_name + os.path.splitext(system_path)[1]
+                shutil.copy2(system_path, os.path.join(self.godot_fonts_path, output_file))
+                if not self.compact_logging:
+                    self._safe_log(get_localized("Console_Convertor_Fonts_Converted").format(
+                        name=font_name, output_file=output_file))
+
+        # 3. Fall back to SystemFont .tres reference
+        if output_file is None:
+            output_file = font_name + '.tres'
+            tres_content = self._generate_system_font_tres(font_data)
+            tres_path = os.path.join(self.godot_fonts_path, output_file)
+            with open(tres_path, 'w', encoding='utf-8') as f:
+                f.write(tres_content)
+            self._safe_log(get_localized("Console_Convertor_Fonts_SystemFontFallback").format(
+                name=font_name, font_name=system_font_name))
+
+        if not self.compact_logging:
+            size = font_data['size']
+            self._safe_log(get_localized("Console_Convertor_Fonts_SizeNote").format(
+                name=font_name, size=size))
+
+        return font_name
+
     def convert_fonts(self):
-        # Ensure the Godot project directory exists
         os.makedirs(self.godot_project_path, exist_ok=True)
         os.makedirs(self.godot_fonts_path, exist_ok=True)
 
-        # Find the fonts folder in the GameMaker project
         gm_fonts_path = os.path.join(self.gm_project_path, 'fonts')
 
         if not os.path.exists(gm_fonts_path):
             self.log_callback(get_localized("Console_Convertor_Fonts_Error_NotFound").format(gm_project_path=self.gm_project_path))
             return
 
-        self.log_callback(get_localized("Console_Convertor_Fonts_NotImplemented"))
+        font_files = self.find_font_files()
+
+        if not font_files:
+            self.log_callback(get_localized("Console_Convertor_Fonts_Error_NotFound").format(gm_project_path=self.gm_project_path))
+            return
+
+        total_fonts = len(font_files)
+        processed_fonts = 0
+
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            futures_map = {executor.submit(self._process_font, ff): ff for ff in font_files}
+            for future in as_completed(futures_map):
+                result = future.result()
+                if result is None:
+                    self.log_callback(get_localized("Console_Convertor_Fonts_Stopped"))
+                    return
+                if result is not False:
+                    processed_fonts += 1
+                    if self.compact_logging:
+                        self._safe_log_progress(result, processed_fonts, total_fonts)
+                    self._safe_progress(int(processed_fonts / total_fonts * 100))
+                else:
+                    processed_fonts += 1
+                    self._safe_progress(int(processed_fonts / total_fonts * 100))
+
+        self.log_callback(get_localized("Console_Convertor_Fonts_Complete"))
 
     def convert_all(self):
         self.convert_fonts()

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -252,7 +252,7 @@ class MainWindow(QMainWindow):
         self._progress.status_label.setText(get_localized("Console_ConversionComplete"))
 
         if self._conversion_running.is_set():
-            self._console.append_log(get_localized("Console_ConversionComplete_B"))
+            self._console.append_log(get_localized("Console_ConversionComplete_B"), success=True)
         else:
             self._console.append_log(get_localized("Console_ConversionStopped"))
 

--- a/src/gui/panels/console_panel.py
+++ b/src/gui/panels/console_panel.py
@@ -1,5 +1,7 @@
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QPlainTextEdit
-from PySide6.QtGui import QTextCursor
+from PySide6.QtGui import QTextCursor, QTextCharFormat, QColor
+
+from src.gui.theme import THEME
 
 
 class ConsolePanel(QWidget):
@@ -12,15 +14,43 @@ class ConsolePanel(QWidget):
         self._text_edit.setReadOnly(True)
         layout.addWidget(self._text_edit)
 
-    def append_log(self, message):
-        self._text_edit.appendPlainText(message)
+        self._default_format = QTextCharFormat()
+        self._default_format.setForeground(QColor(THEME["fg_primary"]))
+
+        self._warning_format = QTextCharFormat()
+        self._warning_format.setForeground(QColor(THEME["log_warning"]))
+
+        self._error_format = QTextCharFormat()
+        self._error_format.setForeground(QColor(THEME["log_error"]))
+
+        self._success_format = QTextCharFormat()
+        self._success_format.setForeground(QColor(THEME["log_success"]))
+
+    def _get_format(self, message):
+        msg_lower = message.lower()
+        if msg_lower.startswith("warning:") or ": warning:" in msg_lower:
+            return self._warning_format
+        if msg_lower.startswith("error:") or ": error:" in msg_lower:
+            return self._error_format
+        return self._default_format
+
+    def append_log(self, message, success=False):
+        fmt = self._success_format if success else self._get_format(message)
+        cursor = self._text_edit.textCursor()
+        cursor.movePosition(QTextCursor.MoveOperation.End)
+        if not self._text_edit.document().isEmpty():
+            cursor.insertBlock()
+        cursor.setCharFormat(fmt)
+        cursor.insertText(message)
         self._text_edit.moveCursor(QTextCursor.MoveOperation.End)
 
     def update_last_line(self, message):
+        fmt = self._get_format(message)
         cursor = self._text_edit.textCursor()
         cursor.movePosition(QTextCursor.MoveOperation.End)
         cursor.movePosition(QTextCursor.MoveOperation.StartOfBlock, QTextCursor.MoveMode.KeepAnchor)
         cursor.removeSelectedText()
+        cursor.setCharFormat(fmt)
         cursor.insertText(message)
         self._text_edit.moveCursor(QTextCursor.MoveOperation.End)
 

--- a/src/gui/theme.py
+++ b/src/gui/theme.py
@@ -23,6 +23,11 @@ THEME = {
     "accent_red": "#d83b01",
     "accent_red_hover": "#a62d00",
 
+    # Log colors
+    "log_success": "#98c379",
+    "log_warning": "#e5c07b",
+    "log_error": "#e06c75",
+
     # Disabled / borders
     "disabled_bg": "#333333",
     "border": "#404040",

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.1.1"
+VERSION = "0.1.2"
 
 def get_version():
     return VERSION

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -1,0 +1,361 @@
+import json
+import os
+import sys
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.fonts import FontConverter, _find_system_font
+
+
+MINIMAL_FONT_YY = {
+    "$GMFont": "",
+    "%Name": "fnt_test",
+    "AntiAlias": 1,
+    "bold": False,
+    "canGenerateBitmap": True,
+    "charset": 0,
+    "first": 0,
+    "fontName": "NonExistentTestFont99999",
+    "glyphs": {},
+    "glyphOperations": 0,
+    "includeTTF": False,
+    "italic": False,
+    "kerningPairs": [],
+    "last": 0,
+    "lineHeight": 16,
+    "maintainGms1Font": False,
+    "name": "fnt_test",
+    "parent": {"name": "Fonts", "path": "folders/Fonts.yy"},
+    "ranges": [{"lower": 32, "upper": 127}],
+    "regenerateBitmap": False,
+    "resourceType": "GMFont",
+    "resourceVersion": "2.0",
+    "sampleText": "",
+    "sdfSpread": 10,
+    "size": 16.0,
+    "styleName": "Regular",
+    "textureGroupId": {"name": "Default", "path": "texturegroups/Default"},
+    "TTFName": "",
+    "usesSDF": False,
+}
+
+
+def _make_font_yy(base_dir, font_name, overrides=None):
+    """Create a font .yy file in the standard GM directory structure."""
+    font_dir = os.path.join(base_dir, "fonts", font_name)
+    os.makedirs(font_dir, exist_ok=True)
+    data = dict(MINIMAL_FONT_YY)
+    data["name"] = font_name
+    data["%Name"] = font_name
+    if overrides:
+        data.update(overrides)
+    yy_path = os.path.join(font_dir, f"{font_name}.yy")
+    with open(yy_path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+    return yy_path
+
+
+class TestFontConverterSystemFont(unittest.TestCase):
+    """Test that fonts not found on system produce SystemFont .tres files."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+        _make_font_yy(self.gm_dir, "fnt_test", {
+            "fontName": "NonExistentTestFont99999", "size": 16.0,
+        })
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def _make_converter(self):
+        return FontConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+
+    def test_creates_tres_file(self):
+        converter = self._make_converter()
+        converter.convert_all()
+        expected = os.path.join(self.godot_dir, "fonts", "fnt_test.tres")
+        self.assertTrue(os.path.isfile(expected),
+                        f"Expected {expected} to exist after conversion")
+
+    def test_tres_content(self):
+        converter = self._make_converter()
+        converter.convert_all()
+        tres_path = os.path.join(self.godot_dir, "fonts", "fnt_test.tres")
+        with open(tres_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn('type="SystemFont"', content)
+        self.assertIn('PackedStringArray("NonExistentTestFont99999")', content)
+        self.assertIn("font_italic = false", content)
+        self.assertIn("font_weight = 400", content)
+        self.assertIn("antialiasing = 1", content)
+
+    def test_logs_warning_for_missing_font(self):
+        converter = self._make_converter()
+        converter.convert_all()
+        warnings = [l for l in self.logs if "Warning:" in l or "warning:" in l.lower()]
+        self.assertTrue(len(warnings) > 0,
+                        "Expected a warning when font is not found on system")
+
+
+class TestFontConverterBold(unittest.TestCase):
+    """Test that bold fonts produce font_weight = 700."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+        _make_font_yy(self.gm_dir, "fnt_bold", {
+            "fontName": "NonExistentTestFont99999", "bold": True,
+        })
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def test_bold_weight(self):
+        converter = FontConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+        converter.convert_all()
+        tres_path = os.path.join(self.godot_dir, "fonts", "fnt_bold.tres")
+        with open(tres_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn("font_weight = 700", content)
+
+
+class TestFontConverterTTF(unittest.TestCase):
+    """Test that fonts with includeTTF=true copy the TTF file."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+        yy_path = _make_font_yy(self.gm_dir, "fnt_custom", {
+            "fontName": "CustomFont",
+            "includeTTF": True,
+            "TTFName": "CustomFont.ttf",
+        })
+        ttf_path = os.path.join(os.path.dirname(yy_path), "CustomFont.ttf")
+        with open(ttf_path, "wb") as f:
+            f.write(b"\x00" * 128)
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def test_copies_ttf(self):
+        converter = FontConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+        converter.convert_all()
+        expected = os.path.join(self.godot_dir, "fonts", "CustomFont.ttf")
+        self.assertTrue(os.path.isfile(expected),
+                        f"Expected TTF at {expected} after conversion")
+
+    def test_no_tres_for_ttf(self):
+        converter = FontConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+        converter.convert_all()
+        tres_path = os.path.join(self.godot_dir, "fonts", "fnt_custom.tres")
+        self.assertFalse(os.path.isfile(tres_path),
+                         "Should not create .tres when TTF was copied")
+
+
+class TestFontConverterTTFMissing(unittest.TestCase):
+    """Test fallback to SystemFont when TTF file is missing and font not on system."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+        _make_font_yy(self.gm_dir, "fnt_missing_ttf", {
+            "fontName": "NonExistentTestFont99999",
+            "includeTTF": True,
+            "TTFName": "MissingFont.ttf",
+        })
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def test_falls_back_to_system_font(self):
+        converter = FontConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+        converter.convert_all()
+        tres_path = os.path.join(self.godot_dir, "fonts", "fnt_missing_ttf.tres")
+        self.assertTrue(os.path.isfile(tres_path),
+                        "Should create SystemFont .tres as fallback")
+        with open(tres_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn('PackedStringArray("NonExistentTestFont99999")', content)
+
+
+class TestFontConverterSystemFontLookup(unittest.TestCase):
+    """Test that fonts found on the system are copied as font files."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.fake_font_dir = tempfile.mkdtemp()
+        self.logs = []
+
+        # Create a fake system font file
+        self.fake_ttf = os.path.join(self.fake_font_dir, "TestFont.ttf")
+        with open(self.fake_ttf, "wb") as f:
+            f.write(b"\x00" * 64)
+
+        _make_font_yy(self.gm_dir, "fnt_sysfont", {"fontName": "TestFont"})
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+        shutil.rmtree(self.fake_font_dir)
+
+    @patch('src.conversion.fonts._get_system_font_dirs')
+    def test_copies_system_font(self, mock_dirs):
+        mock_dirs.return_value = [self.fake_font_dir]
+        converter = FontConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+        converter.convert_all()
+        expected = os.path.join(self.godot_dir, "fonts", "fnt_sysfont.ttf")
+        self.assertTrue(os.path.isfile(expected),
+                        f"Expected system font copied to {expected}")
+
+    @patch('src.conversion.fonts._get_system_font_dirs')
+    def test_no_tres_when_system_font_found(self, mock_dirs):
+        mock_dirs.return_value = [self.fake_font_dir]
+        converter = FontConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+        converter.convert_all()
+        tres_path = os.path.join(self.godot_dir, "fonts", "fnt_sysfont.tres")
+        self.assertFalse(os.path.isfile(tres_path),
+                         "Should not create .tres when system font was found and copied")
+
+
+class TestFindSystemFont(unittest.TestCase):
+    """Test the _find_system_font helper function."""
+
+    def setUp(self):
+        self.font_dir = tempfile.mkdtemp()
+        self.font_file = os.path.join(self.font_dir, "MyFont.ttf")
+        with open(self.font_file, "wb") as f:
+            f.write(b"\x00" * 32)
+
+    def tearDown(self):
+        shutil.rmtree(self.font_dir)
+
+    @patch('src.conversion.fonts._get_system_font_dirs')
+    def test_finds_exact_match(self, mock_dirs):
+        mock_dirs.return_value = [self.font_dir]
+        result = _find_system_font("MyFont")
+        self.assertEqual(result, self.font_file)
+
+    @patch('src.conversion.fonts._get_system_font_dirs')
+    def test_finds_case_insensitive(self, mock_dirs):
+        mock_dirs.return_value = [self.font_dir]
+        result = _find_system_font("myfont")
+        self.assertEqual(result, self.font_file)
+
+    @patch('src.conversion.fonts._get_system_font_dirs')
+    def test_finds_with_regular_suffix(self, mock_dirs):
+        regular_font = os.path.join(self.font_dir, "TestFont-Regular.ttf")
+        with open(regular_font, "wb") as f:
+            f.write(b"\x00" * 32)
+        mock_dirs.return_value = [self.font_dir]
+        result = _find_system_font("TestFont")
+        self.assertEqual(result, regular_font)
+
+    @patch('src.conversion.fonts._get_system_font_dirs')
+    def test_returns_none_when_not_found(self, mock_dirs):
+        mock_dirs.return_value = [self.font_dir]
+        result = _find_system_font("NoSuchFont")
+        self.assertIsNone(result)
+
+
+class TestFontConverterMissingFolder(unittest.TestCase):
+    """No fonts/ directory in GM project should not crash."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def test_missing_fonts_no_crash(self):
+        converter = FontConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+        converter.convert_all()
+        self.assertTrue(len(self.logs) > 0,
+                        "Expected at least one log message for missing fonts folder")
+
+
+class TestFontConverterEmptyFolder(unittest.TestCase):
+    """Empty fonts/ directory should not crash."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+        os.makedirs(os.path.join(self.gm_dir, "fonts"))
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def test_empty_fonts_no_crash(self):
+        converter = FontConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+        converter.convert_all()
+        self.assertTrue(len(self.logs) > 0,
+                        "Expected at least one log message for empty fonts folder")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replaces the `FontConverter` stub with a full implementation that reads GameMaker `.yy` font files and produces Godot font resources
- Three-tier font resolution: bundled TTF from GameMaker > system font file lookup (cross-platform) > `SystemFont` `.tres` fallback with a warning to install the missing font
- Adds colored console log output: yellow for warnings, red for errors, lime green for the completion message
- Adds `update_log_callback`/`compact_logging` support to `FontConverter` (matching other converters)
- Bumps version to 0.1.2
- 15 new unit tests covering all font conversion paths and edge cases

## Test plan
- [x] All 102 tests pass (`python -m unittest discover tests -v`), zero regressions
- [x] Manual test: convert a GameMaker project with fonts and verify `fonts/` directory is created in the Godot output
- [x] Verify `.tres` files open correctly in Godot editor
- [x] Verify warning messages appear in yellow and errors in red in the console
- [x] Verify the completion message appears in lime green

Closes #25