### PR TITLE
Release event transpiler milestone as 0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# macOS
+.DS_Store
+
 # C extensions
 *.so
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.2.0"
+VERSION = "0.3.0"
 
 def get_version():
     return VERSION


### PR DESCRIPTION
## Summary
- Bump the app version to `0.3.0` now that the event transpiler subissues are complete.
- Ignore macOS `.DS_Store` files.

## Verification
- Confirmed all #92 subissues are closed.
- `python3 -m unittest discover` in a temporary virtualenv with Pillow installed: 375 tests passed, 17 skipped.

Closes #92