### PR TITLE
Set startup scene from room order

### DIFF
--- a/Languages/de.json
+++ b/Languages/de.json
@@ -123,6 +123,10 @@
 "Console_Convertor_Objects_SpriteNotFound" : "Warnung: Objekt {object_name} verweist auf Sprite {sprite_name}, dessen Szene nicht gefunden wurde. Objekt wird ohne Sprite erstellt.",
 "Console_Convertor_Objects_ParseError" : "Warnung: {yy_path} konnte nicht gelesen werden, Objekt {object_name} wird uebersprungen.",
 
+"Console_Convertor_Rooms" : "Raeume werden konvertiert...",
+"Console_Convertor_Rooms_Complete" : "Raum-Konvertierung abgeschlossen.",
+"Console_Convertor_Rooms_Stopped" : "Raum-Konvertierung gestoppt.",
+
 "Console_Convertor_Notes" : "Notizen werden konvertiert...",
 "Console_Convertor_Notes_Copied" : "Notiz kopiert: {note_name}",
 "Console_Convertor_Notes_Stopped" : "Notiz-Konvertierung gestoppt.",
@@ -163,7 +167,7 @@
 "Settings_Title" : "Konvertierungseinstellungen",
 "Settings_Files_Heading" : "Wählen Sie zu konvertierende Dateien aus:",
 "Settings_Categories_Headings" : ["Assets", "Projekt", "WIP"],
-"Settings_Categories_Contents" : [["sprites", "fonts", "sounds", "sound_group_folders", "included_files", "objects"], ["game_icon", "project_name", "project_settings", "audio_buses", "notes"], ["shaders", "tilesets"]],
+"Settings_Categories_Contents" : [["sprites", "fonts", "sounds", "sound_group_folders", "included_files", "objects", "rooms"], ["game_icon", "project_name", "project_settings", "audio_buses", "notes"], ["shaders", "tilesets"]],
 "Settings_Labels": {
     "sprites": "Sprites",
     "fonts": "Schriftarten",
@@ -175,6 +179,7 @@
     "audio_buses": "Audio-Busse",
     "notes": "Notizen",
     "objects": "Objekte",
+    "rooms": "Raeume",
     "shaders": "Shader",
     "tilesets": "Tilesets",
     "included_files": "Eingeschlossene Dateien"

--- a/Languages/eng.json
+++ b/Languages/eng.json
@@ -123,6 +123,10 @@
 "Console_Convertor_Objects_SpriteNotFound" : "Warning: Object {object_name} references sprite {sprite_name} whose scene was not found. Creating object without sprite.",
 "Console_Convertor_Objects_ParseError" : "Warning: Could not parse {yy_path}, skipping object {object_name}.",
 
+"Console_Convertor_Rooms" : "Converting rooms...",
+"Console_Convertor_Rooms_Complete" : "Room conversion completed.",
+"Console_Convertor_Rooms_Stopped" : "Room conversion stopped.",
+
 "Console_Convertor_Notes" : "Converting notes...",
 "Console_Convertor_Notes_Copied" : "Copied note: {note_name}",
 "Console_Convertor_Notes_Stopped" : "Note conversion stopped.",
@@ -163,7 +167,7 @@
 "Settings_Title" : "Conversion Settings",
 "Settings_Files_Heading" : "Select files to convert:",
 "Settings_Categories_Headings" : ["Assets", "Project", "WIP"],
-"Settings_Categories_Contents" : [["sprites", "fonts", "sounds", "sound_group_folders", "included_files", "objects"], ["game_icon", "project_name", "project_settings", "audio_buses", "notes"], ["shaders", "tilesets"]],
+"Settings_Categories_Contents" : [["sprites", "fonts", "sounds", "sound_group_folders", "included_files", "objects", "rooms"], ["game_icon", "project_name", "project_settings", "audio_buses", "notes"], ["shaders", "tilesets"]],
 "Settings_Labels": {
     "sprites": "Sprites",
     "fonts": "Fonts",
@@ -175,6 +179,7 @@
     "audio_buses": "Audio Buses",
     "notes": "Notes",
     "objects": "Objects",
+    "rooms": "Rooms",
     "shaders": "Shaders",
     "tilesets": "Tilesets",
     "included_files": "Included Files"

--- a/Languages/template/template.json
+++ b/Languages/template/template.json
@@ -88,6 +88,10 @@
 
 "Console_Convertor_Shaders_Converted" : "Converted {filename} -> {output_path}",
 
+"Console_Convertor_Rooms" : "Converting rooms...",
+"Console_Convertor_Rooms_Complete" : "Room conversion completed.",
+"Console_Convertor_Rooms_Stopped" : "Room conversion stopped.",
+
 "Console_Convertor_Notes" : "Converting notes...",
 "Console_Convertor_Notes_Copied" : "Copied note: {note_name}",
 "Console_Convertor_Notes_Stopped" : "Note conversion stopped.",
@@ -122,7 +126,7 @@
 "Settings_Title" : "Conversion Settings",
 "Settings_Files_Heading" : "Select files to convert:",
 "Settings_Categories_Headings" : ["Assets", "Project", "WIP"],
-"Settings_Categories_Contents" : [["sprites", "fonts", "sounds", "sound_group_folders", "included_files", "objects"], ["game_icon", "project_name", "project_settings", "audio_buses", "notes"], ["shaders", "tilesets"]],
+"Settings_Categories_Contents" : [["sprites", "fonts", "sounds", "sound_group_folders", "included_files", "objects", "rooms"], ["game_icon", "project_name", "project_settings", "audio_buses", "notes"], ["shaders", "tilesets"]],
 
 "Settings_Labels": {
     "sprites": "Sprites",
@@ -135,6 +139,7 @@
     "audio_buses": "Audio Buses",
     "notes": "Notes",
     "objects": "Objects",
+    "rooms": "Rooms",
     "shaders": "Shaders",
     "tilesets": "Tilesets",
     "included_files": "Included Files"

--- a/src/conversion/converter.py
+++ b/src/conversion/converter.py
@@ -4,6 +4,7 @@ from src.conversion.fonts import FontConverter
 from src.conversion.notes import NoteConverter
 from src.conversion.tilesets import TileSetConverter
 from src.conversion.objects import ObjectConverter
+from src.conversion.rooms import RoomConverter
 from src.conversion.shaders import ShaderConverter
 from src.conversion.included_files import IncludedFilesConverter
 from src.conversion.project_settings import ProjectSettingsConverter
@@ -12,7 +13,7 @@ from src.localization import get_localized
 
 
 CONVERSION_CATEGORIES = {
-    "assets": ["sprites", "fonts", "sounds", "sound_group_folders", "included_files", "objects"],
+    "assets": ["sprites", "fonts", "sounds", "sound_group_folders", "included_files", "objects", "rooms"],
     "project": ["game_icon", "project_name", "project_settings", "audio_buses", "notes"],
     "wip": ["shaders", "tilesets"],
 }
@@ -103,6 +104,13 @@ class Converter:
                 compact_logging=self.compact_logging,
                 max_workers=self.max_workers,
             ).convert_all(), "Console_Convertor_Objects"),
+            ("rooms", lambda: RoomConverter(
+                gm_path, godot_path, self.log_callback,
+                self.progress_callback, self.conversion_running.is_set,
+                update_log_callback=self.update_log_callback,
+                compact_logging=self.compact_logging,
+                max_workers=self.max_workers,
+            ).convert_all(), "Console_Convertor_Rooms"),
         ]
 
         for setting_key, converter_fn, log_key in converters:

--- a/src/conversion/project_godot.py
+++ b/src/conversion/project_godot.py
@@ -1,0 +1,105 @@
+import os
+
+
+class GodotProjectFile:
+    """Line-preserving helper for small `project.godot` setting updates."""
+
+    def __init__(self, project_godot_path):
+        self.project_godot_path = project_godot_path
+
+    def set_main_scene(self, scene_path):
+        """Set [application] run/main_scene while preserving unrelated settings."""
+        return self.set_setting("application", "run/main_scene", scene_path)
+
+    def set_setting(self, section, key, value):
+        if not os.path.isfile(self.project_godot_path):
+            return False
+
+        with open(self.project_godot_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        updated = self._set_setting(content, section, key, self._format_value(value))
+        with open(self.project_godot_path, "w", encoding="utf-8") as f:
+            f.write(updated)
+
+        return True
+
+    @staticmethod
+    def _format_value(value):
+        if isinstance(value, str):
+            escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+            return f'"{escaped}"'
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        return str(value)
+
+    @classmethod
+    def _set_setting(cls, content, section, key, formatted_value):
+        lines = content.splitlines(keepends=True)
+        newline = cls._detect_newline(content)
+        section_header = f"[{section}]"
+        setting_line = f"{key}={formatted_value}"
+
+        section_start = None
+        section_end = len(lines)
+        for index, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped == section_header:
+                section_start = index
+                section_end = len(lines)
+                continue
+            if section_start is not None and cls._is_section_header(stripped):
+                section_end = index
+                break
+
+        if section_start is None:
+            return cls._append_section(content, section_header, setting_line, newline)
+
+        for index in range(section_start + 1, section_end):
+            line = lines[index]
+            stripped = line.lstrip()
+            if stripped.startswith(f"{key}="):
+                indent = line[:len(line) - len(stripped)]
+                lines[index] = f"{indent}{setting_line}{cls._line_ending(line, newline)}"
+                return "".join(lines)
+
+        insert_at = cls._setting_insert_index(lines, section_start, section_end)
+        if insert_at > 0 and not cls._ends_with_newline(lines[insert_at - 1]):
+            lines[insert_at - 1] = lines[insert_at - 1] + newline
+        lines.insert(insert_at, setting_line + newline)
+        return "".join(lines)
+
+    @staticmethod
+    def _append_section(content, section_header, setting_line, newline):
+        if not content:
+            return f"{section_header}{newline}{setting_line}{newline}"
+
+        separator = "" if content.endswith(("\n", "\r")) else newline
+        return f"{content}{separator}{newline}{section_header}{newline}{setting_line}{newline}"
+
+    @staticmethod
+    def _is_section_header(stripped_line):
+        return stripped_line.startswith("[") and stripped_line.endswith("]")
+
+    @staticmethod
+    def _detect_newline(content):
+        return "\r\n" if "\r\n" in content else "\n"
+
+    @staticmethod
+    def _line_ending(line, default_newline):
+        if line.endswith("\r\n"):
+            return "\r\n"
+        if line.endswith("\n"):
+            return "\n"
+        return default_newline
+
+    @staticmethod
+    def _ends_with_newline(line):
+        return line.endswith(("\n", "\r"))
+
+    @staticmethod
+    def _setting_insert_index(lines, section_start, section_end):
+        insert_at = section_end
+        while insert_at > section_start + 1 and not lines[insert_at - 1].strip():
+            insert_at -= 1
+        return insert_at

--- a/src/conversion/resource_index.py
+++ b/src/conversion/resource_index.py
@@ -63,6 +63,7 @@ class GameMakerResourceIndex(BaseConverter):
         self.resources = self._empty_resources()
         self.rooms = {}
         self.room_order = []
+        self.used_room_order_fallback = False
 
     def convert_all(self):
         """Build the in-memory index. No Godot files are written."""
@@ -73,6 +74,7 @@ class GameMakerResourceIndex(BaseConverter):
         self.resources = self._empty_resources()
         self.rooms = {}
         self.room_order = []
+        self.used_room_order_fallback = False
         self.yyp_path = self.find_yyp_path()
         self.yyp_data = self._read_yy_file(self.yyp_path) if self.yyp_path else None
 
@@ -91,6 +93,7 @@ class GameMakerResourceIndex(BaseConverter):
                 )
             self._index_disk_resources()
             self._parse_indexed_rooms()
+            self.used_room_order_fallback = True
             self.room_order = sorted(self.rooms)
 
         return self
@@ -215,6 +218,14 @@ class GameMakerResourceIndex(BaseConverter):
         )
 
     def _apply_yyp_room_order(self, yyp_data):
+        if "RoomOrderNodes" not in yyp_data:
+            self.used_room_order_fallback = True
+            self._safe_log(
+                "Warning: RoomOrderNodes missing; using deterministic room order fallback."
+            )
+            self.room_order = sorted(self.rooms)
+            return
+
         ordered = []
         for room_node in yyp_data.get("RoomOrderNodes", []):
             room_id = room_node.get("roomId", {})

--- a/src/conversion/rooms.py
+++ b/src/conversion/rooms.py
@@ -3,6 +3,7 @@ import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from src.conversion.base_converter import BaseConverter
+from src.conversion.project_godot import GodotProjectFile
 from src.conversion.resource_index import GameMakerResourceIndex
 
 
@@ -77,17 +78,55 @@ class RoomConverter(BaseConverter):
 
         width = room.room_settings.get("Width", 1024)
         height = room.room_settings.get("Height", 768)
-        return {"success": True, "name": room.name, "width": width, "height": height}
+        return {
+            "success": True,
+            "name": room.name,
+            "width": width,
+            "height": height,
+            "scene_path": room.godot_path,
+        }
+
+    def _set_startup_scene(self, index, generated_scene_paths):
+        if not generated_scene_paths:
+            self.log_callback(
+                "Warning: No room scene generated; leaving project.godot main_scene unchanged."
+            )
+            return
+
+        first_room = index.first_room()
+        if first_room is None or first_room.name not in generated_scene_paths:
+            self.log_callback(
+                "Warning: First GameMaker room scene was not generated; leaving project.godot main_scene unchanged."
+            )
+            return
+
+        project_file = GodotProjectFile(
+            os.path.join(self.godot_project_path, "project.godot")
+        )
+        scene_path = generated_scene_paths[first_room.name]
+        if project_file.set_main_scene(scene_path):
+            self.log_callback(
+                "Set Godot startup scene to first GameMaker room: {name} ({scene_path})".format(
+                    name=first_room.name,
+                    scene_path=scene_path,
+                )
+            )
+        else:
+            self.log_callback(
+                "Warning: project.godot not found; could not set startup scene."
+            )
 
     def convert_rooms(self):
         index = self._build_resource_index()
         rooms = index.ordered_rooms()
         if not rooms:
+            self._set_startup_scene(index, {})
             self.log_callback("Room conversion completed.")
             return
 
         total = len(rooms)
         processed = 0
+        generated_scene_paths = {}
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             futures_map = {
@@ -102,6 +141,7 @@ class RoomConverter(BaseConverter):
 
                 processed += 1
                 if result["success"]:
+                    generated_scene_paths[result["name"]] = result["scene_path"]
                     if self.compact_logging:
                         self._safe_log_progress(result["name"], processed, total)
                     else:
@@ -115,6 +155,7 @@ class RoomConverter(BaseConverter):
 
                 self._safe_progress(int(processed / total * 100))
 
+        self._set_startup_scene(index, generated_scene_paths)
         self.log_callback("Room conversion completed.")
 
     def convert_all(self):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -25,7 +25,7 @@ class TestConversionCategories(unittest.TestCase):
 
     def test_assets_contents(self):
         self.assertEqual(CONVERSION_CATEGORIES["assets"],
-                         ["sprites", "fonts", "sounds", "sound_group_folders", "included_files", "objects"])
+                         ["sprites", "fonts", "sounds", "sound_group_folders", "included_files", "objects", "rooms"])
 
     def test_project_contents(self):
         self.assertEqual(CONVERSION_CATEGORIES["project"],

--- a/tests/test_project_godot.py
+++ b/tests/test_project_godot.py
@@ -1,0 +1,121 @@
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.project_godot import GodotProjectFile
+
+
+def _write_file(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+class TestGodotProjectFile(unittest.TestCase):
+    def setUp(self):
+        self.godot_dir = tempfile.mkdtemp()
+        self.project_path = os.path.join(self.godot_dir, "project.godot")
+
+    def tearDown(self):
+        shutil.rmtree(self.godot_dir)
+
+    def _read_project(self):
+        with open(self.project_path, "r", encoding="utf-8") as f:
+            return f.read()
+
+    def test_set_main_scene_replaces_existing_and_preserves_settings(self):
+        _write_file(self.project_path, (
+            '[application]\n'
+            'config/name="Existing"\n'
+            'run/main_scene="res://old.tscn"\n'
+            'config/icon="res://icon.png"\n'
+            '\n'
+            '[rendering]\n'
+            'renderer/rendering_method="gl_compatibility"\n'
+        ))
+
+        result = GodotProjectFile(self.project_path).set_main_scene(
+            "res://rooms/r_first/r_first.tscn"
+        )
+
+        content = self._read_project()
+        self.assertTrue(result)
+        self.assertIn('run/main_scene="res://rooms/r_first/r_first.tscn"', content)
+        self.assertNotIn('run/main_scene="res://old.tscn"', content)
+        self.assertIn('config/name="Existing"', content)
+        self.assertIn('config/icon="res://icon.png"', content)
+        self.assertIn('[rendering]', content)
+        self.assertIn('renderer/rendering_method="gl_compatibility"', content)
+
+    def test_set_main_scene_adds_to_existing_application_section(self):
+        _write_file(self.project_path, (
+            '[application]\n'
+            'config/name="Existing"\n'
+            '\n'
+            '[display]\n'
+            'window/size/viewport_width=1280\n'
+        ))
+
+        result = GodotProjectFile(self.project_path).set_main_scene(
+            "res://rooms/r_a/r_a.tscn"
+        )
+
+        content = self._read_project()
+        self.assertTrue(result)
+        self.assertIn('[application]', content)
+        self.assertIn('config/name="Existing"', content)
+        self.assertIn('run/main_scene="res://rooms/r_a/r_a.tscn"', content)
+        self.assertIn('[display]', content)
+        self.assertIn('window/size/viewport_width=1280', content)
+
+    def test_set_main_scene_adds_application_section_when_missing(self):
+        _write_file(self.project_path, (
+            '[rendering]\n'
+            'quality/driver="GLES3"\n'
+        ))
+
+        result = GodotProjectFile(self.project_path).set_main_scene(
+            "res://rooms/r_a/r_a.tscn"
+        )
+
+        content = self._read_project()
+        self.assertTrue(result)
+        self.assertIn('[application]', content)
+        self.assertIn('run/main_scene="res://rooms/r_a/r_a.tscn"', content)
+        self.assertIn('[rendering]', content)
+        self.assertIn('quality/driver="GLES3"', content)
+
+    def test_set_main_scene_does_not_change_other_sections(self):
+        _write_file(self.project_path, (
+            '[other]\n'
+            'run/main_scene="res://other.tscn"\n'
+            '\n'
+            '[application]\n'
+            'config/name="Existing"\n'
+        ))
+
+        result = GodotProjectFile(self.project_path).set_main_scene(
+            "res://rooms/r_a/r_a.tscn"
+        )
+
+        content = self._read_project()
+        self.assertTrue(result)
+        self.assertIn('[other]\nrun/main_scene="res://other.tscn"', content)
+        self.assertIn('run/main_scene="res://rooms/r_a/r_a.tscn"', content)
+
+    def test_set_main_scene_returns_false_when_project_missing(self):
+        result = GodotProjectFile(self.project_path).set_main_scene(
+            "res://rooms/r_a/r_a.tscn"
+        )
+
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_resource_index.py
+++ b/tests/test_resource_index.py
@@ -242,6 +242,28 @@ class TestGameMakerResourceIndex(unittest.TestCase):
         self.assertIsNotNone(index.get_room("r_disk"))
         self.assertTrue(any("falling back" in msg for msg in self.logs))
 
+    def test_missing_room_order_nodes_uses_sorted_fallback_and_logs_warning(self):
+        _write_file(
+            os.path.join(self.gm_dir, "TestProject.yyp"),
+            "{\n"
+            '  "resources":[\n'
+            f'{_resource_entry("rooms", "r_z")},\n'
+            f'{_resource_entry("rooms", "r_a")}\n'
+            "  ],\n"
+            '  "resourceType":"GMProject"\n'
+            "}\n",
+        )
+        self._write_room("r_z")
+        self._write_room("r_a")
+
+        index = self._build_index()
+
+        self.assertEqual([room.name for room in index.ordered_rooms()], ["r_a", "r_z"])
+        self.assertEqual(index.first_room().name, "r_a")
+        self.assertTrue(index.used_room_order_fallback)
+        self.assertTrue(any("RoomOrderNodes missing" in msg for msg in self.logs))
+        self.assertTrue(any("fallback" in msg.lower() for msg in self.logs))
+
     def test_malformed_room_is_skipped_and_logged(self):
         self._write_yyp([("rooms", "r_bad")], room_order=["r_bad"])
         self._write_room("r_bad", content="not valid json {{{")

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -18,15 +18,17 @@ def _write_file(path, content):
         f.write(content)
 
 
-def _make_yyp(room_names):
+def _make_yyp(room_names, room_order=None):
+    room_order = room_order or room_names
     resources = []
-    room_order = []
     for name in room_names:
         resources.append(
             '    {{"id":{{"name":"{name}",'
             '"path":"rooms/{name}/{name}.yy",}},}}'.format(name=name)
         )
-        room_order.append(
+    order_entries = []
+    for name in room_order:
+        order_entries.append(
             '    {{"roomId":{{"name":"{name}",'
             '"path":"rooms/{name}/{name}.yy",}},}}'.format(name=name)
         )
@@ -34,7 +36,7 @@ def _make_yyp(room_names):
     return (
         "{\n"
         f'  "resources":[\n{",\n".join(resources)},\n  ],\n'
-        f'  "RoomOrderNodes":[\n{",\n".join(room_order)},\n  ],\n'
+        f'  "RoomOrderNodes":[\n{",\n".join(order_entries)},\n  ],\n'
         '  "resourceType":"GMProject",\n'
         "}\n"
     )
@@ -105,8 +107,14 @@ class TestRoomConverter(unittest.TestCase):
             max_workers=1,
         )
 
-    def _write_yyp(self, room_names):
-        _write_file(os.path.join(self.gm_dir, "TestProject.yyp"), _make_yyp(room_names))
+    def _write_yyp(self, room_names, room_order=None):
+        _write_file(
+            os.path.join(self.gm_dir, "TestProject.yyp"),
+            _make_yyp(room_names, room_order),
+        )
+
+    def _write_project_godot(self, content='[application]\nconfig/name="Existing"\n'):
+        _write_file(os.path.join(self.godot_dir, "project.godot"), content)
 
     def _write_room(self, name, **kwargs):
         room_path = os.path.join(self.gm_dir, "rooms", name, name + ".yy")
@@ -182,21 +190,110 @@ class TestRoomConverter(unittest.TestCase):
             self.godot_dir, "rooms", "r_unlisted"
         )))
 
+    def test_sets_project_startup_scene_to_first_room_order_node(self):
+        self._write_yyp(["r_second", "r_first"], room_order=["r_first", "r_second"])
+        self._write_room("r_second")
+        self._write_room("r_first")
+        self._write_project_godot(
+            '[application]\n'
+            'config/name="Existing"\n'
+            'run/main_scene="res://old.tscn"\n'
+            '\n'
+            '[display]\n'
+            'window/size/viewport_width=1280\n'
+        )
+
+        self._make_converter().convert_all()
+
+        with open(os.path.join(self.godot_dir, "project.godot"), "r", encoding="utf-8") as f:
+            content = f.read()
+
+        self.assertIn('run/main_scene="res://rooms/r_first/r_first.tscn"', content)
+        self.assertNotIn('run/main_scene="res://old.tscn"', content)
+        self.assertIn('config/name="Existing"', content)
+        self.assertIn('[display]', content)
+        self.assertIn('window/size/viewport_width=1280', content)
+        self.assertTrue(any("startup scene" in log.lower() for log in self.logs))
+        self.assertTrue(any("r_first" in log for log in self.logs))
+
+    def test_sets_project_startup_scene_to_first_room_subfolder_path(self):
+        self._write_yyp(["r_intro"])
+        self._write_room("r_intro", parent_path="folders/Rooms/Game/Intro.yy")
+        self._write_project_godot()
+
+        self._make_converter().convert_all()
+
+        with open(os.path.join(self.godot_dir, "project.godot"), "r", encoding="utf-8") as f:
+            content = f.read()
+
+        self.assertIn(
+            'run/main_scene="res://rooms/Game/Intro/r_intro/r_intro.tscn"',
+            content,
+        )
+        self.assertIn('config/name="Existing"', content)
+
+    def test_missing_room_order_nodes_sets_startup_scene_from_sorted_fallback(self):
+        _write_file(
+            os.path.join(self.gm_dir, "TestProject.yyp"),
+            "{\n"
+            '  "resources":[\n'
+            '    {"id":{"name":"r_z","path":"rooms/r_z/r_z.yy",}},\n'
+            '    {"id":{"name":"r_a","path":"rooms/r_a/r_a.yy",}}\n'
+            "  ],\n"
+            '  "resourceType":"GMProject"\n'
+            "}\n",
+        )
+        self._write_room("r_z")
+        self._write_room("r_a")
+        self._write_project_godot()
+
+        self._make_converter().convert_all()
+
+        with open(os.path.join(self.godot_dir, "project.godot"), "r", encoding="utf-8") as f:
+            content = f.read()
+
+        self.assertIn('run/main_scene="res://rooms/r_a/r_a.tscn"', content)
+        self.assertTrue(any("RoomOrderNodes missing" in log for log in self.logs))
+        self.assertTrue(any("fallback" in log.lower() for log in self.logs))
+
     def test_no_rooms_does_not_crash_or_create_output(self):
         self._make_converter().convert_all()
 
         self.assertFalse(os.path.exists(os.path.join(self.godot_dir, "rooms")))
         self.assertTrue(any("completed" in log.lower() for log in self.logs))
 
+    def test_no_generated_room_scene_leaves_main_scene_unchanged(self):
+        self._write_project_godot(
+            '[application]\n'
+            'config/name="Existing"\n'
+            'run/main_scene="res://keep.tscn"\n'
+        )
+
+        self._make_converter().convert_all()
+
+        with open(os.path.join(self.godot_dir, "project.godot"), "r", encoding="utf-8") as f:
+            content = f.read()
+
+        self.assertIn('run/main_scene="res://keep.tscn"', content)
+        self.assertTrue(any("No room scene generated" in log for log in self.logs))
+        self.assertTrue(any("main_scene unchanged" in log for log in self.logs))
+
     def test_stops_without_writing_scene(self):
         self._write_yyp(["r_test"])
         self._write_room("r_test")
+        self._write_project_godot(
+            '[application]\n'
+            'run/main_scene="res://keep.tscn"\n'
+        )
 
         self._make_converter(conversion_running=lambda: False).convert_all()
 
         self.assertFalse(os.path.exists(os.path.join(
             self.godot_dir, "rooms", "r_test", "r_test.tscn"
         )))
+        with open(os.path.join(self.godot_dir, "project.godot"), "r", encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn('run/main_scene="res://keep.tscn"', content)
         self.assertTrue(any("stopped" in log.lower() for log in self.logs))
 
 


### PR DESCRIPTION
## Summary
- Add a reusable `GodotProjectFile` helper for preserving `project.godot` while updating `application/run/main_scene`.
- Set the Godot startup scene to the first generated GameMaker room after room conversion completes.
- Add deterministic fallback/logging when `RoomOrderNodes` is missing and wire rooms into conversion settings.

## Tests
- `python3 -m unittest tests.test_project_godot tests.test_resource_index tests.test_rooms tests.test_converter`
- `python3 -m unittest discover tests`
- `python3 -m json.tool Languages/eng.json >/dev/null && python3 -m json.tool Languages/de.json >/dev/null && python3 -m json.tool Languages/template/template.json >/dev/null`
- Manual validation against `AsteroidsPLUSPLUS`: generated `rooms/rLoading/rLoading.tscn` and set `run/main_scene="res://rooms/rLoading/rLoading.tscn"`

Closes #156