### PR TITLE
Add GameMaker object conversion

### DIFF
--- a/Languages/de.json
+++ b/Languages/de.json
@@ -108,6 +108,14 @@
 
 "Console_Convertor_Objects" : "Objekte werden konvertiert...",
 "Console_Convertor_Objects_NotImplemented" : "Objekt-Konvertierung ist noch nicht implementiert.",
+"Console_Convertor_Objects_Complete" : "Objekt-Konvertierung abgeschlossen.",
+"Console_Convertor_Objects_Stopped" : "Objekt-Konvertierung gestoppt.",
+"Console_Convertor_Objects_Converted" : "Objekt konvertiert: {object_name}",
+"Console_Convertor_Objects_ConvertedWithSprite" : "Objekt konvertiert: {object_name} (Sprite: {sprite_name})",
+"Console_Convertor_Objects_Error_NotFound" : "Kein Objekte-Ordner im GameMaker-Projekt gefunden.",
+"Console_Convertor_Objects_YYPFilterWarning" : "Warnung: .yyp-Datei konnte nicht geparst werden. Alle Objekte werden konvertiert.",
+"Console_Convertor_Objects_SpriteNotFound" : "Warnung: Objekt {object_name} verweist auf Sprite {sprite_name}, dessen Szene nicht gefunden wurde. Objekt wird ohne Sprite erstellt.",
+"Console_Convertor_Objects_ParseError" : "Warnung: {yy_path} konnte nicht gelesen werden, Objekt {object_name} wird uebersprungen.",
 
 "Console_Convertor_Notes" : "Notizen werden konvertiert...",
 "Console_Convertor_Notes_Copied" : "Notiz kopiert: {note_name}",
@@ -149,7 +157,7 @@
 "Settings_Title" : "Konvertierungseinstellungen",
 "Settings_Files_Heading" : "Wählen Sie zu konvertierende Dateien aus:",
 "Settings_Categories_Headings" : ["Assets", "Projekt", "WIP"],
-"Settings_Categories_Contents" : [["sprites", "fonts", "sounds", "included_files"], ["game_icon", "project_name", "project_settings", "audio_buses", "notes"], ["objects", "shaders", "tilesets"]],
+"Settings_Categories_Contents" : [["sprites", "fonts", "sounds", "included_files", "objects"], ["game_icon", "project_name", "project_settings", "audio_buses", "notes"], ["shaders", "tilesets"]],
 "Settings_Labels": {
     "sprites": "Sprites",
     "fonts": "Schriftarten",

--- a/Languages/eng.json
+++ b/Languages/eng.json
@@ -108,6 +108,14 @@
 
 "Console_Convertor_Objects" : "Converting objects...",
 "Console_Convertor_Objects_NotImplemented" : "Object conversion is not yet implemented.",
+"Console_Convertor_Objects_Complete" : "Object conversion completed.",
+"Console_Convertor_Objects_Stopped" : "Object conversion stopped.",
+"Console_Convertor_Objects_Converted" : "Converted object: {object_name}",
+"Console_Convertor_Objects_ConvertedWithSprite" : "Converted object: {object_name} (sprite: {sprite_name})",
+"Console_Convertor_Objects_Error_NotFound" : "No objects folder found in GameMaker project.",
+"Console_Convertor_Objects_YYPFilterWarning" : "Warning: Could not parse .yyp file for object filtering. All objects will be converted.",
+"Console_Convertor_Objects_SpriteNotFound" : "Warning: Object {object_name} references sprite {sprite_name} whose scene was not found. Creating object without sprite.",
+"Console_Convertor_Objects_ParseError" : "Warning: Could not parse {yy_path}, skipping object {object_name}.",
 
 "Console_Convertor_Notes" : "Converting notes...",
 "Console_Convertor_Notes_Copied" : "Copied note: {note_name}",
@@ -149,7 +157,7 @@
 "Settings_Title" : "Conversion Settings",
 "Settings_Files_Heading" : "Select files to convert:",
 "Settings_Categories_Headings" : ["Assets", "Project", "WIP"],
-"Settings_Categories_Contents" : [["sprites", "fonts", "sounds", "included_files"], ["game_icon", "project_name", "project_settings", "audio_buses", "notes"], ["objects", "shaders", "tilesets"]],
+"Settings_Categories_Contents" : [["sprites", "fonts", "sounds", "included_files", "objects"], ["game_icon", "project_name", "project_settings", "audio_buses", "notes"], ["shaders", "tilesets"]],
 "Settings_Labels": {
     "sprites": "Sprites",
     "fonts": "Fonts",

--- a/src/conversion/converter.py
+++ b/src/conversion/converter.py
@@ -3,6 +3,7 @@ from src.conversion.sounds import SoundConverter
 from src.conversion.fonts import FontConverter
 from src.conversion.notes import NoteConverter
 from src.conversion.tilesets import TileSetConverter
+from src.conversion.objects import ObjectConverter
 from src.conversion.shaders import ShaderConverter
 from src.conversion.included_files import IncludedFilesConverter
 from src.conversion.project_settings import ProjectSettingsConverter
@@ -11,9 +12,9 @@ from src.localization import get_localized
 
 
 CONVERSION_CATEGORIES = {
-    "assets": ["sprites", "fonts", "sounds", "included_files"],
+    "assets": ["sprites", "fonts", "sounds", "included_files", "objects"],
     "project": ["game_icon", "project_name", "project_settings", "audio_buses", "notes"],
-    "wip": ["objects", "shaders", "tilesets"],
+    "wip": ["shaders", "tilesets"],
 }
 
 
@@ -90,9 +91,13 @@ class Converter:
                 compact_logging=self.compact_logging,
                 max_workers=self.max_workers,
             ).convert_all(), "Console_Convertor_IncludedFiles"),
-            ("objects", lambda: self.log_callback(
-                get_localized("Console_Convertor_Objects_NotImplemented")
-            ), "Console_Convertor_Objects"),
+            ("objects", lambda: ObjectConverter(
+                gm_path, godot_path, self.log_callback,
+                self.progress_callback, self.conversion_running.is_set,
+                update_log_callback=self.update_log_callback,
+                compact_logging=self.compact_logging,
+                max_workers=self.max_workers,
+            ).convert_all(), "Console_Convertor_Objects"),
         ]
 
         for setting_key, converter_fn, log_key in converters:

--- a/src/conversion/objects.py
+++ b/src/conversion/objects.py
@@ -1,0 +1,174 @@
+import os
+import re
+import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from src.localization import get_localized
+from src.conversion.base_converter import BaseConverter
+
+
+class ObjectConverter(BaseConverter):
+    def __init__(self, gm_project_path, godot_project_path, log_callback=print, progress_callback=None, conversion_running=None,
+                 update_log_callback=None, compact_logging=False, max_workers=None):
+        super().__init__(gm_project_path, godot_project_path, log_callback, progress_callback, conversion_running,
+                         update_log_callback, compact_logging, max_workers=max_workers)
+        self.godot_objects_path = os.path.join(self.godot_project_path, 'objects')
+
+    def _get_valid_object_names(self):
+        """Parse the .yyp project file and return the set of object names listed in resources.
+
+        Returns None if the .yyp file cannot be found or parsed, allowing
+        the caller to fall back to converting all objects on disk.
+        """
+        try:
+            yyp_files = [f for f in os.listdir(self.gm_project_path) if f.endswith('.yyp')]
+            if not yyp_files:
+                return None
+
+            yyp_path = os.path.join(self.gm_project_path, yyp_files[0])
+            with open(yyp_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+
+            cleaned = re.sub(r',\s*([}\]])', r'\1', content)
+            data = json.loads(cleaned)
+
+            valid_objects = set()
+            for resource in data.get('resources', []):
+                res_id = resource.get('id', {})
+                path = res_id.get('path', '')
+                if path.startswith('objects/'):
+                    valid_objects.add(res_id.get('name', ''))
+
+            return valid_objects
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+            self._safe_log(get_localized("Console_Convertor_Objects_YYPFilterWarning"))
+            return None
+
+    def _parse_object_yy(self, object_name):
+        """Parse an object .yy file and extract the sprite reference.
+
+        Returns a dict with 'sprite_name' (str or None) or None if parsing fails.
+        """
+        yy_path = os.path.join(self.gm_project_path, 'objects', object_name, object_name + '.yy')
+        try:
+            with open(yy_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+            cleaned = re.sub(r',\s*([}\]])', r'\1', content)
+            data = json.loads(cleaned)
+
+            sprite_id = data.get('spriteId')
+            sprite_name = None
+            if sprite_id is not None:
+                sprite_name = sprite_id.get('name', None)
+
+            return {"sprite_name": sprite_name}
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+            self._safe_log(get_localized("Console_Convertor_Objects_ParseError").format(
+                yy_path=yy_path, object_name=object_name))
+            return None
+
+    def _sprite_scene_exists(self, sprite_name):
+        """Check whether the converted sprite scene exists in the Godot project."""
+        tscn_path = os.path.join(self.godot_project_path, 'sprites', sprite_name, sprite_name + '.tscn')
+        return os.path.isfile(tscn_path)
+
+    def _generate_object_scene(self, object_name, sprite_name):
+        """Build the .tscn content string for an object scene.
+
+        If sprite_name is not None, the scene instances the sprite's scene as a child.
+        """
+        if sprite_name is None:
+            parts = ['[gd_scene format=3]\n']
+            parts.append(f'\n[node name="{object_name}" type="Node2D"]\n')
+        else:
+            parts = ['[gd_scene format=3 load_steps=2]\n']
+            parts.append(f'\n[ext_resource type="PackedScene" path="res://sprites/{sprite_name}/{sprite_name}.tscn" id="1"]\n')
+            parts.append(f'\n[node name="{object_name}" type="Node2D"]\n')
+            parts.append(f'\n[node name="{sprite_name}" parent="." instance=ExtResource("1")]\n')
+
+        return ''.join(parts)
+
+    def _process_object(self, object_name):
+        """Process a single object: parse .yy, generate scene, write .tscn file.
+
+        Returns a result dict or None if conversion was stopped.
+        """
+        if not self.conversion_running():
+            return None
+
+        parsed = self._parse_object_yy(object_name)
+        if parsed is None:
+            return {"success": False, "name": object_name}
+
+        sprite_name = parsed["sprite_name"]
+
+        if sprite_name is not None and not self._sprite_scene_exists(sprite_name):
+            self._safe_log(get_localized("Console_Convertor_Objects_SpriteNotFound").format(
+                object_name=object_name, sprite_name=sprite_name))
+            sprite_name = None
+
+        scene_content = self._generate_object_scene(object_name, sprite_name)
+
+        object_dir = os.path.join(self.godot_objects_path, object_name)
+        os.makedirs(object_dir, exist_ok=True)
+        tscn_path = os.path.join(object_dir, f"{object_name}.tscn")
+        with open(tscn_path, 'w', encoding='utf-8') as f:
+            f.write(scene_content)
+
+        return {"success": True, "name": object_name, "has_sprite": sprite_name is not None, "sprite_name": sprite_name}
+
+    def convert_objects(self):
+        os.makedirs(self.godot_objects_path, exist_ok=True)
+
+        gm_objects_path = os.path.join(self.gm_project_path, 'objects')
+        if not os.path.isdir(gm_objects_path):
+            self.log_callback(get_localized("Console_Convertor_Objects_Error_NotFound"))
+            return
+
+        object_names = [
+            name for name in os.listdir(gm_objects_path)
+            if os.path.isdir(os.path.join(gm_objects_path, name))
+            and os.path.isfile(os.path.join(gm_objects_path, name, name + '.yy'))
+        ]
+
+        valid_names = self._get_valid_object_names()
+        if valid_names is not None:
+            object_names = [name for name in object_names if name in valid_names]
+
+        if not object_names:
+            self.log_callback(get_localized("Console_Convertor_Objects_Complete"))
+            return
+
+        total = len(object_names)
+        processed = 0
+
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            futures_map = {
+                executor.submit(self._process_object, name): name
+                for name in object_names
+            }
+            for future in as_completed(futures_map):
+                result = future.result()
+                if result is None:
+                    self.log_callback(get_localized("Console_Convertor_Objects_Stopped"))
+                    return
+
+                processed += 1
+
+                if result["success"]:
+                    if self.compact_logging:
+                        self._safe_log_progress(result["name"], processed, total)
+                    else:
+                        if result["has_sprite"]:
+                            self._safe_log(get_localized("Console_Convertor_Objects_ConvertedWithSprite").format(
+                                object_name=result["name"], sprite_name=result["sprite_name"]))
+                        else:
+                            self._safe_log(get_localized("Console_Convertor_Objects_Converted").format(
+                                object_name=result["name"]))
+
+                self._safe_progress(int(processed / total * 100))
+
+        self.log_callback(get_localized("Console_Convertor_Objects_Complete"))
+
+    def convert_all(self):
+        self.convert_objects()

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -69,7 +69,6 @@ class MainWindow(QMainWindow):
         all_keys = [key for keys in CONVERSION_CATEGORIES.values() for key in keys]
         self._conversion_settings = {key: SettingValue(True) for key in all_keys}
         self._conversion_settings["notes"].set(False)
-        self._conversion_settings["objects"].set(False)
         self._compact_logging = SettingValue(True)
         self._max_workers = multiprocessing.cpu_count()
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -25,7 +25,7 @@ class TestConversionCategories(unittest.TestCase):
 
     def test_assets_contents(self):
         self.assertEqual(CONVERSION_CATEGORIES["assets"],
-                         ["sprites", "fonts", "sounds", "included_files"])
+                         ["sprites", "fonts", "sounds", "included_files", "objects"])
 
     def test_project_contents(self):
         self.assertEqual(CONVERSION_CATEGORIES["project"],
@@ -34,7 +34,7 @@ class TestConversionCategories(unittest.TestCase):
 
     def test_wip_contents(self):
         self.assertEqual(CONVERSION_CATEGORIES["wip"],
-                         ["objects", "shaders", "tilesets"])
+                         ["shaders", "tilesets"])
 
 
 class _FakeBooleanVar:

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,0 +1,297 @@
+import os
+import sys
+import shutil
+import tempfile
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.objects import ObjectConverter
+
+
+def _make_object_yy_content(name, sprite_name=None):
+    """Build a GameMaker object .yy file string."""
+    if sprite_name is not None:
+        sprite_id = (
+            '{{"name": "{sprite_name}", '
+            '"path": "sprites/{sprite_name}/{sprite_name}.yy",}}'
+        ).format(sprite_name=sprite_name)
+    else:
+        sprite_id = "null"
+
+    return (
+        '{{\n'
+        '  "$GMObject": "",\n'
+        '  "%Name": "{name}",\n'
+        '  "eventList": [],\n'
+        '  "managed": true,\n'
+        '  "name": "{name}",\n'
+        '  "overriddenProperties": [],\n'
+        '  "parent": {{"name": "Objects", "path": "folders/Objects.yy",}},\n'
+        '  "parentObjectId": null,\n'
+        '  "persistent": false,\n'
+        '  "physicsObject": false,\n'
+        '  "properties": [],\n'
+        '  "resourceType": "GMObject",\n'
+        '  "resourceVersion": "2.0",\n'
+        '  "solid": false,\n'
+        '  "spriteId": {sprite_id},\n'
+        '  "spriteMaskId": null,\n'
+        '  "visible": true,\n'
+        '}}'
+    ).format(name=name, sprite_id=sprite_id)
+
+
+def _create_fake_sprite_scene(godot_dir, sprite_name):
+    """Create a minimal sprite .tscn file in the Godot project."""
+    sprite_dir = os.path.join(godot_dir, "sprites", sprite_name)
+    os.makedirs(sprite_dir, exist_ok=True)
+    tscn_path = os.path.join(sprite_dir, sprite_name + ".tscn")
+    with open(tscn_path, "w", encoding="utf-8") as f:
+        f.write('[gd_scene format=3]\n\n[node name="{}" type="Area2D"]\n'.format(sprite_name))
+
+
+class TestObjectConverterBasic(unittest.TestCase):
+    """Test ObjectConverter with a minimal fake GameMaker project."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+
+        # Create an object with a sprite reference
+        obj_dir = os.path.join(self.gm_dir, "objects", "o_player")
+        os.makedirs(obj_dir)
+        yy_content = _make_object_yy_content("o_player", sprite_name="s_player")
+        with open(os.path.join(obj_dir, "o_player.yy"), "w") as f:
+            f.write(yy_content)
+
+        # Create an object without a sprite
+        obj_dir2 = os.path.join(self.gm_dir, "objects", "o_controller")
+        os.makedirs(obj_dir2)
+        yy_content2 = _make_object_yy_content("o_controller", sprite_name=None)
+        with open(os.path.join(obj_dir2, "o_controller.yy"), "w") as f:
+            f.write(yy_content2)
+
+        # Create the fake converted sprite scene for o_player's sprite
+        _create_fake_sprite_scene(self.godot_dir, "s_player")
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def _make_converter(self):
+        return ObjectConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+
+    def test_converts_object_to_godot_dir(self):
+        converter = self._make_converter()
+        converter.convert_all()
+
+        godot_obj_dir = os.path.join(self.godot_dir, "objects", "o_player")
+        self.assertTrue(os.path.isdir(godot_obj_dir),
+                        "Expected objects/o_player directory in Godot project")
+
+    def test_generates_tscn_file(self):
+        converter = self._make_converter()
+        converter.convert_all()
+
+        tscn_path = os.path.join(self.godot_dir, "objects", "o_player", "o_player.tscn")
+        self.assertTrue(os.path.isfile(tscn_path), "Expected .tscn file to be generated")
+
+    def test_tscn_instances_sprite(self):
+        converter = self._make_converter()
+        converter.convert_all()
+
+        tscn_path = os.path.join(self.godot_dir, "objects", "o_player", "o_player.tscn")
+        with open(tscn_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        self.assertIn('PackedScene', content)
+        self.assertIn('res://sprites/s_player/s_player.tscn', content)
+        self.assertIn('instance=ExtResource("1")', content)
+        self.assertIn('type="Node2D"', content)
+
+    def test_object_without_sprite(self):
+        converter = self._make_converter()
+        converter.convert_all()
+
+        tscn_path = os.path.join(self.godot_dir, "objects", "o_controller", "o_controller.tscn")
+        self.assertTrue(os.path.isfile(tscn_path), "Expected .tscn file for object without sprite")
+
+        with open(tscn_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        self.assertIn('type="Node2D"', content)
+        self.assertNotIn('ext_resource', content)
+        self.assertNotIn('instance', content)
+
+
+class TestObjectConverterEmpty(unittest.TestCase):
+    """Edge cases: missing objects dir and missing sprites."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def test_empty_objects_no_crash(self):
+        """No objects directory at all should log an error and not crash."""
+        converter = ObjectConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+        converter.convert_all()  # should not raise
+
+        self.assertTrue(len(self.logs) > 0,
+                        "Expected at least one log message for missing objects folder")
+
+    def test_missing_sprite_scene_fallback(self):
+        """Object referencing a sprite whose scene doesn't exist should fall back to no-sprite."""
+        obj_dir = os.path.join(self.gm_dir, "objects", "o_broken")
+        os.makedirs(obj_dir)
+        yy_content = _make_object_yy_content("o_broken", sprite_name="s_nonexistent")
+        with open(os.path.join(obj_dir, "o_broken.yy"), "w") as f:
+            f.write(yy_content)
+
+        converter = ObjectConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+        converter.convert_all()  # should not raise
+
+        # Scene should still be created, but without sprite reference
+        tscn_path = os.path.join(self.godot_dir, "objects", "o_broken", "o_broken.tscn")
+        self.assertTrue(os.path.isfile(tscn_path),
+                        "Should still generate .tscn even when sprite is missing")
+
+        with open(tscn_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        self.assertIn('type="Node2D"', content)
+        self.assertNotIn('ext_resource', content)
+
+
+class TestParseObjectYY(unittest.TestCase):
+    """Test _parse_object_yy directly."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.converter = ObjectConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: None,
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def _write_object_yy(self, object_name, content):
+        obj_dir = os.path.join(self.gm_dir, "objects", object_name)
+        os.makedirs(obj_dir, exist_ok=True)
+        with open(os.path.join(obj_dir, object_name + ".yy"), "w") as f:
+            f.write(content)
+
+    def test_parses_valid_object_with_sprite(self):
+        content = _make_object_yy_content("o_test", sprite_name="s_test")
+        self._write_object_yy("o_test", content)
+
+        result = self.converter._parse_object_yy("o_test")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["sprite_name"], "s_test")
+
+    def test_parses_valid_object_without_sprite(self):
+        content = _make_object_yy_content("o_empty", sprite_name=None)
+        self._write_object_yy("o_empty", content)
+
+        result = self.converter._parse_object_yy("o_empty")
+        self.assertIsNotNone(result)
+        self.assertIsNone(result["sprite_name"])
+
+    def test_returns_none_for_missing(self):
+        result = self.converter._parse_object_yy("nonexistent_object")
+        self.assertIsNone(result)
+
+    def test_handles_trailing_commas(self):
+        content = (
+            '{\n'
+            '  "spriteId": {"name": "s_tc", "path": "sprites/s_tc/s_tc.yy",},\n'
+            '  "name": "o_tc",\n'
+            '  "resourceType": "GMObject",\n'
+            '}'
+        )
+        self._write_object_yy("o_tc", content)
+
+        result = self.converter._parse_object_yy("o_tc")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["sprite_name"], "s_tc")
+
+
+class TestObjectConverterYYPFiltering(unittest.TestCase):
+    """Test that objects are filtered against the .yyp project file."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+
+        # Create two objects on disk
+        for name in ["o_listed", "o_unlisted"]:
+            obj_dir = os.path.join(self.gm_dir, "objects", name)
+            os.makedirs(obj_dir)
+            yy_content = _make_object_yy_content(name, sprite_name=None)
+            with open(os.path.join(obj_dir, name + ".yy"), "w") as f:
+                f.write(yy_content)
+
+        # Create a .yyp that only lists o_listed
+        yyp_content = (
+            '{\n'
+            '  "resources": [\n'
+            '    {"id": {"name": "o_listed", "path": "objects/o_listed/o_listed.yy"}}\n'
+            '  ]\n'
+            '}'
+        )
+        with open(os.path.join(self.gm_dir, "Test.yyp"), "w") as f:
+            f.write(yyp_content)
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def test_only_listed_objects_converted(self):
+        converter = ObjectConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+        converter.convert_all()
+
+        listed_path = os.path.join(self.godot_dir, "objects", "o_listed", "o_listed.tscn")
+        unlisted_path = os.path.join(self.godot_dir, "objects", "o_unlisted", "o_unlisted.tscn")
+
+        self.assertTrue(os.path.isfile(listed_path),
+                        "Object listed in .yyp should be converted")
+        self.assertFalse(os.path.isfile(unlisted_path),
+                         "Object not listed in .yyp should be skipped")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Implement `ObjectConverter` that parses GameMaker object `.yy` files and generates Godot `.tscn` scenes with `Node2D` root nodes
- Objects with assigned sprites instance the already-converted sprite scene as a child node; objects without sprites get a bare `Node2D` scene
- Includes `.yyp` filtering to skip orphaned objects, graceful fallback when a referenced sprite scene is missing, and localization strings for English and German
- Moves objects from the WIP settings category to Assets, enabled by default

Closes #6

## Test plan
- [x] 11 unit tests added in `tests/test_objects.py` — all pass
- [x] Full test suite (146 tests) passes with no regressions
- [x] Manual test: run GM2Godot with a GameMaker project, verify `objects/` folder is created in the Godot project with `.tscn` files that correctly instance sprite scenes