### PR TITLE
Refactor ObjectConverter: extract event mapping and script generation

### DIFF
--- a/src/conversion/event_mapping.py
+++ b/src/conversion/event_mapping.py
@@ -1,0 +1,103 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class EventMapping:
+    """Metadata for mapping a GameMaker event to a Godot function.
+
+    Attributes:
+        godot_func: Godot function name (e.g. "_ready", "_process").
+        params: Function parameter string (e.g. "", "delta", "event").
+        sort_key: Canonical ordering in the generated .gd file.
+        gml_filename: Expected GML source filename (e.g. "Create_0.gml").
+    """
+    godot_func: str
+    params: str
+    sort_key: int
+    gml_filename: str
+
+
+# Input event types that are merged into a single _input(event) function
+INPUT_EVENT_TYPES = frozenset({6, 9, 10})
+
+# The merged input event mapping used when any input event is present
+INPUT_MERGED_MAPPING = EventMapping("_input", "event", 4, "")
+
+# Static lookup for events with fixed (eventType, eventNum) mappings
+_STATIC_MAP = {
+    (0, 0): EventMapping("_ready", "", 0, "Create_0.gml"),
+    (1, 0): EventMapping("_on_destroy", "", 10, "Destroy_0.gml"),
+    (3, 0): EventMapping("_process", "delta", 1, "Step_0.gml"),
+    (3, 1): EventMapping("_physics_process", "delta", 2, "Step_1.gml"),
+    (3, 2): EventMapping("_on_end_step", "", 12, "Step_2.gml"),
+    (8, 0): EventMapping("_draw", "", 3, "Draw_0.gml"),
+    (8, 64): EventMapping("_on_draw_gui", "", 15, "Draw_64.gml"),
+    (12, 0): EventMapping("_exit_tree", "", 5, "CleanUp_0.gml"),
+}
+
+# GameMaker event type number to GML filename prefix
+_GML_EVENT_NAMES = {
+    0: "Create",
+    1: "Destroy",
+    2: "Alarm",
+    3: "Step",
+    4: "Collision",
+    6: "Mouse",
+    7: "Other",
+    8: "Draw",
+    9: "KeyPress",
+    10: "KeyRelease",
+    12: "CleanUp",
+}
+
+
+def is_input_event(event):
+    """Check whether an event dict represents an input event (types 6, 9, 10)."""
+    return event.get('eventType', -1) in INPUT_EVENT_TYPES
+
+
+def map_event(event):
+    """Map a GameMaker event dict to an EventMapping.
+
+    Returns None for input events (types 6, 9, 10) since they are merged
+    into a single _input(event) function by the script generator.
+    """
+    event_type = event.get('eventType', -1)
+    event_num = event.get('eventNum', 0)
+
+    if event_type in INPUT_EVENT_TYPES:
+        return None
+
+    # Try static lookup first
+    mapping = _STATIC_MAP.get((event_type, event_num))
+    if mapping is not None:
+        return mapping
+
+    # Build GML filename for dynamic events
+    gml_prefix = _GML_EVENT_NAMES.get(event_type, f"Event{event_type}")
+    gml_filename = f"{gml_prefix}_{event_num}.gml"
+
+    # Lifecycle events that match on eventType alone (any eventNum)
+    if event_type == 0:
+        return EventMapping("_ready", "", 0, gml_filename)
+    if event_type == 1:
+        return EventMapping("_on_destroy", "", 10, gml_filename)
+    if event_type == 12:
+        return EventMapping("_exit_tree", "", 5, gml_filename)
+
+    # Variable events
+    if event_type == 2:
+        return EventMapping(f"_on_alarm_{event_num}", "", 11, gml_filename)
+    if event_type == 4:
+        collision_obj = event.get('collisionObjectId')
+        if collision_obj and isinstance(collision_obj, dict):
+            obj_name = collision_obj.get('name', 'unknown')
+            return EventMapping(f"_on_collision_{obj_name}", "", 13, gml_filename)
+        return EventMapping("_on_collision", "", 13, gml_filename)
+    if event_type == 7:
+        return EventMapping(f"_on_other_{event_num}", "", 14, gml_filename)
+    if event_type == 8:
+        return EventMapping(f"_on_draw_{event_num}", "", 16, gml_filename)
+
+    # Unknown event type
+    return EventMapping(f"_on_event_{event_type}_{event_num}", "", 20, gml_filename)

--- a/src/conversion/objects.py
+++ b/src/conversion/objects.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
+from src.conversion.script_generator import generate_script_content
 
 
 class ObjectConverter(BaseConverter):
@@ -85,99 +86,6 @@ class ObjectConverter(BaseConverter):
             tscn_path = os.path.join(self.godot_project_path, 'sprites', sprite_name, sprite_name + '.tscn')
         return os.path.isfile(tscn_path)
 
-    def _event_to_function(self, event):
-        """Map a single GameMaker event dict to a (func_name, params, sort_key) tuple.
-
-        sort_key determines canonical ordering: lifecycle funcs first, then
-        _input, then custom functions alphabetically.
-        Returns None for input events (types 6, 9, 10) since they are merged.
-        """
-        event_type = event.get('eventType', -1)
-        event_num = event.get('eventNum', 0)
-
-        # Lifecycle events with direct Godot equivalents
-        if event_type == 0:
-            return ("_ready", "", 0)
-        if event_type == 3 and event_num == 0:
-            return ("_process", "delta", 1)
-        if event_type == 3 and event_num == 1:
-            return ("_physics_process", "delta", 2)
-        if event_type == 8 and event_num == 0:
-            return ("_draw", "", 3)
-        if event_type == 12:
-            return ("_exit_tree", "", 5)
-
-        # Input events are merged into a single _input() — handled separately
-        if event_type in (6, 9, 10):
-            return None
-
-        # Custom functions for remaining event types
-        if event_type == 1:
-            return ("_on_destroy", "", 10)
-        if event_type == 2:
-            return (f"_on_alarm_{event_num}", "", 11)
-        if event_type == 3 and event_num == 2:
-            return ("_on_end_step", "", 12)
-        if event_type == 4:
-            collision_obj = event.get('collisionObjectId')
-            if collision_obj and isinstance(collision_obj, dict):
-                obj_name = collision_obj.get('name', 'unknown')
-                return (f"_on_collision_{obj_name}", "", 13)
-            return ("_on_collision", "", 13)
-        if event_type == 7:
-            return (f"_on_other_{event_num}", "", 14)
-        if event_type == 8 and event_num == 64:
-            return ("_on_draw_gui", "", 15)
-        if event_type == 8:
-            return (f"_on_draw_{event_num}", "", 16)
-
-        # Unknown event type — generate safe fallback
-        return (f"_on_event_{event_type}_{event_num}", "", 20)
-
-    def _generate_script_content(self, object_name, event_list):
-        """Generate .gd script content with empty function stubs for each event.
-
-        Events are mapped to Godot callback functions. Input events (mouse,
-        keyboard) are merged into a single _input() function. Functions are
-        ordered canonically: lifecycle callbacks first, then custom functions.
-        """
-        if not event_list:
-            return "extends Node2D\n"
-
-        functions = []
-        has_input = False
-
-        for event in event_list:
-            event_type = event.get('eventType', -1)
-            if event_type in (6, 9, 10):
-                has_input = True
-                continue
-
-            result = self._event_to_function(event)
-            if result is not None:
-                functions.append(result)
-
-        if has_input:
-            functions.append(("_input", "event", 4))
-
-        # Deduplicate by function name, keep first occurrence
-        seen = set()
-        unique_functions = []
-        for func in functions:
-            if func[0] not in seen:
-                seen.add(func[0])
-                unique_functions.append(func)
-
-        # Sort by sort_key, then alphabetically for same key
-        unique_functions.sort(key=lambda f: (f[2], f[0]))
-
-        lines = ["extends Node2D\n"]
-        for func_name, params, _ in unique_functions:
-            lines.append(f"\n\nfunc {func_name}({params}):")
-            lines.append("\n\tpass\n")
-
-        return ''.join(lines)
-
     def _generate_object_scene(self, object_name, sprite_name, sprite_subfolder="", script_res_path=None):
         """Build the .tscn content string for an object scene.
 
@@ -251,7 +159,7 @@ class ObjectConverter(BaseConverter):
             object_dir = os.path.join(self.godot_objects_path, object_name)
             script_res_path = f"res://objects/{object_name}/{object_name}.gd"
 
-        script_content = self._generate_script_content(object_name, event_list)
+        script_content = generate_script_content(event_list)
         scene_content = self._generate_object_scene(object_name, sprite_name, sprite_subfolder, script_res_path)
 
         os.makedirs(object_dir, exist_ok=True)

--- a/src/conversion/script_generator.py
+++ b/src/conversion/script_generator.py
@@ -1,0 +1,57 @@
+from src.conversion.event_mapping import map_event, is_input_event, INPUT_MERGED_MAPPING
+
+
+def generate_script_content(event_list, code_bodies=None):
+    """Generate .gd script content with function stubs for each event.
+
+    Events are mapped to Godot callback functions. Input events (mouse,
+    keyboard) are merged into a single _input() function. Functions are
+    ordered canonically: lifecycle callbacks first, then custom functions.
+
+    Args:
+        event_list: List of event dicts from a parsed .yy file.
+        code_bodies: Optional dict mapping function names to GDScript code
+            strings. When None, all function bodies are "pass". This is the
+            seam where a future transpiler injects converted GML code.
+
+    Returns:
+        Complete .gd file content as a string.
+    """
+    if not event_list:
+        return "extends Node2D\n"
+
+    functions = []
+    has_input = False
+
+    for event in event_list:
+        if is_input_event(event):
+            has_input = True
+            continue
+
+        mapping = map_event(event)
+        if mapping is not None:
+            functions.append(mapping)
+
+    if has_input:
+        functions.append(INPUT_MERGED_MAPPING)
+
+    # Deduplicate by function name, keep first occurrence
+    seen = set()
+    unique_functions = []
+    for func in functions:
+        if func.godot_func not in seen:
+            seen.add(func.godot_func)
+            unique_functions.append(func)
+
+    # Sort by sort_key, then alphabetically for same key
+    unique_functions.sort(key=lambda f: (f.sort_key, f.godot_func))
+
+    lines = ["extends Node2D\n"]
+    for func in unique_functions:
+        body = "\tpass"
+        if code_bodies and func.godot_func in code_bodies:
+            body = code_bodies[func.godot_func]
+        lines.append(f"\n\nfunc {func.godot_func}({func.params}):")
+        lines.append(f"\n{body}\n")
+
+    return ''.join(lines)

--- a/tests/test_event_mapping.py
+++ b/tests/test_event_mapping.py
@@ -1,0 +1,196 @@
+import os
+import sys
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.event_mapping import (
+    EventMapping, map_event, is_input_event,
+    INPUT_EVENT_TYPES, INPUT_MERGED_MAPPING,
+)
+
+
+class TestIsInputEvent(unittest.TestCase):
+    """Test is_input_event for input and non-input event types."""
+
+    def test_mouse_event(self):
+        self.assertTrue(is_input_event({"eventType": 6, "eventNum": 4}))
+
+    def test_key_press_event(self):
+        self.assertTrue(is_input_event({"eventType": 9, "eventNum": 32}))
+
+    def test_key_release_event(self):
+        self.assertTrue(is_input_event({"eventType": 10, "eventNum": 13}))
+
+    def test_create_event_not_input(self):
+        self.assertFalse(is_input_event({"eventType": 0, "eventNum": 0}))
+
+    def test_step_event_not_input(self):
+        self.assertFalse(is_input_event({"eventType": 3, "eventNum": 0}))
+
+    def test_missing_event_type(self):
+        self.assertFalse(is_input_event({}))
+
+
+class TestMapEventStatic(unittest.TestCase):
+    """Test map_event for events in the static lookup table."""
+
+    def test_create_event(self):
+        m = map_event({"eventType": 0, "eventNum": 0})
+        self.assertEqual(m.godot_func, "_ready")
+        self.assertEqual(m.params, "")
+        self.assertEqual(m.sort_key, 0)
+        self.assertEqual(m.gml_filename, "Create_0.gml")
+
+    def test_step_event(self):
+        m = map_event({"eventType": 3, "eventNum": 0})
+        self.assertEqual(m.godot_func, "_process")
+        self.assertEqual(m.params, "delta")
+        self.assertEqual(m.sort_key, 1)
+        self.assertEqual(m.gml_filename, "Step_0.gml")
+
+    def test_begin_step(self):
+        m = map_event({"eventType": 3, "eventNum": 1})
+        self.assertEqual(m.godot_func, "_physics_process")
+        self.assertEqual(m.params, "delta")
+        self.assertEqual(m.sort_key, 2)
+
+    def test_end_step(self):
+        m = map_event({"eventType": 3, "eventNum": 2})
+        self.assertEqual(m.godot_func, "_on_end_step")
+        self.assertEqual(m.sort_key, 12)
+
+    def test_draw_event(self):
+        m = map_event({"eventType": 8, "eventNum": 0})
+        self.assertEqual(m.godot_func, "_draw")
+        self.assertEqual(m.sort_key, 3)
+        self.assertEqual(m.gml_filename, "Draw_0.gml")
+
+    def test_draw_gui_event(self):
+        m = map_event({"eventType": 8, "eventNum": 64})
+        self.assertEqual(m.godot_func, "_on_draw_gui")
+        self.assertEqual(m.sort_key, 15)
+
+    def test_cleanup_event(self):
+        m = map_event({"eventType": 12, "eventNum": 0})
+        self.assertEqual(m.godot_func, "_exit_tree")
+        self.assertEqual(m.sort_key, 5)
+        self.assertEqual(m.gml_filename, "CleanUp_0.gml")
+
+    def test_destroy_event(self):
+        m = map_event({"eventType": 1, "eventNum": 0})
+        self.assertEqual(m.godot_func, "_on_destroy")
+        self.assertEqual(m.sort_key, 10)
+
+
+class TestMapEventDynamic(unittest.TestCase):
+    """Test map_event for events handled by dynamic logic."""
+
+    def test_alarm_event(self):
+        m = map_event({"eventType": 2, "eventNum": 3})
+        self.assertEqual(m.godot_func, "_on_alarm_3")
+        self.assertEqual(m.sort_key, 11)
+        self.assertEqual(m.gml_filename, "Alarm_3.gml")
+
+    def test_alarm_zero(self):
+        m = map_event({"eventType": 2, "eventNum": 0})
+        self.assertEqual(m.godot_func, "_on_alarm_0")
+
+    def test_collision_with_object(self):
+        m = map_event({
+            "eventType": 4, "eventNum": 0,
+            "collisionObjectId": {"name": "o_bullet"},
+        })
+        self.assertEqual(m.godot_func, "_on_collision_o_bullet")
+        self.assertEqual(m.sort_key, 13)
+        self.assertEqual(m.gml_filename, "Collision_0.gml")
+
+    def test_collision_without_object(self):
+        m = map_event({"eventType": 4, "eventNum": 0})
+        self.assertEqual(m.godot_func, "_on_collision")
+
+    def test_collision_with_null_object(self):
+        m = map_event({"eventType": 4, "eventNum": 0, "collisionObjectId": None})
+        self.assertEqual(m.godot_func, "_on_collision")
+
+    def test_other_event(self):
+        m = map_event({"eventType": 7, "eventNum": 5})
+        self.assertEqual(m.godot_func, "_on_other_5")
+        self.assertEqual(m.sort_key, 14)
+        self.assertEqual(m.gml_filename, "Other_5.gml")
+
+    def test_draw_variant(self):
+        m = map_event({"eventType": 8, "eventNum": 72})
+        self.assertEqual(m.godot_func, "_on_draw_72")
+        self.assertEqual(m.sort_key, 16)
+        self.assertEqual(m.gml_filename, "Draw_72.gml")
+
+    def test_create_nonzero_eventnum(self):
+        """eventType 0 with any eventNum should still map to _ready."""
+        m = map_event({"eventType": 0, "eventNum": 5})
+        self.assertEqual(m.godot_func, "_ready")
+
+    def test_destroy_nonzero_eventnum(self):
+        """eventType 1 with any eventNum should still map to _on_destroy."""
+        m = map_event({"eventType": 1, "eventNum": 3})
+        self.assertEqual(m.godot_func, "_on_destroy")
+
+    def test_cleanup_nonzero_eventnum(self):
+        """eventType 12 with any eventNum should still map to _exit_tree."""
+        m = map_event({"eventType": 12, "eventNum": 5})
+        self.assertEqual(m.godot_func, "_exit_tree")
+
+
+class TestMapEventInputReturnsNone(unittest.TestCase):
+    """Input events should return None (they are merged by the script generator)."""
+
+    def test_mouse_returns_none(self):
+        self.assertIsNone(map_event({"eventType": 6, "eventNum": 4}))
+
+    def test_key_press_returns_none(self):
+        self.assertIsNone(map_event({"eventType": 9, "eventNum": 32}))
+
+    def test_key_release_returns_none(self):
+        self.assertIsNone(map_event({"eventType": 10, "eventNum": 13}))
+
+
+class TestMapEventUnknown(unittest.TestCase):
+    """Unknown event types should produce safe fallback names."""
+
+    def test_unknown_event(self):
+        m = map_event({"eventType": 99, "eventNum": 5})
+        self.assertEqual(m.godot_func, "_on_event_99_5")
+        self.assertEqual(m.sort_key, 20)
+
+    def test_unknown_event_gml_filename(self):
+        m = map_event({"eventType": 99, "eventNum": 5})
+        self.assertEqual(m.gml_filename, "Event99_5.gml")
+
+    def test_step_unknown_eventnum(self):
+        """eventType 3 with eventNum > 2 should fall to unknown."""
+        m = map_event({"eventType": 3, "eventNum": 5})
+        self.assertEqual(m.godot_func, "_on_event_3_5")
+
+    def test_missing_keys(self):
+        m = map_event({})
+        self.assertEqual(m.godot_func, "_on_event_-1_0")
+
+
+class TestEventMappingFrozen(unittest.TestCase):
+    """EventMapping instances should be immutable."""
+
+    def test_cannot_modify(self):
+        m = map_event({"eventType": 0, "eventNum": 0})
+        with self.assertRaises(AttributeError):
+            m.godot_func = "changed"
+
+    def test_input_merged_mapping(self):
+        self.assertEqual(INPUT_MERGED_MAPPING.godot_func, "_input")
+        self.assertEqual(INPUT_MERGED_MAPPING.params, "event")
+        self.assertEqual(INPUT_MERGED_MAPPING.sort_key, 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -1,0 +1,179 @@
+import os
+import sys
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.script_generator import generate_script_content
+
+
+class TestScriptGeneratorBasic(unittest.TestCase):
+    """Basic output shape tests."""
+
+    def test_empty_event_list(self):
+        self.assertEqual(generate_script_content([]), "extends Node2D\n")
+
+    def test_none_event_list_treated_as_empty(self):
+        self.assertEqual(generate_script_content(None), "extends Node2D\n")
+
+    def test_starts_with_extends(self):
+        content = generate_script_content([{"eventType": 0, "eventNum": 0}])
+        self.assertTrue(content.startswith("extends Node2D"))
+
+
+class TestScriptGeneratorEvents(unittest.TestCase):
+    """Test that events produce correct function stubs."""
+
+    def test_create_event(self):
+        content = generate_script_content([{"eventType": 0, "eventNum": 0}])
+        self.assertIn("func _ready():", content)
+        self.assertIn("pass", content)
+
+    def test_step_event(self):
+        content = generate_script_content([{"eventType": 3, "eventNum": 0}])
+        self.assertIn("func _process(delta):", content)
+
+    def test_begin_step(self):
+        content = generate_script_content([{"eventType": 3, "eventNum": 1}])
+        self.assertIn("func _physics_process(delta):", content)
+
+    def test_draw_event(self):
+        content = generate_script_content([{"eventType": 8, "eventNum": 0}])
+        self.assertIn("func _draw():", content)
+
+    def test_cleanup_event(self):
+        content = generate_script_content([{"eventType": 12, "eventNum": 0}])
+        self.assertIn("func _exit_tree():", content)
+
+    def test_destroy_event(self):
+        content = generate_script_content([{"eventType": 1, "eventNum": 0}])
+        self.assertIn("func _on_destroy():", content)
+
+    def test_alarm_event(self):
+        content = generate_script_content([{"eventType": 2, "eventNum": 3}])
+        self.assertIn("func _on_alarm_3():", content)
+
+    def test_collision_event(self):
+        content = generate_script_content([{
+            "eventType": 4, "eventNum": 0,
+            "collisionObjectId": {"name": "o_bullet"},
+        }])
+        self.assertIn("func _on_collision_o_bullet():", content)
+
+    def test_other_event(self):
+        content = generate_script_content([{"eventType": 7, "eventNum": 5}])
+        self.assertIn("func _on_other_5():", content)
+
+    def test_draw_gui_event(self):
+        content = generate_script_content([{"eventType": 8, "eventNum": 64}])
+        self.assertIn("func _on_draw_gui():", content)
+
+    def test_unknown_event(self):
+        content = generate_script_content([{"eventType": 99, "eventNum": 5}])
+        self.assertIn("func _on_event_99_5():", content)
+
+
+class TestScriptGeneratorInputMerging(unittest.TestCase):
+    """Input events (mouse, keyboard) should merge into a single _input."""
+
+    def test_mouse_event_produces_input(self):
+        content = generate_script_content([{"eventType": 6, "eventNum": 4}])
+        self.assertIn("func _input(event):", content)
+
+    def test_multiple_input_events_merged(self):
+        content = generate_script_content([
+            {"eventType": 6, "eventNum": 4},
+            {"eventType": 9, "eventNum": 32},
+            {"eventType": 10, "eventNum": 13},
+        ])
+        self.assertIn("func _input(event):", content)
+        self.assertEqual(content.count("func _input"), 1)
+
+    def test_input_mixed_with_lifecycle(self):
+        content = generate_script_content([
+            {"eventType": 0, "eventNum": 0},
+            {"eventType": 6, "eventNum": 4},
+        ])
+        self.assertIn("func _ready():", content)
+        self.assertIn("func _input(event):", content)
+
+
+class TestScriptGeneratorOrdering(unittest.TestCase):
+    """Functions should be in canonical order."""
+
+    def test_lifecycle_before_input_before_custom(self):
+        content = generate_script_content([
+            {"eventType": 2, "eventNum": 0},   # Alarm (custom)
+            {"eventType": 6, "eventNum": 4},   # Mouse (input)
+            {"eventType": 3, "eventNum": 0},   # Step (lifecycle)
+            {"eventType": 0, "eventNum": 0},   # Create (lifecycle)
+        ])
+        ready_pos = content.index("_ready")
+        process_pos = content.index("_process")
+        input_pos = content.index("_input")
+        alarm_pos = content.index("_on_alarm")
+        self.assertLess(ready_pos, process_pos)
+        self.assertLess(process_pos, input_pos)
+        self.assertLess(input_pos, alarm_pos)
+
+
+class TestScriptGeneratorDeduplication(unittest.TestCase):
+    """Duplicate events should produce only one function."""
+
+    def test_duplicate_create_events(self):
+        content = generate_script_content([
+            {"eventType": 0, "eventNum": 0},
+            {"eventType": 0, "eventNum": 0},
+        ])
+        self.assertEqual(content.count("func _ready"), 1)
+
+    def test_duplicate_input_events(self):
+        content = generate_script_content([
+            {"eventType": 6, "eventNum": 0},
+            {"eventType": 6, "eventNum": 4},
+        ])
+        self.assertEqual(content.count("func _input"), 1)
+
+
+class TestScriptGeneratorCodeBodies(unittest.TestCase):
+    """Test the code_bodies transpiler seam."""
+
+    def test_default_body_is_pass(self):
+        content = generate_script_content([{"eventType": 0, "eventNum": 0}])
+        self.assertIn("\tpass", content)
+
+    def test_custom_body_replaces_pass(self):
+        content = generate_script_content(
+            [{"eventType": 0, "eventNum": 0}],
+            code_bodies={"_ready": "\tvar x = 1"},
+        )
+        self.assertIn("\tvar x = 1", content)
+        self.assertNotIn("\tpass", content)
+
+    def test_partial_code_bodies(self):
+        """Functions not in code_bodies should still get pass."""
+        content = generate_script_content(
+            [
+                {"eventType": 0, "eventNum": 0},
+                {"eventType": 3, "eventNum": 0},
+            ],
+            code_bodies={"_ready": "\tprint('hello')"},
+        )
+        self.assertIn("\tprint('hello')", content)
+        # _process should still have pass
+        process_idx = content.index("func _process")
+        after_process = content[process_idx:]
+        self.assertIn("pass", after_process)
+
+    def test_empty_code_bodies_dict(self):
+        content = generate_script_content(
+            [{"eventType": 0, "eventNum": 0}],
+            code_bodies={},
+        )
+        self.assertIn("\tpass", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Extracts event-to-function mapping from `ObjectConverter._event_to_function` into a data-driven `event_mapping.py` module with an `EventMapping` dataclass and static lookup table
- Extracts script generation from `ObjectConverter._generate_script_content` into a pure `script_generator.py` module with a `code_bodies` parameter as the transpiler injection seam
- Slims `ObjectConverter` to a pure orchestrator (240 lines, down from 331)
- Adds 57 new unit tests; all 263 existing tests pass unchanged

This prepares the codebase for a future GML-to-GDScript transpiler by creating three clean seams:
1. `EventMapping.gml_filename` — tells the transpiler which `.gml` file to read per event
2. `generate_script_content(event_list, code_bodies={...})` — injects transpiled code instead of `pass` stubs
3. `map_event(event)` — queries event metadata (function name, params, ordering)

No output changes — same `.gd` and `.tscn` files are produced.

## Test plan

- [x] All 33 `test_event_mapping.py` tests pass (static, dynamic, input, unknown events)
- [x] All 24 `test_script_generator.py` tests pass (including `code_bodies` transpiler seam)
- [x] All 263 existing tests pass with zero modifications to `test_objects.py`