### PR TITLE
Add GameMaker resource index

### DIFF
--- a/src/conversion/resource_index.py
+++ b/src/conversion/resource_index.py
@@ -1,0 +1,263 @@
+import os
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from src.conversion.base_converter import BaseConverter
+
+
+@dataclass(frozen=True)
+class IndexedResource:
+    """A GameMaker resource with matching generated Godot path metadata."""
+
+    kind: str
+    name: str
+    yy_path: str
+    yyp_path: str
+    godot_path: str
+    subfolder: str = ""
+
+
+@dataclass(frozen=True)
+class IndexedRoom:
+    """Normalized room data needed before actual room scene generation."""
+
+    name: str
+    yy_path: str
+    yyp_path: str
+    godot_path: str
+    subfolder: str = ""
+    room_settings: Dict = field(default_factory=dict)
+    physics_settings: Dict = field(default_factory=dict)
+    view_settings: Dict = field(default_factory=dict)
+    views: List = field(default_factory=list)
+    layers: List = field(default_factory=list)
+    instance_creation_order: List = field(default_factory=list)
+    parent_room: Optional[Dict] = None
+    creation_code_file: str = ""
+    inherit_code: bool = False
+    inherit_creation_order: bool = False
+    inherit_layers: bool = False
+    raw_data: Dict = field(default_factory=dict)
+
+
+class GameMakerResourceIndex(BaseConverter):
+    """Index GameMaker project resources for converters that need cross references."""
+
+    RESOURCE_EXTENSIONS = {
+        "rooms": ".tscn",
+        "objects": ".tscn",
+        "sprites": ".tscn",
+        "tilesets": ".tres",
+    }
+
+    def __init__(self, gm_project_path, godot_project_path, log_callback=print,
+                 progress_callback=None, conversion_running=None,
+                 update_log_callback=None, compact_logging=False,
+                 max_workers=None):
+        super().__init__(gm_project_path, godot_project_path, log_callback,
+                         progress_callback, conversion_running,
+                         update_log_callback, compact_logging,
+                         max_workers=max_workers)
+        self.yyp_path = None
+        self.yyp_data = None
+        self.resources = self._empty_resources()
+        self.rooms = {}
+        self.room_order = []
+
+    def convert_all(self):
+        """Build the in-memory index. No Godot files are written."""
+        return self.build()
+
+    def build(self):
+        """Build and return this resource index."""
+        self.resources = self._empty_resources()
+        self.rooms = {}
+        self.room_order = []
+        self.yyp_path = self.find_yyp_path()
+        self.yyp_data = self._read_yy_file(self.yyp_path) if self.yyp_path else None
+
+        if self.yyp_data is not None:
+            self._index_yyp_resources(self.yyp_data)
+            self._parse_indexed_rooms()
+            self._apply_yyp_room_order(self.yyp_data)
+        else:
+            if self.yyp_path:
+                self._safe_log(
+                    "Could not parse GameMaker project .yyp; falling back to disk scan."
+                )
+            else:
+                self._safe_log(
+                    "No GameMaker project .yyp found; falling back to disk scan."
+                )
+            self._index_disk_resources()
+            self._parse_indexed_rooms()
+            self.room_order = sorted(self.rooms)
+
+        return self
+
+    def find_yyp_path(self):
+        """Return the first .yyp path in the GameMaker project, if any."""
+        try:
+            yyp_files = sorted(
+                name for name in os.listdir(self.gm_project_path)
+                if name.endswith(".yyp")
+            )
+        except OSError:
+            return None
+
+        if not yyp_files:
+            return None
+        return os.path.join(self.gm_project_path, yyp_files[0])
+
+    def get_resource(self, kind, name):
+        """Return an indexed non-room resource, or a room resource, by kind/name."""
+        return self.resources.get(kind, {}).get(name)
+
+    def get_resources(self, kind):
+        """Return all indexed resources for a supported kind."""
+        return dict(self.resources.get(kind, {}))
+
+    def get_room(self, name):
+        """Return normalized room data by name."""
+        return self.rooms.get(name)
+
+    def ordered_rooms(self):
+        """Return normalized rooms in GameMaker room order when available."""
+        return [self.rooms[name] for name in self.room_order if name in self.rooms]
+
+    def first_room(self):
+        """Return the first GameMaker room, or None when no room is indexed."""
+        ordered = self.ordered_rooms()
+        return ordered[0] if ordered else None
+
+    def resolve_gm_path(self, kind, name):
+        """Return the source GameMaker .yy path for a resource, if indexed."""
+        resource = self.get_resource(kind, name)
+        return resource.yy_path if resource else None
+
+    def resolve_godot_path(self, kind, name):
+        """Return the generated res:// path for a resource, if indexed."""
+        resource = self.get_resource(kind, name)
+        return resource.godot_path if resource else None
+
+    def _empty_resources(self):
+        return {kind: {} for kind in self.RESOURCE_EXTENSIONS}
+
+    def _index_yyp_resources(self, yyp_data):
+        for resource_entry in yyp_data.get("resources", []):
+            res_id = resource_entry.get("id", {})
+            yyp_path = res_id.get("path", "")
+            kind = self._kind_from_yyp_path(yyp_path)
+            if kind not in self.RESOURCE_EXTENSIONS:
+                continue
+
+            name = res_id.get("name") or self._name_from_yyp_path(yyp_path)
+            if not name:
+                continue
+
+            yy_path = os.path.normpath(os.path.join(self.gm_project_path, yyp_path))
+            if not os.path.isfile(yy_path):
+                self._safe_log(
+                    f"Skipping missing GameMaker resource {name}: {yy_path}"
+                )
+                continue
+
+            self.resources[kind][name] = self._make_resource(kind, name, yy_path, yyp_path)
+
+    def _index_disk_resources(self):
+        for kind in self.RESOURCE_EXTENSIONS:
+            kind_dir = os.path.join(self.gm_project_path, kind)
+            if not os.path.isdir(kind_dir):
+                continue
+
+            for name in sorted(os.listdir(kind_dir)):
+                resource_dir = os.path.join(kind_dir, name)
+                yy_path = os.path.join(resource_dir, name + ".yy")
+                if not os.path.isdir(resource_dir) or not os.path.isfile(yy_path):
+                    continue
+                yyp_path = "/".join([kind, name, name + ".yy"])
+                self.resources[kind][name] = self._make_resource(
+                    kind, name, yy_path, yyp_path
+                )
+
+    def _parse_indexed_rooms(self):
+        for name, resource in self.resources["rooms"].items():
+            room = self._parse_room(resource)
+            if room is not None:
+                self.rooms[name] = room
+
+    def _parse_room(self, resource):
+        data = self._read_yy_file(resource.yy_path)
+        if data is None:
+            self._safe_log(
+                f"Skipping malformed GameMaker room {resource.name}: {resource.yy_path}"
+            )
+            return None
+
+        return IndexedRoom(
+            name=resource.name,
+            yy_path=resource.yy_path,
+            yyp_path=resource.yyp_path,
+            godot_path=resource.godot_path,
+            subfolder=resource.subfolder,
+            room_settings=data.get("roomSettings") or {},
+            physics_settings=data.get("physicsSettings") or {},
+            view_settings=data.get("viewSettings") or {},
+            views=data.get("views") or [],
+            layers=data.get("layers") or [],
+            instance_creation_order=data.get("instanceCreationOrder") or [],
+            parent_room=data.get("parentRoom"),
+            creation_code_file=data.get("creationCodeFile") or "",
+            inherit_code=bool(data.get("inheritCode", False)),
+            inherit_creation_order=bool(data.get("inheritCreationOrder", False)),
+            inherit_layers=bool(data.get("inheritLayers", False)),
+            raw_data=data,
+        )
+
+    def _apply_yyp_room_order(self, yyp_data):
+        ordered = []
+        for room_node in yyp_data.get("RoomOrderNodes", []):
+            room_id = room_node.get("roomId", {})
+            name = room_id.get("name") or self._name_from_yyp_path(room_id.get("path", ""))
+            if name in self.rooms and name not in ordered:
+                ordered.append(name)
+
+        for name in self.resources["rooms"]:
+            if name in self.rooms and name not in ordered:
+                ordered.append(name)
+
+        self.room_order = ordered
+
+    def _make_resource(self, kind, name, yy_path, yyp_path):
+        subfolder = self._get_subfolder_from_yy(yy_path)
+        return IndexedResource(
+            kind=kind,
+            name=name,
+            yy_path=yy_path,
+            yyp_path=yyp_path,
+            godot_path=self.godot_res_path(kind, name, subfolder),
+            subfolder=subfolder,
+        )
+
+    @classmethod
+    def godot_res_path(cls, kind, name, subfolder=""):
+        """Build a generated res:// path using existing converter conventions."""
+        extension = cls.RESOURCE_EXTENSIONS[kind]
+        path_parts = ["res:/", kind]
+        if subfolder:
+            path_parts.extend(part for part in subfolder.split("/") if part)
+        path_parts.extend([name, name + extension])
+        return "/".join(path_parts)
+
+    @staticmethod
+    def _kind_from_yyp_path(yyp_path):
+        if not yyp_path or "/" not in yyp_path:
+            return ""
+        return yyp_path.split("/", 1)[0]
+
+    @staticmethod
+    def _name_from_yyp_path(yyp_path):
+        if not yyp_path:
+            return ""
+        filename = os.path.basename(yyp_path)
+        return os.path.splitext(filename)[0]

--- a/tests/test_resource_index.py
+++ b/tests/test_resource_index.py
@@ -1,0 +1,283 @@
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.resource_index import GameMakerResourceIndex
+
+
+def _write_file(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+def _resource_entry(kind, name):
+    return (
+        '    {{"id":{{"name":"{name}",'
+        '"path":"{kind}/{name}/{name}.yy",}},}}'
+    ).format(kind=kind, name=name)
+
+
+def _room_order_entry(name):
+    return (
+        '    {{"roomId":{{"name":"{name}",'
+        '"path":"rooms/{name}/{name}.yy",}},}}'
+    ).format(name=name)
+
+
+def _make_yyp(resources, room_order=None):
+    room_order = room_order or []
+    resource_lines = ",\n".join(
+        _resource_entry(kind, name) for kind, name in resources
+    )
+    room_order_lines = ",\n".join(_room_order_entry(name) for name in room_order)
+    return (
+        "{\n"
+        f'  "resources":[\n{resource_lines},\n  ],\n'
+        f'  "RoomOrderNodes":[\n{room_order_lines},\n  ],\n'
+        '  "resourceType":"GMProject",\n'
+        "}\n"
+    )
+
+
+def _make_room_yy(name, parent_path="folders/Rooms.yy"):
+    return (
+        '{{\n'
+        '  "$GMRoom":"v1",\n'
+        '  "%Name":"{name}",\n'
+        '  "name":"{name}",\n'
+        '  "creationCodeFile":"",\n'
+        '  "inheritCode":false,\n'
+        '  "inheritCreationOrder":false,\n'
+        '  "inheritLayers":false,\n'
+        '  "instanceCreationOrder":[],\n'
+        '  "isDnd":false,\n'
+        '  "layers":[],\n'
+        '  "parent":{{"name":"Rooms","path":"{parent_path}",}},\n'
+        '  "parentRoom":null,\n'
+        '  "physicsSettings":{{"PhysicsWorld":false,}},\n'
+        '  "resourceType":"GMRoom",\n'
+        '  "roomSettings":{{"Width":640,"Height":480,"persistent":false,}},\n'
+        '  "views":[],\n'
+        '  "viewSettings":{{"enableViews":false,}},\n'
+        '}}\n'
+    ).format(name=name, parent_path=parent_path)
+
+
+def _make_minimal_yy(name, resource_type, parent_name, parent_path):
+    return (
+        '{{\n'
+        '  "name":"{name}",\n'
+        '  "parent":{{"name":"{parent_name}","path":"{parent_path}",}},\n'
+        '  "resourceType":"{resource_type}",\n'
+        '}}\n'
+    ).format(
+        name=name,
+        parent_name=parent_name,
+        parent_path=parent_path,
+        resource_type=resource_type,
+    )
+
+
+class TestGameMakerResourceIndex(unittest.TestCase):
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def _build_index(self):
+        index = GameMakerResourceIndex(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=lambda msg: self.logs.append(str(msg)),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+        )
+        return index.build()
+
+    def _write_yyp(self, resources, room_order=None):
+        _write_file(
+            os.path.join(self.gm_dir, "TestProject.yyp"),
+            _make_yyp(resources, room_order),
+        )
+
+    def _write_room(self, name, parent_path="folders/Rooms.yy", content=None):
+        _write_file(
+            os.path.join(self.gm_dir, "rooms", name, name + ".yy"),
+            content if content is not None else _make_room_yy(name, parent_path),
+        )
+
+    def _write_resource(self, kind, name, parent_path, resource_type):
+        parent_name = kind.capitalize()
+        _write_file(
+            os.path.join(self.gm_dir, kind, name, name + ".yy"),
+            _make_minimal_yy(name, resource_type, parent_name, parent_path),
+        )
+
+    def test_indexes_yyp_resources_and_preserves_room_order(self):
+        self._write_yyp(
+            [("rooms", "r_second"), ("rooms", "r_first")],
+            room_order=["r_first", "r_second"],
+        )
+        self._write_room("r_first")
+        self._write_room("r_second")
+
+        index = self._build_index()
+
+        self.assertEqual(
+            [room.name for room in index.ordered_rooms()],
+            ["r_first", "r_second"],
+        )
+        self.assertEqual(index.first_room().name, "r_first")
+        self.assertEqual(
+            index.resolve_gm_path("rooms", "r_first"),
+            os.path.join(self.gm_dir, "rooms", "r_first", "r_first.yy"),
+        )
+
+    def test_resolves_resource_gm_paths_for_supported_kinds(self):
+        self._write_yyp([
+            ("rooms", "r_test"),
+            ("objects", "o_player"),
+            ("sprites", "s_player"),
+            ("tilesets", "ts_ground"),
+        ], room_order=["r_test"])
+        self._write_room("r_test")
+        self._write_resource("objects", "o_player", "folders/Objects.yy", "GMObject")
+        self._write_resource("sprites", "s_player", "folders/Sprites.yy", "GMSprite")
+        self._write_resource("tilesets", "ts_ground", "folders/Tile Sets.yy", "GMTileSet")
+
+        index = self._build_index()
+
+        self.assertTrue(index.resolve_gm_path("rooms", "r_test").endswith(
+            os.path.join("rooms", "r_test", "r_test.yy")
+        ))
+        self.assertTrue(index.resolve_gm_path("objects", "o_player").endswith(
+            os.path.join("objects", "o_player", "o_player.yy")
+        ))
+        self.assertTrue(index.resolve_gm_path("sprites", "s_player").endswith(
+            os.path.join("sprites", "s_player", "s_player.yy")
+        ))
+        self.assertTrue(index.resolve_gm_path("tilesets", "ts_ground").endswith(
+            os.path.join("tilesets", "ts_ground", "ts_ground.yy")
+        ))
+
+    def test_computes_godot_paths_with_subfolders(self):
+        self._write_yyp([
+            ("rooms", "r_intro"),
+            ("objects", "o_player"),
+            ("sprites", "s_player"),
+            ("tilesets", "ts_ground"),
+        ], room_order=["r_intro"])
+        self._write_room("r_intro", "folders/Rooms/Game/Intro.yy")
+        self._write_resource(
+            "objects", "o_player", "folders/Objects/Game/Actors.yy", "GMObject"
+        )
+        self._write_resource(
+            "sprites", "s_player", "folders/Sprites/Game/Actors.yy", "GMSprite"
+        )
+        self._write_resource(
+            "tilesets", "ts_ground", "folders/Tile Sets/World.yy", "GMTileSet"
+        )
+
+        index = self._build_index()
+
+        self.assertEqual(
+            index.resolve_godot_path("rooms", "r_intro"),
+            "res://rooms/Game/Intro/r_intro/r_intro.tscn",
+        )
+        self.assertEqual(
+            index.resolve_godot_path("objects", "o_player"),
+            "res://objects/Game/Actors/o_player/o_player.tscn",
+        )
+        self.assertEqual(
+            index.resolve_godot_path("sprites", "s_player"),
+            "res://sprites/Game/Actors/s_player/s_player.tscn",
+        )
+        self.assertEqual(
+            index.resolve_godot_path("tilesets", "ts_ground"),
+            "res://tilesets/World/ts_ground/ts_ground.tres",
+        )
+
+    def test_handles_trailing_commas_in_yyp_and_room_yy(self):
+        self._write_yyp([("rooms", "r_trailing")], room_order=["r_trailing"])
+        self._write_room("r_trailing")
+
+        index = self._build_index()
+        room = index.get_room("r_trailing")
+
+        self.assertIsNotNone(room)
+        self.assertEqual(room.room_settings["Width"], 640)
+        self.assertEqual(room.room_settings["Height"], 480)
+
+    def test_missing_yyp_falls_back_to_disk_scan(self):
+        self._write_room("r_disk")
+        self._write_resource("objects", "o_disk", "folders/Objects.yy", "GMObject")
+        self._write_resource("sprites", "s_disk", "folders/Sprites.yy", "GMSprite")
+        self._write_resource("tilesets", "ts_disk", "folders/Tile Sets.yy", "GMTileSet")
+
+        index = self._build_index()
+
+        self.assertIsNotNone(index.get_room("r_disk"))
+        self.assertIsNotNone(index.get_resource("objects", "o_disk"))
+        self.assertIsNotNone(index.get_resource("sprites", "s_disk"))
+        self.assertIsNotNone(index.get_resource("tilesets", "ts_disk"))
+        self.assertEqual([room.name for room in index.ordered_rooms()], ["r_disk"])
+
+    def test_malformed_yyp_falls_back_to_disk_scan(self):
+        _write_file(os.path.join(self.gm_dir, "BadProject.yyp"), "not valid json {{{")
+        self._write_room("r_disk")
+
+        index = self._build_index()
+
+        self.assertIsNotNone(index.get_room("r_disk"))
+        self.assertTrue(any("falling back" in msg for msg in self.logs))
+
+    def test_malformed_room_is_skipped_and_logged(self):
+        self._write_yyp([("rooms", "r_bad")], room_order=["r_bad"])
+        self._write_room("r_bad", content="not valid json {{{")
+
+        index = self._build_index()
+
+        self.assertIsNone(index.get_room("r_bad"))
+        self.assertTrue(any("r_bad" in msg for msg in self.logs))
+
+    def test_missing_optional_room_fields_do_not_crash(self):
+        self._write_yyp([("rooms", "r_minimal")], room_order=["r_minimal"])
+        self._write_room(
+            "r_minimal",
+            content='{"name":"r_minimal","resourceType":"GMRoom",}',
+        )
+
+        index = self._build_index()
+        room = index.get_room("r_minimal")
+
+        self.assertEqual(room.room_settings, {})
+        self.assertEqual(room.physics_settings, {})
+        self.assertEqual(room.view_settings, {})
+        self.assertEqual(room.views, [])
+        self.assertEqual(room.layers, [])
+        self.assertEqual(room.instance_creation_order, [])
+        self.assertIsNone(room.parent_room)
+        self.assertEqual(room.creation_code_file, "")
+
+    def test_no_scene_output_is_written(self):
+        self._write_yyp([("rooms", "r_empty")], room_order=["r_empty"])
+        self._write_room("r_empty")
+
+        self._build_index()
+
+        self.assertFalse(os.path.exists(os.path.join(self.godot_dir, "rooms")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a `GameMakerResourceIndex` for discovering rooms, objects, sprites, and tilesets from `.yyp` resources or disk fallback.
- Preserve `RoomOrderNodes`, first-room lookup, room metadata parsing, and generated `res://` path resolution.
- Add focused unit coverage for room order, subfolders, trailing commas, fallbacks, malformed rooms, and no scene output.

## Tests
- `python3 -m unittest tests.test_resource_index`
- `python3 -m unittest discover tests`
- Manual validation against `AsteroidsPLUSPLUS`: first room `rLoading`, 22 ordered rooms

Closes #154