### PR TITLE
Add minimal room converter

### DIFF
--- a/src/conversion/rooms.py
+++ b/src/conversion/rooms.py
@@ -1,0 +1,121 @@
+import json
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from src.conversion.base_converter import BaseConverter
+from src.conversion.resource_index import GameMakerResourceIndex
+
+
+class RoomConverter(BaseConverter):
+    """Convert GameMaker rooms into minimal Godot room scenes."""
+
+    def __init__(self, gm_project_path, godot_project_path, log_callback=print,
+                 progress_callback=None, conversion_running=None,
+                 update_log_callback=None, compact_logging=False,
+                 max_workers=None, resource_index=None):
+        super().__init__(gm_project_path, godot_project_path, log_callback,
+                         progress_callback, conversion_running,
+                         update_log_callback, compact_logging,
+                         max_workers=max_workers)
+        self.godot_rooms_path = os.path.join(self.godot_project_path, "rooms")
+        self.resource_index = resource_index
+
+    def _build_resource_index(self):
+        if self.resource_index is not None:
+            return self.resource_index
+        return GameMakerResourceIndex(
+            self.gm_project_path,
+            self.godot_project_path,
+            log_callback=self.log_callback,
+            progress_callback=self.progress_callback,
+            conversion_running=self.conversion_running,
+            update_log_callback=self.update_log_callback,
+            compact_logging=self.compact_logging,
+            max_workers=self.max_workers,
+        ).build()
+
+    def _generate_room_scene(self, room):
+        room_settings = room.room_settings
+        physics_settings = room.physics_settings
+
+        lines = [
+            "[gd_scene format=3]",
+            "",
+            f'[node name="{room.name}" type="Node2D"]',
+            f'metadata/gamemaker_room_width = {json.dumps(room_settings.get("Width", 1024))}',
+            f'metadata/gamemaker_room_height = {json.dumps(room_settings.get("Height", 768))}',
+            f'metadata/gamemaker_room_persistent = {json.dumps(bool(room_settings.get("persistent", False)))}',
+            f'metadata/gamemaker_room_volume = {json.dumps(room.raw_data.get("volume", 1.0))}',
+            f'metadata/gamemaker_physics_world = {json.dumps(bool(physics_settings.get("PhysicsWorld", False)))}',
+            f'metadata/gamemaker_physics_gravity_x = {json.dumps(physics_settings.get("PhysicsWorldGravityX", 0.0))}',
+            f'metadata/gamemaker_physics_gravity_y = {json.dumps(physics_settings.get("PhysicsWorldGravityY", 10.0))}',
+            f'metadata/gamemaker_physics_pixels_to_meters = {json.dumps(physics_settings.get("PhysicsWorldPixToMetres", 0.1))}',
+            f'metadata/gamemaker_source_yy_path = {json.dumps(room.yy_path)}',
+            "",
+        ]
+        return "\n".join(lines)
+
+    def _room_output_path(self, room):
+        if room.godot_path.startswith("res://"):
+            relative_path = room.godot_path[len("res://"):]
+            return os.path.join(self.godot_project_path, *relative_path.split("/"))
+
+        if room.subfolder:
+            return os.path.join(
+                self.godot_rooms_path, room.subfolder, room.name, room.name + ".tscn"
+            )
+        return os.path.join(self.godot_rooms_path, room.name, room.name + ".tscn")
+
+    def _process_room(self, room):
+        if not self.conversion_running():
+            return None
+
+        output_path = self._room_output_path(room)
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(self._generate_room_scene(room))
+
+        width = room.room_settings.get("Width", 1024)
+        height = room.room_settings.get("Height", 768)
+        return {"success": True, "name": room.name, "width": width, "height": height}
+
+    def convert_rooms(self):
+        index = self._build_resource_index()
+        rooms = index.ordered_rooms()
+        if not rooms:
+            self.log_callback("Room conversion completed.")
+            return
+
+        total = len(rooms)
+        processed = 0
+
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            futures_map = {
+                executor.submit(self._process_room, room): room.name
+                for room in rooms
+            }
+            for future in as_completed(futures_map):
+                result = future.result()
+                if result is None:
+                    self.log_callback("Room conversion stopped.")
+                    return
+
+                processed += 1
+                if result["success"]:
+                    if self.compact_logging:
+                        self._safe_log_progress(result["name"], processed, total)
+                    else:
+                        self._safe_log(
+                            "Converted room: {name} ({width}x{height})".format(
+                                name=result["name"],
+                                width=result["width"],
+                                height=result["height"],
+                            )
+                        )
+
+                self._safe_progress(int(processed / total * 100))
+
+        self.log_callback("Room conversion completed.")
+
+    def convert_all(self):
+        self.convert_rooms()

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -1,0 +1,204 @@
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.rooms import RoomConverter
+
+
+def _write_file(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+def _make_yyp(room_names):
+    resources = []
+    room_order = []
+    for name in room_names:
+        resources.append(
+            '    {{"id":{{"name":"{name}",'
+            '"path":"rooms/{name}/{name}.yy",}},}}'.format(name=name)
+        )
+        room_order.append(
+            '    {{"roomId":{{"name":"{name}",'
+            '"path":"rooms/{name}/{name}.yy",}},}}'.format(name=name)
+        )
+
+    return (
+        "{\n"
+        f'  "resources":[\n{",\n".join(resources)},\n  ],\n'
+        f'  "RoomOrderNodes":[\n{",\n".join(room_order)},\n  ],\n'
+        '  "resourceType":"GMProject",\n'
+        "}\n"
+    )
+
+
+def _make_room_yy(name, parent_path="folders/Rooms.yy", width=1024, height=768,
+                  persistent=False, volume=1.0, physics_world=False):
+    persistent_value = "true" if persistent else "false"
+    physics_world_value = "true" if physics_world else "false"
+    return (
+        '{{\n'
+        '  "$GMRoom":"v1",\n'
+        '  "%Name":"{name}",\n'
+        '  "name":"{name}",\n'
+        '  "creationCodeFile":"",\n'
+        '  "inheritCode":false,\n'
+        '  "inheritCreationOrder":false,\n'
+        '  "inheritLayers":false,\n'
+        '  "instanceCreationOrder":[],\n'
+        '  "layers":[],\n'
+        '  "parent":{{"name":"Rooms","path":"{parent_path}",}},\n'
+        '  "parentRoom":null,\n'
+        '  "physicsSettings":{{\n'
+        '    "PhysicsWorld":{physics_world},\n'
+        '    "PhysicsWorldGravityX":0.0,\n'
+        '    "PhysicsWorldGravityY":10.0,\n'
+        '    "PhysicsWorldPixToMetres":0.1,\n'
+        '  }},\n'
+        '  "resourceType":"GMRoom",\n'
+        '  "roomSettings":{{\n'
+        '    "Width":{width},\n'
+        '    "Height":{height},\n'
+        '    "persistent":{persistent},\n'
+        '  }},\n'
+        '  "views":[],\n'
+        '  "viewSettings":{{"enableViews":false,}},\n'
+        '  "volume":{volume},\n'
+        '}}\n'
+    ).format(
+        name=name,
+        parent_path=parent_path,
+        width=width,
+        height=height,
+        persistent=persistent_value,
+        volume=volume,
+        physics_world=physics_world_value,
+    )
+
+
+class TestRoomConverter(unittest.TestCase):
+    def setUp(self):
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs = []
+        self.progress = []
+
+    def tearDown(self):
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def _make_converter(self, conversion_running=lambda: True):
+        return RoomConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=lambda msg: self.logs.append(str(msg)),
+            progress_callback=lambda value: self.progress.append(value),
+            conversion_running=conversion_running,
+            max_workers=1,
+        )
+
+    def _write_yyp(self, room_names):
+        _write_file(os.path.join(self.gm_dir, "TestProject.yyp"), _make_yyp(room_names))
+
+    def _write_room(self, name, **kwargs):
+        room_path = os.path.join(self.gm_dir, "rooms", name, name + ".yy")
+        _write_file(room_path, _make_room_yy(name, **kwargs))
+        return room_path
+
+    def test_generates_minimal_room_scene_with_metadata(self):
+        self._write_yyp(["r_test"])
+        room_yy_path = self._write_room(
+            "r_test",
+            width=1024,
+            height=768,
+            persistent=True,
+            volume=0.75,
+            physics_world=True,
+        )
+
+        self._make_converter().convert_all()
+
+        tscn_path = os.path.join(self.godot_dir, "rooms", "r_test", "r_test.tscn")
+        self.assertTrue(os.path.isfile(tscn_path))
+
+        with open(tscn_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        self.assertIn('[gd_scene format=3]', content)
+        self.assertIn('[node name="r_test" type="Node2D"]', content)
+        self.assertIn('metadata/gamemaker_room_width = 1024', content)
+        self.assertIn('metadata/gamemaker_room_height = 768', content)
+        self.assertIn('metadata/gamemaker_room_persistent = true', content)
+        self.assertIn('metadata/gamemaker_room_volume = 0.75', content)
+        self.assertIn('metadata/gamemaker_physics_world = true', content)
+        self.assertIn('metadata/gamemaker_physics_gravity_x = 0.0', content)
+        self.assertIn('metadata/gamemaker_physics_gravity_y = 10.0', content)
+        self.assertIn('metadata/gamemaker_physics_pixels_to_meters = 0.1', content)
+        self.assertIn(
+            'metadata/gamemaker_source_yy_path = ' + json.dumps(room_yy_path),
+            content,
+        )
+        self.assertNotIn('instance=ExtResource', content)
+        self.assertNotIn('Camera2D', content)
+        self.assertNotIn('TileMap', content)
+        self.assertNotIn('ParallaxBackground', content)
+        self.assertEqual(self.progress[-1], 100)
+        self.assertTrue(any("r_test" in log for log in self.logs))
+
+    def test_preserves_room_subfolders(self):
+        self._write_yyp(["r_intro"])
+        self._write_room("r_intro", parent_path="folders/Rooms/Game/Intro.yy")
+
+        self._make_converter().convert_all()
+
+        self.assertTrue(os.path.isfile(os.path.join(
+            self.godot_dir,
+            "rooms",
+            "Game",
+            "Intro",
+            "r_intro",
+            "r_intro.tscn",
+        )))
+
+    def test_converts_only_rooms_listed_in_yyp(self):
+        self._write_yyp(["r_listed"])
+        self._write_room("r_listed")
+        self._write_room("r_unlisted")
+
+        self._make_converter().convert_all()
+
+        self.assertTrue(os.path.isfile(os.path.join(
+            self.godot_dir, "rooms", "r_listed", "r_listed.tscn"
+        )))
+        self.assertFalse(os.path.exists(os.path.join(
+            self.godot_dir, "rooms", "r_unlisted"
+        )))
+
+    def test_no_rooms_does_not_crash_or_create_output(self):
+        self._make_converter().convert_all()
+
+        self.assertFalse(os.path.exists(os.path.join(self.godot_dir, "rooms")))
+        self.assertTrue(any("completed" in log.lower() for log in self.logs))
+
+    def test_stops_without_writing_scene(self):
+        self._write_yyp(["r_test"])
+        self._write_room("r_test")
+
+        self._make_converter(conversion_running=lambda: False).convert_all()
+
+        self.assertFalse(os.path.exists(os.path.join(
+            self.godot_dir, "rooms", "r_test", "r_test.tscn"
+        )))
+        self.assertTrue(any("stopped" in log.lower() for log in self.logs))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `RoomConverter` to generate one minimal Godot `.tscn` per indexed GameMaker room.
- Preserve room subfolders and write root `Node2D` metadata for dimensions, persistence, volume, physics settings, and source `.yy` path.
- Add focused tests for scene generation, `.yyp` filtering, subfolders, safe empty-room behavior, and stopped conversion.

## Tests
- `python3 -m unittest tests.test_rooms tests.test_resource_index`
- `python3 -m unittest discover tests`
- Manual validation against `AsteroidsPLUSPLUS`: generated `rooms/rLoading/rLoading.tscn`

Closes #155