### PR TITLE
Support remaining event transpiler subissues

### DIFF
--- a/src/conversion/events/mappings/core.py
+++ b/src/conversion/events/mappings/core.py
@@ -9,6 +9,13 @@ STATIC_MAPPINGS = {
     (3, 2): EventMapping("_on_end_step", "", 12, "Step_2.gml"),
     (8, 0): EventMapping("_draw", "", 3, "Draw_0.gml"),
     (8, 64): EventMapping("_on_draw_gui", "", 15, "Draw_64.gml"),
+    (8, 65): EventMapping("_on_resize", "", 6, "Draw_65.gml"),
+    (8, 72): EventMapping("_on_draw_begin", "", 16, "Draw_72.gml"),
+    (8, 73): EventMapping("_on_draw_end", "", 16, "Draw_73.gml"),
+    (8, 74): EventMapping("_on_draw_gui_begin", "", 15, "Draw_74.gml"),
+    (8, 75): EventMapping("_on_draw_gui_end", "", 15, "Draw_75.gml"),
+    (8, 76): EventMapping("_on_pre_draw", "", 16, "Draw_76.gml"),
+    (8, 77): EventMapping("_on_post_draw", "", 16, "Draw_77.gml"),
     (12, 0): EventMapping("_exit_tree", "", 5, "CleanUp_0.gml"),
 }
 

--- a/src/conversion/events/mappings/other_lifecycle.py
+++ b/src/conversion/events/mappings/other_lifecycle.py
@@ -1,0 +1,9 @@
+from src.conversion.events.base import EventMapping
+
+
+STATIC_MAPPINGS = {
+    (7, 2): EventMapping("_on_game_start", "", 14, "Other_2.gml"),
+    (7, 3): EventMapping("_on_game_end", "", 14, "Other_3.gml"),
+    (7, 4): EventMapping("_on_room_start", "", 14, "Other_4.gml"),
+    (7, 5): EventMapping("_on_room_end", "", 14, "Other_5.gml"),
+}

--- a/src/conversion/events/script_features/resize.py
+++ b/src/conversion/events/script_features/resize.py
@@ -1,0 +1,18 @@
+from src.conversion.events.base import EventMapping
+
+
+_READY_FUNC = "_ready"
+_RESIZE_FUNC = "_on_resize"
+_CONNECT_RESIZE_BODY = "\tget_viewport().size_changed.connect(_on_resize)"
+
+
+def get_additional_functions(function_names):
+    if _RESIZE_FUNC in function_names and _READY_FUNC not in function_names:
+        return [EventMapping(_READY_FUNC, "", 0, "")]
+    return []
+
+
+def wrap_body(func, body, function_names):
+    if _RESIZE_FUNC in function_names and func.godot_func == _READY_FUNC:
+        return f"{_CONNECT_RESIZE_BODY}\n{body}"
+    return body

--- a/tests/conversion/events/test_alarm_events.py
+++ b/tests/conversion/events/test_alarm_events.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.event_mapping import map_event
+from src.conversion.script_generator import generate_script_content
+
+
+class TestAlarmEvents(unittest.TestCase):
+    def test_alarm_event_range_maps_to_alarm_callbacks(self):
+        for alarm_index in range(12):
+            with self.subTest(alarm_index=alarm_index):
+                mapping = map_event({"eventType": 2, "eventNum": alarm_index})
+
+                self.assertEqual(mapping.godot_func, f"_on_alarm_{alarm_index}")
+                self.assertEqual(mapping.params, "")
+                self.assertEqual(mapping.sort_key, 11)
+                self.assertEqual(mapping.gml_filename, f"Alarm_{alarm_index}.gml")
+
+    def test_alarm_event_range_generates_callbacks(self):
+        content = generate_script_content([
+            {"eventType": 2, "eventNum": alarm_index}
+            for alarm_index in range(12)
+        ])
+
+        for alarm_index in range(12):
+            with self.subTest(alarm_index=alarm_index):
+                self.assertIn(f"func _on_alarm_{alarm_index}():", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conversion/events/test_cleanup_event.py
+++ b/tests/conversion/events/test_cleanup_event.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.event_mapping import map_event
+from src.conversion.script_generator import generate_script_content
+
+
+class TestCleanupEvent(unittest.TestCase):
+    def test_maps_cleanup_event_to_exit_tree(self):
+        mapping = map_event({"eventType": 12, "eventNum": 0})
+
+        self.assertEqual(mapping.godot_func, "_exit_tree")
+        self.assertEqual(mapping.params, "")
+        self.assertEqual(mapping.sort_key, 5)
+        self.assertEqual(mapping.gml_filename, "CleanUp_0.gml")
+
+    def test_generates_exit_tree_stub(self):
+        content = generate_script_content([{"eventType": 12, "eventNum": 0}])
+
+        self.assertIn("func _exit_tree():", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conversion/events/test_collision_events.py
+++ b/tests/conversion/events/test_collision_events.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.event_mapping import map_event
+from src.conversion.script_generator import generate_script_content
+
+
+class TestCollisionEvents(unittest.TestCase):
+    def test_maps_collision_with_target_object(self):
+        mapping = map_event({
+            "eventType": 4,
+            "eventNum": 0,
+            "collisionObjectId": {"name": "o_enemy"},
+        })
+
+        self.assertEqual(mapping.godot_func, "_on_collision_o_enemy")
+        self.assertEqual(mapping.params, "")
+        self.assertEqual(mapping.sort_key, 13)
+        self.assertEqual(mapping.gml_filename, "Collision_0.gml")
+
+    def test_maps_collision_without_target_object(self):
+        mapping = map_event({"eventType": 4, "eventNum": 0})
+
+        self.assertEqual(mapping.godot_func, "_on_collision")
+        self.assertEqual(mapping.params, "")
+        self.assertEqual(mapping.sort_key, 13)
+        self.assertEqual(mapping.gml_filename, "Collision_0.gml")
+
+    def test_generates_collision_stubs(self):
+        content = generate_script_content([
+            {
+                "eventType": 4,
+                "eventNum": 0,
+                "collisionObjectId": {"name": "o_enemy"},
+            },
+            {"eventType": 4, "eventNum": 0},
+        ])
+
+        self.assertIn("func _on_collision_o_enemy():", content)
+        self.assertIn("func _on_collision():", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conversion/events/test_create_event.py
+++ b/tests/conversion/events/test_create_event.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.event_mapping import map_event
+from src.conversion.script_generator import generate_script_content
+
+
+class TestCreateEvent(unittest.TestCase):
+    def test_maps_create_event_to_ready(self):
+        mapping = map_event({"eventType": 0, "eventNum": 0})
+
+        self.assertEqual(mapping.godot_func, "_ready")
+        self.assertEqual(mapping.params, "")
+        self.assertEqual(mapping.sort_key, 0)
+        self.assertEqual(mapping.gml_filename, "Create_0.gml")
+
+    def test_generates_ready_stub(self):
+        content = generate_script_content([{"eventType": 0, "eventNum": 0}])
+
+        self.assertIn("func _ready():", content)
+        self.assertIn("\tpass", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conversion/events/test_destroy_event.py
+++ b/tests/conversion/events/test_destroy_event.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.event_mapping import map_event
+from src.conversion.script_generator import generate_script_content
+
+
+class TestDestroyEvent(unittest.TestCase):
+    def test_maps_destroy_event_to_destroy_callback(self):
+        mapping = map_event({"eventType": 1, "eventNum": 0})
+
+        self.assertEqual(mapping.godot_func, "_on_destroy")
+        self.assertEqual(mapping.params, "")
+        self.assertEqual(mapping.sort_key, 10)
+        self.assertEqual(mapping.gml_filename, "Destroy_0.gml")
+
+    def test_generates_destroy_stub(self):
+        content = generate_script_content([{"eventType": 1, "eventNum": 0}])
+
+        self.assertIn("func _on_destroy():", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conversion/events/test_draw_events.py
+++ b/tests/conversion/events/test_draw_events.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.event_mapping import map_event
+from src.conversion.script_generator import generate_script_content
+
+
+class TestDrawEvents(unittest.TestCase):
+    def test_maps_draw_event_family(self):
+        cases = [
+            (0, "_draw", 3, "Draw_0.gml"),
+            (64, "_on_draw_gui", 15, "Draw_64.gml"),
+            (65, "_on_resize", 6, "Draw_65.gml"),
+            (72, "_on_draw_begin", 16, "Draw_72.gml"),
+            (73, "_on_draw_end", 16, "Draw_73.gml"),
+            (74, "_on_draw_gui_begin", 15, "Draw_74.gml"),
+            (75, "_on_draw_gui_end", 15, "Draw_75.gml"),
+            (76, "_on_pre_draw", 16, "Draw_76.gml"),
+            (77, "_on_post_draw", 16, "Draw_77.gml"),
+        ]
+
+        for event_num, godot_func, sort_key, gml_filename in cases:
+            with self.subTest(event_num=event_num):
+                mapping = map_event({"eventType": 8, "eventNum": event_num})
+
+                self.assertEqual(mapping.godot_func, godot_func)
+                self.assertEqual(mapping.params, "")
+                self.assertEqual(mapping.sort_key, sort_key)
+                self.assertEqual(mapping.gml_filename, gml_filename)
+
+    def test_generates_draw_event_stubs(self):
+        content = generate_script_content([
+            {"eventType": 8, "eventNum": event_num}
+            for event_num in (0, 64, 65, 72, 73, 74, 75, 76, 77)
+        ])
+
+        for function_name in (
+            "_draw",
+            "_on_draw_gui",
+            "_on_resize",
+            "_on_draw_begin",
+            "_on_draw_end",
+            "_on_draw_gui_begin",
+            "_on_draw_gui_end",
+            "_on_pre_draw",
+            "_on_post_draw",
+        ):
+            self.assertIn(f"func {function_name}():", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conversion/events/test_gesture_events.py
+++ b/tests/conversion/events/test_gesture_events.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.event_mapping import is_input_event, map_event
+from src.conversion.script_generator import generate_script_content
+
+
+class TestGestureEvents(unittest.TestCase):
+    def test_gesture_event_range_merges_into_input(self):
+        for event_num in range(13):
+            with self.subTest(event_num=event_num):
+                self.assertTrue(is_input_event({"eventType": 13, "eventNum": event_num}))
+                self.assertIsNone(map_event({"eventType": 13, "eventNum": event_num}))
+
+    def test_generates_one_input_stub_for_gesture_family(self):
+        content = generate_script_content([
+            {"eventType": 13, "eventNum": event_num}
+            for event_num in range(13)
+        ])
+
+        self.assertIn("func _input(event):", content)
+        self.assertEqual(content.count("func _input"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conversion/events/test_keyboard_events.py
+++ b/tests/conversion/events/test_keyboard_events.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.event_mapping import is_input_event, map_event
+from src.conversion.script_generator import generate_script_content
+
+
+class TestKeyboardEvents(unittest.TestCase):
+    def test_keyboard_event_families_merge_into_input(self):
+        for event_type in (5, 9, 10):
+            with self.subTest(event_type=event_type):
+                self.assertTrue(is_input_event({"eventType": event_type, "eventNum": 65}))
+                self.assertIsNone(map_event({"eventType": event_type, "eventNum": 65}))
+
+    def test_keyboard_special_keys_merge_into_one_input_stub(self):
+        content = generate_script_content([
+            {"eventType": 5, "eventNum": 0},
+            {"eventType": 5, "eventNum": 1},
+            {"eventType": 9, "eventNum": 37},
+            {"eventType": 10, "eventNum": 112},
+        ])
+
+        self.assertIn("func _input(event):", content)
+        self.assertEqual(content.count("func _input"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conversion/events/test_lifecycle_events.py
+++ b/tests/conversion/events/test_lifecycle_events.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.event_mapping import map_event
+from src.conversion.script_generator import generate_script_content
+
+
+class TestLifecycleEvents(unittest.TestCase):
+    def test_maps_game_and_room_lifecycle_events(self):
+        cases = [
+            (2, "_on_game_start", "Other_2.gml"),
+            (3, "_on_game_end", "Other_3.gml"),
+            (4, "_on_room_start", "Other_4.gml"),
+            (5, "_on_room_end", "Other_5.gml"),
+        ]
+
+        for event_num, godot_func, gml_filename in cases:
+            with self.subTest(event_num=event_num):
+                mapping = map_event({"eventType": 7, "eventNum": event_num})
+
+                self.assertEqual(mapping.godot_func, godot_func)
+                self.assertEqual(mapping.params, "")
+                self.assertEqual(mapping.sort_key, 14)
+                self.assertEqual(mapping.gml_filename, gml_filename)
+
+    def test_generates_lifecycle_stubs(self):
+        content = generate_script_content([
+            {"eventType": 7, "eventNum": 2},
+            {"eventType": 7, "eventNum": 3},
+            {"eventType": 7, "eventNum": 4},
+            {"eventType": 7, "eventNum": 5},
+        ])
+
+        self.assertIn("func _on_game_start():", content)
+        self.assertIn("func _on_game_end():", content)
+        self.assertIn("func _on_room_start():", content)
+        self.assertIn("func _on_room_end():", content)
+        self.assertNotIn("func _on_other_2():", content)
+        self.assertNotIn("func _on_other_5():", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conversion/events/test_mouse_events.py
+++ b/tests/conversion/events/test_mouse_events.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.event_mapping import is_input_event, map_event
+from src.conversion.script_generator import generate_script_content
+
+
+class TestMouseEvents(unittest.TestCase):
+    def test_mouse_event_ranges_merge_into_input(self):
+        event_nums = list(range(12)) + list(range(50, 59)) + [60, 61]
+
+        for event_num in event_nums:
+            with self.subTest(event_num=event_num):
+                self.assertTrue(is_input_event({"eventType": 6, "eventNum": event_num}))
+                self.assertIsNone(map_event({"eventType": 6, "eventNum": event_num}))
+
+    def test_generates_one_input_stub_for_mouse_family(self):
+        content = generate_script_content([
+            {"eventType": 6, "eventNum": event_num}
+            for event_num in list(range(12)) + list(range(50, 59)) + [60, 61]
+        ])
+
+        self.assertIn("func _input(event):", content)
+        self.assertEqual(content.count("func _input"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conversion/events/test_registry.py
+++ b/tests/conversion/events/test_registry.py
@@ -23,10 +23,10 @@ class TestEventRegistry(unittest.TestCase):
 
     def test_keeps_dynamic_handlers(self):
         alarm = map_event({"eventType": 2, "eventNum": 3})
-        other = map_event({"eventType": 7, "eventNum": 5})
+        other = map_event({"eventType": 7, "eventNum": 26})
 
         self.assertEqual(alarm.godot_func, "_on_alarm_3")
-        self.assertEqual(other.godot_func, "_on_other_5")
+        self.assertEqual(other.godot_func, "_on_other_26")
 
 
 if __name__ == "__main__":

--- a/tests/conversion/events/test_step_events.py
+++ b/tests/conversion/events/test_step_events.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.event_mapping import map_event
+from src.conversion.script_generator import generate_script_content
+
+
+class TestStepEvents(unittest.TestCase):
+    def test_maps_step_events(self):
+        cases = [
+            (0, "_process", "delta", 1, "Step_0.gml"),
+            (1, "_physics_process", "delta", 2, "Step_1.gml"),
+            (2, "_on_end_step", "", 12, "Step_2.gml"),
+        ]
+
+        for event_num, godot_func, params, sort_key, gml_filename in cases:
+            with self.subTest(event_num=event_num):
+                mapping = map_event({"eventType": 3, "eventNum": event_num})
+
+                self.assertEqual(mapping.godot_func, godot_func)
+                self.assertEqual(mapping.params, params)
+                self.assertEqual(mapping.sort_key, sort_key)
+                self.assertEqual(mapping.gml_filename, gml_filename)
+
+    def test_generates_step_stubs(self):
+        content = generate_script_content([
+            {"eventType": 3, "eventNum": 0},
+            {"eventType": 3, "eventNum": 1},
+            {"eventType": 3, "eventNum": 2},
+        ])
+
+        self.assertIn("func _process(delta):", content)
+        self.assertIn("func _physics_process(delta):", content)
+        self.assertIn("func _on_end_step():", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_event_mapping.py
+++ b/tests/test_event_mapping.py
@@ -21,6 +21,12 @@ class TestIsInputEvent(unittest.TestCase):
     def test_mouse_event(self):
         self.assertTrue(is_input_event({"eventType": 6, "eventNum": 4}))
 
+    def test_mouse_event_variants(self):
+        # GameMaker ev_mouse ranges covered by issue #96.
+        for event_num in (0, 11, 50, 58, 60, 61):
+            with self.subTest(event_num=event_num):
+                self.assertTrue(is_input_event({"eventType": 6, "eventNum": event_num}))
+
     def test_key_press_event(self):
         self.assertTrue(is_input_event({"eventType": 9, "eventNum": 32}))
 
@@ -28,7 +34,9 @@ class TestIsInputEvent(unittest.TestCase):
         self.assertTrue(is_input_event({"eventType": 10, "eventNum": 13}))
 
     def test_gesture_event(self):
-        self.assertTrue(is_input_event({"eventType": 13, "eventNum": 3}))
+        for event_num in range(13):
+            with self.subTest(event_num=event_num):
+                self.assertTrue(is_input_event({"eventType": 13, "eventNum": event_num}))
 
     def test_create_event_not_input(self):
         self.assertFalse(is_input_event({"eventType": 0, "eventNum": 0}))
@@ -78,6 +86,22 @@ class TestMapEventStatic(unittest.TestCase):
         m = map_event({"eventType": 8, "eventNum": 64})
         self.assertEqual(m.godot_func, "_on_draw_gui")
         self.assertEqual(m.sort_key, 15)
+
+    def test_draw_family_events(self):
+        expected = {
+            65: "_on_resize",
+            72: "_on_draw_begin",
+            73: "_on_draw_end",
+            74: "_on_draw_gui_begin",
+            75: "_on_draw_gui_end",
+            76: "_on_pre_draw",
+            77: "_on_post_draw",
+        }
+        for event_num, godot_func in expected.items():
+            with self.subTest(event_num=event_num):
+                m = map_event({"eventType": 8, "eventNum": event_num})
+                self.assertEqual(m.godot_func, godot_func)
+                self.assertEqual(m.gml_filename, f"Draw_{event_num}.gml")
 
     def test_no_more_lives_event(self):
         m = map_event({"eventType": 7, "eventNum": 6})
@@ -141,14 +165,14 @@ class TestMapEventDynamic(unittest.TestCase):
         self.assertEqual(m.godot_func, "_on_collision")
 
     def test_other_event(self):
-        m = map_event({"eventType": 7, "eventNum": 5})
-        self.assertEqual(m.godot_func, "_on_other_5")
+        m = map_event({"eventType": 7, "eventNum": 26})
+        self.assertEqual(m.godot_func, "_on_other_26")
         self.assertEqual(m.sort_key, 14)
-        self.assertEqual(m.gml_filename, "Other_5.gml")
+        self.assertEqual(m.gml_filename, "Other_26.gml")
 
     def test_draw_variant(self):
         m = map_event({"eventType": 8, "eventNum": 72})
-        self.assertEqual(m.godot_func, "_on_draw_72")
+        self.assertEqual(m.godot_func, "_on_draw_begin")
         self.assertEqual(m.sort_key, 16)
         self.assertEqual(m.gml_filename, "Draw_72.gml")
 
@@ -174,6 +198,11 @@ class TestMapEventInputReturnsNone(unittest.TestCase):
     def test_mouse_returns_none(self):
         self.assertIsNone(map_event({"eventType": 6, "eventNum": 4}))
 
+    def test_mouse_variants_return_none(self):
+        for event_num in (0, 11, 50, 58, 60, 61):
+            with self.subTest(event_num=event_num):
+                self.assertIsNone(map_event({"eventType": 6, "eventNum": event_num}))
+
     def test_keyboard_returns_none(self):
         self.assertIsNone(map_event({"eventType": 5, "eventNum": 65}))
 
@@ -184,7 +213,9 @@ class TestMapEventInputReturnsNone(unittest.TestCase):
         self.assertIsNone(map_event({"eventType": 10, "eventNum": 13}))
 
     def test_gesture_returns_none(self):
-        self.assertIsNone(map_event({"eventType": 13, "eventNum": 3}))
+        for event_num in range(13):
+            with self.subTest(event_num=event_num):
+                self.assertIsNone(map_event({"eventType": 13, "eventNum": event_num}))
 
 
 class TestMapEventUnknown(unittest.TestCase):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -587,6 +587,25 @@ class TestScriptGeneration(unittest.TestCase):
         self.assertIn("func _input(event):", content)
         self.assertEqual(content.count("func _input"), 1, "Should have exactly one _input function")
 
+    def test_mouse_event_ranges_merged(self):
+        """All ev_mouse ranges should still merge into one _input(event)."""
+        self._setup_object("o_test", event_list=[
+            {"eventType": 6, "eventNum": 0},
+            {"eventType": 6, "eventNum": 11},
+            {"eventType": 6, "eventNum": 50},
+            {"eventType": 6, "eventNum": 58},
+            {"eventType": 6, "eventNum": 60},
+            {"eventType": 6, "eventNum": 61},
+        ])
+        converter = self._make_converter()
+        converter.convert_all()
+
+        gd_path = os.path.join(self.godot_dir, "objects", "o_test", "o_test.gd")
+        with open(gd_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        self.assertIn("func _input(event):", content)
+        self.assertEqual(content.count("func _input"), 1)
+
     def test_script_attached_to_tscn(self):
         """The .tscn file should reference the .gd script."""
         self._setup_object("o_test")
@@ -659,14 +678,14 @@ class TestScriptGeneration(unittest.TestCase):
 
     def test_script_with_other_event(self):
         """eventType 7 should produce func _on_other_N()."""
-        self._setup_object("o_test", event_list=[{"eventType": 7, "eventNum": 5}])
+        self._setup_object("o_test", event_list=[{"eventType": 7, "eventNum": 26}])
         converter = self._make_converter()
         converter.convert_all()
 
         gd_path = os.path.join(self.godot_dir, "objects", "o_test", "o_test.gd")
         with open(gd_path, 'r', encoding='utf-8') as f:
             content = f.read()
-        self.assertIn("func _on_other_5():", content)
+        self.assertIn("func _on_other_26():", content)
 
     def test_script_with_no_more_lives_event(self):
         """eventType 7, eventNum 6 should add the legacy lives setter."""

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -63,8 +63,8 @@ class TestScriptGeneratorEvents(unittest.TestCase):
         self.assertIn("func _on_collision_o_bullet():", content)
 
     def test_other_event(self):
-        content = generate_script_content([{"eventType": 7, "eventNum": 5}])
-        self.assertIn("func _on_other_5():", content)
+        content = generate_script_content([{"eventType": 7, "eventNum": 26}])
+        self.assertIn("func _on_other_26():", content)
 
     def test_no_more_lives_event(self):
         content = generate_script_content([{"eventType": 7, "eventNum": 6}])
@@ -109,6 +109,33 @@ class TestScriptGeneratorEvents(unittest.TestCase):
         content = generate_script_content([{"eventType": 8, "eventNum": 64}])
         self.assertIn("func _on_draw_gui():", content)
 
+    def test_draw_family_events(self):
+        content = generate_script_content([
+            {"eventType": 8, "eventNum": 72},
+            {"eventType": 8, "eventNum": 73},
+            {"eventType": 8, "eventNum": 74},
+            {"eventType": 8, "eventNum": 75},
+            {"eventType": 8, "eventNum": 76},
+            {"eventType": 8, "eventNum": 77},
+        ])
+
+        for function_name in (
+            "_on_draw_begin",
+            "_on_draw_end",
+            "_on_draw_gui_begin",
+            "_on_draw_gui_end",
+            "_on_pre_draw",
+            "_on_post_draw",
+        ):
+            self.assertIn(f"func {function_name}():", content)
+
+    def test_resize_event_connects_viewport_size_changed(self):
+        content = generate_script_content([{"eventType": 8, "eventNum": 65}])
+
+        self.assertIn("func _ready():", content)
+        self.assertIn("get_viewport().size_changed.connect(_on_resize)", content)
+        self.assertIn("func _on_resize():", content)
+
     def test_unknown_event(self):
         content = generate_script_content([{"eventType": 99, "eventNum": 5}])
         self.assertIn("func _on_event_99_5():", content)
@@ -125,9 +152,25 @@ class TestScriptGeneratorInputMerging(unittest.TestCase):
         content = generate_script_content([{"eventType": 6, "eventNum": 4}])
         self.assertIn("func _input(event):", content)
 
-    def test_gesture_event_produces_input(self):
-        content = generate_script_content([{"eventType": 13, "eventNum": 3}])
+    def test_mouse_event_ranges_produce_input(self):
+        content = generate_script_content([
+            {"eventType": 6, "eventNum": 0},
+            {"eventType": 6, "eventNum": 11},
+            {"eventType": 6, "eventNum": 50},
+            {"eventType": 6, "eventNum": 58},
+            {"eventType": 6, "eventNum": 60},
+            {"eventType": 6, "eventNum": 61},
+        ])
         self.assertIn("func _input(event):", content)
+        self.assertEqual(content.count("func _input"), 1)
+
+    def test_gesture_event_produces_input(self):
+        content = generate_script_content([
+            {"eventType": 13, "eventNum": event_num}
+            for event_num in range(13)
+        ])
+        self.assertIn("func _input(event):", content)
+        self.assertEqual(content.count("func _input"), 1)
 
     def test_multiple_input_events_merged(self):
         content = generate_script_content([


### PR DESCRIPTION
## Summary
- Adds explicit draw family mappings for resize, draw begin, draw end, GUI begin, GUI end, pre draw, and post draw events.
- Adds semantic game and room lifecycle mappings for `Other_2.gml` through `Other_5.gml`.
- Adds focused regression coverage for all remaining event transpiler subissues under #92.

## Validation
- `python3 -m unittest tests.test_event_mapping tests.test_script_generator tests.test_objects tests.conversion.events.test_registry tests.conversion.events.test_script_features tests.conversion.events.test_create_event tests.conversion.events.test_destroy_event tests.conversion.events.test_cleanup_event tests.conversion.events.test_step_events tests.conversion.events.test_keyboard_events tests.conversion.events.test_mouse_events tests.conversion.events.test_gesture_events tests.conversion.events.test_alarm_events tests.conversion.events.test_draw_events tests.conversion.events.test_collision_events tests.conversion.events.test_lifecycle_events`
- `python3 -m unittest discover tests/conversion/events`
- `python3 -m unittest discover tests` was attempted, but the local system Python is missing `PIL` and package installation is blocked by the externally managed environment.

closes #94
closes #95
closes #96
closes #97
closes #98
closes #99
closes #101
closes #102
closes #105
closes #107
closes #110