### PR TITLE
Support close button event

### DIFF
--- a/src/conversion/event_mapping.py
+++ b/src/conversion/event_mapping.py
@@ -37,6 +37,7 @@ _STATIC_MAP = {
     (12, 0): EventMapping("_exit_tree", "", 5, "CleanUp_0.gml"),
     (7, 6): EventMapping("_on_no_more_lives", "", 14, "Other_6.gml"),
     (7, 9): EventMapping("_on_no_more_health", "", 14, "Other_9.gml"),
+    (7, 30): EventMapping("_notification", "what", 6, "Other_30.gml"),
 }
 
 # GameMaker event type number to GML filename prefix

--- a/src/conversion/script_generator.py
+++ b/src/conversion/script_generator.py
@@ -1,6 +1,21 @@
 from src.conversion.event_mapping import map_event, is_input_event, INPUT_MERGED_MAPPING
 
 
+_CLOSE_BUTTON_FUNC = "_notification"
+_READY_FUNC = "_ready"
+_DISABLE_AUTO_QUIT_BODY = "\tget_tree().auto_accept_quit = false"
+
+
+def _get_function_body(func, code_bodies):
+    if code_bodies and func.godot_func in code_bodies:
+        return code_bodies[func.godot_func]
+    return "\tpass"
+
+
+def _indent_body(body):
+    return "\n".join(f"\t{line}" if line else line for line in body.splitlines())
+
+
 def generate_script_content(event_list, code_bodies=None):
     """Generate .gd script content with function stubs for each event.
 
@@ -47,6 +62,7 @@ def generate_script_content(event_list, code_bodies=None):
     unique_functions.sort(key=lambda f: (f.sort_key, f.godot_func))
 
     function_names = {func.godot_func for func in unique_functions}
+    has_close_button = _CLOSE_BUTTON_FUNC in function_names
 
     lines = ["extends Node2D\n"]
     if "_on_no_more_lives" in function_names:
@@ -66,10 +82,16 @@ def generate_script_content(event_list, code_bodies=None):
             "\n\t\t\t_on_no_more_health()\n"
         )
 
+    if has_close_button and _READY_FUNC not in function_names:
+        lines.append(f"\n\nfunc {_READY_FUNC}():")
+        lines.append(f"\n{_DISABLE_AUTO_QUIT_BODY}\n")
+
     for func in unique_functions:
-        body = "\tpass"
-        if code_bodies and func.godot_func in code_bodies:
-            body = code_bodies[func.godot_func]
+        body = _get_function_body(func, code_bodies)
+        if has_close_button and func.godot_func == _READY_FUNC:
+            body = f"{_DISABLE_AUTO_QUIT_BODY}\n{body}"
+        elif func.godot_func == _CLOSE_BUTTON_FUNC:
+            body = "\tif what == NOTIFICATION_WM_CLOSE_REQUEST:\n" + _indent_body(body)
         lines.append(f"\n\nfunc {func.godot_func}({func.params}):")
         lines.append(f"\n{body}\n")
 

--- a/tests/test_event_mapping.py
+++ b/tests/test_event_mapping.py
@@ -91,6 +91,13 @@ class TestMapEventStatic(unittest.TestCase):
         self.assertEqual(m.sort_key, 14)
         self.assertEqual(m.gml_filename, "Other_9.gml")
 
+    def test_close_button_event(self):
+        m = map_event({"eventType": 7, "eventNum": 30})
+        self.assertEqual(m.godot_func, "_notification")
+        self.assertEqual(m.params, "what")
+        self.assertEqual(m.sort_key, 6)
+        self.assertEqual(m.gml_filename, "Other_30.gml")
+
     def test_cleanup_event(self):
         m = map_event({"eventType": 12, "eventNum": 0})
         self.assertEqual(m.godot_func, "_exit_tree")

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -680,6 +680,19 @@ class TestScriptGeneration(unittest.TestCase):
         self.assertIn("var lives = 0:", content)
         self.assertIn("func _on_no_more_lives():", content)
 
+    def test_script_with_close_button_event(self):
+        """eventType 7, eventNum 30 should generate close request handling."""
+        self._setup_object("o_test", event_list=[{"eventType": 7, "eventNum": 30}])
+        converter = self._make_converter()
+        converter.convert_all()
+
+        gd_path = os.path.join(self.godot_dir, "objects", "o_test", "o_test.gd")
+        with open(gd_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        self.assertIn("get_tree().auto_accept_quit = false", content)
+        self.assertIn("func _notification(what):", content)
+        self.assertIn("NOTIFICATION_WM_CLOSE_REQUEST", content)
+
     def test_script_with_draw_gui_event(self):
         """eventType 8, eventNum 64 should produce func _on_draw_gui()."""
         self._setup_object("o_test", event_list=[{"eventType": 8, "eventNum": 64}])

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -80,6 +80,31 @@ class TestScriptGeneratorEvents(unittest.TestCase):
         self.assertIn("_on_no_more_health()", content)
         self.assertIn("func _on_no_more_health():", content)
 
+    def test_close_button_event(self):
+        content = generate_script_content([{"eventType": 7, "eventNum": 30}])
+        self.assertIn("func _ready():", content)
+        self.assertIn("get_tree().auto_accept_quit = false", content)
+        self.assertIn("func _notification(what):", content)
+        self.assertIn("if what == NOTIFICATION_WM_CLOSE_REQUEST:", content)
+
+    def test_close_button_event_wraps_code_body(self):
+        content = generate_script_content(
+            [{"eventType": 7, "eventNum": 30}],
+            code_bodies={"_notification": "\tget_tree().quit()"},
+        )
+        self.assertIn(
+            "\tif what == NOTIFICATION_WM_CLOSE_REQUEST:\n\t\tget_tree().quit()",
+            content,
+        )
+
+    def test_close_button_uses_existing_ready_event(self):
+        content = generate_script_content([
+            {"eventType": 0, "eventNum": 0},
+            {"eventType": 7, "eventNum": 30},
+        ])
+        self.assertEqual(content.count("func _ready"), 1)
+        self.assertIn("get_tree().auto_accept_quit = false", content)
+
     def test_draw_gui_event(self):
         content = generate_script_content([{"eventType": 8, "eventNum": 64}])
         self.assertIn("func _on_draw_gui():", content)


### PR DESCRIPTION
## Summary
- Adds a close button event mapping for `Other_30.gml`.
- Generates `_notification(what)` handling for close requests.
- Disables automatic quit when the close button event exists.
- Adds tests for the new event support.

Closes #114 