### PR TITLE
Support remaining milestone 4 input events and bump version to 0.2.0

### DIFF
--- a/Languages/de.json
+++ b/Languages/de.json
@@ -13,7 +13,7 @@
 "Language" : "Deutsch",
 "Language_Code" : "de",
 "Author" : "übersetzt von [Ihr Name]",
-"Version" : "0.0.16",
+"Version" : "0.2.0",
 
 "About_Title" : "Über GM2Godot",
 "About_Description" : "GM2Godot ist ein Werkzeug, das Entwicklern hilft, ihre GameMaker-Projekte zur Godot Engine zu migrieren.\nEs automatisiert die Konvertierung verschiedener Projekt-Assets und -Einstellungen und macht den Übergang reibungsloser.",

--- a/Languages/eng.json
+++ b/Languages/eng.json
@@ -13,7 +13,7 @@
 "Language" : "English",
 "Language_Code" : "eng",
 "Author" : "written by Infiland, structured by HalfofBilly",
-"Version" : "0.0.16",
+"Version" : "0.2.0",
 
 "About_Title" : "About GM2Godot",
 "About_Description" : "GM2Godot is a tool designed to help developers migrate their GameMaker projects to the Godot Engine.\nIt automates the conversion of various project assets and settings, making the transition smoother.",

--- a/src/conversion/event_mapping.py
+++ b/src/conversion/event_mapping.py
@@ -17,8 +17,10 @@ class EventMapping:
     gml_filename: str
 
 
-# Input event types that are merged into a single _input(event) function
-INPUT_EVENT_TYPES = frozenset({6, 9, 10})
+# Input event types that are merged into a single _input(event) function.
+# GameMaker keyboard-down events also route through the shared input stub for
+# now so they are recognized as supported input instead of unknown events.
+INPUT_EVENT_TYPES = frozenset({5, 6, 9, 10, 13})
 
 # The merged input event mapping used when any input event is present
 INPUT_MERGED_MAPPING = EventMapping("_input", "event", 4, "")
@@ -42,17 +44,19 @@ _GML_EVENT_NAMES = {
     2: "Alarm",
     3: "Step",
     4: "Collision",
+    5: "Keyboard",
     6: "Mouse",
     7: "Other",
     8: "Draw",
     9: "KeyPress",
     10: "KeyRelease",
     12: "CleanUp",
+    13: "Gesture",
 }
 
 
 def is_input_event(event):
-    """Check whether an event dict represents an input event (types 6, 9, 10)."""
+    """Check whether an event dict represents a supported input event."""
     return event.get('eventType', -1) in INPUT_EVENT_TYPES
 
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.1.5"
+VERSION = "0.2.0"
 
 def get_version():
     return VERSION

--- a/tests/test_event_mapping.py
+++ b/tests/test_event_mapping.py
@@ -15,6 +15,9 @@ from src.conversion.event_mapping import (
 class TestIsInputEvent(unittest.TestCase):
     """Test is_input_event for input and non-input event types."""
 
+    def test_keyboard_event(self):
+        self.assertTrue(is_input_event({"eventType": 5, "eventNum": 65}))
+
     def test_mouse_event(self):
         self.assertTrue(is_input_event({"eventType": 6, "eventNum": 4}))
 
@@ -23,6 +26,9 @@ class TestIsInputEvent(unittest.TestCase):
 
     def test_key_release_event(self):
         self.assertTrue(is_input_event({"eventType": 10, "eventNum": 13}))
+
+    def test_gesture_event(self):
+        self.assertTrue(is_input_event({"eventType": 13, "eventNum": 3}))
 
     def test_create_event_not_input(self):
         self.assertFalse(is_input_event({"eventType": 0, "eventNum": 0}))
@@ -149,11 +155,17 @@ class TestMapEventInputReturnsNone(unittest.TestCase):
     def test_mouse_returns_none(self):
         self.assertIsNone(map_event({"eventType": 6, "eventNum": 4}))
 
+    def test_keyboard_returns_none(self):
+        self.assertIsNone(map_event({"eventType": 5, "eventNum": 65}))
+
     def test_key_press_returns_none(self):
         self.assertIsNone(map_event({"eventType": 9, "eventNum": 32}))
 
     def test_key_release_returns_none(self):
         self.assertIsNone(map_event({"eventType": 10, "eventNum": 13}))
+
+    def test_gesture_returns_none(self):
+        self.assertIsNone(map_event({"eventType": 13, "eventNum": 3}))
 
 
 class TestMapEventUnknown(unittest.TestCase):

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -78,15 +78,25 @@ class TestScriptGeneratorEvents(unittest.TestCase):
 class TestScriptGeneratorInputMerging(unittest.TestCase):
     """Input events (mouse, keyboard) should merge into a single _input."""
 
+    def test_keyboard_event_produces_input(self):
+        content = generate_script_content([{"eventType": 5, "eventNum": 65}])
+        self.assertIn("func _input(event):", content)
+
     def test_mouse_event_produces_input(self):
         content = generate_script_content([{"eventType": 6, "eventNum": 4}])
         self.assertIn("func _input(event):", content)
 
+    def test_gesture_event_produces_input(self):
+        content = generate_script_content([{"eventType": 13, "eventNum": 3}])
+        self.assertIn("func _input(event):", content)
+
     def test_multiple_input_events_merged(self):
         content = generate_script_content([
+            {"eventType": 5, "eventNum": 65},
             {"eventType": 6, "eventNum": 4},
             {"eventType": 9, "eventNum": 32},
             {"eventType": 10, "eventNum": 13},
+            {"eventType": 13, "eventNum": 3},
         ])
         self.assertIn("func _input(event):", content)
         self.assertEqual(content.count("func _input"), 1)


### PR DESCRIPTION
## Summary
- treat GameMaker keyboard and gesture events as supported input events so generated scripts merge them into `_input(event)` instead of unknown handlers
- add regression coverage for keyboard and gesture event mapping and script generation
- bump application and language metadata to `0.2.0`

## Testing
- `python -m pytest -q`