### PR TITLE
Group sounds by audio group and export map

### DIFF
--- a/Languages/de.json
+++ b/Languages/de.json
@@ -107,6 +107,7 @@
 "Console_Convertor_Sounds_FileMissing" : "Warnung: Sound '{name}' verweist auf '{sound_file}', die nicht gefunden wurde, wird übersprungen.",
 "Console_Convertor_Sounds_VolumeNote" : "  Hinweis: {name} Lautstärke={volume} (ca. {volume_db} dB in Godot)",
 "Console_Convertor_Sounds_BusNote" : "  Hinweis: {name} verwendet Audio-Bus '{bus_name}'",
+"Console_Convertor_Sounds_MapGenerated" : "{map_path} mit {sounds_num} Sound-zu-Gruppe-Zuordnungen generiert.",
 
 "Console_Convertor_Shaders" : "Shader werden konvertiert...",
 "Console_Convertor_Shaders_Converted" : "{filename} konvertiert -> {output_path}",
@@ -162,11 +163,12 @@
 "Settings_Title" : "Konvertierungseinstellungen",
 "Settings_Files_Heading" : "Wählen Sie zu konvertierende Dateien aus:",
 "Settings_Categories_Headings" : ["Assets", "Projekt", "WIP"],
-"Settings_Categories_Contents" : [["sprites", "fonts", "sounds", "included_files", "objects"], ["game_icon", "project_name", "project_settings", "audio_buses", "notes"], ["shaders", "tilesets"]],
+"Settings_Categories_Contents" : [["sprites", "fonts", "sounds", "sound_group_folders", "included_files", "objects"], ["game_icon", "project_name", "project_settings", "audio_buses", "notes"], ["shaders", "tilesets"]],
 "Settings_Labels": {
     "sprites": "Sprites",
     "fonts": "Schriftarten",
     "sounds": "Sounds",
+    "sound_group_folders": "Soundgruppen-Ordner",
     "game_icon": "Spiel-Symbol",
     "project_name": "Projektname",
     "project_settings": "Projekteinstellungen",

--- a/Languages/eng.json
+++ b/Languages/eng.json
@@ -107,6 +107,7 @@
 "Console_Convertor_Sounds_FileMissing" : "Warning: Sound '{name}' references '{sound_file}' which was not found, skipping.",
 "Console_Convertor_Sounds_VolumeNote" : "  Note: {name} volume={volume} (approx. {volume_db} dB in Godot)",
 "Console_Convertor_Sounds_BusNote" : "  Note: {name} uses audio bus '{bus_name}'",
+"Console_Convertor_Sounds_MapGenerated" : "Generated {map_path} with {sounds_num} sound-to-group mappings.",
 
 "Console_Convertor_Shaders" : "Converting shaders...",
 "Console_Convertor_Shaders_Converted" : "Converted {filename} -> {output_path}",
@@ -162,11 +163,12 @@
 "Settings_Title" : "Conversion Settings",
 "Settings_Files_Heading" : "Select files to convert:",
 "Settings_Categories_Headings" : ["Assets", "Project", "WIP"],
-"Settings_Categories_Contents" : [["sprites", "fonts", "sounds", "included_files", "objects"], ["game_icon", "project_name", "project_settings", "audio_buses", "notes"], ["shaders", "tilesets"]],
+"Settings_Categories_Contents" : [["sprites", "fonts", "sounds", "sound_group_folders", "included_files", "objects"], ["game_icon", "project_name", "project_settings", "audio_buses", "notes"], ["shaders", "tilesets"]],
 "Settings_Labels": {
     "sprites": "Sprites",
     "fonts": "Fonts",
     "sounds": "Sounds",
+    "sound_group_folders": "Sound Group Folders",
     "game_icon": "Game Icon",
     "project_name": "Project Name",
     "project_settings": "Project Settings",

--- a/Languages/template/template.json
+++ b/Languages/template/template.json
@@ -84,6 +84,7 @@
 "Console_Convertor_Sounds_Error_NotFound" : "No sound files found in the GameMaker project.",
 "Console_Convertor_Sounds_Complete" : "Sound conversion completed.",
 "Console_Convertor_Sounds_Stopped" : "Sound conversion stopped.",
+"Console_Convertor_Sounds_MapGenerated" : "Generated {map_path} with {sounds_num} sound-to-group mappings.",
 
 "Console_Convertor_Shaders_Converted" : "Converted {filename} -> {output_path}",
 
@@ -121,7 +122,23 @@
 "Settings_Title" : "Conversion Settings",
 "Settings_Files_Heading" : "Select files to convert:",
 "Settings_Categories_Headings" : ["Assets", "Project", "WIP"],
-"Settings_Categories_Contents" : [["sprites", "fonts", "sounds"], ["game_icon", "project_name", "project_settings", "audio_buses", "notes"], ["objects", "shaders", "tilesets"]],
+"Settings_Categories_Contents" : [["sprites", "fonts", "sounds", "sound_group_folders", "included_files", "objects"], ["game_icon", "project_name", "project_settings", "audio_buses", "notes"], ["shaders", "tilesets"]],
+
+"Settings_Labels": {
+    "sprites": "Sprites",
+    "fonts": "Fonts",
+    "sounds": "Sounds",
+    "sound_group_folders": "Sound Group Folders",
+    "game_icon": "Game Icon",
+    "project_name": "Project Name",
+    "project_settings": "Project Settings",
+    "audio_buses": "Audio Buses",
+    "notes": "Notes",
+    "objects": "Objects",
+    "shaders": "Shaders",
+    "tilesets": "Tilesets",
+    "included_files": "Included Files"
+},
 
 "Settings_Button_SelectAll" : "Select All",
 "Settings_Button_DeselectAll" : "Deselect All",

--- a/src/conversion/converter.py
+++ b/src/conversion/converter.py
@@ -12,7 +12,7 @@ from src.localization import get_localized
 
 
 CONVERSION_CATEGORIES = {
-    "assets": ["sprites", "fonts", "sounds", "included_files", "objects"],
+    "assets": ["sprites", "fonts", "sounds", "sound_group_folders", "included_files", "objects"],
     "project": ["game_icon", "project_name", "project_settings", "audio_buses", "notes"],
     "wip": ["shaders", "tilesets"],
 }
@@ -30,6 +30,10 @@ class Converter:
         self.max_workers = max_workers
 
     def convert(self, gm_path, gm_platform, godot_path, settings):
+        group_sounds_by_audio_group = False
+        if "sound_group_folders" in settings:
+            group_sounds_by_audio_group = settings["sound_group_folders"].get()
+
         project_settings = ProjectSettingsConverter(
             gm_path, godot_path, self.log_callback,
             self.progress_callback, self.conversion_running.is_set,
@@ -69,6 +73,7 @@ class Converter:
                 update_log_callback=self.update_log_callback,
                 compact_logging=self.compact_logging,
                 max_workers=self.max_workers,
+                organize_by_audio_group=group_sounds_by_audio_group,
             ).convert_all(), "Console_Convertor_Sounds"),
             ("notes", lambda: NoteConverter(
                 gm_path, godot_path, self.log_callback,

--- a/src/conversion/sounds.py
+++ b/src/conversion/sounds.py
@@ -1,3 +1,4 @@
+import json
 import math
 import os
 import shutil
@@ -9,10 +10,12 @@ from src.conversion.base_converter import BaseConverter
 
 class SoundConverter(BaseConverter):
     def __init__(self, gm_project_path, godot_project_path, log_callback=print, progress_callback=None, conversion_running=None,
-                 update_log_callback=None, compact_logging=False, max_workers=None):
+                 update_log_callback=None, compact_logging=False, max_workers=None,
+                 organize_by_audio_group=False):
         super().__init__(gm_project_path, godot_project_path, log_callback, progress_callback, conversion_running,
                          update_log_callback, compact_logging, max_workers=max_workers)
         self.godot_sounds_path = os.path.join(self.godot_project_path, 'sounds')
+        self.organize_by_audio_group = bool(organize_by_audio_group)
 
     def find_sound_files(self):
         sound_folder = os.path.join(self.gm_project_path, 'sounds')
@@ -54,6 +57,37 @@ class SoundConverter(BaseConverter):
         if volume <= 0.0:
             return -80.0
         return 20.0 * math.log10(volume)
+
+    def _build_output_paths(self, sound_name, subfolder, audio_group):
+        output_parts = []
+
+        if self.organize_by_audio_group:
+            output_parts.append(audio_group or 'audiogroup_default')
+
+        if subfolder:
+            output_parts.extend(part for part in subfolder.split('/') if part)
+
+        output_parts.append(sound_name)
+
+        output_dir = os.path.join(self.godot_sounds_path, *output_parts)
+        res_subfolder = '/'.join(output_parts)
+        return output_dir, res_subfolder
+
+    def _write_audio_group_map(self, audio_group_map):
+        map_path = os.path.join(self.godot_sounds_path, 'audio_group_map.json')
+        ordered_map = {name: audio_group_map[name] for name in sorted(audio_group_map)}
+        payload = {
+            'format_version': 1,
+            'sounds': ordered_map,
+        }
+
+        with open(map_path, 'w', encoding='utf-8') as f:
+            json.dump(payload, f, indent=2)
+            f.write('\n')
+
+        if not self.compact_logging:
+            self._safe_log(get_localized("Console_Convertor_Sounds_MapGenerated").format(
+                map_path='sounds/audio_group_map.json', sounds_num=len(ordered_map)))
 
     def _generate_import_file(self, sound_file, subfolder=""):
         ext = os.path.splitext(sound_file)[1].lower()
@@ -133,35 +167,30 @@ class SoundConverter(BaseConverter):
 
         sound_data = self._parse_sound_yy(yy_path)
         if sound_data is None:
-            return False
+            sound_name = os.path.splitext(os.path.basename(yy_path))[0]
+            return {'success': False, 'name': sound_name, 'audio_group': 'audiogroup_default'}
 
         sound_name = sound_data['name']
         sound_file = sound_data['soundFile']
+        audio_group = sound_data['audioGroupId'] or 'audiogroup_default'
 
         if not sound_file:
             self._safe_log(get_localized("Console_Convertor_Sounds_NoFile").format(name=sound_name))
-            return False
+            return {'success': False, 'name': sound_name, 'audio_group': audio_group}
 
         audio_path = os.path.join(os.path.dirname(yy_path), sound_file)
         if not os.path.isfile(audio_path):
             self._safe_log(get_localized("Console_Convertor_Sounds_FileMissing").format(
                 name=sound_name, sound_file=sound_file))
-            return False
+            return {'success': False, 'name': sound_name, 'audio_group': audio_group}
 
         subfolder = self._get_subfolder_from_yy(yy_path)
-        if subfolder:
-            output_dir = os.path.join(self.godot_sounds_path, subfolder, sound_name)
-        else:
-            output_dir = os.path.join(self.godot_sounds_path, sound_name)
+        output_dir, res_subfolder = self._build_output_paths(sound_name, subfolder, audio_group)
         os.makedirs(output_dir, exist_ok=True)
 
         dest_path = os.path.join(output_dir, sound_file)
         shutil.copy2(audio_path, dest_path)
 
-        if subfolder:
-            res_subfolder = f"{subfolder}/{sound_name}"
-        else:
-            res_subfolder = sound_name
         import_content = self._generate_import_file(sound_file, res_subfolder)
         if import_content is not None:
             import_path = dest_path + '.import'
@@ -178,12 +207,11 @@ class SoundConverter(BaseConverter):
                     name=sound_name, volume=sound_data['volume'],
                     volume_db=f"{volume_db:.1f}"))
 
-            audio_group = sound_data['audioGroupId']
             if audio_group != 'audiogroup_default':
                 self._safe_log(get_localized("Console_Convertor_Sounds_BusNote").format(
                     name=sound_name, bus_name=audio_group))
 
-        return sound_name
+        return {'success': True, 'name': sound_name, 'audio_group': audio_group}
 
     def convert_sounds(self):
         os.makedirs(self.godot_project_path, exist_ok=True)
@@ -195,7 +223,7 @@ class SoundConverter(BaseConverter):
             self.log_callback(get_localized("Console_Convertor_Sounds_Error_NotFound"))
             return
 
-        sound_files = self.find_sound_files()
+        sound_files = sorted(self.find_sound_files())
 
         if not sound_files:
             self.log_callback(get_localized("Console_Convertor_Sounds_Error_NotFound"))
@@ -203,6 +231,7 @@ class SoundConverter(BaseConverter):
 
         total_sounds = len(sound_files)
         processed_sounds = 0
+        audio_group_map = {}
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             futures_map = {executor.submit(self._process_sound, sf): sf for sf in sound_files}
@@ -211,14 +240,17 @@ class SoundConverter(BaseConverter):
                 if result is None:
                     self.log_callback(get_localized("Console_Convertor_Sounds_Stopped"))
                     return
-                if result is not False:
-                    processed_sounds += 1
+
+                processed_sounds += 1
+
+                if result['success']:
+                    audio_group_map[result['name']] = result['audio_group']
                     if self.compact_logging:
-                        self._safe_log_progress(result, processed_sounds, total_sounds)
-                    self._safe_progress(int(processed_sounds / total_sounds * 100))
-                else:
-                    processed_sounds += 1
-                    self._safe_progress(int(processed_sounds / total_sounds * 100))
+                        self._safe_log_progress(result['name'], processed_sounds, total_sounds)
+
+                self._safe_progress(int(processed_sounds / total_sounds * 100))
+
+        self._write_audio_group_map(audio_group_map)
 
         self.log_callback(get_localized("Console_Convertor_Sounds_Complete"))
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -69,6 +69,7 @@ class MainWindow(QMainWindow):
         all_keys = [key for keys in CONVERSION_CATEGORIES.values() for key in keys]
         self._conversion_settings = {key: SettingValue(True) for key in all_keys}
         self._conversion_settings["notes"].set(False)
+        self._conversion_settings["sound_group_folders"].set(False)
         self._compact_logging = SettingValue(True)
         self._max_workers = multiprocessing.cpu_count()
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.1.4"
+VERSION = "0.1.5"
 
 def get_version():
     return VERSION

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -25,7 +25,7 @@ class TestConversionCategories(unittest.TestCase):
 
     def test_assets_contents(self):
         self.assertEqual(CONVERSION_CATEGORIES["assets"],
-                         ["sprites", "fonts", "sounds", "included_files", "objects"])
+                         ["sprites", "fonts", "sounds", "sound_group_folders", "included_files", "objects"])
 
     def test_project_contents(self):
         self.assertEqual(CONVERSION_CATEGORIES["project"],

--- a/tests/test_sounds.py
+++ b/tests/test_sounds.py
@@ -251,6 +251,71 @@ class TestSoundConverterMetadata(unittest.TestCase):
         self.assertEqual(result['audioGroupId'], "audiogroup_sfx")
 
 
+class TestSoundConverterAudioGroupMap(unittest.TestCase):
+    """Test sound-to-audio-group mapping export."""
+
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def _make_converter(self, **kwargs):
+        defaults = dict(
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+            organize_by_audio_group=False,
+        )
+        defaults.update(kwargs)
+        return SoundConverter(self.gm_dir, self.godot_dir, **defaults)
+
+    def test_generates_audio_group_map_file(self):
+        _make_sound_yy(self.gm_dir, "snd_music", overrides={
+            "audioGroupId": {"name": "audiogroup_music", "path": "audiogroups/audiogroup_music.yy"},
+        })
+        _make_sound_yy(self.gm_dir, "snd_click")
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        map_path = os.path.join(self.godot_dir, "sounds", "audio_group_map.json")
+        self.assertTrue(os.path.isfile(map_path))
+
+        with open(map_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        self.assertEqual(data.get("format_version"), 1)
+        self.assertEqual(data["sounds"]["snd_music"], "audiogroup_music")
+        self.assertEqual(data["sounds"]["snd_click"], "audiogroup_default")
+
+    def test_map_skips_failed_sound_entries(self):
+        _make_sound_yy(self.gm_dir, "ok")
+
+        # Build a .yy that references a missing audio file
+        sound_dir = os.path.join(self.gm_dir, "sounds", "ghost")
+        os.makedirs(sound_dir, exist_ok=True)
+        data = dict(MINIMAL_SOUND_YY)
+        data["name"] = "ghost"
+        data["%Name"] = "ghost"
+        data["soundFile"] = "ghost.wav"
+        with open(os.path.join(sound_dir, "ghost.yy"), "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        map_path = os.path.join(self.godot_dir, "sounds", "audio_group_map.json")
+        with open(map_path, "r", encoding="utf-8") as f:
+            exported = json.load(f)["sounds"]
+
+        self.assertIn("ok", exported)
+        self.assertNotIn("ghost", exported)
+
+
 class TestSoundConverterVolumeConversion(unittest.TestCase):
     """Test the volume-to-dB static method."""
 
@@ -279,13 +344,15 @@ class TestSoundConverterSubfolders(unittest.TestCase):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_converter(self):
-        return SoundConverter(
-            self.gm_dir, self.godot_dir,
+    def _make_converter(self, **kwargs):
+        defaults = dict(
             log_callback=lambda msg: self.logs.append(msg),
             progress_callback=lambda v: None,
             conversion_running=lambda: True,
+            organize_by_audio_group=False,
         )
+        defaults.update(kwargs)
+        return SoundConverter(self.gm_dir, self.godot_dir, **defaults)
 
     def test_subfolder_hierarchy(self):
         _make_sound_yy(self.gm_dir, "explosion", overrides={
@@ -322,6 +389,41 @@ class TestSoundConverterSubfolders(unittest.TestCase):
         expected = os.path.join(self.godot_dir, "sounds", "beep", "beep.wav")
         self.assertTrue(os.path.isfile(expected),
                         f"Expected {expected} at root level")
+
+    def test_grouped_folders_enabled(self):
+        _make_sound_yy(self.gm_dir, "theme", overrides={
+            "audioGroupId": {"name": "audiogroup_music", "path": "audiogroups/audiogroup_music.yy"},
+            "parent": {"name": "SFX", "path": "folders/Sounds/SFX.yy"},
+        })
+
+        converter = self._make_converter(organize_by_audio_group=True)
+        converter.convert_all()
+
+        expected = os.path.join(
+            self.godot_dir, "sounds", "audiogroup_music", "SFX", "theme", "theme.wav"
+        )
+        self.assertTrue(os.path.isfile(expected),
+                        f"Expected {expected} in grouped folder hierarchy")
+
+    def test_grouped_import_file_path(self):
+        _make_sound_yy(self.gm_dir, "theme", overrides={
+            "audioGroupId": {"name": "audiogroup_music", "path": "audiogroups/audiogroup_music.yy"},
+            "parent": {"name": "SFX", "path": "folders/Sounds/SFX.yy"},
+        })
+
+        converter = self._make_converter(organize_by_audio_group=True)
+        converter.convert_all()
+
+        import_path = os.path.join(
+            self.godot_dir, "sounds", "audiogroup_music", "SFX", "theme", "theme.wav.import"
+        )
+        self.assertTrue(os.path.isfile(import_path))
+        with open(import_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn(
+            'source_file="res://sounds/audiogroup_music/SFX/theme/theme.wav"',
+            content,
+        )
 
 
 class TestSoundConverterEdgeCases(unittest.TestCase):


### PR DESCRIPTION
Add a new sound_group_folders option to organize exported sounds into folders by their audio group and produce an audio_group_map.json. Locale files and the template were updated to expose the new setting label/text. Converter now reads the setting and passes organize_by_audio_group into SoundConverter; SoundConverter builds output paths accordingly, writes a sorted audio_group_map.json, and adjusts logging. GUI default for the new setting is set to false. Tests were updated/added to cover the new category, grouped-folder behavior, and map generation. Version bumped to 0.1.5.