### PR TITLE
Support multi-layer sprites and room backgrounds

### DIFF
--- a/src/conversion/room_layers.py
+++ b/src/conversion/room_layers.py
@@ -37,18 +37,38 @@ class RoomLayerSerializationContext:
         self.ext_resource_ids = {}
         self.creation_order = _instance_creation_order(room)
 
+    def ext_resource_id(self, resource_type, resource_path):
+        key = (resource_type, resource_path)
+        if key not in self.ext_resource_ids:
+            self.ext_resource_ids[key] = str(len(self.ext_resource_ids) + 1)
+        return self.ext_resource_ids[key]
+
     def object_scene_ext_resource_id(self, object_name):
         scene_path = self.object_scene_path(object_name)
         if scene_path is None:
             return None
-        if scene_path not in self.ext_resource_ids:
-            self.ext_resource_ids[scene_path] = str(len(self.ext_resource_ids) + 1)
-        return self.ext_resource_ids[scene_path]
+        return self.ext_resource_id("PackedScene", scene_path)
 
     def object_scene_path(self, object_name):
         if not object_name or self.resource_index is None:
             return None
         scene_path = self.resource_index.resolve_godot_path("objects", object_name)
+        if scene_path is None:
+            return None
+        if not self._scene_path_exists(scene_path):
+            return None
+        return scene_path
+
+    def sprite_scene_ext_resource_id(self, sprite_name):
+        scene_path = self.sprite_scene_path(sprite_name)
+        if scene_path is None:
+            return None
+        return self.ext_resource_id("PackedScene", scene_path)
+
+    def sprite_scene_path(self, sprite_name):
+        if not sprite_name or self.resource_index is None:
+            return None
+        scene_path = self.resource_index.resolve_godot_path("sprites", sprite_name)
         if scene_path is None:
             return None
         if not self._scene_path_exists(scene_path):
@@ -61,11 +81,12 @@ class RoomLayerSerializationContext:
 
     def ext_resource_lines(self):
         return [
-            '[ext_resource type="PackedScene" path={path} id="{resource_id}"]'.format(
+            '[ext_resource type="{resource_type}" path={path} id="{resource_id}"]'.format(
+                resource_type=resource_type,
                 path=godot_string(path),
                 resource_id=resource_id,
             )
-            for path, resource_id in self.ext_resource_ids.items()
+            for (resource_type, path), resource_id in self.ext_resource_ids.items()
         ]
 
     def _scene_path_exists(self, scene_path):
@@ -107,6 +128,9 @@ def _serialize_layer(layer, parent_path, sibling_names, lines, context):
     lines.extend(_layer_node_lines(layer, node_name, parent_path, original_name, resource_type))
 
     child_parent_path = node_name if parent_path == "." else f"{parent_path}/{node_name}"
+
+    if resource_type == "GMRBackgroundLayer":
+        lines.extend(_background_visual_lines(layer, child_parent_path, original_name, context))
 
     if resource_type == "GMRInstanceLayer":
         lines.extend(_instance_node_lines(layer, child_parent_path, original_name, context))
@@ -197,6 +221,147 @@ def _layer_node_lines(layer, node_name, parent_path, original_name, resource_typ
 def _append_optional_metadata(lines, source, source_key, metadata_key):
     if source_key in source:
         lines.append(f"metadata/{metadata_key} = {godot_value(source.get(source_key))}")
+
+
+def _background_visual_lines(layer, parent_path, layer_name, context):
+    sprite_name = _background_sprite_name(layer)
+    if sprite_name:
+        ext_resource_id = context.sprite_scene_ext_resource_id(sprite_name)
+        if ext_resource_id is None:
+            context.warn(
+                "Warning: Could not resolve sprite scene for GameMaker background layer "
+                "{layer_name} in room {room_name}, sprite {sprite_name}; no visual child emitted.".format(
+                    layer_name=layer_name,
+                    room_name=context.room.name,
+                    sprite_name=sprite_name,
+                )
+            )
+            return []
+        return _background_sprite_lines(layer, parent_path, sprite_name, ext_resource_id, context)
+
+    return _background_color_lines(layer, parent_path, context)
+
+
+def _background_color_lines(layer, parent_path, context):
+    width, height = _room_size(context)
+    lines = [
+        f'[node name="BackgroundVisual" type="ColorRect" parent={godot_string(parent_path)}]',
+        f"visible = {godot_value(bool(layer.get('visible', True)))}",
+        "position = Vector2({x}, {y})".format(
+            x=_format_number(layer.get("x", 0)),
+            y=_format_number(layer.get("y", 0)),
+        ),
+        "size = Vector2({width}, {height})".format(
+            width=_format_number(width),
+            height=_format_number(height),
+        ),
+        "color = {color}".format(color=_godot_color(layer.get("colour", 4278190080))),
+    ]
+    lines.extend(_background_metadata_lines(layer, "color"))
+    _warn_background_runtime_requirements(layer, context)
+    lines.append("")
+    return lines
+
+
+def _background_sprite_lines(layer, parent_path, sprite_name, ext_resource_id, context):
+    node_name = _sanitize_node_name(sprite_name) or "BackgroundSprite"
+    lines = [
+        '[node name={name} parent={parent} instance=ExtResource("{resource_id}")]'.format(
+            name=godot_string(node_name),
+            parent=godot_string(parent_path),
+            resource_id=ext_resource_id,
+        ),
+        f"visible = {godot_value(bool(layer.get('visible', True)))}",
+        "position = Vector2({x}, {y})".format(
+            x=_format_number(layer.get("x", 0)),
+            y=_format_number(layer.get("y", 0)),
+        ),
+        "modulate = {color}".format(color=_godot_color(layer.get("colour", 4294967295))),
+    ]
+    lines.extend(_background_metadata_lines(layer, "sprite"))
+    _warn_background_runtime_requirements(layer, context)
+    lines.append("")
+    return lines
+
+
+def _background_metadata_lines(layer, visual_type):
+    colour = layer.get("colour")
+    lines = [
+        "metadata/gamemaker_background_visual = true",
+        f"metadata/gamemaker_background_visual_type = {godot_value(visual_type)}",
+        f"metadata/gamemaker_background_sprite = {godot_value(_background_sprite_name(layer))}",
+        f"metadata/gamemaker_background_colour = {godot_value(colour)}",
+        f"metadata/gamemaker_background_colour_rgba = {godot_value(_decode_gamemaker_colour(colour))}",
+    ]
+    for source_key, metadata_key in (
+        ("x", "gamemaker_background_x"),
+        ("y", "gamemaker_background_y"),
+        ("stretch", "gamemaker_background_stretch"),
+        ("htiled", "gamemaker_background_htiled"),
+        ("vtiled", "gamemaker_background_vtiled"),
+        ("hspeed", "gamemaker_background_hspeed"),
+        ("vspeed", "gamemaker_background_vspeed"),
+        ("animationFPS", "gamemaker_background_animation_fps"),
+        ("animationSpeedType", "gamemaker_background_animation_speed_type"),
+        ("userdefinedAnimFPS", "gamemaker_background_userdefined_anim_fps"),
+    ):
+        _append_optional_metadata(lines, layer, source_key, metadata_key)
+    return lines
+
+
+def _warn_background_runtime_requirements(layer, context):
+    if not (_truthy(layer.get("htiled")) or _truthy(layer.get("vtiled"))
+            or _nonzero(layer.get("hspeed")) or _nonzero(layer.get("vspeed"))):
+        return
+    context.warn(
+        "Warning: GameMaker background layer {layer_name} in room {room_name} uses "
+        "scrolling/tiling; runtime support is required for hspeed/vspeed/htiled/vtiled.".format(
+            layer_name=_layer_name(layer),
+            room_name=context.room.name,
+        )
+    )
+
+
+def _background_sprite_name(layer):
+    sprite_id = layer.get("spriteId") or {}
+    return sprite_id.get("name") if isinstance(sprite_id, dict) else None
+
+
+def _room_size(context):
+    settings = context.room.room_settings or {}
+    return settings.get("Width", 1024), settings.get("Height", 768)
+
+
+def _godot_color(value):
+    r, g, b, a = _decode_gamemaker_colour(value)
+    return "Color({r}, {g}, {b}, {a})".format(
+        r=_format_color_component(r),
+        g=_format_color_component(g),
+        b=_format_color_component(b),
+        a=_format_color_component(a),
+    )
+
+
+def _decode_gamemaker_colour(value):
+    try:
+        packed = int(value)
+    except (TypeError, ValueError):
+        packed = 4278190080
+    packed = packed & 0xFFFFFFFF
+    return [
+        (packed & 0xFF) / 255.0,
+        ((packed >> 8) & 0xFF) / 255.0,
+        ((packed >> 16) & 0xFF) / 255.0,
+        ((packed >> 24) & 0xFF) / 255.0,
+    ]
+
+
+def _format_color_component(value):
+    if value == 0:
+        return "0"
+    if value == 1:
+        return "1"
+    return ("{:.6f}".format(value)).rstrip("0").rstrip(".")
 
 
 def _instance_node_lines(layer, parent_path, layer_name, context):
@@ -361,6 +526,17 @@ def _format_number(value):
     if number.is_integer():
         return str(int(number))
     return str(number)
+
+
+def _truthy(value):
+    return bool(value)
+
+
+def _nonzero(value):
+    try:
+        return float(value) != 0.0
+    except (TypeError, ValueError):
+        return False
 
 
 def _sanitize_node_name(name):

--- a/src/conversion/sprites.py
+++ b/src/conversion/sprites.py
@@ -356,15 +356,15 @@ class SpriteConverter(BaseConverter):
 
             frame_guids = [frame['name'] for frame in data['frames']]
 
-            primary_layer_guid = None
-            for layer in data.get('layers', []):
-                if layer.get('visible', True):
-                    primary_layer_guid = layer['name']
-                    break
-            if primary_layer_guid is None and data.get('layers'):
-                primary_layer_guid = data['layers'][0]['name']
+            visible_layer_guids = [
+                layer['name']
+                for layer in data.get('layers', [])
+                if layer.get('visible', True)
+            ]
+            if not visible_layer_guids and data.get('layers'):
+                visible_layer_guids = [data['layers'][0]['name']]
 
-            return (frame_guids, primary_layer_guid)
+            return (frame_guids, visible_layer_guids)
         except (OSError, json.JSONDecodeError, KeyError, TypeError, IndexError):
             self._safe_log(get_localized("Console_Convertor_Sprites_YYParseFailed").format(
                 yy_path=yy_path, sprite_name=sprite_name))
@@ -373,9 +373,9 @@ class SpriteConverter(BaseConverter):
     def _build_ordered_frame_list(self, sprite_name, all_image_paths):
         result = self._parse_sprite_yy(sprite_name)
         if result is None:
-            return sorted(all_image_paths)
+            return [[path] for path in sorted(all_image_paths)]
 
-        frame_guids, primary_layer_guid = result
+        frame_guids, layer_guids = result
 
         path_index = {}
         for path in all_image_paths:
@@ -385,19 +385,23 @@ class SpriteConverter(BaseConverter):
             path_index.setdefault(frame_guid, {})[filename] = path
 
         ordered = []
-        layer_filename = primary_layer_guid + '.png' if primary_layer_guid else None
         for guid in frame_guids:
             frame_files = path_index.get(guid, {})
             if not frame_files:
                 continue
-            if layer_filename and layer_filename in frame_files:
-                ordered.append(frame_files[layer_filename])
+            frame_layers = [
+                frame_files[layer_guid + '.png']
+                for layer_guid in layer_guids
+                if layer_guid + '.png' in frame_files
+            ]
+            if frame_layers:
+                ordered.append(frame_layers)
             else:
-                ordered.append(next(iter(frame_files.values())))
+                ordered.append([next(iter(frame_files.values()))])
 
-        return ordered if ordered else sorted(all_image_paths)
+        return ordered if ordered else [[path] for path in sorted(all_image_paths)]
 
-    def _process_sprite(self, sprite_name, index, gm_sprite_path, images_count, subfolder=""):
+    def _process_sprite(self, sprite_name, index, gm_sprite_paths, images_count, subfolder=""):
         if not self.conversion_running():
             return None
 
@@ -405,10 +409,20 @@ class SpriteConverter(BaseConverter):
         sprite_dir = os.path.join(self.godot_sprites_path, subfolder, sprite_name) if subfolder else os.path.join(self.godot_sprites_path, sprite_name)
         godot_sprite_path = os.path.join(sprite_dir, new_filename)
 
-        with Image.open(gm_sprite_path) as img:
-            img.save(godot_sprite_path, 'PNG')
+        if len(gm_sprite_paths) == 1:
+            with Image.open(gm_sprite_paths[0]) as img:
+                img.save(godot_sprite_path, 'PNG')
+        else:
+            composed = None
+            for gm_sprite_path in gm_sprite_paths:
+                with Image.open(gm_sprite_path) as img:
+                    layer = img.convert('RGBA')
+                if composed is None:
+                    composed = Image.new('RGBA', layer.size, (0, 0, 0, 0))
+                composed.alpha_composite(layer)
+            composed.save(godot_sprite_path, 'PNG')
 
-        return (sprite_name, index, images_count, gm_sprite_path, new_filename)
+        return (sprite_name, index, images_count, gm_sprite_paths[0], new_filename)
 
     def convert_sprites(self):
         os.makedirs(self.godot_sprites_path, exist_ok=True)

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -110,6 +110,18 @@ def _make_object_yy(name, parent_path="folders/Objects.yy"):
     ).format(name=name, parent_path=parent_path)
 
 
+def _make_sprite_yy(name, parent_path="folders/Sprites.yy"):
+    return (
+        '{{\n'
+        '  "$GMSprite":"",\n'
+        '  "%Name":"{name}",\n'
+        '  "name":"{name}",\n'
+        '  "parent":{{"name":"Sprites","path":"{parent_path}",}},\n'
+        '  "resourceType":"GMSprite",\n'
+        '}}\n'
+    ).format(name=name, parent_path=parent_path)
+
+
 class TestRoomConverter(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
@@ -159,6 +171,22 @@ class TestRoomConverter(unittest.TestCase):
             name + ".tscn",
         )
         _write_file(scene_path, '[gd_scene format=3]\n\n[node name="{}" type="Node2D"]\n'.format(name))
+        return scene_path
+
+    def _write_sprite(self, name, parent_path="folders/Sprites.yy"):
+        sprite_path = os.path.join(self.gm_dir, "sprites", name, name + ".yy")
+        _write_file(sprite_path, _make_sprite_yy(name, parent_path))
+        return sprite_path
+
+    def _write_sprite_scene(self, name, *subfolders):
+        scene_path = os.path.join(
+            self.godot_dir,
+            "sprites",
+            *subfolders,
+            name,
+            name + ".tscn",
+        )
+        _write_file(scene_path, '[gd_scene format=3]\n\n[node name="{}" type="Area2D"]\n'.format(name))
         return scene_path
 
     def _read_scene(self, room_name, *subfolders):
@@ -288,6 +316,87 @@ class TestRoomConverter(unittest.TestCase):
         self.assertNotIn('Sprite2D', content)
         self.assertNotIn('TileMap', content)
         self.assertNotIn('ParallaxBackground', content)
+
+    def test_background_layer_without_sprite_emits_color_visual(self):
+        self._write_yyp(["r_background"])
+        self._write_room("r_background", width=320, height=180, layers=[
+            {
+                "%Name": "Backgrounds",
+                "resourceType": "GMRBackgroundLayer",
+                "depth": 500,
+                "colour": 4294967295,
+            },
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_background")
+
+        self.assertIn('[node name="Backgrounds" type="Node2D" parent="."]', content)
+        self.assertIn('[node name="BackgroundVisual" type="ColorRect" parent="Backgrounds"]', content)
+        self.assertIn('size = Vector2(320, 180)', content)
+        self.assertIn('color = Color(1, 1, 1, 1)', content)
+        self.assertIn('metadata/gamemaker_background_visual = true', content)
+        self.assertIn('metadata/gamemaker_background_visual_type = "color"', content)
+
+    def test_background_layer_with_sprite_instances_sprite_scene(self):
+        self._write_yyp(["r_background"], extra_resources=[("sprites", "s_background")])
+        self._write_sprite("s_background")
+        self._write_sprite_scene("s_background")
+        self._write_room("r_background", layers=[
+            {
+                "%Name": "Backgrounds",
+                "resourceType": "GMRBackgroundLayer",
+                "spriteId": {"name": "s_background", "path": "sprites/s_background/s_background.yy"},
+                "x": 16,
+                "y": 32,
+                "colour": 4294967295,
+            },
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_background")
+
+        self.assertIn(
+            '[ext_resource type="PackedScene" path="res://sprites/s_background/s_background.tscn" id="1"]',
+            content,
+        )
+        self.assertIn(
+            '[node name="s_background" parent="Backgrounds" instance=ExtResource("1")]',
+            content,
+        )
+        self.assertIn('position = Vector2(16, 32)', content)
+        self.assertIn('modulate = Color(1, 1, 1, 1)', content)
+        self.assertIn('metadata/gamemaker_background_visual_type = "sprite"', content)
+
+    def test_background_layer_preserves_scrolling_tiling_metadata_and_warns(self):
+        self._write_yyp(["r_background"])
+        self._write_room("r_background", layers=[
+            {
+                "%Name": "MovingBackground",
+                "resourceType": "GMRBackgroundLayer",
+                "htiled": True,
+                "vtiled": False,
+                "hspeed": 2,
+                "vspeed": 0,
+                "stretch": True,
+                "animationFPS": 12,
+                "animationSpeedType": 0,
+            },
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_background")
+
+        self.assertIn('metadata/gamemaker_background_htiled = true', content)
+        self.assertIn('metadata/gamemaker_background_vtiled = false', content)
+        self.assertIn('metadata/gamemaker_background_hspeed = 2', content)
+        self.assertIn('metadata/gamemaker_background_vspeed = 0', content)
+        self.assertIn('metadata/gamemaker_background_stretch = true', content)
+        self.assertIn('metadata/gamemaker_background_animation_fps = 12', content)
+        self.assertTrue(any(
+            "scrolling/tiling" in log and "MovingBackground" in log
+            for log in self.logs
+        ))
 
     def test_layer_depth_maps_to_inverse_z_index(self):
         self._write_yyp(["r_depths"])

--- a/tests/test_sprites.py
+++ b/tests/test_sprites.py
@@ -279,10 +279,11 @@ class TestSpriteConverterFrameOrdering(unittest.TestCase):
 
 
 class TestSpriteConverterMultiLayer(unittest.TestCase):
-    """Test that multi-layer sprites pick the first visible layer."""
+    """Test that multi-layer sprites composite visible layers."""
 
     FRAME_GUID = "aaaaaaaa-0000-0000-0000-000000000000"
-    LAYER_VISIBLE = "22222222-0000-0000-0000-000000000000"
+    LAYER_VISIBLE_A = "22222222-0000-0000-0000-000000000000"
+    LAYER_VISIBLE_B = "33333333-0000-0000-0000-000000000000"
     LAYER_HIDDEN = "11111111-0000-0000-0000-000000000000"
 
     def setUp(self):
@@ -293,28 +294,33 @@ class TestSpriteConverterMultiLayer(unittest.TestCase):
         sprite_dir = os.path.join(self.gm_dir, "sprites", "multi_layer")
         os.makedirs(sprite_dir)
 
-        # Hidden layer listed first, visible layer second
+        # Hidden layer listed first, then two visible layers.
         yy_content = _make_yy_content(
             "multi_layer", [self.FRAME_GUID],
-            [self.LAYER_HIDDEN, self.LAYER_VISIBLE],
-            layer_visible=[False, True])
+            [self.LAYER_HIDDEN, self.LAYER_VISIBLE_A, self.LAYER_VISIBLE_B],
+            layer_visible=[False, True, True])
         with open(os.path.join(sprite_dir, "multi_layer.yy"), "w") as f:
             f.write(yy_content)
 
         frame_dir = os.path.join(sprite_dir, "layers", self.FRAME_GUID)
         os.makedirs(frame_dir)
-        # Hidden layer: red
-        img = Image.new("RGBA", (2, 2), "red")
+
+        img = Image.new("RGBA", (2, 2), (255, 0, 0, 255))
         img.save(os.path.join(frame_dir, self.LAYER_HIDDEN + ".png"), "PNG")
-        # Visible layer: green
-        img = Image.new("RGBA", (2, 2), "green")
-        img.save(os.path.join(frame_dir, self.LAYER_VISIBLE + ".png"), "PNG")
+
+        img = Image.new("RGBA", (2, 2), (0, 0, 0, 0))
+        img.putpixel((0, 0), (0, 255, 0, 255))
+        img.save(os.path.join(frame_dir, self.LAYER_VISIBLE_A + ".png"), "PNG")
+
+        img = Image.new("RGBA", (2, 2), (0, 0, 0, 0))
+        img.putpixel((1, 0), (0, 0, 255, 255))
+        img.save(os.path.join(frame_dir, self.LAYER_VISIBLE_B + ".png"), "PNG")
 
     def tearDown(self):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def test_picks_first_visible_layer(self):
+    def test_composites_visible_layers_and_ignores_hidden_layers(self):
         converter = SpriteConverter(
             self.gm_dir, self.godot_dir,
             log_callback=lambda msg: self.logs.append(msg),
@@ -328,9 +334,10 @@ class TestSpriteConverterMultiLayer(unittest.TestCase):
         self.assertEqual(len(png_files), 1, "Should output 1 file, not 1 per layer")
 
         with Image.open(os.path.join(godot_dir, png_files[0])) as img:
-            pixel = img.getpixel((0, 0))[:3]
-        self.assertEqual(pixel, (0, 128, 0),
-                         "Should use the visible layer (green), not hidden (red)")
+            converted = img.convert("RGBA")
+            self.assertEqual(converted.getpixel((0, 0)), (0, 255, 0, 255))
+            self.assertEqual(converted.getpixel((1, 0)), (0, 0, 255, 255))
+            self.assertEqual(converted.getpixel((1, 1))[3], 0)
 
 
 class TestParseSpriteYY(unittest.TestCase):
@@ -362,9 +369,9 @@ class TestParseSpriteYY(unittest.TestCase):
 
         result = self.converter._parse_sprite_yy("test_spr")
         self.assertIsNotNone(result)
-        frame_guids, layer_guid = result
+        frame_guids, layer_guids = result
         self.assertEqual(frame_guids, guids)
-        self.assertEqual(layer_guid, "layer1")
+        self.assertEqual(layer_guids, ["layer1"])
 
     def test_trailing_commas_handled(self):
         # Write content with trailing commas (as real .yy files have)
@@ -384,15 +391,15 @@ class TestParseSpriteYY(unittest.TestCase):
         result = self.converter._parse_sprite_yy("bad")
         self.assertIsNone(result)
 
-    def test_selects_first_visible_layer(self):
+    def test_selects_visible_layers(self):
         guids = ["frame1"]
         layers = ["hidden_layer", "visible_layer"]
         self._write_yy("vis", _make_yy_content("vis", guids, layers,
                                                  layer_visible=[False, True]))
         result = self.converter._parse_sprite_yy("vis")
         self.assertIsNotNone(result)
-        _, layer_guid = result
-        self.assertEqual(layer_guid, "visible_layer")
+        _, layer_guids = result
+        self.assertEqual(layer_guids, ["visible_layer"])
 
 
 def _make_yyp_content(sprite_names, extra_resources=None):


### PR DESCRIPTION
## Summary
- Composite all visible GameMaker sprite layers into each exported Godot frame.
- Preserve existing sprite frame ordering and fallback behavior while covering hidden/multiple visible layers.
- Add room background visuals for solid colors and sprite-backed backgrounds, preserving tiling/scrolling/animation metadata with warnings where runtime support is still required.

## Tests
- python3 -m unittest tests.test_sprites
- python3 -m unittest tests.test_rooms
- python3 -m unittest discover

Closes #172
Refs #160