### PR TITLE
Convert room instance layers

### DIFF
--- a/src/conversion/room_layers.py
+++ b/src/conversion/room_layers.py
@@ -1,5 +1,7 @@
 import json
+import os
 import re
+from dataclasses import dataclass, field
 
 
 KNOWN_LAYER_TYPES = {
@@ -21,26 +23,83 @@ def godot_value(value):
     return json.dumps(value)
 
 
-def serialize_room_layers(room, warn_callback=None):
-    """Serialize GameMaker room layers as Godot Node2D placeholders."""
-    lines = []
+@dataclass
+class SerializedRoomLayers:
+    ext_resource_lines: list = field(default_factory=list)
+    node_lines: list = field(default_factory=list)
+
+
+class RoomLayerSerializationContext:
+    def __init__(self, room, resource_index=None, warn_callback=None):
+        self.room = room
+        self.resource_index = resource_index
+        self.warn_callback = warn_callback
+        self.ext_resource_ids = {}
+        self.creation_order = _instance_creation_order(room)
+
+    def object_scene_ext_resource_id(self, object_name):
+        scene_path = self.object_scene_path(object_name)
+        if scene_path is None:
+            return None
+        if scene_path not in self.ext_resource_ids:
+            self.ext_resource_ids[scene_path] = str(len(self.ext_resource_ids) + 1)
+        return self.ext_resource_ids[scene_path]
+
+    def object_scene_path(self, object_name):
+        if not object_name or self.resource_index is None:
+            return None
+        scene_path = self.resource_index.resolve_godot_path("objects", object_name)
+        if scene_path is None:
+            return None
+        if not self._scene_path_exists(scene_path):
+            return None
+        return scene_path
+
+    def warn(self, message):
+        if self.warn_callback is not None:
+            self.warn_callback(message)
+
+    def ext_resource_lines(self):
+        return [
+            '[ext_resource type="PackedScene" path={path} id="{resource_id}"]'.format(
+                path=godot_string(path),
+                resource_id=resource_id,
+            )
+            for path, resource_id in self.ext_resource_ids.items()
+        ]
+
+    def _scene_path_exists(self, scene_path):
+        if not scene_path.startswith("res://"):
+            return False
+        relative_path = scene_path[len("res://"):]
+        filesystem_path = os.path.join(
+            self.resource_index.godot_project_path,
+            *relative_path.split("/"),
+        )
+        return os.path.isfile(filesystem_path)
+
+
+def serialize_room_layers(room, resource_index=None, warn_callback=None):
+    """Serialize GameMaker room layers and supported layer children."""
+    context = RoomLayerSerializationContext(room, resource_index, warn_callback)
+    node_lines = []
     used_names = {}
     for layer in room.layers:
-        _serialize_layer(layer, room.name, ".", used_names, lines, warn_callback)
-    return lines
+        _serialize_layer(layer, ".", used_names, node_lines, context)
+    return SerializedRoomLayers(context.ext_resource_lines(), node_lines)
 
 
-def _serialize_layer(layer, room_name, parent_path, sibling_names, lines, warn_callback):
+def _serialize_layer(layer, parent_path, sibling_names, lines, context):
     original_name = _layer_name(layer)
     node_name = _unique_name(_sanitize_node_name(original_name), sibling_names)
     resource_type = _layer_resource_type(layer)
 
-    if resource_type not in KNOWN_LAYER_TYPES and warn_callback is not None:
-        warn_callback(
+    if resource_type not in KNOWN_LAYER_TYPES:
+        context.warn(
             "Warning: Unsupported room layer type {resource_type} in room {room_name}, "
             "layer {layer_name}; emitted Node2D placeholder.".format(
                 resource_type=resource_type,
-                room_name=room_name,
+                room_name=context.room.name,
                 layer_name=original_name,
             )
         )
@@ -48,15 +107,18 @@ def _serialize_layer(layer, room_name, parent_path, sibling_names, lines, warn_c
     lines.extend(_layer_node_lines(layer, node_name, parent_path, original_name, resource_type))
 
     child_parent_path = node_name if parent_path == "." else f"{parent_path}/{node_name}"
+
+    if resource_type == "GMRInstanceLayer":
+        lines.extend(_instance_node_lines(layer, child_parent_path, original_name, context))
+
     child_names = {}
     for child_layer in _child_layers(layer):
         _serialize_layer(
             child_layer,
-            room_name,
             child_parent_path,
             child_names,
             lines,
-            warn_callback,
+            context,
         )
 
 
@@ -137,6 +199,126 @@ def _append_optional_metadata(lines, source, source_key, metadata_key):
         lines.append(f"metadata/{metadata_key} = {godot_value(source.get(source_key))}")
 
 
+def _instance_node_lines(layer, parent_path, layer_name, context):
+    lines = []
+    instances = layer.get("instances") or []
+    ordered_instances = _ordered_instances(instances, context.creation_order)
+    sibling_names = {}
+    for instance, order_index, _original_index in ordered_instances:
+        instance_name = _instance_name(instance)
+        object_id = instance.get("objectId") or {}
+        object_name = object_id.get("name")
+
+        if instance.get("ignore") is True:
+            context.warn(
+                "Warning: Skipping ignored GameMaker room instance {instance_name} "
+                "in room {room_name}, layer {layer_name}.".format(
+                    instance_name=instance_name,
+                    room_name=context.room.name,
+                    layer_name=layer_name,
+                )
+            )
+            continue
+
+        node_name = _unique_name(_sanitize_node_name(instance_name), sibling_names)
+        ext_resource_id = context.object_scene_ext_resource_id(object_name)
+        if ext_resource_id is None:
+            context.warn(
+                "Warning: Could not resolve object scene for GameMaker room instance "
+                "{instance_name} in room {room_name}, layer {layer_name}, object {object_name}; "
+                "emitted Node2D placeholder.".format(
+                    instance_name=instance_name,
+                    room_name=context.room.name,
+                    layer_name=layer_name,
+                    object_name=object_name or "<missing>",
+                )
+            )
+
+        lines.extend(
+            _instance_scene_lines(
+                instance,
+                node_name,
+                parent_path,
+                instance_name,
+                object_name,
+                ext_resource_id,
+                order_index,
+            )
+        )
+    return lines
+
+
+def _instance_scene_lines(instance, node_name, parent_path, instance_name, object_name,
+                          ext_resource_id, order_index):
+    if ext_resource_id is None:
+        lines = [f'[node name={godot_string(node_name)} type="Node2D" parent={godot_string(parent_path)}]']
+    else:
+        lines = [
+            '[node name={name} parent={parent} instance=ExtResource("{resource_id}")]'.format(
+                name=godot_string(node_name),
+                parent=godot_string(parent_path),
+                resource_id=ext_resource_id,
+            )
+        ]
+
+    lines.extend([
+        "position = Vector2({x}, {y})".format(
+            x=_format_number(instance.get("x", 0)),
+            y=_format_number(instance.get("y", 0)),
+        ),
+        "rotation_degrees = {rotation}".format(
+            rotation=_format_number(instance.get("rotation", 0))
+        ),
+        "scale = Vector2({scale_x}, {scale_y})".format(
+            scale_x=_format_number(instance.get("scaleX", 1)),
+            scale_y=_format_number(instance.get("scaleY", 1)),
+        ),
+        f"metadata/gamemaker_instance_name = {godot_value(instance_name)}",
+        f"metadata/gamemaker_instance_node_name = {godot_value(node_name)}",
+        f"metadata/gamemaker_instance_object_name = {godot_value(object_name)}",
+        f"metadata/gamemaker_instance_creation_order_index = {godot_value(order_index)}",
+        f"metadata/gamemaker_instance_ignored = {godot_value(bool(instance.get('ignore', False)))}",
+        f"metadata/gamemaker_colour = {godot_value(instance.get('colour'))}",
+        f"metadata/gamemaker_image_index = {godot_value(instance.get('imageIndex'))}",
+        f"metadata/gamemaker_image_speed = {godot_value(instance.get('imageSpeed'))}",
+        f"metadata/gamemaker_object_id = {godot_value(instance.get('objectId'))}",
+        f"metadata/gamemaker_properties = {godot_value(instance.get('properties', []))}",
+        f"metadata/gamemaker_has_creation_code = {godot_value(bool(instance.get('hasCreationCode', False)))}",
+    ])
+
+    if ext_resource_id is None:
+        lines.append("metadata/gamemaker_placeholder = true")
+        lines.append("metadata/gamemaker_unresolved_object_scene = true")
+
+    lines.append("")
+    return lines
+
+
+def _ordered_instances(instances, creation_order):
+    indexed = []
+    for original_index, instance in enumerate(instances):
+        order_index = creation_order.get(_instance_name(instance))
+        sort_order = order_index if order_index is not None else len(creation_order) + original_index
+        indexed.append((sort_order, original_index, instance, order_index))
+    indexed.sort(key=lambda item: (item[0], item[1]))
+    return [(instance, order_index, original_index) for _sort, original_index, instance, order_index in indexed]
+
+
+def _instance_creation_order(room):
+    order = {}
+    for index, entry in enumerate(room.instance_creation_order):
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("%Name") or entry.get("name")
+        if name and name not in order:
+            order[name] = index
+    return order
+
+
+def _instance_name(instance):
+    return instance.get("%Name") or instance.get("name") or "Instance"
+
+
 def _layer_name(layer):
     return layer.get("%Name") or layer.get("name") or "Layer"
 
@@ -169,6 +351,16 @@ def _coerce_int(value):
         return int(float(value))
     except (TypeError, ValueError):
         return 0
+
+
+def _format_number(value):
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        number = 0.0
+    if number.is_integer():
+        return str(int(number))
+    return str(number)
 
 
 def _sanitize_node_name(name):

--- a/src/conversion/rooms.py
+++ b/src/conversion/rooms.py
@@ -36,13 +36,29 @@ class RoomConverter(BaseConverter):
             max_workers=self.max_workers,
         ).build()
 
-    def _generate_room_scene(self, room):
+    def _generate_room_scene(self, room, resource_index=None):
         room_settings = room.room_settings
         physics_settings = room.physics_settings
+        serialized_layers = serialize_room_layers(
+            room,
+            resource_index=resource_index,
+            warn_callback=self._safe_log,
+        )
 
-        lines = [
-            "[gd_scene format=3]",
-            "",
+        if serialized_layers.ext_resource_lines:
+            lines = [
+                f"[gd_scene format=3 load_steps={len(serialized_layers.ext_resource_lines) + 1}]",
+                "",
+            ]
+            lines.extend(serialized_layers.ext_resource_lines)
+            lines.append("")
+        else:
+            lines = [
+                "[gd_scene format=3]",
+                "",
+            ]
+
+        lines.extend([
             f'[node name={godot_string(room.name)} type="Node2D"]',
             f'metadata/gamemaker_room_width = {json.dumps(room_settings.get("Width", 1024))}',
             f'metadata/gamemaker_room_height = {json.dumps(room_settings.get("Height", 768))}',
@@ -54,8 +70,8 @@ class RoomConverter(BaseConverter):
             f'metadata/gamemaker_physics_pixels_to_meters = {json.dumps(physics_settings.get("PhysicsWorldPixToMetres", 0.1))}',
             f'metadata/gamemaker_source_yy_path = {json.dumps(room.yy_path)}',
             "",
-        ]
-        lines.extend(serialize_room_layers(room, warn_callback=self._safe_log))
+        ])
+        lines.extend(serialized_layers.node_lines)
         return "\n".join(lines)
 
     def _room_output_path(self, room):
@@ -69,14 +85,14 @@ class RoomConverter(BaseConverter):
             )
         return os.path.join(self.godot_rooms_path, room.name, room.name + ".tscn")
 
-    def _process_room(self, room):
+    def _process_room(self, room, resource_index=None):
         if not self.conversion_running():
             return None
 
         output_path = self._room_output_path(room)
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
         with open(output_path, "w", encoding="utf-8") as f:
-            f.write(self._generate_room_scene(room))
+            f.write(self._generate_room_scene(room, resource_index))
 
         width = room.room_settings.get("Width", 1024)
         height = room.room_settings.get("Height", 768)
@@ -132,7 +148,7 @@ class RoomConverter(BaseConverter):
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             futures_map = {
-                executor.submit(self._process_room, room): room.name
+                executor.submit(self._process_room, room, index): room.name
                 for room in rooms
             }
             for future in as_completed(futures_map):

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -18,13 +18,19 @@ def _write_file(path, content):
         f.write(content)
 
 
-def _make_yyp(room_names, room_order=None):
+def _make_yyp(room_names, room_order=None, extra_resources=None):
     room_order = room_order or room_names
+    extra_resources = extra_resources or []
     resources = []
     for name in room_names:
         resources.append(
             '    {{"id":{{"name":"{name}",'
             '"path":"rooms/{name}/{name}.yy",}},}}'.format(name=name)
+        )
+    for kind, name in extra_resources:
+        resources.append(
+            '    {{"id":{{"name":"{name}",'
+            '"path":"{kind}/{name}/{name}.yy",}},}}'.format(kind=kind, name=name)
         )
     order_entries = []
     for name in room_order:
@@ -43,10 +49,12 @@ def _make_yyp(room_names, room_order=None):
 
 
 def _make_room_yy(name, parent_path="folders/Rooms.yy", width=1024, height=768,
-                  persistent=False, volume=1.0, physics_world=False, layers=None):
+                  persistent=False, volume=1.0, physics_world=False, layers=None,
+                  instance_creation_order=None):
     persistent_value = "true" if persistent else "false"
     physics_world_value = "true" if physics_world else "false"
     layers_json = json.dumps(layers if layers is not None else [])
+    instance_creation_order_json = json.dumps(instance_creation_order or [])
     return (
         '{{\n'
         '  "$GMRoom":"v1",\n'
@@ -56,7 +64,7 @@ def _make_room_yy(name, parent_path="folders/Rooms.yy", width=1024, height=768,
         '  "inheritCode":false,\n'
         '  "inheritCreationOrder":false,\n'
         '  "inheritLayers":false,\n'
-        '  "instanceCreationOrder":[],\n'
+        '  "instanceCreationOrder":{instance_creation_order_json},\n'
         '  "layers":{layers_json},\n'
         '  "parent":{{"name":"Rooms","path":"{parent_path}",}},\n'
         '  "parentRoom":null,\n'
@@ -85,7 +93,21 @@ def _make_room_yy(name, parent_path="folders/Rooms.yy", width=1024, height=768,
         volume=volume,
         physics_world=physics_world_value,
         layers_json=layers_json,
+        instance_creation_order_json=instance_creation_order_json,
     )
+
+
+def _make_object_yy(name, parent_path="folders/Objects.yy"):
+    return (
+        '{{\n'
+        '  "$GMObject":"",\n'
+        '  "%Name":"{name}",\n'
+        '  "name":"{name}",\n'
+        '  "eventList":[],\n'
+        '  "parent":{{"name":"Objects","path":"{parent_path}",}},\n'
+        '  "resourceType":"GMObject",\n'
+        '}}\n'
+    ).format(name=name, parent_path=parent_path)
 
 
 class TestRoomConverter(unittest.TestCase):
@@ -109,10 +131,10 @@ class TestRoomConverter(unittest.TestCase):
             max_workers=1,
         )
 
-    def _write_yyp(self, room_names, room_order=None):
+    def _write_yyp(self, room_names, room_order=None, extra_resources=None):
         _write_file(
             os.path.join(self.gm_dir, "TestProject.yyp"),
-            _make_yyp(room_names, room_order),
+            _make_yyp(room_names, room_order, extra_resources),
         )
 
     def _write_project_godot(self, content='[application]\nconfig/name="Existing"\n'):
@@ -122,6 +144,22 @@ class TestRoomConverter(unittest.TestCase):
         room_path = os.path.join(self.gm_dir, "rooms", name, name + ".yy")
         _write_file(room_path, _make_room_yy(name, **kwargs))
         return room_path
+
+    def _write_object(self, name, parent_path="folders/Objects.yy"):
+        object_path = os.path.join(self.gm_dir, "objects", name, name + ".yy")
+        _write_file(object_path, _make_object_yy(name, parent_path))
+        return object_path
+
+    def _write_object_scene(self, name, *subfolders):
+        scene_path = os.path.join(
+            self.godot_dir,
+            "objects",
+            *subfolders,
+            name,
+            name + ".tscn",
+        )
+        _write_file(scene_path, '[gd_scene format=3]\n\n[node name="{}" type="Node2D"]\n'.format(name))
+        return scene_path
 
     def _read_scene(self, room_name, *subfolders):
         tscn_path = os.path.join(
@@ -358,6 +396,180 @@ class TestRoomConverter(unittest.TestCase):
         self.assertIn('[node name="Slash_Name" type="Node2D" parent="."]', content)
         self.assertNotIn('[node name="internal_name"', content)
         self.assertIn('metadata/gamemaker_layer_name = "Slash/Name"', content)
+
+    def test_instance_layer_emits_object_scene_children(self):
+        self._write_yyp(["r_instances"], extra_resources=[("objects", "o_player")])
+        self._write_object("o_player")
+        self._write_object_scene("o_player")
+        self._write_room("r_instances", layers=[
+            {
+                "%Name": "Instances",
+                "resourceType": "GMRInstanceLayer",
+                "instances": [
+                    {
+                        "name": "inst_player",
+                        "objectId": {"name": "o_player", "path": "objects/o_player/o_player.yy"},
+                        "x": 100,
+                        "y": 200,
+                        "rotation": 90,
+                        "scaleX": 2,
+                        "scaleY": 0.5,
+                        "colour": 4294967295,
+                        "imageIndex": 3,
+                        "imageSpeed": 0.25,
+                        "hasCreationCode": True,
+                        "properties": [{"name": "hp", "value": 10}],
+                    }
+                ],
+            }
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_instances")
+
+        self.assertIn('[gd_scene format=3 load_steps=2]', content)
+        self.assertIn(
+            '[ext_resource type="PackedScene" path="res://objects/o_player/o_player.tscn" id="1"]',
+            content,
+        )
+        self.assertIn(
+            '[node name="inst_player" parent="Instances" instance=ExtResource("1")]',
+            content,
+        )
+        self.assertIn('position = Vector2(100, 200)', content)
+        self.assertIn('rotation_degrees = 90', content)
+        self.assertIn('scale = Vector2(2, 0.5)', content)
+        self.assertIn('metadata/gamemaker_instance_name = "inst_player"', content)
+        self.assertIn('metadata/gamemaker_instance_object_name = "o_player"', content)
+        self.assertIn('metadata/gamemaker_colour = 4294967295', content)
+        self.assertIn('metadata/gamemaker_image_index = 3', content)
+        self.assertIn('metadata/gamemaker_image_speed = 0.25', content)
+        self.assertIn('metadata/gamemaker_object_id = {"name": "o_player"', content)
+        self.assertIn('metadata/gamemaker_properties = [{"name": "hp", "value": 10}]', content)
+        self.assertIn('metadata/gamemaker_has_creation_code = true', content)
+
+    def test_instance_layer_reuses_object_scene_ext_resource(self):
+        self._write_yyp(["r_reuse"], extra_resources=[("objects", "o_enemy")])
+        self._write_object("o_enemy")
+        self._write_object_scene("o_enemy")
+        self._write_room("r_reuse", layers=[
+            {
+                "%Name": "Instances",
+                "resourceType": "GMRInstanceLayer",
+                "instances": [
+                    {"name": "inst_enemy_a", "objectId": {"name": "o_enemy"}},
+                    {"name": "inst_enemy_b", "objectId": {"name": "o_enemy"}},
+                ],
+            }
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_reuse")
+
+        self.assertEqual(content.count('path="res://objects/o_enemy/o_enemy.tscn"'), 1)
+        self.assertIn('[node name="inst_enemy_a" parent="Instances" instance=ExtResource("1")]', content)
+        self.assertIn('[node name="inst_enemy_b" parent="Instances" instance=ExtResource("1")]', content)
+
+    def test_instance_layer_resolves_object_subfolder_path(self):
+        self._write_yyp(["r_subfolder"], extra_resources=[("objects", "o_player")])
+        self._write_object("o_player", parent_path="folders/Objects/Game/Actors.yy")
+        self._write_object_scene("o_player", "Game", "Actors")
+        self._write_room("r_subfolder", layers=[
+            {
+                "%Name": "Instances",
+                "resourceType": "GMRInstanceLayer",
+                "instances": [{"name": "inst_player", "objectId": {"name": "o_player"}}],
+            }
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_subfolder")
+
+        self.assertIn(
+            'path="res://objects/Game/Actors/o_player/o_player.tscn"',
+            content,
+        )
+
+    def test_ignored_instances_are_skipped_with_warning(self):
+        self._write_yyp(["r_ignored"], extra_resources=[("objects", "o_player")])
+        self._write_object("o_player")
+        self._write_object_scene("o_player")
+        self._write_room("r_ignored", layers=[
+            {
+                "%Name": "Instances",
+                "resourceType": "GMRInstanceLayer",
+                "instances": [
+                    {"name": "inst_ignored", "objectId": {"name": "o_player"}, "ignore": True}
+                ],
+            }
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_ignored")
+
+        self.assertNotIn('[node name="inst_ignored"', content)
+        self.assertNotIn('[ext_resource type="PackedScene"', content)
+        self.assertTrue(any(
+            "Skipping ignored GameMaker room instance inst_ignored" in log
+            for log in self.logs
+        ))
+
+    def test_unresolved_object_instance_emits_placeholder_with_warning(self):
+        self._write_yyp(["r_missing"])
+        self._write_room("r_missing", layers=[
+            {
+                "%Name": "Instances",
+                "resourceType": "GMRInstanceLayer",
+                "instances": [
+                    {"name": "inst_missing", "objectId": {"name": "o_missing"}, "x": 10, "y": 20}
+                ],
+            }
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_missing")
+
+        self.assertNotIn('[ext_resource type="PackedScene"', content)
+        self.assertIn('[node name="inst_missing" type="Node2D" parent="Instances"]', content)
+        self.assertIn('position = Vector2(10, 20)', content)
+        self.assertIn('metadata/gamemaker_placeholder = true', content)
+        self.assertIn('metadata/gamemaker_unresolved_object_scene = true', content)
+        self.assertTrue(any(
+            "Could not resolve object scene" in log and "inst_missing" in log
+            for log in self.logs
+        ))
+
+    def test_instance_creation_order_controls_layer_child_order(self):
+        self._write_yyp(["r_order"], extra_resources=[("objects", "o_enemy")])
+        self._write_object("o_enemy")
+        self._write_object_scene("o_enemy")
+        self._write_room(
+            "r_order",
+            instance_creation_order=[
+                {"name": "inst_a", "path": "rooms/r_order/r_order.yy"},
+                {"name": "inst_b", "path": "rooms/r_order/r_order.yy"},
+            ],
+            layers=[
+                {
+                    "%Name": "Instances",
+                    "resourceType": "GMRInstanceLayer",
+                    "instances": [
+                        {"name": "inst_b", "objectId": {"name": "o_enemy"}},
+                        {"name": "inst_a", "objectId": {"name": "o_enemy"}},
+                    ],
+                }
+            ],
+        )
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_order")
+
+        self.assertLess(
+            content.index('[node name="inst_a" parent="Instances"'),
+            content.index('[node name="inst_b" parent="Instances"'),
+        )
+        self.assertIn('metadata/gamemaker_instance_creation_order_index = 0', content)
+        self.assertIn('metadata/gamemaker_instance_creation_order_index = 1', content)
 
     def test_sets_project_startup_scene_to_first_room_order_node(self):
         self._write_yyp(["r_second", "r_first"], room_order=["r_first", "r_second"])


### PR DESCRIPTION
## Summary
- Convert `GMRInstanceLayer` entries into Godot child nodes under generated layer placeholders.
- Resolve object scene paths through `GameMakerResourceIndex`, allocate/reuse `PackedScene` ext resources, and emit transform/metadata for each instance.
- Skip ignored instances with warnings and emit `Node2D` placeholders for unresolved or missing object scenes.

## Tests
- `python3 -m unittest tests.test_rooms`
- `python3 -m unittest discover tests`
- Manual validation against `AsteroidsPLUSPLUS` after object conversion: `rMainMenu` emitted object instance ext resources, skipped ignored instances with warnings, and kept startup scene on `res://rooms/rLoading/rLoading.tscn`

Closes #158