### PR TITLE
Support SimpleTopDown movement conversion

### DIFF
--- a/.github/workflows/tcc-conversion-test.yml
+++ b/.github/workflows/tcc-conversion-test.yml
@@ -22,6 +22,14 @@ jobs:
       - name: Install test dependencies
         run: pip install Pillow
 
+      - name: Clone SimpleTopDown test game (shallow)
+        run: git clone --depth 1 --no-recurse-submodules https://github.com/Infiland/GM2GodotGameTest_SimpleTopDown.git "${{ runner.temp }}/GM2GodotGameTest_SimpleTopDown"
+
+      - name: Run SimpleTopDown conversion test
+        env:
+          SIMPLE_TOPDOWN_PROJECT_PATH: ${{ runner.temp }}/GM2GodotGameTest_SimpleTopDown
+        run: python -m unittest tests.test_simple_topdown_conversion -v
+
       - name: Clone The Colorful Creature (shallow)
         run: git clone --depth 1 --no-recurse-submodules https://github.com/Infiland/TheColorfulCreature.git "${{ runner.temp }}/TheColorfulCreature"
 

--- a/src/conversion/gml_transpiler.py
+++ b/src/conversion/gml_transpiler.py
@@ -149,25 +149,30 @@ _NAME_REPLACEMENTS = {
     "undefined": "null",
 }
 
+_INSTANCE_NAME_REPLACEMENTS = {
+    "x": "position.x",
+    "y": "position.y",
+}
 
-def transpile_gml_expression(source):
+_VIRTUAL_KEY_ACTIONS = {
+    "vk_left": "ui_left",
+    "vk_right": "ui_right",
+    "vk_up": "ui_up",
+    "vk_down": "ui_down",
+}
+
+
+def transpile_gml_expression(source, local_names=None):
     """Transpile a single GML expression to a GDScript expression."""
     parser = _ExpressionParser(_tokenize(source))
     expr = parser.parse()
-    return _emit_expression(expr)[0]
+    return _emit_expression(expr, _normalize_local_names(local_names))[0]
 
 
 def transpile_gml_code(source, indent="\t"):
-    """Transpile simple expression/assignment GML statements to GDScript.
-
-    This intentionally covers the expressions-and-operators milestone slice:
-    declarations, assignments, compound assignments, nullish assignment,
-    increment/decrement statements, and expression statements. Control flow is
-    left for later GML language-structure issues.
-    """
-    lines = []
-    for statement in _split_statements(_strip_comments(source)):
-        lines.extend(_transpile_statement(statement.strip()))
+    """Transpile supported GML statements to GDScript."""
+    parser = _StatementParser(_tokenize(_strip_comments(source)))
+    lines = parser.parse()
 
     if not lines:
         return f"{indent}pass"
@@ -313,6 +318,164 @@ class _ExpressionParser:
         return self._peek().kind == "EOF"
 
 
+class _StatementParser:
+    def __init__(self, tokens, local_names=None):
+        self.tokens = tokens
+        self.position = 0
+        self.local_names = set(local_names or [])
+
+    def parse(self, terminator=None):
+        lines = []
+        while not self._at_end() and not self._check(terminator):
+            if self._match(";"):
+                continue
+            lines.extend(self._parse_statement())
+        return lines
+
+    def _parse_statement(self):
+        if self._check_identifier("if"):
+            return self._parse_if_statement()
+
+        statement_tokens = self._read_simple_statement()
+        if not statement_tokens:
+            return []
+        return _transpile_statement(_tokens_to_source(statement_tokens), self.local_names)
+
+    def _parse_if_statement(self):
+        self._consume_identifier("if")
+        condition_tokens = self._read_condition_tokens()
+        if not condition_tokens:
+            raise GMLTranspileError("Expected if condition")
+
+        condition = transpile_gml_expression(
+            _tokens_to_source(condition_tokens),
+            local_names=self.local_names,
+        )
+        body_lines = self._parse_body()
+        lines = [f"if {condition}:"]
+        lines.extend(_indent_lines(body_lines or ["pass"]))
+
+        if self._match_identifier("else"):
+            if self._check_identifier("if"):
+                else_lines = self._parse_if_statement()
+                lines.append(f"elif {else_lines[0][3:]}")
+                lines.extend(else_lines[1:])
+            else:
+                else_body_lines = self._parse_body()
+                lines.append("else:")
+                lines.extend(_indent_lines(else_body_lines or ["pass"]))
+
+        return lines
+
+    def _parse_body(self):
+        if self._match("{"):
+            lines = self.parse(terminator="}")
+            self._consume("}")
+            return lines
+        if self._at_end() or self._check("}"):
+            return []
+        return self._parse_statement()
+
+    def _read_condition_tokens(self):
+        if self._match("("):
+            return self._read_balanced_tokens("(", ")")
+
+        tokens = []
+        depth = 0
+        while not self._at_end():
+            token = self._peek()
+            if depth == 0 and token.value == "{":
+                break
+            if depth == 0 and token.value == ";":
+                break
+
+            if token.value in "([":
+                depth += 1
+            elif token.value in ")]" and depth > 0:
+                depth -= 1
+            tokens.append(self._advance())
+
+        return tokens
+
+    def _read_balanced_tokens(self, opener, closer):
+        tokens = []
+        depth = 1
+        while not self._at_end():
+            token = self._advance()
+            if token.value == opener:
+                depth += 1
+            elif token.value == closer:
+                depth -= 1
+                if depth == 0:
+                    return tokens
+            tokens.append(token)
+
+        raise GMLTranspileError(f"Expected '{closer}'")
+
+    def _read_simple_statement(self):
+        tokens = []
+        depth = 0
+        while not self._at_end():
+            token = self._peek()
+            if depth == 0 and token.value == "}":
+                break
+            if depth == 0 and token.value == ";":
+                self._advance()
+                break
+
+            if token.value in "([{":
+                depth += 1
+            elif token.value in ")]}":
+                if depth > 0:
+                    depth -= 1
+            tokens.append(self._advance())
+
+        return tokens
+
+    def _match(self, value):
+        if self._check(value):
+            self.position += 1
+            return True
+        return False
+
+    def _match_identifier(self, value):
+        if self._check_identifier(value):
+            self.position += 1
+            return True
+        return False
+
+    def _consume(self, value):
+        if not self._match(value):
+            raise GMLTranspileError(f"Expected '{value}', got: {self._peek().value}")
+
+    def _consume_identifier(self, value):
+        if not self._match_identifier(value):
+            raise GMLTranspileError(f"Expected '{value}', got: {self._peek().value}")
+
+    def _check(self, value):
+        if value is None:
+            return False
+        return self._peek().value == value
+
+    def _check_identifier(self, value):
+        token = self._peek()
+        return token.kind == "IDENT" and token.value == value
+
+    def _advance(self):
+        token = self._peek()
+        if not self._at_end():
+            self.position += 1
+        return token
+
+    def _peek(self):
+        if self.position >= len(self.tokens):
+            return _EOF
+        return self.tokens[self.position]
+
+    def _at_end(self):
+        return self._peek().kind == "EOF"
+
+
 def _tokenize(source):
     tokens = []
     index = 0
@@ -385,62 +548,95 @@ def _read_string(source, start):
     raise GMLTranspileError("Unterminated string literal")
 
 
-def _emit_expression(expr):
+def _normalize_local_names(local_names):
+    return frozenset(local_names or [])
+
+
+def _tokens_to_source(tokens):
+    return " ".join(token.value for token in tokens if token.kind != "EOF")
+
+
+def _indent_lines(lines):
+    return [f"\t{line}" if line else "" for line in lines]
+
+
+def _emit_expression(expr, local_names=None):
+    local_names = _normalize_local_names(local_names)
     if isinstance(expr, _Literal):
         return expr.value, _PRIMARY_PRECEDENCE
     if isinstance(expr, _Name):
-        return expr.value, _PRIMARY_PRECEDENCE
+        value = expr.value
+        if value not in local_names:
+            value = _INSTANCE_NAME_REPLACEMENTS.get(value, value)
+        return value, _PRIMARY_PRECEDENCE
     if isinstance(expr, _Grouped):
-        return f"({_emit_expression(expr.expr)[0]})", _PRIMARY_PRECEDENCE
+        return f"({_emit_expression(expr.expr, local_names)[0]})", _PRIMARY_PRECEDENCE
     if isinstance(expr, _Unary):
-        operand = _emit_child(expr.operand, _UNARY_PRECEDENCE)
+        operand = _emit_child(expr.operand, _UNARY_PRECEDENCE, local_names=local_names)
         if expr.operator == "!":
             return f"not {operand}", _UNARY_PRECEDENCE
         if expr.operator == "not":
             return f"not {operand}", _UNARY_PRECEDENCE
         return f"{expr.operator}{operand}", _UNARY_PRECEDENCE
     if isinstance(expr, _Binary):
-        return _emit_binary(expr)
+        return _emit_binary(expr, local_names)
     if isinstance(expr, _Ternary):
-        condition = _emit_child(expr.condition, _TERNARY_PRECEDENCE)
-        true_expr = _emit_child(expr.true_expr, _TERNARY_PRECEDENCE)
-        false_expr = _emit_child(expr.false_expr, _TERNARY_PRECEDENCE)
+        condition = _emit_child(expr.condition, _TERNARY_PRECEDENCE, local_names=local_names)
+        true_expr = _emit_child(expr.true_expr, _TERNARY_PRECEDENCE, local_names=local_names)
+        false_expr = _emit_child(expr.false_expr, _TERNARY_PRECEDENCE, local_names=local_names)
         return f"{true_expr} if {condition} else {false_expr}", _TERNARY_PRECEDENCE
     if isinstance(expr, _Call):
-        callee = _emit_child(expr.callee, _POSTFIX_PRECEDENCE)
-        args = ", ".join(_emit_expression(arg)[0] for arg in expr.args)
+        builtin_call = _emit_builtin_call(expr, local_names)
+        if builtin_call is not None:
+            return builtin_call, _POSTFIX_PRECEDENCE
+        callee = _emit_child(expr.callee, _POSTFIX_PRECEDENCE, local_names=local_names)
+        args = ", ".join(_emit_expression(arg, local_names)[0] for arg in expr.args)
         return f"{callee}({args})", _POSTFIX_PRECEDENCE
     if isinstance(expr, _Index):
-        target = _emit_child(expr.target, _POSTFIX_PRECEDENCE)
-        index = _emit_expression(expr.index)[0]
+        target = _emit_child(expr.target, _POSTFIX_PRECEDENCE, local_names=local_names)
+        index = _emit_expression(expr.index, local_names)[0]
         return f"{target}[{index}]", _POSTFIX_PRECEDENCE
     if isinstance(expr, _Member):
-        target = _emit_child(expr.target, _POSTFIX_PRECEDENCE)
+        target = _emit_child(expr.target, _POSTFIX_PRECEDENCE, local_names=local_names)
         return f"{target}.{expr.member}", _POSTFIX_PRECEDENCE
     raise GMLTranspileError("Unknown expression node")
 
 
-def _emit_binary(expr):
+def _emit_builtin_call(expr, local_names):
+    if isinstance(expr.callee, _Name) and expr.callee.value == "keyboard_check" and len(expr.args) == 1:
+        key = expr.args[0]
+        if isinstance(key, _Name) and key.value in _VIRTUAL_KEY_ACTIONS:
+            return f'Input.is_action_pressed("{_VIRTUAL_KEY_ACTIONS[key.value]}")'
+    return None
+
+
+def _emit_binary(expr, local_names):
     operator = _OPERATOR_REPLACEMENTS.get(expr.operator, expr.operator)
 
     if expr.operator == "div":
-        left = _emit_expression(expr.left)[0]
-        right = _emit_expression(expr.right)[0]
+        left = _emit_expression(expr.left, local_names)[0]
+        right = _emit_expression(expr.right, local_names)[0]
         return f"int({left} / {right})", _PRIMARY_PRECEDENCE
 
     if expr.operator == "??":
-        left = _emit_expression(expr.left)[0]
-        right = _emit_child(expr.right, _TERNARY_PRECEDENCE)
+        left = _emit_expression(expr.left, local_names)[0]
+        right = _emit_child(expr.right, _TERNARY_PRECEDENCE, local_names=local_names)
         return f"{left} if {left} != null else {right}", _TERNARY_PRECEDENCE
 
     precedence = _BINARY_PRECEDENCE[expr.operator]
-    left = _emit_child(expr.left, precedence)
-    right = _emit_child(expr.right, precedence, is_right_child=True, parent_operator=expr.operator)
+    left = _emit_child(expr.left, precedence, local_names=local_names)
+    right = _emit_child(
+        expr.right,
+        precedence,
+        is_right_child=True,
+        parent_operator=expr.operator,
+        local_names=local_names,
+    )
     return f"{left} {operator} {right}", precedence
 
 
-def _emit_child(expr, parent_precedence, is_right_child=False, parent_operator=None):
-    text, precedence = _emit_expression(expr)
+def _emit_child(expr, parent_precedence, is_right_child=False, parent_operator=None, local_names=None):
+    text, precedence = _emit_expression(expr, local_names)
     needs_parentheses = precedence < parent_precedence
     if is_right_child and precedence == parent_precedence and parent_operator not in _RIGHT_ASSOCIATIVE:
         needs_parentheses = True
@@ -528,44 +724,53 @@ def _split_statements(source):
     return [statement for statement in statements if statement.strip()]
 
 
-def _transpile_statement(statement):
+def _transpile_statement(statement, local_names=None):
     if not statement:
         return []
 
+    if local_names is None:
+        local_names = set()
+
     if statement.startswith("var "):
-        return _transpile_var_statement(statement[4:].strip())
+        return _transpile_var_statement(statement[4:].strip(), local_names)
 
     increment = _parse_increment_statement(statement)
     if increment is not None:
         target, delta = increment
-        return [f"{transpile_gml_expression(target)} {'+=' if delta > 0 else '-='} 1"]
+        return [f"{transpile_gml_expression(target, local_names)} {'+=' if delta > 0 else '-='} 1"]
 
     assignment = _split_assignment(statement)
     if assignment is not None:
         target, operator, value = assignment
-        target = transpile_gml_expression(target)
-        value = transpile_gml_expression(value)
+        target = transpile_gml_expression(target, local_names)
+        value = transpile_gml_expression(value, local_names)
         if operator == "??=":
             return [f"if {target} == null:", f"\t{target} = {value}"]
         return [f"{target} {operator} {value}"]
 
-    return [transpile_gml_expression(statement)]
+    return [transpile_gml_expression(statement, local_names)]
 
 
-def _transpile_var_statement(statement):
+def _transpile_var_statement(statement, local_names=None):
     lines = []
+    if local_names is None:
+        local_names = set()
     for declaration in _split_top_level(statement, ","):
         declaration = declaration.strip()
         if not declaration:
             continue
         assignment = _split_assignment(declaration)
         if assignment is None:
-            lines.append(f"var {declaration}")
+            name = declaration.strip()
+            lines.append(f"var {name}")
+            local_names.add(name)
             continue
         name, operator, value = assignment
         if operator != "=":
             raise GMLTranspileError("Variable declarations only support '=' assignments")
-        lines.append(f"var {name.strip()} = {transpile_gml_expression(value)}")
+        name = name.strip()
+        lines.append(f"var {name} = {transpile_gml_expression(value, local_names)}")
+        local_names.add(name)
     return lines
 
 

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -70,13 +70,13 @@ class TestGMLStatementTranspiler(unittest.TestCase):
     def test_transpiles_compound_assignments(self):
         self.assertEqual(
             transpile_gml_code("x += y * 2;", indent=""),
-            "x += y * 2",
+            "position.x += position.y * 2",
         )
 
     def test_transpiles_nullish_assignment(self):
         self.assertEqual(
-            transpile_gml_code("x ??= 10;", indent=""),
-            "if x == null:\n\tx = 10",
+            transpile_gml_code("score ??= 10;", indent=""),
+            "if score == null:\n\tscore = 10",
         )
 
     def test_transpiles_increment_decrement_statements(self):
@@ -87,6 +87,46 @@ class TestGMLStatementTranspiler(unittest.TestCase):
         self.assertEqual(
             transpile_gml_code("show_debug_message(score ?? 0);", indent=""),
             "show_debug_message(score if score != null else 0)",
+        )
+
+    def test_local_vars_shadow_instance_position_builtins(self):
+        self.assertEqual(
+            transpile_gml_code("var x = 1, y = x + 2; x += y;", indent=""),
+            "var x = 1\nvar y = x + 2\nx += y",
+        )
+
+    def test_transpiles_if_blocks(self):
+        self.assertEqual(
+            transpile_gml_code("if score > 0 { score -= 1; } else { score = 0; }", indent=""),
+            "if score > 0:\n\tscore -= 1\nelse:\n\tscore = 0",
+        )
+
+    def test_transpiles_keyboard_check_and_position_movement(self):
+        source = """
+        if keyboard_check(vk_left) {
+            x -= 10;
+        }
+        if keyboard_check(vk_right) {
+            x += 10;
+        }
+        if keyboard_check(vk_up) {
+            y -= 10;
+        }
+        if keyboard_check(vk_down) {
+            y += 10;
+        }
+        """
+
+        self.assertEqual(
+            transpile_gml_code(source, indent=""),
+            "if Input.is_action_pressed(\"ui_left\"):\n"
+            "\tposition.x -= 10\n"
+            "if Input.is_action_pressed(\"ui_right\"):\n"
+            "\tposition.x += 10\n"
+            "if Input.is_action_pressed(\"ui_up\"):\n"
+            "\tposition.y -= 10\n"
+            "if Input.is_action_pressed(\"ui_down\"):\n"
+            "\tposition.y += 10",
         )
 
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -517,6 +517,31 @@ class TestScriptGeneration(unittest.TestCase):
             content = f.read()
         self.assertIn("func _process(delta):", content)
 
+    def test_script_transpiles_topdown_step_movement(self):
+        """Step polling movement should become Godot held-input movement."""
+        self._setup_object("o_player", event_list=[{"eventType": 3, "eventNum": 0}])
+        source_path = os.path.join(self.gm_dir, "objects", "o_player", "Step_0.gml")
+        with open(source_path, "w", encoding="utf-8") as f:
+            f.write(
+                "if keyboard_check(vk_left) { x -= 10; }\n"
+                "if keyboard_check(vk_right) { x += 10; }\n"
+                "if keyboard_check(vk_up) { y -= 10; }\n"
+                "if keyboard_check(vk_down) { y += 10; }\n"
+            )
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        gd_path = os.path.join(self.godot_dir, "objects", "o_player", "o_player.gd")
+        with open(gd_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        self.assertIn("func _process(delta):", content)
+        self.assertIn("\tif Input.is_action_pressed(\"ui_left\"):\n\t\tposition.x -= 10", content)
+        self.assertIn("\tif Input.is_action_pressed(\"ui_right\"):\n\t\tposition.x += 10", content)
+        self.assertIn("\tif Input.is_action_pressed(\"ui_up\"):\n\t\tposition.y -= 10", content)
+        self.assertIn("\tif Input.is_action_pressed(\"ui_down\"):\n\t\tposition.y += 10", content)
+
     def test_script_with_begin_step(self):
         """eventType 3, eventNum 1 should produce func _physics_process(delta)."""
         self._setup_object("o_test", event_list=[{"eventType": 3, "eventNum": 1}])

--- a/tests/test_simple_topdown_conversion.py
+++ b/tests/test_simple_topdown_conversion.py
@@ -1,0 +1,126 @@
+import os
+import shutil
+import sys
+import tempfile
+import threading
+import unittest
+from datetime import date
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.converter import CONVERSION_CATEGORIES, Converter
+from src.gui.setting_value import SettingValue
+
+
+def _get_simple_topdown_path():
+    """Return SimpleTopDown project path from env var, or None if unavailable."""
+    path = os.environ.get("SIMPLE_TOPDOWN_PROJECT_PATH")
+    if not path or not os.path.isdir(path):
+        return None
+    return path
+
+
+@unittest.skipUnless(
+    _get_simple_topdown_path(),
+    "SIMPLE_TOPDOWN_PROJECT_PATH not set or not a valid directory",
+)
+class TestSimpleTopDownConversion(unittest.TestCase):
+    """Integration test: convert the SimpleTopDown GameMaker test project."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.project_path = _get_simple_topdown_path()
+        today = date.today().strftime("%Y%m%d")
+        cls.godot_dir = tempfile.mkdtemp(prefix=f"simple_topdown_{today}_")
+
+        with open(os.path.join(cls.godot_dir, "project.godot"), "w", encoding="utf-8") as f:
+            f.write(
+                '[gd_resource]\n\n'
+                '[application]\n'
+                'config/name="Placeholder"\n'
+                'config/icon="res://old_icon.png"\n'
+            )
+
+        all_keys = (
+            CONVERSION_CATEGORIES["assets"]
+            + CONVERSION_CATEGORIES["project"]
+            + CONVERSION_CATEGORIES["wip"]
+        )
+        settings = {key: SettingValue(True) for key in all_keys}
+
+        cls.logs = []
+        conversion_running = threading.Event()
+        conversion_running.set()
+
+        converter = Converter(
+            log_callback=lambda msg: cls.logs.append(msg),
+            progress_callback=lambda v: None,
+            status_callback=lambda msg: None,
+            conversion_running=conversion_running,
+            compact_logging=True,
+        )
+        converter.convert(cls.project_path, "windows", cls.godot_dir, settings)
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "godot_dir") and os.path.isdir(cls.godot_dir):
+            shutil.rmtree(cls.godot_dir)
+
+    def _find_generated_file(self, resource_dir, filename):
+        root_dir = os.path.join(self.godot_dir, resource_dir)
+        for root, _dirs, files in os.walk(root_dir):
+            if filename in files:
+                return os.path.join(root, filename)
+        self.fail(f"Expected {filename} somewhere under {resource_dir}/")
+
+    def _read_generated_file(self, resource_dir, filename):
+        path = self._find_generated_file(resource_dir, filename)
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+
+    def test_player_step_transpiles_keyboard_movement(self):
+        content = self._read_generated_file("objects", "o_player.gd")
+
+        self.assertIn("func _process(delta):", content)
+        self.assertIn('if Input.is_action_pressed("ui_left"):', content)
+        self.assertIn("position.x -= 10", content)
+        self.assertIn('if Input.is_action_pressed("ui_right"):', content)
+        self.assertIn("position.x += 10", content)
+        self.assertIn('if Input.is_action_pressed("ui_up"):', content)
+        self.assertIn("position.y -= 10", content)
+        self.assertIn('if Input.is_action_pressed("ui_down"):', content)
+        self.assertIn("position.y += 10", content)
+        self.assertNotIn("keyboard_check", content)
+        self.assertNotIn("vk_left", content)
+
+    def test_player_object_instances_sprite(self):
+        content = self._read_generated_file("objects", "o_player.tscn")
+
+        self.assertIn('type="Node2D"', content)
+        self.assertIn('res://sprites/s_player/s_player.tscn', content)
+        self.assertIn('script = ExtResource', content)
+
+    def test_starting_room_instantiates_player(self):
+        content = self._read_generated_file("rooms", "r_StartingRoom.tscn")
+
+        self.assertIn('metadata/gamemaker_room_width = 1366', content)
+        self.assertIn('metadata/gamemaker_room_height = 768', content)
+        self.assertIn('o_player.tscn', content)
+        self.assertIn('position = Vector2(704, 384)', content)
+
+    def test_startup_scene_points_to_starting_room(self):
+        with open(os.path.join(self.godot_dir, "project.godot"), "r", encoding="utf-8") as f:
+            content = f.read()
+
+        self.assertIn('run/main_scene=', content)
+        self.assertIn('r_StartingRoom.tscn', content)
+
+    def test_no_tracebacks_in_logs(self):
+        joined = "\n".join(str(msg) for msg in self.logs)
+        self.assertNotIn("Traceback", joined, "Conversion produced a Python traceback")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a SimpleTopDown conversion integration test and run it before TCC in CI.
- Transpile GML `if`/`else` blocks, `keyboard_check(vk_left/right/up/down)`, and GameMaker `x`/`y` movement for Node2D scripts.
- Cover local `var` shadowing and object Step movement regression cases.

## Verification
- `python3 -m unittest tests.test_gml_transpiler -v`
- `python3 -m unittest tests.test_objects -v`
- `SIMPLE_TOPDOWN_PROJECT_PATH=/var/folders/57/0_18fq094z92tx_kd6yz0kwh0000gn/T/opencode/GM2GodotGameTest_SimpleTopDown python3 -m unittest tests.test_simple_topdown_conversion -v`
- `python3 -m unittest discover tests/ -v`

Related to #129, #130, #447, and #448.