### PR TITLE
Support wallpaper event transpiler

### DIFF
--- a/src/conversion/events/mappings/other_wallpaper.py
+++ b/src/conversion/events/mappings/other_wallpaper.py
@@ -1,0 +1,7 @@
+from src.conversion.events.base import EventMapping
+
+
+STATIC_MAPPINGS = {
+    (7, 79): EventMapping("_on_wallpaper_config", "", 14, "Other_79.gml"),
+    (7, 81): EventMapping("_on_wallpaper_subscription_data", "", 14, "Other_81.gml"),
+}

--- a/tests/conversion/events/test_wallpaper_events.py
+++ b/tests/conversion/events/test_wallpaper_events.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.event_mapping import map_event
+from src.conversion.script_generator import generate_script_content
+
+
+WALLPAPER_EVENTS = [
+    (79, "_on_wallpaper_config", "Other_79.gml"),
+    (81, "_on_wallpaper_subscription_data", "Other_81.gml"),
+]
+
+
+class TestWallpaperEvents(unittest.TestCase):
+    def test_maps_wallpaper_events(self):
+        for event_num, godot_func, gml_filename in WALLPAPER_EVENTS:
+            with self.subTest(event_num=event_num):
+                mapping = map_event({"eventType": 7, "eventNum": event_num})
+
+                self.assertEqual(mapping.godot_func, godot_func)
+                self.assertEqual(mapping.params, "")
+                self.assertEqual(mapping.sort_key, 14)
+                self.assertEqual(mapping.gml_filename, gml_filename)
+
+    def test_generates_wallpaper_event_stubs(self):
+        content = generate_script_content([
+            {"eventType": 7, "eventNum": event_num}
+            for event_num, _godot_func, _gml_filename in WALLPAPER_EVENTS
+        ])
+
+        for _event_num, godot_func, _gml_filename in WALLPAPER_EVENTS:
+            with self.subTest(godot_func=godot_func):
+                self.assertIn(f"func {godot_func}():", content)
+
+        self.assertEqual(content.count("\tpass"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add named mappings for GameMaker live wallpaper events `Other_79.gml` and `Other_81.gml`.
- Cover wallpaper event mapping metadata and generated handler stubs with tests.

## Tests
- `python3 -m unittest tests.conversion.events.test_wallpaper_events tests.conversion.events.test_broadcast_message tests.conversion.events.test_async_audio`

Closes #150