### PR TITLE
Generate room layer placeholders

### DIFF
--- a/src/conversion/room_layers.py
+++ b/src/conversion/room_layers.py
@@ -1,0 +1,185 @@
+import json
+import re
+
+
+KNOWN_LAYER_TYPES = {
+    "GMRInstanceLayer",
+    "GMRBackgroundLayer",
+    "GMRTileLayer",
+    "GMRAssetLayer",
+    "GMREffectLayer",
+}
+
+
+def godot_string(value):
+    """Format a Python value as a quoted Godot string literal."""
+    return json.dumps(str(value))
+
+
+def godot_value(value):
+    """Format simple JSON-compatible values as Godot text-scene values."""
+    return json.dumps(value)
+
+
+def serialize_room_layers(room, warn_callback=None):
+    """Serialize GameMaker room layers as Godot Node2D placeholders."""
+    lines = []
+    used_names = {}
+    for layer in room.layers:
+        _serialize_layer(layer, room.name, ".", used_names, lines, warn_callback)
+    return lines
+
+
+def _serialize_layer(layer, room_name, parent_path, sibling_names, lines, warn_callback):
+    original_name = _layer_name(layer)
+    node_name = _unique_name(_sanitize_node_name(original_name), sibling_names)
+    resource_type = _layer_resource_type(layer)
+
+    if resource_type not in KNOWN_LAYER_TYPES and warn_callback is not None:
+        warn_callback(
+            "Warning: Unsupported room layer type {resource_type} in room {room_name}, "
+            "layer {layer_name}; emitted Node2D placeholder.".format(
+                resource_type=resource_type,
+                room_name=room_name,
+                layer_name=original_name,
+            )
+        )
+
+    lines.extend(_layer_node_lines(layer, node_name, parent_path, original_name, resource_type))
+
+    child_parent_path = node_name if parent_path == "." else f"{parent_path}/{node_name}"
+    child_names = {}
+    for child_layer in _child_layers(layer):
+        _serialize_layer(
+            child_layer,
+            room_name,
+            child_parent_path,
+            child_names,
+            lines,
+            warn_callback,
+        )
+
+
+def _layer_node_lines(layer, node_name, parent_path, original_name, resource_type):
+    visible = bool(layer.get("visible", True))
+    depth = _coerce_int(layer.get("depth", 0))
+    z_index = -depth
+
+    lines = [
+        f'[node name={godot_string(node_name)} type="Node2D" parent={godot_string(parent_path)}]',
+        f"visible = {godot_value(visible)}",
+        f"z_index = {z_index}",
+        f"metadata/gamemaker_layer_name = {godot_value(original_name)}",
+        f"metadata/gamemaker_layer_node_name = {godot_value(node_name)}",
+        f"metadata/gamemaker_layer_type = {godot_value(resource_type)}",
+        f"metadata/gamemaker_layer_depth = {godot_value(depth)}",
+        f"metadata/gamemaker_layer_visible = {godot_value(visible)}",
+        f"metadata/gamemaker_layer_grid_x = {godot_value(layer.get('gridX'))}",
+        f"metadata/gamemaker_layer_grid_y = {godot_value(layer.get('gridY'))}",
+        f"metadata/gamemaker_layer_properties = {godot_value(layer.get('properties', []))}",
+        "metadata/gamemaker_placeholder = true",
+    ]
+
+    _append_optional_metadata(lines, layer, "name", "gamemaker_layer_internal_name")
+    _append_optional_metadata(lines, layer, "userdefinedDepth", "gamemaker_layer_userdefined_depth")
+    _append_optional_metadata(lines, layer, "inheritVisibility", "gamemaker_layer_inherit_visibility")
+    _append_optional_metadata(lines, layer, "inheritLayerDepth", "gamemaker_layer_inherit_layer_depth")
+    _append_optional_metadata(lines, layer, "inheritLayerSettings", "gamemaker_layer_inherit_layer_settings")
+    _append_optional_metadata(lines, layer, "inheritSubLayers", "gamemaker_layer_inherit_sub_layers")
+
+    if resource_type == "GMREffectLayer":
+        lines.append(
+            f"metadata/gamemaker_layer_effect_type = {godot_value(layer.get('effectType'))}"
+        )
+        lines.append(
+            f"metadata/gamemaker_layer_effect_properties = {godot_value(layer.get('properties', []))}"
+        )
+
+    if resource_type == "GMRInstanceLayer":
+        instances = layer.get("instances") or []
+        lines.append(f"metadata/gamemaker_instance_count = {len(instances)}")
+        lines.append(
+            f"metadata/gamemaker_instance_names = {godot_value(_item_names(instances))}"
+        )
+    elif resource_type == "GMRAssetLayer":
+        assets = layer.get("assets") or []
+        lines.append(f"metadata/gamemaker_asset_count = {len(assets)}")
+        lines.append(f"metadata/gamemaker_asset_names = {godot_value(_item_names(assets))}")
+    elif resource_type == "GMRBackgroundLayer":
+        sprite_id = layer.get("spriteId") or {}
+        lines.append(
+            f"metadata/gamemaker_background_sprite = {godot_value(sprite_id.get('name'))}"
+        )
+        for key in ("colour", "htiled", "vtiled", "hspeed", "vspeed", "stretch"):
+            _append_optional_metadata(lines, layer, key, f"gamemaker_background_{key}")
+    elif resource_type == "GMRTileLayer":
+        tileset_id = layer.get("tilesetId") or {}
+        tiles = layer.get("tiles") or {}
+        lines.append(f"metadata/gamemaker_tileset = {godot_value(tileset_id.get('name'))}")
+        _append_optional_metadata(lines, tiles, "SerialiseWidth", "gamemaker_tile_serialise_width")
+        _append_optional_metadata(lines, tiles, "SerialiseHeight", "gamemaker_tile_serialise_height")
+        _append_optional_metadata(lines, tiles, "TileDataFormat", "gamemaker_tile_data_format")
+        lines.append(
+            "metadata/gamemaker_tile_compressed_data_count = {count}".format(
+                count=len(tiles.get("TileCompressedData") or [])
+            )
+        )
+
+    if resource_type not in KNOWN_LAYER_TYPES:
+        lines.append("metadata/gamemaker_unsupported_layer = true")
+
+    lines.append("")
+    return lines
+
+
+def _append_optional_metadata(lines, source, source_key, metadata_key):
+    if source_key in source:
+        lines.append(f"metadata/{metadata_key} = {godot_value(source.get(source_key))}")
+
+
+def _layer_name(layer):
+    return layer.get("%Name") or layer.get("name") or "Layer"
+
+
+def _layer_resource_type(layer):
+    resource_type = layer.get("resourceType")
+    if resource_type:
+        return resource_type
+    for key in layer:
+        if key.startswith("$GMR"):
+            return key[1:]
+    return "UnknownLayer"
+
+
+def _child_layers(layer):
+    children = layer.get("layers") or layer.get("children") or []
+    return children if isinstance(children, list) else []
+
+
+def _item_names(items):
+    names = []
+    for item in items:
+        if isinstance(item, dict):
+            names.append(item.get("%Name") or item.get("name") or "")
+    return [name for name in names if name]
+
+
+def _coerce_int(value):
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _sanitize_node_name(name):
+    sanitized = str(name).replace("/", "_").replace('"', "_").replace("\\", "_")
+    sanitized = re.sub(r"\s+", " ", sanitized).strip()
+    return sanitized or "Layer"
+
+
+def _unique_name(base_name, used_names):
+    count = used_names.get(base_name, 0) + 1
+    used_names[base_name] = count
+    if count == 1:
+        return base_name
+    return f"{base_name}_{count}"

--- a/src/conversion/rooms.py
+++ b/src/conversion/rooms.py
@@ -4,6 +4,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from src.conversion.base_converter import BaseConverter
 from src.conversion.project_godot import GodotProjectFile
+from src.conversion.room_layers import godot_string, serialize_room_layers
 from src.conversion.resource_index import GameMakerResourceIndex
 
 
@@ -42,7 +43,7 @@ class RoomConverter(BaseConverter):
         lines = [
             "[gd_scene format=3]",
             "",
-            f'[node name="{room.name}" type="Node2D"]',
+            f'[node name={godot_string(room.name)} type="Node2D"]',
             f'metadata/gamemaker_room_width = {json.dumps(room_settings.get("Width", 1024))}',
             f'metadata/gamemaker_room_height = {json.dumps(room_settings.get("Height", 768))}',
             f'metadata/gamemaker_room_persistent = {json.dumps(bool(room_settings.get("persistent", False)))}',
@@ -54,6 +55,7 @@ class RoomConverter(BaseConverter):
             f'metadata/gamemaker_source_yy_path = {json.dumps(room.yy_path)}',
             "",
         ]
+        lines.extend(serialize_room_layers(room, warn_callback=self._safe_log))
         return "\n".join(lines)
 
     def _room_output_path(self, room):

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -43,9 +43,10 @@ def _make_yyp(room_names, room_order=None):
 
 
 def _make_room_yy(name, parent_path="folders/Rooms.yy", width=1024, height=768,
-                  persistent=False, volume=1.0, physics_world=False):
+                  persistent=False, volume=1.0, physics_world=False, layers=None):
     persistent_value = "true" if persistent else "false"
     physics_world_value = "true" if physics_world else "false"
+    layers_json = json.dumps(layers if layers is not None else [])
     return (
         '{{\n'
         '  "$GMRoom":"v1",\n'
@@ -56,7 +57,7 @@ def _make_room_yy(name, parent_path="folders/Rooms.yy", width=1024, height=768,
         '  "inheritCreationOrder":false,\n'
         '  "inheritLayers":false,\n'
         '  "instanceCreationOrder":[],\n'
-        '  "layers":[],\n'
+        '  "layers":{layers_json},\n'
         '  "parent":{{"name":"Rooms","path":"{parent_path}",}},\n'
         '  "parentRoom":null,\n'
         '  "physicsSettings":{{\n'
@@ -83,6 +84,7 @@ def _make_room_yy(name, parent_path="folders/Rooms.yy", width=1024, height=768,
         persistent=persistent_value,
         volume=volume,
         physics_world=physics_world_value,
+        layers_json=layers_json,
     )
 
 
@@ -120,6 +122,17 @@ class TestRoomConverter(unittest.TestCase):
         room_path = os.path.join(self.gm_dir, "rooms", name, name + ".yy")
         _write_file(room_path, _make_room_yy(name, **kwargs))
         return room_path
+
+    def _read_scene(self, room_name, *subfolders):
+        tscn_path = os.path.join(
+            self.godot_dir,
+            "rooms",
+            *subfolders,
+            room_name,
+            room_name + ".tscn",
+        )
+        with open(tscn_path, "r", encoding="utf-8") as f:
+            return f.read()
 
     def test_generates_minimal_room_scene_with_metadata(self):
         self._write_yyp(["r_test"])
@@ -189,6 +202,162 @@ class TestRoomConverter(unittest.TestCase):
         self.assertFalse(os.path.exists(os.path.join(
             self.godot_dir, "rooms", "r_unlisted"
         )))
+
+    def test_generates_room_layer_placeholders_with_depth_and_visibility(self):
+        self._write_yyp(["r_layers"])
+        self._write_room("r_layers", layers=[
+            {
+                "%Name": "Instances",
+                "name": "internal_instances",
+                "resourceType": "GMRInstanceLayer",
+                "visible": True,
+                "depth": 100,
+                "gridX": 32,
+                "gridY": 16,
+                "properties": {"alpha": 1},
+                "instances": [{"name": "inst_a"}],
+            },
+            {
+                "name": "Backgrounds",
+                "resourceType": "GMRBackgroundLayer",
+                "visible": False,
+                "depth": -200,
+                "gridX": 64,
+                "gridY": 64,
+                "properties": {},
+            },
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_layers")
+
+        self.assertIn('[node name="Instances" type="Node2D" parent="."]', content)
+        self.assertIn('visible = true', content)
+        self.assertIn('z_index = -100', content)
+        self.assertIn('metadata/gamemaker_layer_type = "GMRInstanceLayer"', content)
+        self.assertIn('metadata/gamemaker_layer_depth = 100', content)
+        self.assertIn('metadata/gamemaker_layer_grid_x = 32', content)
+        self.assertIn('metadata/gamemaker_layer_grid_y = 16', content)
+        self.assertIn('metadata/gamemaker_layer_properties = {"alpha": 1}', content)
+        self.assertIn('metadata/gamemaker_instance_count = 1', content)
+        self.assertIn('metadata/gamemaker_instance_names = ["inst_a"]', content)
+
+        self.assertIn('[node name="Backgrounds" type="Node2D" parent="."]', content)
+        self.assertIn('visible = false', content)
+        self.assertIn('z_index = 200', content)
+        self.assertIn('metadata/gamemaker_background_sprite = null', content)
+        self.assertNotIn('instance=ExtResource', content)
+        self.assertNotIn('Sprite2D', content)
+        self.assertNotIn('TileMap', content)
+        self.assertNotIn('ParallaxBackground', content)
+
+    def test_layer_depth_maps_to_inverse_z_index(self):
+        self._write_yyp(["r_depths"])
+        self._write_room("r_depths", layers=[
+            {"%Name": "Depth200", "resourceType": "GMRInstanceLayer", "depth": 200},
+            {"%Name": "Depth100", "resourceType": "GMRInstanceLayer", "depth": 100},
+            {"%Name": "Depth0", "resourceType": "GMRInstanceLayer", "depth": 0},
+            {"%Name": "DepthMinus100", "resourceType": "GMRInstanceLayer", "depth": -100},
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_depths")
+
+        self.assertIn('[node name="Depth200" type="Node2D" parent="."]\nvisible = true\nz_index = -200', content)
+        self.assertIn('[node name="Depth100" type="Node2D" parent="."]\nvisible = true\nz_index = -100', content)
+        self.assertIn('[node name="Depth0" type="Node2D" parent="."]\nvisible = true\nz_index = 0', content)
+        self.assertIn('[node name="DepthMinus100" type="Node2D" parent="."]\nvisible = true\nz_index = 100', content)
+
+    def test_generates_nested_layer_placeholders_depth_first(self):
+        self._write_yyp(["r_nested"])
+        self._write_room("r_nested", layers=[
+            {
+                "%Name": "Parent",
+                "resourceType": "GMRInstanceLayer",
+                "depth": 10,
+                "layers": [
+                    {"%Name": "ChildA", "resourceType": "GMRTileLayer", "depth": 20},
+                    {"%Name": "ChildB", "resourceType": "GMRAssetLayer", "depth": 30},
+                ],
+            },
+            {"%Name": "Sibling", "resourceType": "GMRBackgroundLayer", "depth": 40},
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_nested")
+
+        parent_idx = content.index('[node name="Parent" type="Node2D" parent="."]')
+        child_a_idx = content.index('[node name="ChildA" type="Node2D" parent="Parent"]')
+        child_b_idx = content.index('[node name="ChildB" type="Node2D" parent="Parent"]')
+        sibling_idx = content.index('[node name="Sibling" type="Node2D" parent="."]')
+
+        self.assertLess(parent_idx, child_a_idx)
+        self.assertLess(child_a_idx, child_b_idx)
+        self.assertLess(child_b_idx, sibling_idx)
+        self.assertIn('metadata/gamemaker_tile_compressed_data_count = 0', content)
+        self.assertIn('metadata/gamemaker_asset_count = 0', content)
+
+    def test_effect_layer_preserves_effect_metadata(self):
+        self._write_yyp(["r_effect"])
+        self._write_room("r_effect", layers=[
+            {
+                "%Name": "FX",
+                "resourceType": "GMREffectLayer",
+                "visible": True,
+                "depth": 5,
+                "effectType": "_filter_whitenoise",
+                "properties": [
+                    {"name": "g_WhiteNoiseIntensity", "type": 0, "value": "0.15"},
+                ],
+            }
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_effect")
+
+        self.assertIn('[node name="FX" type="Node2D" parent="."]', content)
+        self.assertIn('z_index = -5', content)
+        self.assertIn('metadata/gamemaker_layer_type = "GMREffectLayer"', content)
+        self.assertIn('metadata/gamemaker_layer_effect_type = "_filter_whitenoise"', content)
+        self.assertIn('metadata/gamemaker_layer_effect_properties = [{"name": "g_WhiteNoiseIntensity"', content)
+
+    def test_unsupported_layer_type_warns_and_emits_placeholder(self):
+        self._write_yyp(["r_unknown"])
+        self._write_room("r_unknown", layers=[
+            {"%Name": "Mystery", "resourceType": "GMRMysteryLayer", "depth": 0}
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_unknown")
+
+        self.assertIn('[node name="Mystery" type="Node2D" parent="."]', content)
+        self.assertIn('metadata/gamemaker_layer_type = "GMRMysteryLayer"', content)
+        self.assertIn('metadata/gamemaker_unsupported_layer = true', content)
+        self.assertTrue(any(
+            "Unsupported room layer type GMRMysteryLayer" in log
+            and "r_unknown" in log
+            and "Mystery" in log
+            for log in self.logs
+        ))
+
+    def test_layer_names_prefer_display_name_and_are_uniqued(self):
+        self._write_yyp(["r_names"])
+        self._write_room("r_names", layers=[
+            {"%Name": "Display Name", "name": "internal_name", "resourceType": "GMRInstanceLayer"},
+            {"%Name": "Display Name", "resourceType": "GMRInstanceLayer"},
+            {"name": "FallbackName", "resourceType": "GMRInstanceLayer"},
+            {"%Name": "Slash/Name", "resourceType": "GMRInstanceLayer"},
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_names")
+
+        self.assertIn('[node name="Display Name" type="Node2D" parent="."]', content)
+        self.assertIn('[node name="Display Name_2" type="Node2D" parent="."]', content)
+        self.assertIn('[node name="FallbackName" type="Node2D" parent="."]', content)
+        self.assertIn('[node name="Slash_Name" type="Node2D" parent="."]', content)
+        self.assertNotIn('[node name="internal_name"', content)
+        self.assertIn('metadata/gamemaker_layer_name = "Slash/Name"', content)
 
     def test_sets_project_startup_scene_to_first_room_order_node(self):
         self._write_yyp(["r_second", "r_first"], room_order=["r_first", "r_second"])


### PR DESCRIPTION
## Summary
- Add a modular `room_layers` serializer that emits one `Node2D` placeholder per GameMaker room layer.
- Preserve layer names, visibility, inverse depth ordering (`z_index = -depth`), nesting, common metadata, and effect metadata.
- Warn and preserve placeholders for unknown layer types without converting instances/backgrounds/tiles/assets yet.

## Tests
- `python3 -m unittest tests.test_rooms`
- `python3 -m unittest discover tests`
- Manual validation against `AsteroidsPLUSPLUS`: `rComputer` generated 9 layer placeholder nodes with effect metadata and startup scene remained `res://rooms/rLoading/rLoading.tscn`

Closes #157