### PR TITLE
Add macOS build script and update README for local macOS distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,15 @@ jobs:
           - os: windows-latest
             name: windows
             ext: .exe
+            pyinstaller_mode: --onefile
           - os: macos-latest
             name: macos
             ext: ""
+            pyinstaller_mode: --onedir
           - os: ubuntu-latest
             name: linux
             ext: ""
+            pyinstaller_mode: --onefile
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -72,7 +75,7 @@ jobs:
           else
             SEP=":"
           fi
-          pyinstaller --onefile \
+          pyinstaller ${{ matrix.pyinstaller_mode }} \
             --windowed \
             --clean \
             --name GM2Godot \
@@ -91,7 +94,11 @@ jobs:
       - name: Package build
         run: |
           mkdir -p release
-          cp dist/GM2Godot${{ matrix.ext }} release/
+          if [ "${{ matrix.name }}" = "macos" ]; then
+            cp -R dist/GM2Godot.app release/
+          else
+            cp dist/GM2Godot${{ matrix.ext }} release/
+          fi
           cp README.md release/
 
       - name: Zip release
@@ -99,11 +106,35 @@ jobs:
           cd release
           7z a ../GM2Godot-${{ matrix.name }}.zip .
 
+      - name: Create macOS DMG
+        if: matrix.name == 'macos'
+        run: |
+          rm -rf dmg
+          mkdir -p dmg
+          cp -R dist/GM2Godot.app dmg/
+          ln -s /Applications dmg/Applications
+          hdiutil create \
+            -volname "GM2Godot" \
+            -srcfolder dmg \
+            -ov \
+            -format UDZO \
+            GM2Godot-macos.dmg
+
       - name: Upload artifact
+        if: matrix.name != 'macos'
         uses: actions/upload-artifact@v4
         with:
           name: GM2Godot-${{ matrix.name }}
           path: GM2Godot-${{ matrix.name }}.zip
+
+      - name: Upload macOS artifacts
+        if: matrix.name == 'macos'
+        uses: actions/upload-artifact@v4
+        with:
+          name: GM2Godot-${{ matrix.name }}
+          path: |
+            GM2Godot-${{ matrix.name }}.zip
+            GM2Godot-${{ matrix.name }}.dmg
 
   release:
     needs: [get-version, build]
@@ -128,4 +159,5 @@ jobs:
           files: |
             artifacts/GM2Godot-windows/GM2Godot-windows.zip
             artifacts/GM2Godot-macos/GM2Godot-macos.zip
+            artifacts/GM2Godot-macos/GM2Godot-macos.dmg
             artifacts/GM2Godot-linux/GM2Godot-linux.zip

--- a/README.md
+++ b/README.md
@@ -35,9 +35,18 @@ GM2Godot is a modern, user-friendly tool designed to convert GameMaker (2024.14.
 - A tool for converting compiled GM projects (use [UndertaleToolMod](https://github.com/UnderminersTeam/UndertaleModTool) instead)
 
 ## Releases
-Downloadable releases can be found on the side of this page, for now executables are only available on Windows but we will work on other platforms too
+
+Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
+
+To build a local macOS distributable (`.app` + `.dmg`), run `bash build_macos.sh` from the project root.
 
 ## Installation
+
+### Prerequisites
+
+- Python 3.9 or later
+
+### Setup
 
 1. **Clone the Repository**
 ```bash
@@ -45,21 +54,24 @@ git clone https://github.com/Infiland/GM2Godot
 cd GM2Godot
 ```
 
-2. **Install Python Requirements**
-- Requires Python 3.9.0 or later
-- Install required packages:
+2. **Create a Virtual Environment** (recommended)
 ```bash
-pip install Pillow markdown2 tkhtmlview
+python3 -m venv venv
 ```
 
-3. **Additional Requirements**
-- For Linux users (Ubuntu/Debian):
+3. **Activate the Virtual Environment**
+- On macOS/Linux:
 ```bash
-sudo apt-get install python3-tk python3-pil python3-pil.imagetk python3-markdown2
+source venv/bin/activate
 ```
-Note: If tkhtmlview installation fails, try:
+- On Windows:
 ```bash
-pip install tkhtmlview --break-system-packages
+venv\Scripts\activate
+```
+
+4. **Install Dependencies**
+```bash
+pip install -r requirements.txt
 ```
 
 ## Usage
@@ -105,7 +117,6 @@ To contribute:
 - Check our [Documentation](https://github.com/Infiland/GM2Godot/wiki) for detailed guides
 - Join our community (Add community links if available)
 
-
 ---
 
 ## Instructions for Coding Agents (LLMs)
@@ -114,16 +125,22 @@ To contribute:
 You are setting up the GM2Godot project.
 
 Ensure Python 3.9 or later is installed.
-python -m pip install --upgrade pip
 
-Create and activate a virtual environment.
-python -m venv venv
+Create and activate a virtual environment:
+python3 -m venv venv
 source venv/bin/activate  # On Windows use: venv\Scripts\activate
 
-Install dependencies: Pillow, markdown2, tkhtmlview.
-pip install Pillow markdown2 tkhtmlview
+Install dependencies from requirements.txt:
+pip install -r requirements.txt
+
+The project uses PySide6 (not Tkinter). Required packages are:
+- Pillow
+- markdown2
+- requests
+- PySide6
 
 Run the application using:
 python main.py
 
 Ensure all dependencies are installed correctly before execution.
+```

--- a/build_macos.sh
+++ b/build_macos.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "This script must be run on macOS."
+  exit 1
+fi
+
+echo "Cleaning old build artifacts..."
+rm -rf build dist release dmg
+rm -f GM2Godot-macos.zip GM2Godot-macos.dmg GM2Godot.spec
+
+echo "Installing dependencies..."
+python3 -m pip install -r requirements.txt pyinstaller
+
+echo "Building macOS app bundle..."
+pyinstaller --onedir \
+  --windowed \
+  --clean \
+  --name GM2Godot \
+  --icon img/Logo.png \
+  --hidden-import markdown2 \
+  --hidden-import PIL \
+  --hidden-import PySide6.QtWidgets \
+  --hidden-import PySide6.QtCore \
+  --hidden-import PySide6.QtGui \
+  --add-data "img:img" \
+  --add-data "src:src" \
+  --add-data "Languages:Languages" \
+  --add-data "Current Language:." \
+  main.py
+
+echo "Preparing release directory..."
+mkdir -p release
+cp -R dist/GM2Godot.app release/
+cp README.md release/
+
+echo "Creating zip archive..."
+(
+  cd release
+  ditto -c -k --sequesterRsrc --keepParent GM2Godot.app ../GM2Godot-macos.zip
+)
+
+echo "Creating DMG image..."
+mkdir -p dmg
+cp -R release/GM2Godot.app dmg/
+ln -s /Applications dmg/Applications
+hdiutil create \
+  -volname "GM2Godot" \
+  -srcfolder dmg \
+  -ov \
+  -format UDZO \
+  GM2Godot-macos.dmg
+
+echo "Build complete."
+echo "App bundle: dist/GM2Godot.app"
+echo "Zip: GM2Godot-macos.zip"
+echo "DMG: GM2Godot-macos.dmg"


### PR DESCRIPTION
- Introduced `build_macos.sh` script to automate the building of the macOS app bundle, including cleaning old artifacts, installing dependencies, and creating a DMG image.
- Updated README to include instructions for building a local macOS distributable and clarified the installation prerequisites and setup steps for all platforms.

Fixes #125 