### PR TITLE
Respect GameMaker folder hierarchy in converted output

### DIFF
--- a/src/conversion/base_converter.py
+++ b/src/conversion/base_converter.py
@@ -1,4 +1,6 @@
+import json
 import os
+import re
 import threading
 from abc import ABC, abstractmethod
 
@@ -52,6 +54,41 @@ class BaseConverter(ABC):
         """Thread-safe version of _log_progress."""
         with self._lock:
             self._log_progress(item_name, current, total)
+
+    def _read_yy_file(self, yy_path):
+        """Read and parse a GameMaker .yy file, cleaning trailing commas."""
+        try:
+            with open(yy_path, 'r', encoding='utf-8') as f:
+                content = f.read()
+            cleaned = re.sub(r',\s*([}\]])', r'\1', content)
+            return json.loads(cleaned)
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+            return None
+
+    def _get_subfolder_from_yy(self, yy_path):
+        """Extract the IDE subfolder path from a resource's .yy file.
+
+        Reads parent.path (e.g. "folders/Objects/Game/Abilities.yy"),
+        strips "folders/" prefix, ".yy" suffix, and the first path component
+        (resource type), returning the remaining subfolder (e.g. "Game/Abilities").
+
+        Returns "" for root-level resources or on any parse failure.
+        """
+        data = self._read_yy_file(yy_path)
+        if data is None:
+            return ""
+        try:
+            parent_path = data['parent']['path']
+            if parent_path.startswith('folders/'):
+                parent_path = parent_path[len('folders/'):]
+            if parent_path.endswith('.yy'):
+                parent_path = parent_path[:-len('.yy')]
+            parts = parent_path.split('/')
+            if len(parts) <= 1:
+                return ""
+            return '/'.join(parts[1:])
+        except (KeyError, TypeError, AttributeError):
+            return ""
 
     @abstractmethod
     def convert_all(self):

--- a/src/conversion/fonts.py
+++ b/src/conversion/fonts.py
@@ -126,12 +126,19 @@ class FontConverter(BaseConverter):
         system_font_name = font_data['fontName']
         output_file = None
 
+        subfolder = self._get_subfolder_from_yy(yy_path)
+        if subfolder:
+            output_dir = os.path.join(self.godot_fonts_path, subfolder)
+        else:
+            output_dir = self.godot_fonts_path
+        os.makedirs(output_dir, exist_ok=True)
+
         # 1. Try bundled TTF from GameMaker project
         if font_data['includeTTF'] and font_data['TTFName']:
             ttf_path = os.path.join(os.path.dirname(yy_path), font_data['TTFName'])
             if os.path.isfile(ttf_path):
                 output_file = font_data['TTFName']
-                shutil.copy2(ttf_path, os.path.join(self.godot_fonts_path, output_file))
+                shutil.copy2(ttf_path, os.path.join(output_dir, output_file))
                 if not self.compact_logging:
                     self._safe_log(get_localized("Console_Convertor_Fonts_CopiedTTF").format(
                         name=font_name, output_file=output_file))
@@ -144,7 +151,7 @@ class FontConverter(BaseConverter):
             system_path = _find_system_font(system_font_name)
             if system_path:
                 output_file = font_name + os.path.splitext(system_path)[1]
-                shutil.copy2(system_path, os.path.join(self.godot_fonts_path, output_file))
+                shutil.copy2(system_path, os.path.join(output_dir, output_file))
                 if not self.compact_logging:
                     self._safe_log(get_localized("Console_Convertor_Fonts_Converted").format(
                         name=font_name, output_file=output_file))
@@ -153,7 +160,7 @@ class FontConverter(BaseConverter):
         if output_file is None:
             output_file = font_name + '.tres'
             tres_content = self._generate_system_font_tres(font_data)
-            tres_path = os.path.join(self.godot_fonts_path, output_file)
+            tres_path = os.path.join(output_dir, output_file)
             with open(tres_path, 'w', encoding='utf-8') as f:
                 f.write(tres_content)
             self._safe_log(get_localized("Console_Convertor_Fonts_SystemFontFallback").format(

--- a/src/conversion/notes.py
+++ b/src/conversion/notes.py
@@ -28,12 +28,18 @@ class NoteConverter(BaseConverter):
 
         os.makedirs(godot_notes_path, exist_ok=True)
 
-        # Collect all note files
+        # Collect all note files and their subfolders
         note_files = []
+        note_subfolders = {}
         for root, dirs, files in os.walk(gm_notes_path):
             for file in files:
                 if file.endswith('.txt'):
-                    note_files.append(os.path.join(root, file))
+                    src_path = os.path.join(root, file)
+                    note_name = os.path.splitext(file)[0]
+                    note_files.append(src_path)
+                    # Look for corresponding .yy file in the same directory
+                    yy_path = os.path.join(root, note_name + '.yy')
+                    note_subfolders[src_path] = self._get_subfolder_from_yy(yy_path)
 
         if not note_files:
             return
@@ -41,7 +47,12 @@ class NoteConverter(BaseConverter):
         # Pre-create all directories
         for src_file in note_files:
             note_name = os.path.splitext(os.path.basename(src_file))[0]
-            os.makedirs(os.path.join(godot_notes_path, note_name), exist_ok=True)
+            subfolder = note_subfolders.get(src_file, "")
+            if subfolder:
+                note_dir = os.path.join(godot_notes_path, subfolder, note_name)
+            else:
+                note_dir = os.path.join(godot_notes_path, note_name)
+            os.makedirs(note_dir, exist_ok=True)
 
         total_notes = len(note_files)
         processed_notes = 0
@@ -50,7 +61,11 @@ class NoteConverter(BaseConverter):
             futures_map = {}
             for src_file in note_files:
                 note_name = os.path.splitext(os.path.basename(src_file))[0]
-                dst_file = os.path.join(godot_notes_path, note_name, os.path.basename(src_file))
+                subfolder = note_subfolders.get(src_file, "")
+                if subfolder:
+                    dst_file = os.path.join(godot_notes_path, subfolder, note_name, os.path.basename(src_file))
+                else:
+                    dst_file = os.path.join(godot_notes_path, note_name, os.path.basename(src_file))
                 future = executor.submit(self._process_note, src_file, dst_file, note_name)
                 futures_map[future] = note_name
 

--- a/src/conversion/objects.py
+++ b/src/conversion/objects.py
@@ -15,7 +15,7 @@ class ObjectConverter(BaseConverter):
         self.godot_objects_path = os.path.join(self.godot_project_path, 'objects')
 
     def _get_valid_object_names(self):
-        """Parse the .yyp project file and return the set of object names listed in resources.
+        """Parse the .yyp project file and return a dict of object name -> subfolder.
 
         Returns None if the .yyp file cannot be found or parsed, allowing
         the caller to fall back to converting all objects on disk.
@@ -32,12 +32,14 @@ class ObjectConverter(BaseConverter):
             cleaned = re.sub(r',\s*([}\]])', r'\1', content)
             data = json.loads(cleaned)
 
-            valid_objects = set()
+            valid_objects = {}
             for resource in data.get('resources', []):
                 res_id = resource.get('id', {})
                 path = res_id.get('path', '')
                 if path.startswith('objects/'):
-                    valid_objects.add(res_id.get('name', ''))
+                    name = res_id.get('name', '')
+                    yy_path = os.path.join(self.gm_project_path, 'objects', name, name + '.yy')
+                    valid_objects[name] = self._get_subfolder_from_yy(yy_path)
 
             return valid_objects
         except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
@@ -67,12 +69,20 @@ class ObjectConverter(BaseConverter):
                 yy_path=yy_path, object_name=object_name))
             return None
 
-    def _sprite_scene_exists(self, sprite_name):
+    def _get_sprite_subfolder(self, sprite_name):
+        """Resolve a sprite's subfolder by reading its .yy file from the GM project."""
+        yy_path = os.path.join(self.gm_project_path, 'sprites', sprite_name, sprite_name + '.yy')
+        return self._get_subfolder_from_yy(yy_path)
+
+    def _sprite_scene_exists(self, sprite_name, sprite_subfolder=""):
         """Check whether the converted sprite scene exists in the Godot project."""
-        tscn_path = os.path.join(self.godot_project_path, 'sprites', sprite_name, sprite_name + '.tscn')
+        if sprite_subfolder:
+            tscn_path = os.path.join(self.godot_project_path, 'sprites', sprite_subfolder, sprite_name, sprite_name + '.tscn')
+        else:
+            tscn_path = os.path.join(self.godot_project_path, 'sprites', sprite_name, sprite_name + '.tscn')
         return os.path.isfile(tscn_path)
 
-    def _generate_object_scene(self, object_name, sprite_name):
+    def _generate_object_scene(self, object_name, sprite_name, sprite_subfolder=""):
         """Build the .tscn content string for an object scene.
 
         If sprite_name is not None, the scene instances the sprite's scene as a child.
@@ -81,14 +91,18 @@ class ObjectConverter(BaseConverter):
             parts = ['[gd_scene format=3]\n']
             parts.append(f'\n[node name="{object_name}" type="Node2D"]\n')
         else:
+            if sprite_subfolder:
+                sprite_res_path = f"res://sprites/{sprite_subfolder}/{sprite_name}/{sprite_name}.tscn"
+            else:
+                sprite_res_path = f"res://sprites/{sprite_name}/{sprite_name}.tscn"
             parts = ['[gd_scene format=3 load_steps=2]\n']
-            parts.append(f'\n[ext_resource type="PackedScene" path="res://sprites/{sprite_name}/{sprite_name}.tscn" id="1"]\n')
+            parts.append(f'\n[ext_resource type="PackedScene" path="{sprite_res_path}" id="1"]\n')
             parts.append(f'\n[node name="{object_name}" type="Node2D"]\n')
             parts.append(f'\n[node name="{sprite_name}" parent="." instance=ExtResource("1")]\n')
 
         return ''.join(parts)
 
-    def _process_object(self, object_name):
+    def _process_object(self, object_name, subfolder=""):
         """Process a single object: parse .yy, generate scene, write .tscn file.
 
         Returns a result dict or None if conversion was stopped.
@@ -101,15 +115,21 @@ class ObjectConverter(BaseConverter):
             return {"success": False, "name": object_name}
 
         sprite_name = parsed["sprite_name"]
+        sprite_subfolder = ""
 
-        if sprite_name is not None and not self._sprite_scene_exists(sprite_name):
-            self._safe_log(get_localized("Console_Convertor_Objects_SpriteNotFound").format(
-                object_name=object_name, sprite_name=sprite_name))
-            sprite_name = None
+        if sprite_name is not None:
+            sprite_subfolder = self._get_sprite_subfolder(sprite_name)
+            if not self._sprite_scene_exists(sprite_name, sprite_subfolder):
+                self._safe_log(get_localized("Console_Convertor_Objects_SpriteNotFound").format(
+                    object_name=object_name, sprite_name=sprite_name))
+                sprite_name = None
 
-        scene_content = self._generate_object_scene(object_name, sprite_name)
+        scene_content = self._generate_object_scene(object_name, sprite_name, sprite_subfolder)
 
-        object_dir = os.path.join(self.godot_objects_path, object_name)
+        if subfolder:
+            object_dir = os.path.join(self.godot_objects_path, subfolder, object_name)
+        else:
+            object_dir = os.path.join(self.godot_objects_path, object_name)
         os.makedirs(object_dir, exist_ok=True)
         tscn_path = os.path.join(object_dir, f"{object_name}.tscn")
         with open(tscn_path, 'w', encoding='utf-8') as f:
@@ -132,8 +152,14 @@ class ObjectConverter(BaseConverter):
         ]
 
         valid_names = self._get_valid_object_names()
+        object_subfolders = {}
         if valid_names is not None:
             object_names = [name for name in object_names if name in valid_names]
+            object_subfolders = {name: valid_names[name] for name in object_names}
+        else:
+            for name in object_names:
+                yy_path = os.path.join(self.gm_project_path, 'objects', name, name + '.yy')
+                object_subfolders[name] = self._get_subfolder_from_yy(yy_path)
 
         if not object_names:
             self.log_callback(get_localized("Console_Convertor_Objects_Complete"))
@@ -144,7 +170,7 @@ class ObjectConverter(BaseConverter):
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             futures_map = {
-                executor.submit(self._process_object, name): name
+                executor.submit(self._process_object, name, object_subfolders.get(name, "")): name
                 for name in object_names
             }
             for future in as_completed(futures_map):

--- a/src/conversion/shaders.py
+++ b/src/conversion/shaders.py
@@ -58,12 +58,17 @@ class ShaderConverter(BaseConverter):
         with open(output_file, 'w', encoding='utf-8') as f:
             f.write(content)
 
-    def _process_shader(self, input_path):
+    def _process_shader(self, input_path, subfolder=""):
         if not self.conversion_running():
             return None
         filename = os.path.basename(input_path)
         output_name = os.path.splitext(filename)[0] + '.gdshader'
-        output_path = os.path.join(self.godot_shaders_path, output_name)
+        if subfolder:
+            output_dir = os.path.join(self.godot_shaders_path, subfolder)
+        else:
+            output_dir = self.godot_shaders_path
+        os.makedirs(output_dir, exist_ok=True)
+        output_path = os.path.join(output_dir, output_name)
         self.convert_shader(input_path, output_path)
         return (filename, output_name)
 
@@ -76,11 +81,19 @@ class ShaderConverter(BaseConverter):
 
         os.makedirs(self.godot_shaders_path, exist_ok=True)
 
+        # Collect shader files with their subfolder info
         shader_files = []
+        shader_subfolders = {}
         for root, _, files in os.walk(gm_shaders_path):
             for f in files:
                 if f.endswith(('.vsh', '.fsh')):
-                    shader_files.append(os.path.join(root, f))
+                    full_path = os.path.join(root, f)
+                    shader_files.append(full_path)
+                    # Determine subfolder from the shader's .yy file
+                    shader_dir = os.path.dirname(full_path)
+                    shader_name = os.path.basename(shader_dir)
+                    yy_path = os.path.join(shader_dir, shader_name + '.yy')
+                    shader_subfolders[full_path] = self._get_subfolder_from_yy(yy_path)
 
         if not shader_files:
             self.log_callback("No shader files (.vsh/.fsh) found.")
@@ -91,7 +104,7 @@ class ShaderConverter(BaseConverter):
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             futures_map = {
-                executor.submit(self._process_shader, path): path
+                executor.submit(self._process_shader, path, shader_subfolders.get(path, "")): path
                 for path in shader_files
             }
             for future in as_completed(futures_map):

--- a/src/conversion/sprites.py
+++ b/src/conversion/sprites.py
@@ -17,7 +17,7 @@ class SpriteConverter(BaseConverter):
         self.godot_sprites_path = os.path.join(self.godot_project_path, 'sprites')
 
     def _get_valid_sprite_names(self):
-        """Parse the .yyp project file and return the set of sprite names listed in resources.
+        """Parse the .yyp project file and return a dict of sprite name -> subfolder.
 
         Returns None if the .yyp file cannot be found or parsed, allowing
         the caller to fall back to converting all sprites on disk.
@@ -34,17 +34,26 @@ class SpriteConverter(BaseConverter):
             cleaned = re.sub(r',\s*([}\]])', r'\1', content)
             data = json.loads(cleaned)
 
-            valid_sprites = set()
+            valid_sprites = {}
             for resource in data.get('resources', []):
                 res_id = resource.get('id', {})
                 path = res_id.get('path', '')
                 if path.startswith('sprites/'):
-                    valid_sprites.add(res_id.get('name', ''))
+                    name = res_id.get('name', '')
+                    yy_path = os.path.join(self.gm_project_path, 'sprites', name, name + '.yy')
+                    valid_sprites[name] = self._get_subfolder_from_yy(yy_path)
 
             return valid_sprites
         except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
             self._safe_log(get_localized("Console_Convertor_Sprites_YYPFilterWarning"))
             return None
+
+    @staticmethod
+    def _sprite_res_path(subfolder, sprite_name):
+        """Build a res://sprites/... path, avoiding double slashes."""
+        if subfolder:
+            return f"res://sprites/{subfolder}/{sprite_name}"
+        return f"res://sprites/{sprite_name}"
 
     def _find_all_sprite_images(self):
         sprite_folder = os.path.join(self.gm_project_path, 'sprites')
@@ -239,16 +248,17 @@ class SpriteConverter(BaseConverter):
 
         return (sub_resource_text, shape_id, node_text)
 
-    def _write_static_scene(self, sprite_name, collision_sub, collision_node):
+    def _write_static_scene(self, sprite_name, collision_sub, collision_node, subfolder=""):
         """Generate a Sprite2D .tscn scene file.
 
-        Creates the file at godot_sprites_path/{sprite_name}/{sprite_name}.tscn.
+        Creates the file at godot_sprites_path/{subfolder}/{sprite_name}/{sprite_name}.tscn.
         """
         has_collision = collision_sub is not None
         load_steps = 2 if has_collision else 1
+        res_prefix = self._sprite_res_path(subfolder, sprite_name)
 
         parts = [f'[gd_scene format=3 load_steps={load_steps}]\n']
-        parts.append(f'\n[ext_resource type="Texture2D" path="res://sprites/{sprite_name}/{sprite_name}.png" id="1"]\n')
+        parts.append(f'\n[ext_resource type="Texture2D" path="{res_prefix}/{sprite_name}.png" id="1"]\n')
 
         if has_collision:
             parts.append(f'\n{collision_sub}')
@@ -262,26 +272,27 @@ class SpriteConverter(BaseConverter):
 
         tscn_content = ''.join(parts)
 
-        tscn_dir = os.path.join(self.godot_sprites_path, sprite_name)
+        tscn_dir = os.path.join(self.godot_sprites_path, subfolder, sprite_name) if subfolder else os.path.join(self.godot_sprites_path, sprite_name)
         os.makedirs(tscn_dir, exist_ok=True)
         tscn_path = os.path.join(tscn_dir, f"{sprite_name}.tscn")
         with open(tscn_path, 'w', encoding='utf-8') as f:
             f.write(tscn_content)
 
-    def _write_animated_scene(self, sprite_name, frame_count, animation_data, collision_sub, collision_node):
+    def _write_animated_scene(self, sprite_name, frame_count, animation_data, collision_sub, collision_node, subfolder=""):
         """Generate an AnimatedSprite2D .tscn scene file with embedded SpriteFrames.
 
-        Creates the file at godot_sprites_path/{sprite_name}/{sprite_name}.tscn.
+        Creates the file at godot_sprites_path/{subfolder}/{sprite_name}/{sprite_name}.tscn.
         """
         has_collision = collision_sub is not None
         # ext_resources (one per frame) + SpriteFrames sub_resource + optional collision sub_resource
         load_steps = frame_count + 1 + (1 if has_collision else 0)
+        res_prefix = self._sprite_res_path(subfolder, sprite_name)
 
         parts = [f'[gd_scene format=3 load_steps={load_steps}]\n']
 
         # One ext_resource per frame
         for i in range(1, frame_count + 1):
-            parts.append(f'\n[ext_resource type="Texture2D" path="res://sprites/{sprite_name}/{sprite_name}_{i}.png" id="{i}"]\n')
+            parts.append(f'\n[ext_resource type="Texture2D" path="{res_prefix}/{sprite_name}_{i}.png" id="{i}"]\n')
 
         # Build frame entries for the SpriteFrames animation array
         durations = animation_data.get("frame_durations", [])
@@ -314,26 +325,26 @@ class SpriteConverter(BaseConverter):
 
         tscn_content = ''.join(parts)
 
-        tscn_dir = os.path.join(self.godot_sprites_path, sprite_name)
+        tscn_dir = os.path.join(self.godot_sprites_path, subfolder, sprite_name) if subfolder else os.path.join(self.godot_sprites_path, sprite_name)
         os.makedirs(tscn_dir, exist_ok=True)
         tscn_path = os.path.join(tscn_dir, f"{sprite_name}.tscn")
         with open(tscn_path, 'w', encoding='utf-8') as f:
             f.write(tscn_content)
 
-    def _generate_sprite_scene(self, sprite_name, collision_data, frame_count, animation_data=None):
+    def _generate_sprite_scene(self, sprite_name, collision_data, frame_count, animation_data=None, subfolder=""):
         """Generate a .tscn scene file for a sprite.
 
         Creates either an AnimatedSprite2D scene (multi-frame with animation data)
         or a Sprite2D scene (single-frame or no animation data).
 
-        Creates the file at godot_sprites_path/{sprite_name}/{sprite_name}.tscn.
+        Creates the file at godot_sprites_path/{subfolder}/{sprite_name}/{sprite_name}.tscn.
         """
         collision_sub, shape_id, collision_node = self._build_collision_block(collision_data)
 
         if frame_count > 1 and animation_data is not None:
-            self._write_animated_scene(sprite_name, frame_count, animation_data, collision_sub, collision_node)
+            self._write_animated_scene(sprite_name, frame_count, animation_data, collision_sub, collision_node, subfolder)
         else:
-            self._write_static_scene(sprite_name, collision_sub, collision_node)
+            self._write_static_scene(sprite_name, collision_sub, collision_node, subfolder)
 
     def _parse_sprite_yy(self, sprite_name):
         yy_path = os.path.join(self.gm_project_path, 'sprites', sprite_name, sprite_name + '.yy')
@@ -386,12 +397,13 @@ class SpriteConverter(BaseConverter):
 
         return ordered if ordered else sorted(all_image_paths)
 
-    def _process_sprite(self, sprite_name, index, gm_sprite_path, images_count):
+    def _process_sprite(self, sprite_name, index, gm_sprite_path, images_count, subfolder=""):
         if not self.conversion_running():
             return None
 
         new_filename = f"{sprite_name}_{index}.png" if images_count > 1 else f"{sprite_name}.png"
-        godot_sprite_path = os.path.join(self.godot_sprites_path, sprite_name, new_filename)
+        sprite_dir = os.path.join(self.godot_sprites_path, subfolder, sprite_name) if subfolder else os.path.join(self.godot_sprites_path, sprite_name)
+        godot_sprite_path = os.path.join(sprite_dir, new_filename)
 
         with Image.open(gm_sprite_path) as img:
             img.save(godot_sprite_path, 'PNG')
@@ -404,15 +416,21 @@ class SpriteConverter(BaseConverter):
         sprite_images = self._find_all_sprite_images()
 
         valid_names = self._get_valid_sprite_names()
+        sprite_subfolders = {}
         if valid_names is not None:
             filtered = {}
             for name, images in sprite_images.items():
                 if name in valid_names:
                     filtered[name] = images
+                    sprite_subfolders[name] = valid_names[name]
                 else:
                     self._safe_log(get_localized("Console_Convertor_Sprites_Skipped").format(
                         sprite_name=name))
             sprite_images = filtered
+        else:
+            for name in sprite_images:
+                yy_path = os.path.join(self.gm_project_path, 'sprites', name, name + '.yy')
+                sprite_subfolders[name] = self._get_subfolder_from_yy(yy_path)
 
         if not sprite_images:
             self.log_callback(get_localized("Console_Convertor_Sprites_Error_NotFound"))
@@ -420,22 +438,25 @@ class SpriteConverter(BaseConverter):
 
         # Pre-create all sprite directories
         for sprite_name in sprite_images:
-            os.makedirs(os.path.join(self.godot_sprites_path, sprite_name), exist_ok=True)
+            subfolder = sprite_subfolders.get(sprite_name, "")
+            sprite_dir = os.path.join(self.godot_sprites_path, subfolder, sprite_name) if subfolder else os.path.join(self.godot_sprites_path, sprite_name)
+            os.makedirs(sprite_dir, exist_ok=True)
 
         # Flatten all work items
         work_items = []
         for sprite_name, images in sprite_images.items():
             ordered_images = self._build_ordered_frame_list(sprite_name, images)
+            subfolder = sprite_subfolders.get(sprite_name, "")
             for index, gm_sprite_path in enumerate(ordered_images, start=1):
-                work_items.append((sprite_name, index, gm_sprite_path, len(ordered_images)))
+                work_items.append((sprite_name, index, gm_sprite_path, len(ordered_images), subfolder))
 
         total_images = len(work_items)
         processed_images = 0
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             futures_map = {
-                executor.submit(self._process_sprite, name, idx, path, count): (name, idx, path, count)
-                for name, idx, path, count in work_items
+                executor.submit(self._process_sprite, name, idx, path, count, sub): (name, idx, path, count, sub)
+                for name, idx, path, count, sub in work_items
             }
             for future in as_completed(futures_map):
                 result = future.result()
@@ -462,8 +483,9 @@ class SpriteConverter(BaseConverter):
             frame_count = len(self._build_ordered_frame_list(sprite_name, images))
             collision_data = self._parse_collision_data(sprite_name)
             animation_data = self._parse_animation_data(sprite_name)
+            subfolder = sprite_subfolders.get(sprite_name, "")
 
-            self._generate_sprite_scene(sprite_name, collision_data, frame_count, animation_data)
+            self._generate_sprite_scene(sprite_name, collision_data, frame_count, animation_data, subfolder)
 
             self._safe_log(get_localized("Console_Convertor_Sprites_SceneGenerated").format(name=sprite_name))
             if frame_count > 1 and animation_data is not None:

--- a/src/conversion/tilesets.py
+++ b/src/conversion/tilesets.py
@@ -18,7 +18,7 @@ class TileSetConverter(BaseConverter):
         self.godot_tilesets_path = os.path.join(self.godot_project_path, 'tilesets')
 
     def _get_valid_tileset_names(self):
-        """Parse the .yyp project file and return the set of tileset names listed in resources.
+        """Parse the .yyp project file and return a dict of tileset name -> subfolder.
 
         Returns None if the .yyp file cannot be found or parsed, allowing
         the caller to fall back to converting all tilesets on disk.
@@ -35,12 +35,14 @@ class TileSetConverter(BaseConverter):
             cleaned = re.sub(r',\s*([}\]])', r'\1', content)
             data = json.loads(cleaned)
 
-            valid_tilesets = set()
+            valid_tilesets = {}
             for resource in data.get('resources', []):
                 res_id = resource.get('id', {})
                 path = res_id.get('path', '')
                 if path.startswith('tilesets/'):
-                    valid_tilesets.add(res_id.get('name', ''))
+                    name = res_id.get('name', '')
+                    yy_path = os.path.join(self.gm_project_path, 'tilesets', name, name + '.yy')
+                    valid_tilesets[name] = self._get_subfolder_from_yy(yy_path)
 
             return valid_tilesets
         except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
@@ -125,7 +127,7 @@ class TileSetConverter(BaseConverter):
 
         return None
 
-    def _generate_tileset_tres(self, tileset_name, tileset_data):
+    def _generate_tileset_tres(self, tileset_name, tileset_data, subfolder=""):
         """Generate a Godot TileSet .tres resource string."""
         tile_w = tileset_data["tileWidth"]
         tile_h = tileset_data["tileHeight"]
@@ -134,10 +136,15 @@ class TileSetConverter(BaseConverter):
         tilexoff = tileset_data["tilexoff"]
         tileyoff = tileset_data["tileyoff"]
 
+        if subfolder:
+            res_path = f"res://tilesets/{subfolder}/{tileset_name}/{tileset_name}.png"
+        else:
+            res_path = f"res://tilesets/{tileset_name}/{tileset_name}.png"
+
         lines = []
         lines.append('[gd_resource type="TileSet" format=3]')
         lines.append('')
-        lines.append(f'[ext_resource type="Texture2D" path="res://tilesets/{tileset_name}/{tileset_name}.png" id="1"]')
+        lines.append(f'[ext_resource type="Texture2D" path="{res_path}" id="1"]')
         lines.append('')
         lines.append('[sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_1"]')
         lines.append('texture = ExtResource("1")')
@@ -156,7 +163,7 @@ class TileSetConverter(BaseConverter):
 
         return '\n'.join(lines)
 
-    def _process_tileset(self, tileset_name):
+    def _process_tileset(self, tileset_name, subfolder=""):
         """Process a single tileset: parse, copy image, generate .tres.
 
         Returns a dict with conversion results, or None if stopped.
@@ -177,7 +184,10 @@ class TileSetConverter(BaseConverter):
                     "sprite_name": sprite_name}
 
         # Create output directory
-        output_dir = os.path.join(self.godot_tilesets_path, tileset_name)
+        if subfolder:
+            output_dir = os.path.join(self.godot_tilesets_path, subfolder, tileset_name)
+        else:
+            output_dir = os.path.join(self.godot_tilesets_path, tileset_name)
         os.makedirs(output_dir, exist_ok=True)
 
         # Copy the sprite image as the tileset texture
@@ -185,7 +195,7 @@ class TileSetConverter(BaseConverter):
         shutil.copy2(image_path, dest_image)
 
         # Generate and write the .tres file
-        tres_content = self._generate_tileset_tres(tileset_name, tileset_data)
+        tres_content = self._generate_tileset_tres(tileset_name, tileset_data, subfolder)
         tres_path = os.path.join(output_dir, tileset_name + '.tres')
         with open(tres_path, 'w', encoding='utf-8') as f:
             f.write(tres_content)
@@ -214,8 +224,14 @@ class TileSetConverter(BaseConverter):
 
         # Filter against .yyp if available
         valid_names = self._get_valid_tileset_names()
+        tileset_subfolders = {}
         if valid_names is not None:
             tileset_names = [n for n in tileset_names if n in valid_names]
+            tileset_subfolders = {n: valid_names[n] for n in tileset_names}
+        else:
+            for name in tileset_names:
+                yy_path = os.path.join(self.gm_project_path, 'tilesets', name, name + '.yy')
+                tileset_subfolders[name] = self._get_subfolder_from_yy(yy_path)
 
         if not tileset_names:
             self.log_callback(get_localized("Console_Convertor_Tilesets_Complete"))
@@ -226,7 +242,7 @@ class TileSetConverter(BaseConverter):
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             futures_map = {
-                executor.submit(self._process_tileset, name): name
+                executor.submit(self._process_tileset, name, tileset_subfolders.get(name, "")): name
                 for name in tileset_names
             }
             for future in as_completed(futures_map):

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.1.3"
+VERSION = "0.1.4"
 
 def get_version():
     return VERSION

--- a/tests/test_base_converter.py
+++ b/tests/test_base_converter.py
@@ -1,5 +1,7 @@
 import os
+import shutil
 import sys
+import tempfile
 import threading
 import unittest
 
@@ -173,6 +175,101 @@ class TestBaseConverterCompactLogging(unittest.TestCase):
         converter._log_progress("item", 2, 3)
         # Both should go to log_callback since update_log_callback defaults to it
         self.assertEqual(len(messages), 2)
+
+
+class TestReadYYFile(unittest.TestCase):
+    """Test _read_yy_file() JSON parsing with trailing-comma cleanup."""
+
+    def setUp(self):
+        class StubConverter(BaseConverter):
+            def convert_all(self):
+                pass
+
+        self.converter = StubConverter("/gm", "/godot")
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir)
+
+    def test_reads_valid_json(self):
+        yy_path = os.path.join(self.tmp_dir, "test.yy")
+        with open(yy_path, "w") as f:
+            f.write('{"name": "test", "value": 42}')
+        result = self.converter._read_yy_file(yy_path)
+        self.assertEqual(result, {"name": "test", "value": 42})
+
+    def test_cleans_trailing_commas(self):
+        yy_path = os.path.join(self.tmp_dir, "test.yy")
+        with open(yy_path, "w") as f:
+            f.write('{"name": "test", "items": [1, 2, 3,],}')
+        result = self.converter._read_yy_file(yy_path)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["items"], [1, 2, 3])
+
+    def test_returns_none_for_missing_file(self):
+        result = self.converter._read_yy_file("/nonexistent/path.yy")
+        self.assertIsNone(result)
+
+    def test_returns_none_for_invalid_json(self):
+        yy_path = os.path.join(self.tmp_dir, "bad.yy")
+        with open(yy_path, "w") as f:
+            f.write("not valid json {{{")
+        result = self.converter._read_yy_file(yy_path)
+        self.assertIsNone(result)
+
+
+class TestGetSubfolderFromYY(unittest.TestCase):
+    """Test _get_subfolder_from_yy() extraction of IDE folder paths."""
+
+    def setUp(self):
+        class StubConverter(BaseConverter):
+            def convert_all(self):
+                pass
+
+        self.converter = StubConverter("/gm", "/godot")
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir)
+
+    def _write_yy(self, parent_path):
+        yy_path = os.path.join(self.tmp_dir, "test.yy")
+        content = '{{"name": "test", "parent": {{"name": "folder", "path": "{path}",}},}}'.format(
+            path=parent_path)
+        with open(yy_path, "w") as f:
+            f.write(content)
+        return yy_path
+
+    def test_nested_path(self):
+        yy_path = self._write_yy("folders/Sprites/Player/Abilities.yy")
+        self.assertEqual(self.converter._get_subfolder_from_yy(yy_path), "Player/Abilities")
+
+    def test_deeply_nested_path(self):
+        yy_path = self._write_yy("folders/Objects/Game/Enemies/Bosses.yy")
+        self.assertEqual(self.converter._get_subfolder_from_yy(yy_path), "Game/Enemies/Bosses")
+
+    def test_root_level_path(self):
+        yy_path = self._write_yy("folders/Sprites.yy")
+        self.assertEqual(self.converter._get_subfolder_from_yy(yy_path), "")
+
+    def test_single_subfolder(self):
+        yy_path = self._write_yy("folders/Objects/CLASSIC.yy")
+        self.assertEqual(self.converter._get_subfolder_from_yy(yy_path), "CLASSIC")
+
+    def test_missing_parent_field(self):
+        yy_path = os.path.join(self.tmp_dir, "no_parent.yy")
+        with open(yy_path, "w") as f:
+            f.write('{"name": "test"}')
+        self.assertEqual(self.converter._get_subfolder_from_yy(yy_path), "")
+
+    def test_missing_file(self):
+        self.assertEqual(self.converter._get_subfolder_from_yy("/nonexistent.yy"), "")
+
+    def test_malformed_file(self):
+        yy_path = os.path.join(self.tmp_dir, "bad.yy")
+        with open(yy_path, "w") as f:
+            f.write("not json")
+        self.assertEqual(self.converter._get_subfolder_from_yy(yy_path), "")
 
 
 if __name__ == "__main__":

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -357,5 +357,53 @@ class TestFontConverterEmptyFolder(unittest.TestCase):
                         "Expected at least one log message for empty fonts folder")
 
 
+class TestFontConverterSubfolders(unittest.TestCase):
+    """Test that fonts respect GameMaker's folder hierarchy."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+        _make_font_yy(self.gm_dir, "fnt_ui", {
+            "fontName": "NonExistentTestFont99999",
+            "parent": {"name": "UI", "path": "folders/Fonts/UI.yy"},
+        })
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def test_font_in_subfolder(self):
+        converter = FontConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+        converter.convert_all()
+
+        expected = os.path.join(self.godot_dir, "fonts", "UI", "fnt_ui.tres")
+        self.assertTrue(os.path.isfile(expected),
+                        f"Expected font at {expected}")
+
+    def test_root_level_font_stays_flat(self):
+        """Font with root-level parent should remain in fonts/."""
+        _make_font_yy(self.gm_dir, "fnt_root", {
+            "fontName": "NonExistentTestFont99999",
+            "parent": {"name": "Fonts", "path": "folders/Fonts.yy"},
+        })
+        converter = FontConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+        converter.convert_all()
+
+        expected = os.path.join(self.godot_dir, "fonts", "fnt_root.tres")
+        self.assertTrue(os.path.isfile(expected),
+                        "Root-level font should stay in fonts/")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -90,5 +90,56 @@ class TestNoteConverterMissingFolder(unittest.TestCase):
                         "Expected at least one log message for missing notes folder")
 
 
+class TestNoteConverterSubfolders(unittest.TestCase):
+    """Test that notes respect GameMaker's folder hierarchy."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+
+        # Create a note with a .yy file that specifies a subfolder
+        note_dir = os.path.join(self.gm_dir, "notes", "my_note")
+        os.makedirs(note_dir)
+        with open(os.path.join(note_dir, "my_note.txt"), "w") as f:
+            f.write("Note content")
+        with open(os.path.join(note_dir, "my_note.yy"), "w") as f:
+            f.write('{"name": "my_note", "parent": {"name": "Design", "path": "folders/Notes/Design.yy",},}')
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def _make_converter(self):
+        return NoteConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+
+    def test_note_in_subfolder(self):
+        converter = self._make_converter()
+        converter.convert_all()
+
+        expected = os.path.join(self.godot_dir, "notes", "Design", "my_note", "my_note.txt")
+        self.assertTrue(os.path.isfile(expected),
+                        f"Expected note at {expected}")
+
+    def test_note_without_yy_stays_flat(self):
+        """A note without a .yy file should default to root."""
+        note_dir = os.path.join(self.gm_dir, "notes", "plain_note")
+        os.makedirs(note_dir)
+        with open(os.path.join(note_dir, "plain_note.txt"), "w") as f:
+            f.write("Plain note")
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        expected = os.path.join(self.godot_dir, "notes", "plain_note", "plain_note.txt")
+        self.assertTrue(os.path.isfile(expected),
+                        "Note without .yy should remain at root level")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -11,7 +11,7 @@ if PROJECT_ROOT not in sys.path:
 from src.conversion.objects import ObjectConverter
 
 
-def _make_object_yy_content(name, sprite_name=None):
+def _make_object_yy_content(name, sprite_name=None, parent_path="folders/Objects.yy"):
     """Build a GameMaker object .yy file string."""
     if sprite_name is not None:
         sprite_id = (
@@ -29,7 +29,7 @@ def _make_object_yy_content(name, sprite_name=None):
         '  "managed": true,\n'
         '  "name": "{name}",\n'
         '  "overriddenProperties": [],\n'
-        '  "parent": {{"name": "Objects", "path": "folders/Objects.yy",}},\n'
+        '  "parent": {{"name": "Objects", "path": "{parent_path}",}},\n'
         '  "parentObjectId": null,\n'
         '  "persistent": false,\n'
         '  "physicsObject": false,\n'
@@ -41,16 +41,30 @@ def _make_object_yy_content(name, sprite_name=None):
         '  "spriteMaskId": null,\n'
         '  "visible": true,\n'
         '}}'
-    ).format(name=name, sprite_id=sprite_id)
+    ).format(name=name, sprite_id=sprite_id, parent_path=parent_path)
 
 
-def _create_fake_sprite_scene(godot_dir, sprite_name):
+def _create_fake_sprite_scene(godot_dir, sprite_name, subfolder=""):
     """Create a minimal sprite .tscn file in the Godot project."""
-    sprite_dir = os.path.join(godot_dir, "sprites", sprite_name)
+    if subfolder:
+        sprite_dir = os.path.join(godot_dir, "sprites", subfolder, sprite_name)
+    else:
+        sprite_dir = os.path.join(godot_dir, "sprites", sprite_name)
     os.makedirs(sprite_dir, exist_ok=True)
     tscn_path = os.path.join(sprite_dir, sprite_name + ".tscn")
     with open(tscn_path, "w", encoding="utf-8") as f:
         f.write('[gd_scene format=3]\n\n[node name="{}" type="Area2D"]\n'.format(sprite_name))
+
+
+def _make_sprite_yy_content(sprite_name, parent_path="folders/Sprites.yy"):
+    """Build a minimal sprite .yy file with parent folder info."""
+    return (
+        '{{\n'
+        '  "name": "{name}",\n'
+        '  "parent": {{"name": "Sprites", "path": "{parent_path}",}},\n'
+        '  "resourceType": "GMSprite",\n'
+        '}}'
+    ).format(name=sprite_name, parent_path=parent_path)
 
 
 class TestObjectConverterBasic(unittest.TestCase):
@@ -291,6 +305,88 @@ class TestObjectConverterYYPFiltering(unittest.TestCase):
                         "Object listed in .yyp should be converted")
         self.assertFalse(os.path.isfile(unlisted_path),
                          "Object not listed in .yyp should be skipped")
+
+
+class TestObjectConverterSubfolders(unittest.TestCase):
+    """Test that objects respect GameMaker's folder hierarchy."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def _make_converter(self):
+        return ObjectConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+
+    def test_object_in_subfolder(self):
+        """Object with nested parent path should be placed in subfolder."""
+        obj_dir = os.path.join(self.gm_dir, "objects", "o_boss")
+        os.makedirs(obj_dir)
+        yy_content = _make_object_yy_content("o_boss", sprite_name=None,
+                                              parent_path="folders/Objects/Game/Enemies.yy")
+        with open(os.path.join(obj_dir, "o_boss.yy"), "w") as f:
+            f.write(yy_content)
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        tscn_path = os.path.join(self.godot_dir, "objects", "Game", "Enemies", "o_boss", "o_boss.tscn")
+        self.assertTrue(os.path.isfile(tscn_path),
+                        "Object should be in objects/Game/Enemies/o_boss/")
+
+    def test_object_with_sprite_in_subfolder(self):
+        """Object should resolve sprite cross-reference with correct subfolder path."""
+        # Create object
+        obj_dir = os.path.join(self.gm_dir, "objects", "o_player")
+        os.makedirs(obj_dir)
+        yy_content = _make_object_yy_content("o_player", sprite_name="s_player",
+                                              parent_path="folders/Objects.yy")
+        with open(os.path.join(obj_dir, "o_player.yy"), "w") as f:
+            f.write(yy_content)
+
+        # Create sprite .yy in GM project (for subfolder resolution)
+        sprite_gm_dir = os.path.join(self.gm_dir, "sprites", "s_player")
+        os.makedirs(sprite_gm_dir)
+        sprite_yy = _make_sprite_yy_content("s_player", parent_path="folders/Sprites/Player.yy")
+        with open(os.path.join(sprite_gm_dir, "s_player.yy"), "w") as f:
+            f.write(sprite_yy)
+
+        # Create converted sprite scene at the subfolder location
+        _create_fake_sprite_scene(self.godot_dir, "s_player", subfolder="Player")
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        tscn_path = os.path.join(self.godot_dir, "objects", "o_player", "o_player.tscn")
+        with open(tscn_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        self.assertIn('res://sprites/Player/s_player/s_player.tscn', content)
+
+    def test_root_level_object_stays_flat(self):
+        """Object with root-level parent should stay in flat structure."""
+        obj_dir = os.path.join(self.gm_dir, "objects", "o_ctrl")
+        os.makedirs(obj_dir)
+        yy_content = _make_object_yy_content("o_ctrl", sprite_name=None,
+                                              parent_path="folders/Objects.yy")
+        with open(os.path.join(obj_dir, "o_ctrl.yy"), "w") as f:
+            f.write(yy_content)
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        tscn_path = os.path.join(self.godot_dir, "objects", "o_ctrl", "o_ctrl.tscn")
+        self.assertTrue(os.path.isfile(tscn_path),
+                        "Root-level object should remain at objects/o_ctrl/")
 
 
 if __name__ == "__main__":

--- a/tests/test_shaders.py
+++ b/tests/test_shaders.py
@@ -140,5 +140,39 @@ class TestShaderConverterEmpty(unittest.TestCase):
                         "Expected log message when shaders directory missing")
 
 
+class TestShaderConverterSubfolders(unittest.TestCase):
+    """Test that shaders respect GameMaker's folder hierarchy."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+
+        # Create a shader in a named directory with a .yy specifying subfolder
+        shader_dir = os.path.join(self.gm_dir, "shaders", "sh_blur")
+        os.makedirs(shader_dir)
+        with open(os.path.join(shader_dir, "sh_blur.fsh"), "w") as f:
+            f.write(SAMPLE_FSH)
+        with open(os.path.join(shader_dir, "sh_blur.yy"), "w") as f:
+            f.write('{"name": "sh_blur", "parent": {"name": "Effects", "path": "folders/Shaders/Effects.yy",},}')
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def test_shader_in_subfolder(self):
+        converter = ShaderConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+        converter.convert_all()
+
+        expected = os.path.join(self.godot_dir, "shaders", "Effects", "sh_blur.gdshader")
+        self.assertTrue(os.path.isfile(expected),
+                        f"Expected shader at {expected}")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sprites.py
+++ b/tests/test_sprites.py
@@ -443,7 +443,7 @@ class TestGetValidSpriteNames(unittest.TestCase):
 
         converter = self._make_converter()
         result = converter._get_valid_sprite_names()
-        self.assertEqual(result, {"s_player", "s_enemy", "s_bullet"})
+        self.assertEqual(set(result.keys()), {"s_player", "s_enemy", "s_bullet"})
 
     def test_handles_trailing_commas(self):
         # Trailing commas are present in the _make_yyp_content output
@@ -453,7 +453,7 @@ class TestGetValidSpriteNames(unittest.TestCase):
 
         converter = self._make_converter()
         result = converter._get_valid_sprite_names()
-        self.assertEqual(result, {"s_test"})
+        self.assertEqual(set(result.keys()), {"s_test"})
 
     def test_returns_none_when_no_yyp(self):
         converter = self._make_converter()
@@ -468,7 +468,7 @@ class TestGetValidSpriteNames(unittest.TestCase):
         result = converter._get_valid_sprite_names()
         self.assertIsNone(result)
 
-    def test_returns_empty_set_when_no_sprites(self):
+    def test_returns_empty_dict_when_no_sprites(self):
         sound_resource = '{"id":{"name":"snd_boom","path":"sounds/snd_boom/snd_boom.yy",},}'
         yyp = _make_yyp_content([], extra_resources=[sound_resource])
         with open(os.path.join(self.gm_dir, "Game.yyp"), "w") as f:
@@ -477,7 +477,7 @@ class TestGetValidSpriteNames(unittest.TestCase):
         converter = self._make_converter()
         result = converter._get_valid_sprite_names()
         self.assertIsNotNone(result)
-        self.assertEqual(result, set())
+        self.assertEqual(result, {})
 
 
 class TestSpriteConverterFiltering(unittest.TestCase):

--- a/tests/test_tilesets.py
+++ b/tests/test_tilesets.py
@@ -14,7 +14,8 @@ from src.conversion.tilesets import TileSetConverter
 
 def _make_tileset_yy_content(name, sprite_name, tile_width=16, tile_height=16,
                               tilehsep=0, tilevsep=0, tilexoff=0, tileyoff=0,
-                              tile_count=2, out_columns=1):
+                              tile_count=2, out_columns=1,
+                              parent_path="folders/Tilesets.yy"):
     """Build a GameMaker tileset .yy file string."""
     return (
         '{{\n'
@@ -31,6 +32,7 @@ def _make_tileset_yy_content(name, sprite_name, tile_width=16, tile_height=16,
         '  "out_columns": {out_columns},\n'
         '  "tileAnimationFrames": [],\n'
         '  "tileAnimationSpeed": 15.0,\n'
+        '  "parent": {{"name": "Tilesets", "path": "{parent_path}",}},\n'
         '  "resourceType": "GMTileSet",\n'
         '  "resourceVersion": "2.0",\n'
         '}}'
@@ -40,6 +42,7 @@ def _make_tileset_yy_content(name, sprite_name, tile_width=16, tile_height=16,
         tilehsep=tilehsep, tilevsep=tilevsep,
         tilexoff=tilexoff, tileyoff=tileyoff,
         tile_count=tile_count, out_columns=out_columns,
+        parent_path=parent_path,
     )
 
 
@@ -254,6 +257,58 @@ class TestParseTilesetYY(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(result["sprite_name"], "s_tc")
         self.assertEqual(result["tileWidth"], 16)
+
+
+class TestTileSetConverterSubfolders(unittest.TestCase):
+    """Test that tilesets respect GameMaker's folder hierarchy."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+
+        tileset_dir = os.path.join(self.gm_dir, "tilesets", "ts_terrain")
+        os.makedirs(tileset_dir)
+        yy_content = _make_tileset_yy_content("ts_terrain", "s_terrain",
+                                               tile_width=16, tile_height=16,
+                                               tile_count=4,
+                                               parent_path="folders/Tilesets/World.yy")
+        with open(os.path.join(tileset_dir, "ts_terrain.yy"), "w") as f:
+            f.write(yy_content)
+
+        _make_sprite_for_tileset(self.gm_dir, "s_terrain", width=64, height=64)
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def test_tileset_in_subfolder(self):
+        converter = TileSetConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+        converter.convert_all()
+
+        tres_path = os.path.join(self.godot_dir, "tilesets", "World", "ts_terrain", "ts_terrain.tres")
+        self.assertTrue(os.path.isfile(tres_path),
+                        f"Expected tileset at {tres_path}")
+
+    def test_tileset_tres_has_subfolder_res_path(self):
+        converter = TileSetConverter(
+            self.gm_dir, self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+        converter.convert_all()
+
+        tres_path = os.path.join(self.godot_dir, "tilesets", "World", "ts_terrain", "ts_terrain.tres")
+        with open(tres_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        self.assertIn('res://tilesets/World/ts_terrain/ts_terrain.png', content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Reads each resource's `parent.path` from its `.yy` file to determine its folder position in the GameMaker IDE
- Preserves that folder hierarchy in the Godot output (e.g., `sprites/Game/Enemies/s_asteroid/` instead of flat `sprites/s_asteroid/`)
- Updates all 6 affected converters: sprites, objects, tilesets, fonts, notes, and shaders
- Resolves cross-references correctly (object scenes reference sprites at their new subfolder paths)
- Gracefully falls back to root-level placement when `.yy` files are missing or malformed
- Sounds and included_files converters already preserved hierarchy — no changes needed
- Bumps version to 0.1.4

Closes #87

## Test plan
- [x] All 167 existing + new unit tests pass
- [x] New tests verify nested subfolder output for each converter
- [x] New tests verify root-level resources stay flat (backward compatible)
- [x] New tests verify cross-reference resolution (objects → sprites with subfolders)
- [x] New tests for `_read_yy_file()` and `_get_subfolder_from_yy()` base utilities
- [x] Manual test with a real GameMaker project to confirm folder structure matches IDE layout