### PR TITLE
Preserve room creation code metadata

### DIFF
--- a/src/conversion/resource_index.py
+++ b/src/conversion/resource_index.py
@@ -37,6 +37,7 @@ class IndexedRoom:
     inherit_code: bool = False
     inherit_creation_order: bool = False
     inherit_layers: bool = False
+    is_dnd: bool = False
     raw_data: Dict = field(default_factory=dict)
 
 
@@ -214,6 +215,7 @@ class GameMakerResourceIndex(BaseConverter):
             inherit_code=bool(data.get("inheritCode", False)),
             inherit_creation_order=bool(data.get("inheritCreationOrder", False)),
             inherit_layers=bool(data.get("inheritLayers", False)),
+            is_dnd=bool(data.get("isDnd", False)),
             raw_data=data,
         )
 

--- a/src/conversion/room_creation_code.py
+++ b/src/conversion/room_creation_code.py
@@ -1,0 +1,111 @@
+import os
+from dataclasses import dataclass
+
+
+ROOM_EXECUTION_ORDER = [
+    "object_create",
+    "instance_creation_code",
+    "room_creation_code",
+    "room_start",
+]
+
+
+@dataclass(frozen=True)
+class CreationCodeMetadata:
+    has_code: bool
+    inherit_code: bool
+    is_dnd: bool
+    source_path: str
+    exists: bool
+    execution_phase: str
+    execution_phase_index: int
+
+
+def resolve_room_creation_code(room, gm_project_path, warn_callback=None):
+    """Resolve room creation-code metadata without transpiling GML."""
+    source_file = room.creation_code_file or ""
+    source_path = _resolve_room_creation_code_path(room, gm_project_path, source_file)
+    metadata = CreationCodeMetadata(
+        has_code=bool(source_file),
+        inherit_code=bool(room.inherit_code),
+        is_dnd=bool(getattr(room, "is_dnd", False)),
+        source_path=source_path,
+        exists=bool(source_path and os.path.isfile(source_path)),
+        execution_phase="room_creation_code",
+        execution_phase_index=ROOM_EXECUTION_ORDER.index("room_creation_code"),
+    )
+
+    if metadata.has_code and not metadata.exists and warn_callback is not None:
+        warn_callback(
+            "Warning: Missing GameMaker room creation code file for room {room}: {path}".format(
+                room=room.name,
+                path=metadata.source_path,
+            )
+        )
+
+    return metadata
+
+
+def resolve_instance_creation_code(room, instance, warn_callback=None):
+    """Resolve per-instance creation-code metadata without transpiling GML."""
+    instance_name = _instance_name(instance)
+    has_code = bool(instance.get("hasCreationCode", False))
+    source_path = ""
+    if has_code:
+        source_path = os.path.join(
+            os.path.dirname(room.yy_path),
+            f"InstanceCreationCode_{instance_name}.gml",
+        )
+
+    metadata = CreationCodeMetadata(
+        has_code=has_code,
+        inherit_code=bool(instance.get("inheritCode", False)),
+        is_dnd=bool(instance.get("isDnd", False)),
+        source_path=source_path,
+        exists=bool(source_path and os.path.isfile(source_path)),
+        execution_phase="instance_creation_code",
+        execution_phase_index=ROOM_EXECUTION_ORDER.index("instance_creation_code"),
+    )
+
+    if metadata.has_code and not metadata.exists and warn_callback is not None:
+        warn_callback(
+            "Warning: Missing GameMaker instance creation code file for room {room}, "
+            "instance {instance}: {path}".format(
+                room=room.name,
+                instance=instance_name,
+                path=metadata.source_path,
+            )
+        )
+
+    return metadata
+
+
+def instance_creation_order_names(room):
+    names = []
+    for entry in room.instance_creation_order:
+        if isinstance(entry, dict):
+            name = entry.get("%Name") or entry.get("name")
+            if name:
+                names.append(name)
+    return names
+
+
+def _resolve_room_creation_code_path(room, gm_project_path, source_file):
+    if not source_file:
+        return ""
+
+    normalized = source_file.replace("\\", "/")
+    if normalized.startswith("${project_dir}/"):
+        normalized = normalized[len("${project_dir}/"):]
+
+    if os.path.isabs(normalized):
+        return os.path.normpath(normalized)
+
+    if normalized.startswith("rooms/"):
+        return os.path.normpath(os.path.join(gm_project_path, normalized))
+
+    return os.path.normpath(os.path.join(os.path.dirname(room.yy_path), normalized))
+
+
+def _instance_name(instance):
+    return instance.get("%Name") or instance.get("name") or "Instance"

--- a/src/conversion/room_layers.py
+++ b/src/conversion/room_layers.py
@@ -3,6 +3,8 @@ import os
 import re
 from dataclasses import dataclass, field
 
+from src.conversion.room_creation_code import resolve_instance_creation_code
+
 
 KNOWN_LAYER_TYPES = {
     "GMRInstanceLayer",
@@ -30,8 +32,9 @@ class SerializedRoomLayers:
 
 
 class RoomLayerSerializationContext:
-    def __init__(self, room, resource_index=None, warn_callback=None):
+    def __init__(self, room, gm_project_path=None, resource_index=None, warn_callback=None):
         self.room = room
+        self.gm_project_path = gm_project_path
         self.resource_index = resource_index
         self.warn_callback = warn_callback
         self.ext_resource_ids = {}
@@ -79,9 +82,9 @@ class RoomLayerSerializationContext:
         return os.path.isfile(filesystem_path)
 
 
-def serialize_room_layers(room, resource_index=None, warn_callback=None):
+def serialize_room_layers(room, gm_project_path=None, resource_index=None, warn_callback=None):
     """Serialize GameMaker room layers and supported layer children."""
-    context = RoomLayerSerializationContext(room, resource_index, warn_callback)
+    context = RoomLayerSerializationContext(room, gm_project_path, resource_index, warn_callback)
     node_lines = []
     used_names = {}
     for layer in room.layers:
@@ -243,13 +246,19 @@ def _instance_node_lines(layer, parent_path, layer_name, context):
                 object_name,
                 ext_resource_id,
                 order_index,
+                context,
             )
         )
     return lines
 
 
 def _instance_scene_lines(instance, node_name, parent_path, instance_name, object_name,
-                          ext_resource_id, order_index):
+                          ext_resource_id, order_index, context):
+    creation_code = resolve_instance_creation_code(
+        context.room,
+        instance,
+        warn_callback=context.warn,
+    )
     if ext_resource_id is None:
         lines = [f'[node name={godot_string(node_name)} type="Node2D" parent={godot_string(parent_path)}]']
     else:
@@ -283,7 +292,13 @@ def _instance_scene_lines(instance, node_name, parent_path, instance_name, objec
         f"metadata/gamemaker_image_speed = {godot_value(instance.get('imageSpeed'))}",
         f"metadata/gamemaker_object_id = {godot_value(instance.get('objectId'))}",
         f"metadata/gamemaker_properties = {godot_value(instance.get('properties', []))}",
-        f"metadata/gamemaker_has_creation_code = {godot_value(bool(instance.get('hasCreationCode', False)))}",
+        f"metadata/gamemaker_has_creation_code = {godot_value(creation_code.has_code)}",
+        f"metadata/gamemaker_inherit_code = {godot_value(creation_code.inherit_code)}",
+        f"metadata/gamemaker_is_dnd = {godot_value(creation_code.is_dnd)}",
+        f"metadata/gamemaker_creation_code_source_path = {godot_value(creation_code.source_path)}",
+        f"metadata/gamemaker_creation_code_file_exists = {godot_value(creation_code.exists)}",
+        f"metadata/gamemaker_creation_code_execution_phase = {godot_value(creation_code.execution_phase)}",
+        f"metadata/gamemaker_creation_code_execution_phase_index = {godot_value(creation_code.execution_phase_index)}",
     ])
 
     if ext_resource_id is None:

--- a/src/conversion/rooms.py
+++ b/src/conversion/rooms.py
@@ -4,6 +4,11 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from src.conversion.base_converter import BaseConverter
 from src.conversion.project_godot import GodotProjectFile
+from src.conversion.room_creation_code import (
+    ROOM_EXECUTION_ORDER,
+    instance_creation_order_names,
+    resolve_room_creation_code,
+)
 from src.conversion.room_layers import godot_string, serialize_room_layers
 from src.conversion.resource_index import GameMakerResourceIndex
 
@@ -39,8 +44,14 @@ class RoomConverter(BaseConverter):
     def _generate_room_scene(self, room, resource_index=None):
         room_settings = room.room_settings
         physics_settings = room.physics_settings
+        room_creation_code = resolve_room_creation_code(
+            room,
+            self.gm_project_path,
+            warn_callback=self._safe_log,
+        )
         serialized_layers = serialize_room_layers(
             room,
+            gm_project_path=self.gm_project_path,
             resource_index=resource_index,
             warn_callback=self._safe_log,
         )
@@ -69,6 +80,16 @@ class RoomConverter(BaseConverter):
             f'metadata/gamemaker_physics_gravity_y = {json.dumps(physics_settings.get("PhysicsWorldGravityY", 10.0))}',
             f'metadata/gamemaker_physics_pixels_to_meters = {json.dumps(physics_settings.get("PhysicsWorldPixToMetres", 0.1))}',
             f'metadata/gamemaker_source_yy_path = {json.dumps(room.yy_path)}',
+            f'metadata/gamemaker_creation_code_file = {json.dumps(room.creation_code_file)}',
+            f'metadata/gamemaker_creation_code_source_path = {json.dumps(room_creation_code.source_path)}',
+            f'metadata/gamemaker_has_creation_code = {json.dumps(room_creation_code.has_code)}',
+            f'metadata/gamemaker_inherit_code = {json.dumps(room_creation_code.inherit_code)}',
+            f'metadata/gamemaker_is_dnd = {json.dumps(room_creation_code.is_dnd)}',
+            f'metadata/gamemaker_creation_code_file_exists = {json.dumps(room_creation_code.exists)}',
+            f'metadata/gamemaker_execution_order = {json.dumps(ROOM_EXECUTION_ORDER)}',
+            f'metadata/gamemaker_instance_creation_order = {json.dumps(instance_creation_order_names(room))}',
+            f'metadata/gamemaker_room_creation_code_execution_phase = {json.dumps(room_creation_code.execution_phase)}',
+            f'metadata/gamemaker_room_creation_code_execution_phase_index = {json.dumps(room_creation_code.execution_phase_index)}',
             "",
         ])
         lines.extend(serialized_layers.node_lines)

--- a/tests/test_resource_index.py
+++ b/tests/test_resource_index.py
@@ -219,6 +219,27 @@ class TestGameMakerResourceIndex(unittest.TestCase):
         self.assertEqual(room.room_settings["Width"], 640)
         self.assertEqual(room.room_settings["Height"], 480)
 
+    def test_indexes_room_creation_code_metadata(self):
+        content = _make_room_yy("r_code").replace(
+            '"creationCodeFile":"",',
+            '"creationCodeFile":"rooms/r_code/RoomCreationCode.gml",',
+        ).replace(
+            '"inheritCode":false,',
+            '"inheritCode":true,',
+        ).replace(
+            '"isDnd":false,',
+            '"isDnd":true,',
+        )
+        self._write_yyp([("rooms", "r_code")], room_order=["r_code"])
+        self._write_room("r_code", content=content)
+
+        index = self._build_index()
+        room = index.get_room("r_code")
+
+        self.assertEqual(room.creation_code_file, "rooms/r_code/RoomCreationCode.gml")
+        self.assertTrue(room.inherit_code)
+        self.assertTrue(room.is_dnd)
+
     def test_missing_yyp_falls_back_to_disk_scan(self):
         self._write_room("r_disk")
         self._write_resource("objects", "o_disk", "folders/Objects.yy", "GMObject")

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -50,9 +50,12 @@ def _make_yyp(room_names, room_order=None, extra_resources=None):
 
 def _make_room_yy(name, parent_path="folders/Rooms.yy", width=1024, height=768,
                   persistent=False, volume=1.0, physics_world=False, layers=None,
-                  instance_creation_order=None):
+                  instance_creation_order=None, creation_code_file="",
+                  inherit_code=False, is_dnd=False):
     persistent_value = "true" if persistent else "false"
     physics_world_value = "true" if physics_world else "false"
+    inherit_code_value = "true" if inherit_code else "false"
+    is_dnd_value = "true" if is_dnd else "false"
     layers_json = json.dumps(layers if layers is not None else [])
     instance_creation_order_json = json.dumps(instance_creation_order or [])
     return (
@@ -60,11 +63,12 @@ def _make_room_yy(name, parent_path="folders/Rooms.yy", width=1024, height=768,
         '  "$GMRoom":"v1",\n'
         '  "%Name":"{name}",\n'
         '  "name":"{name}",\n'
-        '  "creationCodeFile":"",\n'
-        '  "inheritCode":false,\n'
+        '  "creationCodeFile":{creation_code_file},\n'
+        '  "inheritCode":{inherit_code},\n'
         '  "inheritCreationOrder":false,\n'
         '  "inheritLayers":false,\n'
         '  "instanceCreationOrder":{instance_creation_order_json},\n'
+        '  "isDnd":{is_dnd},\n'
         '  "layers":{layers_json},\n'
         '  "parent":{{"name":"Rooms","path":"{parent_path}",}},\n'
         '  "parentRoom":null,\n'
@@ -94,6 +98,9 @@ def _make_room_yy(name, parent_path="folders/Rooms.yy", width=1024, height=768,
         physics_world=physics_world_value,
         layers_json=layers_json,
         instance_creation_order_json=instance_creation_order_json,
+        creation_code_file=json.dumps(creation_code_file),
+        inherit_code=inherit_code_value,
+        is_dnd=is_dnd_value,
     )
 
 
@@ -570,6 +577,207 @@ class TestRoomConverter(unittest.TestCase):
         )
         self.assertIn('metadata/gamemaker_instance_creation_order_index = 0', content)
         self.assertIn('metadata/gamemaker_instance_creation_order_index = 1', content)
+
+    def test_room_root_emits_creation_code_metadata(self):
+        self._write_yyp(["r_code"])
+        room_creation_path = os.path.join(
+            self.gm_dir, "rooms", "r_code", "RoomCreationCode.gml"
+        )
+        _write_file(room_creation_path, "// metadata only\n")
+        self._write_room(
+            "r_code",
+            creation_code_file="RoomCreationCode.gml",
+            inherit_code=True,
+            is_dnd=True,
+        )
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_code")
+
+        self.assertIn('metadata/gamemaker_creation_code_file = "RoomCreationCode.gml"', content)
+        self.assertIn(
+            'metadata/gamemaker_creation_code_source_path = ' + json.dumps(room_creation_path),
+            content,
+        )
+        self.assertIn('metadata/gamemaker_has_creation_code = true', content)
+        self.assertIn('metadata/gamemaker_inherit_code = true', content)
+        self.assertIn('metadata/gamemaker_is_dnd = true', content)
+        self.assertIn('metadata/gamemaker_creation_code_file_exists = true', content)
+        self.assertIn(
+            'metadata/gamemaker_execution_order = ["object_create", "instance_creation_code", "room_creation_code", "room_start"]',
+            content,
+        )
+        self.assertIn(
+            'metadata/gamemaker_room_creation_code_execution_phase = "room_creation_code"',
+            content,
+        )
+        self.assertIn('metadata/gamemaker_room_creation_code_execution_phase_index = 2', content)
+        self.assertNotIn('func ', content)
+        self.assertNotIn('.gd', content)
+
+    def test_room_creation_code_missing_warns_and_marks_missing(self):
+        self._write_yyp(["r_missing_code"])
+        missing_path = os.path.join(
+            self.gm_dir, "rooms", "r_missing_code", "MissingCreationCode.gml"
+        )
+        self._write_room(
+            "r_missing_code",
+            creation_code_file="MissingCreationCode.gml",
+        )
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_missing_code")
+
+        self.assertIn(
+            'metadata/gamemaker_creation_code_source_path = ' + json.dumps(missing_path),
+            content,
+        )
+        self.assertIn('metadata/gamemaker_creation_code_file_exists = false', content)
+        self.assertTrue(any(
+            "Missing GameMaker room creation code file" in log
+            and "r_missing_code" in log
+            and missing_path in log
+            for log in self.logs
+        ))
+
+    def test_instance_emits_creation_code_metadata(self):
+        self._write_yyp(["r_instance_code"], extra_resources=[("objects", "o_player")])
+        self._write_object("o_player")
+        self._write_object_scene("o_player")
+        instance_code_path = os.path.join(
+            self.gm_dir,
+            "rooms",
+            "r_instance_code",
+            "InstanceCreationCode_inst_player.gml",
+        )
+        _write_file(instance_code_path, "// metadata only\n")
+        self._write_room("r_instance_code", layers=[
+            {
+                "%Name": "Instances",
+                "resourceType": "GMRInstanceLayer",
+                "instances": [
+                    {
+                        "name": "inst_player",
+                        "objectId": {"name": "o_player"},
+                        "hasCreationCode": True,
+                        "inheritCode": True,
+                        "isDnd": True,
+                    }
+                ],
+            }
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_instance_code")
+
+        self.assertIn('metadata/gamemaker_has_creation_code = true', content)
+        self.assertIn('metadata/gamemaker_inherit_code = true', content)
+        self.assertIn('metadata/gamemaker_is_dnd = true', content)
+        self.assertIn(
+            'metadata/gamemaker_creation_code_source_path = ' + json.dumps(instance_code_path),
+            content,
+        )
+        self.assertIn('metadata/gamemaker_creation_code_file_exists = true', content)
+        self.assertIn(
+            'metadata/gamemaker_creation_code_execution_phase = "instance_creation_code"',
+            content,
+        )
+        self.assertIn('metadata/gamemaker_creation_code_execution_phase_index = 1', content)
+        self.assertNotIn('func ', content)
+        self.assertNotIn('.gd', content)
+
+    def test_instance_creation_code_missing_warns_and_marks_missing(self):
+        self._write_yyp(["r_missing_instance_code"], extra_resources=[("objects", "o_player")])
+        self._write_object("o_player")
+        self._write_object_scene("o_player")
+        missing_path = os.path.join(
+            self.gm_dir,
+            "rooms",
+            "r_missing_instance_code",
+            "InstanceCreationCode_inst_player.gml",
+        )
+        self._write_room("r_missing_instance_code", layers=[
+            {
+                "%Name": "Instances",
+                "resourceType": "GMRInstanceLayer",
+                "instances": [
+                    {
+                        "name": "inst_player",
+                        "objectId": {"name": "o_player"},
+                        "hasCreationCode": True,
+                    }
+                ],
+            }
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_missing_instance_code")
+
+        self.assertIn(
+            'metadata/gamemaker_creation_code_source_path = ' + json.dumps(missing_path),
+            content,
+        )
+        self.assertIn('metadata/gamemaker_creation_code_file_exists = false', content)
+        self.assertTrue(any(
+            "Missing GameMaker instance creation code file" in log
+            and "inst_player" in log
+            and "r_missing_instance_code" in log
+            and missing_path in log
+            for log in self.logs
+        ))
+
+    def test_execution_metadata_preserves_lifecycle_order(self):
+        self._write_yyp(["r_lifecycle"], extra_resources=[("objects", "o_enemy")])
+        self._write_object("o_enemy")
+        self._write_object_scene("o_enemy")
+        _write_file(
+            os.path.join(self.gm_dir, "rooms", "r_lifecycle", "InstanceCreationCode_inst_a.gml"),
+            "// metadata only\n",
+        )
+        _write_file(
+            os.path.join(self.gm_dir, "rooms", "r_lifecycle", "InstanceCreationCode_inst_b.gml"),
+            "// metadata only\n",
+        )
+        self._write_room(
+            "r_lifecycle",
+            instance_creation_order=[
+                {"name": "inst_a", "path": "rooms/r_lifecycle/r_lifecycle.yy"},
+                {"name": "inst_b", "path": "rooms/r_lifecycle/r_lifecycle.yy"},
+            ],
+            layers=[
+                {
+                    "%Name": "Instances",
+                    "resourceType": "GMRInstanceLayer",
+                    "instances": [
+                        {"name": "inst_b", "objectId": {"name": "o_enemy"}, "hasCreationCode": True},
+                        {"name": "inst_a", "objectId": {"name": "o_enemy"}, "hasCreationCode": True},
+                    ],
+                }
+            ],
+        )
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_lifecycle")
+
+        self.assertIn(
+            'metadata/gamemaker_execution_order = ["object_create", "instance_creation_code", "room_creation_code", "room_start"]',
+            content,
+        )
+        self.assertIn('metadata/gamemaker_instance_creation_order = ["inst_a", "inst_b"]', content)
+        self.assertLess(
+            content.index('[node name="inst_a" parent="Instances"'),
+            content.index('[node name="inst_b" parent="Instances"'),
+        )
+        self.assertIn('metadata/gamemaker_instance_creation_order_index = 0', content)
+        self.assertIn('metadata/gamemaker_instance_creation_order_index = 1', content)
+        self.assertEqual(
+            content.count('metadata/gamemaker_creation_code_execution_phase = "instance_creation_code"'),
+            2,
+        )
+        self.assertEqual(
+            content.count('metadata/gamemaker_creation_code_execution_phase_index = 1'),
+            2,
+        )
 
     def test_sets_project_startup_scene_to_first_room_order_node(self):
         self._write_yyp(["r_second", "r_first"], room_order=["r_first", "r_second"])


### PR DESCRIPTION
## Summary
- Add metadata-only creation-code helpers for room and instance creation code source resolution.
- Preserve room root metadata for `creationCodeFile`, `inheritCode`, `isDnd`, lifecycle order, instance creation order, source paths, and file existence.
- Preserve instance metadata for `hasCreationCode`, `inheritCode`, `isDnd`, resolved `InstanceCreationCode_<instance>.gml` paths, file existence, and execution phase.
- Warn when referenced room or instance creation code files are missing; no GML transpilation or scripts are generated.

## Tests
- `python3 -m unittest tests.test_resource_index tests.test_rooms`
- `python3 -m unittest discover tests`
- Manual validation against `AsteroidsPLUSPLUS`: `rSoundTest` metadata includes `InstanceCreationCode_inst_37A8044D.gml`, marks existing files true, and emits no missing-code warnings

Closes #159