### PR TITLE
Support GML infinity semantics

### DIFF
--- a/src/conversion/gml_runtime.py
+++ b/src/conversion/gml_runtime.py
@@ -1,0 +1,67 @@
+import os
+
+
+GML_RUNTIME_RELATIVE_PATH = os.path.join("gm2godot", "gml_runtime.gd")
+GML_RUNTIME_RESOURCE_PATH = "res://gm2godot/gml_runtime.gd"
+
+GML_RUNTIME_SCRIPT = """extends RefCounted
+
+static func gml_div(left, right):
+	return float(left) / float(right)
+
+
+static func is_infinity(value):
+	return _is_number(value) and is_inf(float(value))
+
+
+static func gml_typeof(value):
+	var value_type = typeof(value)
+	if value_type == TYPE_NIL:
+		return "undefined"
+	if value_type == TYPE_BOOL:
+		return "bool"
+	if value_type == TYPE_INT or value_type == TYPE_FLOAT:
+		return "number"
+	if value_type == TYPE_STRING or value_type == TYPE_STRING_NAME:
+		return "string"
+	if value_type == TYPE_ARRAY:
+		return "array"
+	if value_type == TYPE_DICTIONARY:
+		return "struct"
+	if value_type == TYPE_CALLABLE:
+		return "method"
+	if value_type == TYPE_OBJECT:
+		return "struct"
+	return "unknown"
+
+
+static func gml_string(value):
+	if is_infinity(value):
+		return "-infinity" if float(value) < 0.0 else "infinity"
+	if _is_nan_number(value):
+		return "NaN"
+	return str(value)
+
+
+static func gml_bool(value):
+	if _is_number(value):
+		return float(value) > 0.5
+	return bool(value)
+
+
+static func _is_number(value):
+	var value_type = typeof(value)
+	return value_type == TYPE_INT or value_type == TYPE_FLOAT
+
+
+static func _is_nan_number(value):
+	return _is_number(value) and is_nan(float(value))
+"""
+
+
+def write_gml_runtime(godot_project_path):
+    runtime_path = os.path.join(godot_project_path, GML_RUNTIME_RELATIVE_PATH)
+    os.makedirs(os.path.dirname(runtime_path), exist_ok=True)
+    with open(runtime_path, "w", encoding="utf-8") as f:
+        f.write(GML_RUNTIME_SCRIPT)
+    return runtime_path

--- a/src/conversion/gml_transpiler.py
+++ b/src/conversion/gml_transpiler.py
@@ -146,6 +146,9 @@ _OPERATOR_REPLACEMENTS = {
 }
 
 _NAME_REPLACEMENTS = {
+    "infinity": "INF",
+    "NaN": "NAN",
+    "nan": "NAN",
     "undefined": "null",
 }
 
@@ -159,6 +162,13 @@ _VIRTUAL_KEY_ACTIONS = {
     "vk_right": "ui_right",
     "vk_up": "ui_up",
     "vk_down": "ui_down",
+}
+
+_RUNTIME_FUNCTIONS = {
+    "is_infinity": "is_infinity",
+    "typeof": "gml_typeof",
+    "string": "gml_string",
+    "bool": "gml_bool",
 }
 
 
@@ -607,6 +617,13 @@ def _emit_builtin_call(expr, local_names):
         key = expr.args[0]
         if isinstance(key, _Name) and key.value in _VIRTUAL_KEY_ACTIONS:
             return f'Input.is_action_pressed("{_VIRTUAL_KEY_ACTIONS[key.value]}")'
+    if (
+        isinstance(expr.callee, _Name)
+        and expr.callee.value in _RUNTIME_FUNCTIONS
+        and len(expr.args) == 1
+    ):
+        arg = _emit_expression(expr.args[0], local_names)[0]
+        return f"GMRuntime.{_RUNTIME_FUNCTIONS[expr.callee.value]}({arg})"
     return None
 
 
@@ -622,6 +639,11 @@ def _emit_binary(expr, local_names):
         left = _emit_expression(expr.left, local_names)[0]
         right = _emit_child(expr.right, _TERNARY_PRECEDENCE, local_names=local_names)
         return f"{left} if {left} != null else {right}", _TERNARY_PRECEDENCE
+
+    if expr.operator == "/":
+        left = _emit_expression(expr.left, local_names)[0]
+        right = _emit_expression(expr.right, local_names)[0]
+        return f"GMRuntime.gml_div({left}, {right})", _POSTFIX_PRECEDENCE
 
     precedence = _BINARY_PRECEDENCE[expr.operator]
     left = _emit_child(expr.left, precedence, local_names=local_names)
@@ -746,6 +768,8 @@ def _transpile_statement(statement, local_names=None):
         value = transpile_gml_expression(value, local_names)
         if operator == "??=":
             return [f"if {target} == null:", f"\t{target} = {value}"]
+        if operator == "/=":
+            return [f"{target} = GMRuntime.gml_div({target}, {value})"]
         return [f"{target} {operator} {value}"]
 
     return [transpile_gml_expression(statement, local_names)]

--- a/src/conversion/objects.py
+++ b/src/conversion/objects.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
 from src.conversion.event_mapping import map_event
+from src.conversion.gml_runtime import write_gml_runtime
 from src.conversion.gml_transpiler import GMLTranspileError, transpile_gml_code
 from src.conversion.script_generator import generate_script_content
 
@@ -220,6 +221,8 @@ class ObjectConverter(BaseConverter):
         if not os.path.isdir(gm_objects_path):
             self.log_callback(get_localized("Console_Convertor_Objects_Error_NotFound"))
             return
+
+        write_gml_runtime(self.godot_project_path)
 
         object_names = [
             name for name in os.listdir(gm_objects_path)

--- a/src/conversion/script_generator.py
+++ b/src/conversion/script_generator.py
@@ -1,5 +1,10 @@
 from src.conversion.event_mapping import map_event, is_input_event, INPUT_MERGED_MAPPING
 from src.conversion.events.features import get_script_features
+from src.conversion.gml_runtime import GML_RUNTIME_RESOURCE_PATH
+
+
+def _uses_gml_runtime(code_bodies):
+    return any("GMRuntime." in body for body in (code_bodies or {}).values())
 
 
 def _get_function_body(func, code_bodies):
@@ -72,6 +77,8 @@ def generate_script_content(event_list, code_bodies=None):
     unique_functions.sort(key=lambda f: (f.sort_key, f.godot_func))
 
     lines = ["extends Node2D\n"]
+    if _uses_gml_runtime(code_bodies):
+        lines.append(f'\n\nconst GMRuntime = preload("{GML_RUNTIME_RESOURCE_PATH}")\n')
     for feature in script_features:
         emit_prelude = getattr(feature, "emit_prelude", None)
         if emit_prelude is not None:

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -28,6 +28,52 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
         self.assertEqual(transpile_gml_expression("score div 10"), "int(score / 10)")
         self.assertEqual(transpile_gml_expression("score mod 3"), "score % 3")
 
+    def test_transpiles_runtime_safe_real_division(self):
+        self.assertEqual(
+            transpile_gml_expression("1 / 0"),
+            "GMRuntime.gml_div(1, 0)",
+        )
+        self.assertEqual(
+            transpile_gml_expression("a / b + c"),
+            "GMRuntime.gml_div(a, b) + c",
+        )
+
+    def test_transpiles_infinity_and_nan_constants(self):
+        self.assertEqual(transpile_gml_expression("infinity"), "INF")
+        self.assertEqual(transpile_gml_expression("NaN"), "NAN")
+
+    def test_preserves_infinity_equality_cases(self):
+        self.assertEqual(
+            transpile_gml_expression("infinity == infinity"),
+            "INF == INF",
+        )
+        self.assertEqual(
+            transpile_gml_expression("infinity == NaN"),
+            "INF == NAN",
+        )
+        self.assertEqual(
+            transpile_gml_expression("infinity == undefined"),
+            "INF == null",
+        )
+
+    def test_transpiles_infinity_variable_functions(self):
+        self.assertEqual(
+            transpile_gml_expression("is_infinity(infinity)"),
+            "GMRuntime.is_infinity(INF)",
+        )
+        self.assertEqual(
+            transpile_gml_expression("typeof(infinity)"),
+            "GMRuntime.gml_typeof(INF)",
+        )
+        self.assertEqual(
+            transpile_gml_expression("string(infinity)"),
+            "GMRuntime.gml_string(INF)",
+        )
+        self.assertEqual(
+            transpile_gml_expression("bool(infinity)"),
+            "GMRuntime.gml_bool(INF)",
+        )
+
     def test_transpiles_bitwise_operators(self):
         self.assertEqual(
             transpile_gml_expression("flags & mask | 4"),
@@ -71,6 +117,12 @@ class TestGMLStatementTranspiler(unittest.TestCase):
         self.assertEqual(
             transpile_gml_code("x += y * 2;", indent=""),
             "position.x += position.y * 2",
+        )
+
+    def test_transpiles_divide_assignment_through_runtime(self):
+        self.assertEqual(
+            transpile_gml_code("x /= 0;", indent=""),
+            "position.x = GMRuntime.gml_div(position.x, 0)",
         )
 
     def test_transpiles_nullish_assignment(self):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -506,6 +506,31 @@ class TestScriptGeneration(unittest.TestCase):
         self.assertIn("\tscore += int(speed / 2)", content)
         self.assertNotIn("\tpass", content)
 
+    def test_script_transpiles_infinity_runtime_support(self):
+        """Infinity-sensitive GML should use the shared runtime support layer."""
+        self._setup_object("o_test", event_list=[{"eventType": 0, "eventNum": 0}])
+        source_path = os.path.join(self.gm_dir, "objects", "o_test", "Create_0.gml")
+        with open(source_path, "w", encoding="utf-8") as f:
+            f.write(
+                "var limit = infinity; "
+                "var ratio = 1 / 0; "
+                "show_debug_message(string(limit));"
+            )
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        gd_path = os.path.join(self.godot_dir, "objects", "o_test", "o_test.gd")
+        with open(gd_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        runtime_path = os.path.join(self.godot_dir, "gm2godot", "gml_runtime.gd")
+        self.assertTrue(os.path.isfile(runtime_path))
+        self.assertIn('const GMRuntime = preload("res://gm2godot/gml_runtime.gd")', content)
+        self.assertIn("\tvar limit = INF", content)
+        self.assertIn("\tvar ratio = GMRuntime.gml_div(1, 0)", content)
+        self.assertIn("\tshow_debug_message(GMRuntime.gml_string(limit))", content)
+
     def test_script_with_step_event(self):
         """eventType 3, eventNum 0 should produce func _process(delta)."""
         self._setup_object("o_test", event_list=[{"eventType": 3, "eventNum": 0}])

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -244,6 +244,15 @@ class TestScriptGeneratorCodeBodies(unittest.TestCase):
         self.assertIn("\tvar x = 1", content)
         self.assertNotIn("\tpass", content)
 
+    def test_runtime_prelude_added_when_body_uses_runtime(self):
+        content = generate_script_content(
+            [{"eventType": 0, "eventNum": 0}],
+            code_bodies={"_ready": "\tvalue = GMRuntime.gml_div(1, 0)"},
+        )
+
+        self.assertIn('const GMRuntime = preload("res://gm2godot/gml_runtime.gd")', content)
+        self.assertIn("\tvalue = GMRuntime.gml_div(1, 0)", content)
+
     def test_partial_code_bodies(self):
         """Functions not in code_bodies should still get pass."""
         content = generate_script_content(


### PR DESCRIPTION
## Summary
- Map GML `infinity`/`NaN` constants to Godot `INF`/`NAN`.
- Add shared generated `GMRuntime` helpers for division, `is_infinity`, `typeof`, `string`, and `bool` semantics.
- Preload runtime support only when converted scripts use runtime helpers.

## Tests
- `python3 -m unittest tests.test_gml_transpiler tests.test_script_generator tests.test_objects`
- `python3 -m unittest discover tests`

Closes #426
Closes #427
Closes #428
Closes #429
Part of #352