### PR TITLE
Add type hints and pyright config

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from src.gui.main_window import MainWindow
 from src.gui.theme import generate_stylesheet
 
 
-def main():
+def main() -> None:
     app = QApplication(sys.argv)
     app.setStyleSheet(generate_stylesheet())
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,12 @@
+{
+  "include": [
+    "main.py",
+    "src",
+    "tests"
+  ],
+  "exclude": [
+    "venv",
+    "**/__pycache__"
+  ],
+  "typeCheckingMode": "strict"
+}

--- a/src/conversion/base_converter.py
+++ b/src/conversion/base_converter.py
@@ -1,47 +1,51 @@
+from __future__ import annotations
+
 import json
 import os
 import re
 import threading
 from abc import ABC, abstractmethod
+from typing import Any, cast
 
 from src.localization import get_localized
+from src.conversion.type_defs import ConversionRunning, JsonDict, LogCallback, ProgressCallback, StrPath
 
 
 class BaseConverter(ABC):
     """Base class for all GM2Godot converters."""
 
-    def __init__(self, gm_project_path, godot_project_path,
-                 log_callback=print, progress_callback=None,
-                 conversion_running=None,
-                 update_log_callback=None, compact_logging=False,
-                 max_workers=None):
-        self.gm_project_path = gm_project_path
-        self.godot_project_path = godot_project_path
-        self.log_callback = log_callback
+    def __init__(self, gm_project_path: StrPath, godot_project_path: StrPath,
+                 log_callback: LogCallback = print, progress_callback: ProgressCallback | None = None,
+                 conversion_running: ConversionRunning | None = None,
+                 update_log_callback: LogCallback | None = None, compact_logging: bool = False,
+                 max_workers: int | None = None) -> None:
+        self.gm_project_path = os.fspath(gm_project_path)
+        self.godot_project_path = os.fspath(godot_project_path)
+        self.log_callback: LogCallback = log_callback
         self.progress_callback = progress_callback
-        self.conversion_running = conversion_running or (lambda: True)
-        self.update_log_callback = update_log_callback or log_callback
+        self.conversion_running: ConversionRunning = conversion_running or (lambda: True)
+        self.update_log_callback: LogCallback = update_log_callback or log_callback
         self.compact_logging = compact_logging
-        self.max_workers = max_workers or os.cpu_count()
+        self.max_workers = max_workers or os.cpu_count() or 1
         self._lock = threading.Lock()
 
-    def _safe_log(self, message):
+    def _safe_log(self, message: str) -> None:
         """Thread-safe wrapper for log_callback. Use in multi-threaded converters."""
         with self._lock:
             self.log_callback(message)
 
-    def _safe_update_log(self, message):
+    def _safe_update_log(self, message: str) -> None:
         """Thread-safe wrapper for update_log_callback. Use in multi-threaded converters."""
         with self._lock:
             self.update_log_callback(message)
 
-    def _safe_progress(self, value):
+    def _safe_progress(self, value: int | float) -> None:
         """Thread-safe wrapper for progress_callback. Use in multi-threaded converters."""
         with self._lock:
             if self.progress_callback:
                 self.progress_callback(value)
 
-    def _log_progress(self, item_name, current, total):
+    def _log_progress(self, item_name: str, current: int, total: int) -> None:
         """Log compact progress. First item appends a line; subsequent items update it in place."""
         msg = get_localized("Console_Compact_Progress").format(
             name=item_name, current=current, total=total)
@@ -50,22 +54,23 @@ class BaseConverter(ABC):
         else:
             self.update_log_callback(msg)
 
-    def _safe_log_progress(self, item_name, current, total):
+    def _safe_log_progress(self, item_name: str, current: int, total: int) -> None:
         """Thread-safe version of _log_progress."""
         with self._lock:
             self._log_progress(item_name, current, total)
 
-    def _read_yy_file(self, yy_path):
+    def _read_yy_file(self, yy_path: StrPath) -> JsonDict | None:
         """Read and parse a GameMaker .yy file, cleaning trailing commas."""
         try:
             with open(yy_path, 'r', encoding='utf-8') as f:
                 content = f.read()
             cleaned = re.sub(r',\s*([}\]])', r'\1', content)
-            return json.loads(cleaned)
+            data = json.loads(cleaned)
+            return cast(JsonDict, data) if isinstance(data, dict) else None
         except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
             return None
 
-    def _get_subfolder_from_yy(self, yy_path):
+    def _get_subfolder_from_yy(self, yy_path: StrPath) -> str:
         """Extract the IDE subfolder path from a resource's .yy file.
 
         Reads parent.path (e.g. "folders/Objects/Game/Abilities.yy"),
@@ -78,7 +83,13 @@ class BaseConverter(ABC):
         if data is None:
             return ""
         try:
-            parent_path = data['parent']['path']
+            raw_parent = data.get('parent')
+            if not isinstance(raw_parent, dict):
+                return ""
+            parent = cast(JsonDict, raw_parent)
+            parent_path = parent.get('path')
+            if not isinstance(parent_path, str):
+                return ""
             if parent_path.startswith('folders/'):
                 parent_path = parent_path[len('folders/'):]
             if parent_path.endswith('.yy'):
@@ -91,6 +102,6 @@ class BaseConverter(ABC):
             return ""
 
     @abstractmethod
-    def convert_all(self):
+    def convert_all(self) -> Any:
         """Run the full conversion for this converter type."""
         pass

--- a/src/conversion/converter.py
+++ b/src/conversion/converter.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Callable, Mapping, Protocol, TypeAlias
+
 from src.conversion.sprites import SpriteConverter
 from src.conversion.sounds import SoundConverter
 from src.conversion.fonts import FontConverter
@@ -8,29 +12,40 @@ from src.conversion.rooms import RoomConverter
 from src.conversion.shaders import ShaderConverter
 from src.conversion.included_files import IncludedFilesConverter
 from src.conversion.project_settings import ProjectSettingsConverter
+from src.conversion.type_defs import BoolSetting, LogCallback, ProgressCallback
 
 from src.localization import get_localized
 
 
-CONVERSION_CATEGORIES = {
+CONVERSION_CATEGORIES: dict[str, list[str]] = {
     "assets": ["sprites", "fonts", "sounds", "sound_group_folders", "included_files", "objects", "rooms"],
     "project": ["game_icon", "project_name", "project_settings", "audio_buses", "notes"],
     "wip": ["shaders", "tilesets"],
 }
 
 
+class RunningFlag(Protocol):
+    def is_set(self) -> bool: ...
+
+
+ConverterFn: TypeAlias = Callable[[], object]
+
+
 class Converter:
-    def __init__(self, log_callback, progress_callback, status_callback, conversion_running,
-                 update_log_callback=None, compact_logging=False, max_workers=None):
-        self.log_callback = log_callback
-        self.progress_callback = progress_callback
-        self.status_callback = status_callback
+    def __init__(self, log_callback: LogCallback, progress_callback: ProgressCallback,
+                 status_callback: LogCallback, conversion_running: RunningFlag,
+                 update_log_callback: LogCallback | None = None, compact_logging: bool = False,
+                 max_workers: int | None = None) -> None:
+        self.log_callback: LogCallback = log_callback
+        self.progress_callback: ProgressCallback = progress_callback
+        self.status_callback: LogCallback = status_callback
         self.conversion_running = conversion_running
-        self.update_log_callback = update_log_callback or log_callback
+        self.update_log_callback: LogCallback = update_log_callback or log_callback
         self.compact_logging = compact_logging
         self.max_workers = max_workers
 
-    def convert(self, gm_path, gm_platform, godot_path, settings):
+    def convert(self, gm_path: str, gm_platform: str, godot_path: str,
+                settings: Mapping[str, BoolSetting]) -> None:
         group_sounds_by_audio_group = False
         if "sound_group_folders" in settings:
             group_sounds_by_audio_group = settings["sound_group_folders"].get()
@@ -42,7 +57,7 @@ class Converter:
             max_workers=self.max_workers,
         )
 
-        converters = [
+        converters: list[tuple[str, ConverterFn, str]] = [
             ("game_icon", project_settings.convert_icon, "Console_Convertor_Icon"),
             ("project_name", project_settings.update_project_name, "Console_Convertor_Name"),
             ("project_settings", project_settings.update_project_settings, "Console_Convertor_Settings"),

--- a/src/conversion/events/base.py
+++ b/src/conversion/events/base.py
@@ -1,4 +1,13 @@
 from dataclasses import dataclass
+from typing import Callable, TypeAlias
+
+from src.conversion.type_defs import JsonDict
+
+
+EventKey: TypeAlias = tuple[int, int]
+EventHandler: TypeAlias = Callable[[JsonDict, str], "EventMapping"]
+StaticMappings: TypeAlias = dict[EventKey, "EventMapping"]
+EventTypeHandlers: TypeAlias = dict[int, EventHandler]
 
 
 @dataclass(frozen=True)

--- a/src/conversion/events/features.py
+++ b/src/conversion/events/features.py
@@ -1,13 +1,16 @@
 import importlib
 import pkgutil
+from types import ModuleType
+from typing import Any, cast
 
 from src.conversion.events import script_features
 
 
-def get_script_features():
-    modules = sorted(pkgutil.iter_modules(script_features.__path__), key=lambda module: module.name)
+def get_script_features() -> list[ModuleType]:
+    package_info = cast(Any, script_features)
+    modules = sorted(pkgutil.iter_modules(package_info.__path__), key=lambda module: module.name)
     return [
-        importlib.import_module(f"{script_features.__name__}.{module.name}")
+        importlib.import_module(f"{package_info.__name__}.{module.name}")
         for module in modules
         if not module.ispkg
     ]

--- a/src/conversion/events/mappings/core.py
+++ b/src/conversion/events/mappings/core.py
@@ -1,7 +1,10 @@
-from src.conversion.events.base import EventMapping
+from typing import cast
+
+from src.conversion.events.base import EventMapping, EventTypeHandlers, StaticMappings
+from src.conversion.type_defs import JsonDict
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (0, 0): EventMapping("_ready", "", 0, "Create_0.gml"),
     (1, 0): EventMapping("_on_destroy", "", 10, "Destroy_0.gml"),
     (3, 0): EventMapping("_process", "delta", 1, "Step_0.gml"),
@@ -20,39 +23,40 @@ STATIC_MAPPINGS = {
 }
 
 
-def map_create_event(_event, gml_filename):
+def map_create_event(_event: JsonDict, gml_filename: str) -> EventMapping:
     return EventMapping("_ready", "", 0, gml_filename)
 
 
-def map_destroy_event(_event, gml_filename):
+def map_destroy_event(_event: JsonDict, gml_filename: str) -> EventMapping:
     return EventMapping("_on_destroy", "", 10, gml_filename)
 
 
-def map_cleanup_event(_event, gml_filename):
+def map_cleanup_event(_event: JsonDict, gml_filename: str) -> EventMapping:
     return EventMapping("_exit_tree", "", 5, gml_filename)
 
 
-def map_alarm_event(event, gml_filename):
+def map_alarm_event(event: JsonDict, gml_filename: str) -> EventMapping:
     return EventMapping(f"_on_alarm_{event.get('eventNum', 0)}", "", 11, gml_filename)
 
 
-def map_collision_event(event, gml_filename):
+def map_collision_event(event: JsonDict, gml_filename: str) -> EventMapping:
     collision_obj = event.get('collisionObjectId')
     if collision_obj and isinstance(collision_obj, dict):
-        obj_name = collision_obj.get('name', 'unknown')
+        collision_data = cast(JsonDict, collision_obj)
+        obj_name = cast(str, collision_data.get('name', 'unknown'))
         return EventMapping(f"_on_collision_{obj_name}", "", 13, gml_filename)
     return EventMapping("_on_collision", "", 13, gml_filename)
 
 
-def map_other_event(event, gml_filename):
+def map_other_event(event: JsonDict, gml_filename: str) -> EventMapping:
     return EventMapping(f"_on_other_{event.get('eventNum', 0)}", "", 14, gml_filename)
 
 
-def map_draw_event(event, gml_filename):
+def map_draw_event(event: JsonDict, gml_filename: str) -> EventMapping:
     return EventMapping(f"_on_draw_{event.get('eventNum', 0)}", "", 16, gml_filename)
 
 
-EVENT_TYPE_HANDLERS = {
+EVENT_TYPE_HANDLERS: EventTypeHandlers = {
     0: map_create_event,
     1: map_destroy_event,
     2: map_alarm_event,

--- a/src/conversion/events/mappings/input.py
+++ b/src/conversion/events/mappings/input.py
@@ -4,5 +4,5 @@ from src.conversion.events.base import EventMapping
 # Input event types are merged into a single _input(event) function.
 # GameMaker keyboard-down events also route through the shared input stub for
 # now so they are recognized as supported input instead of unknown events.
-INPUT_EVENT_TYPES = {5, 6, 9, 10, 13}
+INPUT_EVENT_TYPES: set[int] = {5, 6, 9, 10, 13}
 INPUT_MERGED_MAPPING = EventMapping("_input", "event", 4, "")

--- a/src/conversion/events/mappings/other_animation.py
+++ b/src/conversion/events/mappings/other_animation.py
@@ -1,7 +1,7 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, 7): EventMapping("_on_animation_end", "", 14, "Other_7.gml"),
     (7, 58): EventMapping("_on_animation_update", "", 14, "Other_58.gml"),
     (7, 59): EventMapping("_on_animation_event", "", 14, "Other_59.gml"),

--- a/src/conversion/events/mappings/other_async_audio.py
+++ b/src/conversion/events/mappings/other_async_audio.py
@@ -1,7 +1,7 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, 73): EventMapping("_on_audio_recording_async", "", 14, "Other_73.gml"),
     (7, 74): EventMapping("_on_audio_playback_async", "", 14, "Other_74.gml"),
     (7, 80): EventMapping("_on_audio_playback_ended_async", "", 14, "Other_80.gml"),

--- a/src/conversion/events/mappings/other_async_dialog.py
+++ b/src/conversion/events/mappings/other_async_dialog.py
@@ -1,6 +1,6 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, 63): EventMapping("_on_async_dialog", "", 14, "Other_63.gml"),
 }

--- a/src/conversion/events/mappings/other_async_http.py
+++ b/src/conversion/events/mappings/other_async_http.py
@@ -1,6 +1,6 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, 62): EventMapping("_on_http_request_completed", "", 14, "Other_62.gml"),
 }

--- a/src/conversion/events/mappings/other_async_image_loaded.py
+++ b/src/conversion/events/mappings/other_async_image_loaded.py
@@ -1,6 +1,6 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, 60): EventMapping("_on_async_image_loaded", "", 14, "Other_60.gml"),
 }

--- a/src/conversion/events/mappings/other_async_networking.py
+++ b/src/conversion/events/mappings/other_async_networking.py
@@ -1,6 +1,6 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, 68): EventMapping("_on_async_networking", "", 14, "Other_68.gml"),
 }

--- a/src/conversion/events/mappings/other_async_platform.py
+++ b/src/conversion/events/mappings/other_async_platform.py
@@ -1,7 +1,7 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, 66): EventMapping("_on_async_in_app_purchase", "", 14, "Other_66.gml"),
     (7, 67): EventMapping("_on_async_cloud_save", "", 14, "Other_67.gml"),
     (7, 70): EventMapping("_on_async_social", "", 14, "Other_70.gml"),

--- a/src/conversion/events/mappings/other_async_save_load.py
+++ b/src/conversion/events/mappings/other_async_save_load.py
@@ -1,6 +1,6 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, 72): EventMapping("_on_async_save_load", "", 14, "Other_72.gml"),
 }

--- a/src/conversion/events/mappings/other_async_sound_loaded.py
+++ b/src/conversion/events/mappings/other_async_sound_loaded.py
@@ -1,6 +1,6 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, 61): EventMapping("_on_async_sound_loaded", "", 14, "Other_61.gml"),
 }

--- a/src/conversion/events/mappings/other_async_steam.py
+++ b/src/conversion/events/mappings/other_async_steam.py
@@ -1,6 +1,6 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, 69): EventMapping("_on_async_steam", "", 14, "Other_69.gml"),
 }

--- a/src/conversion/events/mappings/other_async_system.py
+++ b/src/conversion/events/mappings/other_async_system.py
@@ -1,6 +1,6 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, 75): EventMapping("_on_async_system", "", 14, "Other_75.gml"),
 }

--- a/src/conversion/events/mappings/other_broadcast_message.py
+++ b/src/conversion/events/mappings/other_broadcast_message.py
@@ -1,6 +1,6 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, 76): EventMapping("_on_broadcast_message", "", 14, "Other_76.gml"),
 }

--- a/src/conversion/events/mappings/other_close_button.py
+++ b/src/conversion/events/mappings/other_close_button.py
@@ -1,6 +1,6 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, 30): EventMapping("_notification", "what", 6, "Other_30.gml"),
 }

--- a/src/conversion/events/mappings/other_legacy_health_lives.py
+++ b/src/conversion/events/mappings/other_legacy_health_lives.py
@@ -1,7 +1,7 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, 6): EventMapping("_on_no_more_lives", "", 14, "Other_6.gml"),
     (7, 9): EventMapping("_on_no_more_health", "", 14, "Other_9.gml"),
 }

--- a/src/conversion/events/mappings/other_lifecycle.py
+++ b/src/conversion/events/mappings/other_lifecycle.py
@@ -1,7 +1,7 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, 2): EventMapping("_on_game_start", "", 14, "Other_2.gml"),
     (7, 3): EventMapping("_on_game_end", "", 14, "Other_3.gml"),
     (7, 4): EventMapping("_on_room_start", "", 14, "Other_4.gml"),

--- a/src/conversion/events/mappings/other_path_ended.py
+++ b/src/conversion/events/mappings/other_path_ended.py
@@ -1,6 +1,6 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, 8): EventMapping("_on_path_ended", "", 14, "Other_8.gml"),
 }

--- a/src/conversion/events/mappings/other_room_boundary.py
+++ b/src/conversion/events/mappings/other_room_boundary.py
@@ -1,7 +1,7 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, 0): EventMapping("_on_outside_room", "", 14, "Other_0.gml"),
     (7, 1): EventMapping("_on_intersect_boundary", "", 14, "Other_1.gml"),
 }

--- a/src/conversion/events/mappings/other_user_events.py
+++ b/src/conversion/events/mappings/other_user_events.py
@@ -1,7 +1,7 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, event_num): EventMapping(
         f"_user_event_{event_num - 10}",
         "",

--- a/src/conversion/events/mappings/other_wallpaper.py
+++ b/src/conversion/events/mappings/other_wallpaper.py
@@ -1,7 +1,7 @@
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, StaticMappings
 
 
-STATIC_MAPPINGS = {
+STATIC_MAPPINGS: StaticMappings = {
     (7, 79): EventMapping("_on_wallpaper_config", "", 14, "Other_79.gml"),
     (7, 81): EventMapping("_on_wallpaper_subscription_data", "", 14, "Other_81.gml"),
 }

--- a/src/conversion/events/registry.py
+++ b/src/conversion/events/registry.py
@@ -1,11 +1,14 @@
 import importlib
 import pkgutil
+from types import ModuleType
+from typing import Any, Iterator, cast
 
 from src.conversion.events import mappings
-from src.conversion.events.base import EventMapping
+from src.conversion.events.base import EventMapping, EventTypeHandlers, StaticMappings
+from src.conversion.type_defs import JsonDict
 
 
-_GML_EVENT_NAMES = {
+_GML_EVENT_NAMES: dict[int, str] = {
     0: "Create",
     1: "Destroy",
     2: "Alarm",
@@ -22,24 +25,25 @@ _GML_EVENT_NAMES = {
 }
 
 
-def _iter_package_modules(package):
-    modules = sorted(pkgutil.iter_modules(package.__path__), key=lambda module: module.name)
+def _iter_package_modules(package: ModuleType) -> Iterator[ModuleType]:
+    package_info = cast(Any, package)
+    modules = sorted(pkgutil.iter_modules(package_info.__path__), key=lambda module: module.name)
     for module in modules:
-        yield importlib.import_module(f"{package.__name__}.{module.name}")
+        yield importlib.import_module(f"{package_info.__name__}.{module.name}")
 
 
-def _load_mapping_registry():
-    static_map = {}
-    event_type_handlers = {}
-    input_event_types = set()
-    input_merged_mapping = None
+def _load_mapping_registry() -> tuple[StaticMappings, EventTypeHandlers, frozenset[int], EventMapping]:
+    static_map: StaticMappings = {}
+    event_type_handlers: EventTypeHandlers = {}
+    input_event_types: set[int] = set()
+    input_merged_mapping: EventMapping | None = None
 
     for module in _iter_package_modules(mappings):
-        static_map.update(getattr(module, "STATIC_MAPPINGS", {}))
-        event_type_handlers.update(getattr(module, "EVENT_TYPE_HANDLERS", {}))
-        input_event_types.update(getattr(module, "INPUT_EVENT_TYPES", set()))
+        static_map.update(cast(StaticMappings, getattr(module, "STATIC_MAPPINGS", {})))
+        event_type_handlers.update(cast(EventTypeHandlers, getattr(module, "EVENT_TYPE_HANDLERS", {})))
+        input_event_types.update(cast(set[int], getattr(module, "INPUT_EVENT_TYPES", set[int]())))
 
-        module_input_mapping = getattr(module, "INPUT_MERGED_MAPPING", None)
+        module_input_mapping = cast(EventMapping | None, getattr(module, "INPUT_MERGED_MAPPING", None))
         if module_input_mapping is not None:
             input_merged_mapping = module_input_mapping
 
@@ -52,19 +56,19 @@ def _load_mapping_registry():
 _STATIC_MAP, _EVENT_TYPE_HANDLERS, INPUT_EVENT_TYPES, INPUT_MERGED_MAPPING = _load_mapping_registry()
 
 
-def is_input_event(event):
+def is_input_event(event: JsonDict) -> bool:
     """Check whether an event dict represents a supported input event."""
     return event.get('eventType', -1) in INPUT_EVENT_TYPES
 
 
-def map_event(event):
+def map_event(event: JsonDict) -> EventMapping | None:
     """Map a GameMaker event dict to an EventMapping.
 
     Returns None for input events since they are merged into a single
     _input(event) function by the script generator.
     """
-    event_type = event.get('eventType', -1)
-    event_num = event.get('eventNum', 0)
+    event_type = cast(int, event.get('eventType', -1))
+    event_num = cast(int, event.get('eventNum', 0))
 
     if event_type in INPUT_EVENT_TYPES:
         return None

--- a/src/conversion/events/script_features/close_button.py
+++ b/src/conversion/events/script_features/close_button.py
@@ -6,13 +6,13 @@ _READY_FUNC = "_ready"
 _DISABLE_AUTO_QUIT_BODY = "\tget_tree().auto_accept_quit = false"
 
 
-def get_additional_functions(function_names):
+def get_additional_functions(function_names: set[str]) -> list[EventMapping]:
     if _CLOSE_BUTTON_FUNC in function_names and _READY_FUNC not in function_names:
         return [EventMapping(_READY_FUNC, "", 0, "")]
     return []
 
 
-def wrap_body(func, body, function_names):
+def wrap_body(func: EventMapping, body: str, function_names: set[str]) -> str:
     if _CLOSE_BUTTON_FUNC not in function_names:
         return body
 
@@ -23,5 +23,5 @@ def wrap_body(func, body, function_names):
     return body
 
 
-def _indent_body(body):
+def _indent_body(body: str) -> str:
     return "\n".join(f"\t{line}" if line else line for line in body.splitlines())

--- a/src/conversion/events/script_features/legacy_health_lives.py
+++ b/src/conversion/events/script_features/legacy_health_lives.py
@@ -1,4 +1,4 @@
-def emit_prelude(lines, function_names):
+def emit_prelude(lines: list[str], function_names: set[str]) -> None:
     if "_on_no_more_lives" in function_names:
         lines.append(
             "\n\nvar lives = 0:"

--- a/src/conversion/events/script_features/resize.py
+++ b/src/conversion/events/script_features/resize.py
@@ -6,13 +6,13 @@ _RESIZE_FUNC = "_on_resize"
 _CONNECT_RESIZE_BODY = "\tget_viewport().size_changed.connect(_on_resize)"
 
 
-def get_additional_functions(function_names):
+def get_additional_functions(function_names: set[str]) -> list[EventMapping]:
     if _RESIZE_FUNC in function_names and _READY_FUNC not in function_names:
         return [EventMapping(_READY_FUNC, "", 0, "")]
     return []
 
 
-def wrap_body(func, body, function_names):
+def wrap_body(func: EventMapping, body: str, function_names: set[str]) -> str:
     if _RESIZE_FUNC in function_names and func.godot_func == _READY_FUNC:
         return f"{_CONNECT_RESIZE_BODY}\n{body}"
     return body

--- a/src/conversion/fonts.py
+++ b/src/conversion/fonts.py
@@ -1,20 +1,35 @@
+from __future__ import annotations
+
 import json
 import os
 import platform
 import re
 import shutil
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from typing import Literal, TypedDict, cast
 
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
+from src.conversion.type_defs import ConversionRunning, JsonDict, LogCallback, ProgressCallback, StrPath
 
 FONT_EXTENSIONS = ('.ttf', '.otf', '.ttc', '.otc', '.woff', '.woff2')
 
 
-def _get_system_font_dirs():
+class FontData(TypedDict):
+    fontName: str
+    name: str
+    size: float
+    bold: bool
+    italic: bool
+    AntiAlias: int
+    includeTTF: bool
+    TTFName: str
+
+
+def _get_system_font_dirs() -> list[str]:
     """Return a list of system font directories for the current OS."""
     system = platform.system()
-    dirs = []
+    dirs: list[str] = []
     if system == 'Windows':
         windir = os.environ.get('WINDIR', r'C:\Windows')
         dirs.append(os.path.join(windir, 'Fonts'))
@@ -37,7 +52,7 @@ def _get_system_font_dirs():
     return [d for d in dirs if os.path.isdir(d)]
 
 
-def _find_system_font(font_name):
+def _find_system_font(font_name: str) -> str | None:
     """Search system font directories for a font file matching the given name.
 
     Returns the path to the font file if found, None otherwise.
@@ -61,15 +76,17 @@ def _find_system_font(font_name):
 
 
 class FontConverter(BaseConverter):
-    def __init__(self, gm_project_path, godot_project_path, log_callback=print, progress_callback=None, conversion_running=None,
-                 update_log_callback=None, compact_logging=False, max_workers=None):
+    def __init__(self, gm_project_path: StrPath, godot_project_path: StrPath, log_callback: LogCallback = print,
+                 progress_callback: ProgressCallback | None = None, conversion_running: ConversionRunning | None = None,
+                 update_log_callback: LogCallback | None = None, compact_logging: bool = False,
+                 max_workers: int | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback, progress_callback, conversion_running,
                          update_log_callback, compact_logging, max_workers=max_workers)
         self.godot_fonts_path = os.path.join(self.godot_project_path, 'fonts')
 
-    def find_font_files(self):
+    def find_font_files(self) -> list[str]:
         font_folder = os.path.join(self.gm_project_path, 'fonts')
-        font_files = []
+        font_files: list[str] = []
         for root, _, files in os.walk(font_folder):
             font_files.extend(
                 os.path.join(root, file)
@@ -78,27 +95,27 @@ class FontConverter(BaseConverter):
             )
         return font_files
 
-    def _parse_font_yy(self, yy_path):
+    def _parse_font_yy(self, yy_path: str) -> FontData | None:
         try:
             with open(yy_path, 'r', encoding='utf-8') as f:
                 content = f.read()
             cleaned = re.sub(r',\s*([}\]])', r'\1', content)
-            data = json.loads(cleaned)
+            data = cast(JsonDict, json.loads(cleaned))
             return {
-                'fontName': data['fontName'],
-                'name': data['name'],
-                'size': data.get('size', 12.0),
-                'bold': data.get('bold', False),
-                'italic': data.get('italic', False),
-                'AntiAlias': data.get('AntiAlias', 0),
-                'includeTTF': data.get('includeTTF', False),
-                'TTFName': data.get('TTFName', ''),
+                'fontName': str(data['fontName']),
+                'name': str(data['name']),
+                'size': float(data.get('size', 12.0)),
+                'bold': bool(data.get('bold', False)),
+                'italic': bool(data.get('italic', False)),
+                'AntiAlias': int(data.get('AntiAlias', 0)),
+                'includeTTF': bool(data.get('includeTTF', False)),
+                'TTFName': str(data.get('TTFName', '')),
             }
         except (OSError, json.JSONDecodeError, KeyError, TypeError):
             self._safe_log(get_localized("Console_Convertor_Fonts_ParseError").format(yy_path=yy_path))
             return None
 
-    def _generate_system_font_tres(self, font_data):
+    def _generate_system_font_tres(self, font_data: FontData) -> str:
         font_name = font_data['fontName']
         italic = "true" if font_data['italic'] else "false"
         weight = 700 if font_data['bold'] else 400
@@ -114,7 +131,7 @@ class FontConverter(BaseConverter):
             f'antialiasing = {antialiasing}\n'
         )
 
-    def _process_font(self, yy_path):
+    def _process_font(self, yy_path: str) -> str | Literal[False] | None:
         if not self.conversion_running():
             return None
 
@@ -124,7 +141,7 @@ class FontConverter(BaseConverter):
 
         font_name = font_data['name']
         system_font_name = font_data['fontName']
-        output_file = None
+        output_file: str | None = None
 
         subfolder = self._get_subfolder_from_yy(yy_path)
         if subfolder:
@@ -173,7 +190,7 @@ class FontConverter(BaseConverter):
 
         return font_name
 
-    def convert_fonts(self):
+    def convert_fonts(self) -> None:
         os.makedirs(self.godot_project_path, exist_ok=True)
         os.makedirs(self.godot_fonts_path, exist_ok=True)
 
@@ -193,7 +210,7 @@ class FontConverter(BaseConverter):
         processed_fonts = 0
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            futures_map = {executor.submit(self._process_font, ff): ff for ff in font_files}
+            futures_map: dict[Future[str | Literal[False] | None], str] = {executor.submit(self._process_font, ff): ff for ff in font_files}
             for future in as_completed(futures_map):
                 result = future.result()
                 if result is None:
@@ -210,5 +227,5 @@ class FontConverter(BaseConverter):
 
         self.log_callback(get_localized("Console_Convertor_Fonts_Complete"))
 
-    def convert_all(self):
+    def convert_all(self) -> None:
         self.convert_fonts()

--- a/src/conversion/gml_runtime.py
+++ b/src/conversion/gml_runtime.py
@@ -59,7 +59,7 @@ static func _is_nan_number(value):
 """
 
 
-def write_gml_runtime(godot_project_path):
+def write_gml_runtime(godot_project_path: str) -> str:
     runtime_path = os.path.join(godot_project_path, GML_RUNTIME_RELATIVE_PATH)
     os.makedirs(os.path.dirname(runtime_path), exist_ok=True)
     with open(runtime_path, "w", encoding="utf-8") as f:

--- a/src/conversion/gml_transpiler.py
+++ b/src/conversion/gml_transpiler.py
@@ -1,4 +1,25 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import Iterable, Literal, MutableSet, TypeAlias
+
+
+_AssignmentOperator: TypeAlias = Literal[
+    "??=",
+    "<<=",
+    ">>=",
+    "+=",
+    "-=",
+    "*=",
+    "/=",
+    "%=",
+    "&=",
+    "|=",
+    "^=",
+    "=",
+]
+
+_IncrementDelta: TypeAlias = Literal[-1, 1]
 
 
 class GMLTranspileError(ValueError):
@@ -24,44 +45,47 @@ class _Literal:
 @dataclass(frozen=True)
 class _Unary:
     operator: str
-    operand: object
+    operand: _Expression
 
 
 @dataclass(frozen=True)
 class _Binary:
-    left: object
+    left: _Expression
     operator: str
-    right: object
+    right: _Expression
 
 
 @dataclass(frozen=True)
 class _Ternary:
-    condition: object
-    true_expr: object
-    false_expr: object
+    condition: _Expression
+    true_expr: _Expression
+    false_expr: _Expression
 
 
 @dataclass(frozen=True)
 class _Call:
-    callee: object
-    args: tuple
+    callee: _Expression
+    args: tuple[_Expression, ...]
 
 
 @dataclass(frozen=True)
 class _Index:
-    target: object
-    index: object
+    target: _Expression
+    index: _Expression
 
 
 @dataclass(frozen=True)
 class _Member:
-    target: object
+    target: _Expression
     member: str
 
 
 @dataclass(frozen=True)
 class _Grouped:
-    expr: object
+    expr: _Expression
+
+
+_Expression: TypeAlias = _Name | _Literal | _Unary | _Binary | _Ternary | _Call | _Index | _Member | _Grouped
 
 
 _EOF = _Token("EOF", "")
@@ -91,7 +115,7 @@ _MULTI_CHAR_OPERATORS = (
     ">>",
 )
 
-_ASSIGNMENT_OPERATORS = (
+_ASSIGNMENT_OPERATORS: tuple[_AssignmentOperator, ...] = (
     "??=",
     "<<=",
     ">>=",
@@ -178,14 +202,18 @@ _RUNTIME_FUNCTIONS = {
 }
 
 
-def transpile_gml_expression(source, local_names=None):
+def transpile_gml_expression(source: str, local_names: Iterable[str] | None = None) -> str:
     """Transpile a single GML expression to a GDScript expression."""
     parser = _ExpressionParser(_expression_tokens(source))
     expr = parser.parse()
     return _emit_expression(expr, _normalize_local_names(local_names))[0]
 
 
-def transpile_gml_code(source, indent="\t", instance_variables=None):
+def transpile_gml_code(
+    source: str,
+    indent: str = "\t",
+    instance_variables: MutableSet[str] | None = None,
+) -> str:
     """Transpile supported GML statements to GDScript."""
     parser = _StatementParser(
         _tokenize(_strip_comments(source)),
@@ -200,17 +228,17 @@ def transpile_gml_code(source, indent="\t", instance_variables=None):
 
 
 class _ExpressionParser:
-    def __init__(self, tokens):
+    def __init__(self, tokens: list[_Token]) -> None:
         self.tokens = tokens
         self.position = 0
 
-    def parse(self):
+    def parse(self) -> _Expression:
         expr = self._parse_expression()
         if not self._at_end():
             raise GMLTranspileError(f"Unexpected token: {self._peek().value}")
         return expr
 
-    def _parse_expression(self, min_precedence=0):
+    def _parse_expression(self, min_precedence: int = 0) -> _Expression:
         left = self._parse_unary()
 
         while True:
@@ -239,18 +267,18 @@ class _ExpressionParser:
 
         return left
 
-    def _parse_unary(self):
+    def _parse_unary(self) -> _Expression:
         operator = self._current_unary_operator()
         if operator in ("+", "-", "!", "not", "~"):
             self._advance()
             return _Unary(operator, self._parse_unary())
         return self._parse_postfix()
 
-    def _parse_postfix(self):
+    def _parse_postfix(self) -> _Expression:
         expr = self._parse_primary()
         while True:
             if self._match("("):
-                args = []
+                args: list[_Expression] = []
                 if not self._check(")"):
                     while True:
                         args.append(self._parse_expression())
@@ -275,7 +303,7 @@ class _ExpressionParser:
 
         return expr
 
-    def _parse_primary(self):
+    def _parse_primary(self) -> _Expression:
         token = self._advance()
         if token.kind == "NUMBER" or token.kind == "STRING":
             return _Literal(token.value)
@@ -287,7 +315,7 @@ class _ExpressionParser:
             return _Grouped(expr)
         raise GMLTranspileError(f"Expected expression, got: {token.value}")
 
-    def _current_operator(self):
+    def _current_operator(self) -> str | None:
         token = self._peek()
         if token.kind == "IDENT" and token.value in _BINARY_PRECEDENCE:
             return token.value
@@ -295,7 +323,7 @@ class _ExpressionParser:
             return token.value
         return None
 
-    def _current_unary_operator(self):
+    def _current_unary_operator(self) -> str | None:
         token = self._peek()
         if token.kind == "IDENT" and token.value == "not":
             return token.value
@@ -303,56 +331,61 @@ class _ExpressionParser:
             return token.value
         return None
 
-    def _match(self, value):
+    def _match(self, value: str) -> bool:
         if self._check(value):
             self.position += 1
             return True
         return False
 
-    def _consume(self, value):
+    def _consume(self, value: str) -> None:
         if not self._match(value):
             raise GMLTranspileError(f"Expected '{value}', got: {self._peek().value}")
 
-    def _consume_identifier(self):
+    def _consume_identifier(self) -> str:
         token = self._advance()
         if token.kind != "IDENT":
             raise GMLTranspileError(f"Expected identifier, got: {token.value}")
         return token.value
 
-    def _check(self, value):
+    def _check(self, value: str) -> bool:
         return self._peek().value == value
 
-    def _advance(self):
+    def _advance(self) -> _Token:
         token = self._peek()
         if not self._at_end():
             self.position += 1
         return token
 
-    def _peek(self):
+    def _peek(self) -> _Token:
         if self.position >= len(self.tokens):
             return _EOF
         return self.tokens[self.position]
 
-    def _at_end(self):
+    def _at_end(self) -> bool:
         return self._peek().kind == "EOF"
 
 
 class _StatementParser:
-    def __init__(self, tokens, local_names=None, instance_variables=None):
+    def __init__(
+        self,
+        tokens: list[_Token],
+        local_names: Iterable[str] | None = None,
+        instance_variables: MutableSet[str] | None = None,
+    ) -> None:
         self.tokens = tokens
         self.position = 0
         self.local_names = set(local_names or [])
         self.instance_variables = instance_variables
 
-    def parse(self, terminator=None):
-        lines = []
+    def parse(self, terminator: str | None = None) -> list[str]:
+        lines: list[str] = []
         while not self._at_end() and not self._check(terminator):
             if self._match(";") or self._match("\n"):
                 continue
             lines.extend(self._parse_statement())
         return lines
 
-    def _parse_statement(self):
+    def _parse_statement(self) -> list[str]:
         if self._check_identifier("if"):
             return self._parse_if_statement()
 
@@ -365,7 +398,7 @@ class _StatementParser:
             self.instance_variables,
         )
 
-    def _parse_if_statement(self):
+    def _parse_if_statement(self) -> list[str]:
         self._consume_identifier("if")
         condition_tokens = self._read_condition_tokens()
         if not condition_tokens:
@@ -392,7 +425,7 @@ class _StatementParser:
 
         return lines
 
-    def _parse_body(self):
+    def _parse_body(self) -> list[str]:
         if self._match("{"):
             lines = self.parse(terminator="}")
             self._consume("}")
@@ -401,11 +434,11 @@ class _StatementParser:
             return []
         return self._parse_statement()
 
-    def _read_condition_tokens(self):
+    def _read_condition_tokens(self) -> list[_Token]:
         if self._match("("):
             return self._read_balanced_tokens("(", ")")
 
-        tokens = []
+        tokens: list[_Token] = []
         depth = 0
         while not self._at_end():
             token = self._peek()
@@ -422,12 +455,12 @@ class _StatementParser:
 
         return tokens
 
-    def _skip_newlines(self):
+    def _skip_newlines(self) -> None:
         while self._match("\n"):
             pass
 
-    def _read_balanced_tokens(self, opener, closer):
-        tokens = []
+    def _read_balanced_tokens(self, opener: str, closer: str) -> list[_Token]:
+        tokens: list[_Token] = []
         depth = 1
         while not self._at_end():
             token = self._advance()
@@ -441,8 +474,8 @@ class _StatementParser:
 
         raise GMLTranspileError(f"Expected '{closer}'")
 
-    def _read_simple_statement(self):
-        tokens = []
+    def _read_simple_statement(self) -> list[_Token]:
+        tokens: list[_Token] = []
         depth = 0
         while not self._at_end():
             token = self._peek()
@@ -461,52 +494,52 @@ class _StatementParser:
 
         return tokens
 
-    def _match(self, value):
+    def _match(self, value: str) -> bool:
         if self._check(value):
             self.position += 1
             return True
         return False
 
-    def _match_identifier(self, value):
+    def _match_identifier(self, value: str) -> bool:
         if self._check_identifier(value):
             self.position += 1
             return True
         return False
 
-    def _consume(self, value):
+    def _consume(self, value: str) -> None:
         if not self._match(value):
             raise GMLTranspileError(f"Expected '{value}', got: {self._peek().value}")
 
-    def _consume_identifier(self, value):
+    def _consume_identifier(self, value: str) -> None:
         if not self._match_identifier(value):
             raise GMLTranspileError(f"Expected '{value}', got: {self._peek().value}")
 
-    def _check(self, value):
+    def _check(self, value: str | None) -> bool:
         if value is None:
             return False
         return self._peek().value == value
 
-    def _check_identifier(self, value):
+    def _check_identifier(self, value: str) -> bool:
         token = self._peek()
         return token.kind == "IDENT" and token.value == value
 
-    def _advance(self):
+    def _advance(self) -> _Token:
         token = self._peek()
         if not self._at_end():
             self.position += 1
         return token
 
-    def _peek(self):
+    def _peek(self) -> _Token:
         if self.position >= len(self.tokens):
             return _EOF
         return self.tokens[self.position]
 
-    def _at_end(self):
+    def _at_end(self) -> bool:
         return self._peek().kind == "EOF"
 
 
-def _tokenize(source):
-    tokens = []
+def _tokenize(source: str) -> list[_Token]:
+    tokens: list[_Token] = []
     index = 0
     while index < len(source):
         char = source[index]
@@ -568,11 +601,11 @@ def _tokenize(source):
     return tokens
 
 
-def _expression_tokens(source):
+def _expression_tokens(source: str) -> list[_Token]:
     return [token for token in _tokenize(source) if token.kind != "NEWLINE"]
 
 
-def _read_string(source, start):
+def _read_string(source: str, start: int) -> str:
     quote = source[start]
     index = start + 1
     escaped = False
@@ -588,19 +621,22 @@ def _read_string(source, start):
     raise GMLTranspileError("Unterminated string literal")
 
 
-def _normalize_local_names(local_names):
+def _normalize_local_names(local_names: Iterable[str] | None) -> frozenset[str]:
     return frozenset(local_names or [])
 
 
-def _tokens_to_source(tokens):
+def _tokens_to_source(tokens: Iterable[_Token]) -> str:
     return " ".join(token.value for token in tokens if token.kind not in ("EOF", "NEWLINE"))
 
 
-def _indent_lines(lines):
+def _indent_lines(lines: Iterable[str]) -> list[str]:
     return [f"\t{line}" if line else "" for line in lines]
 
 
-def _emit_expression(expr, local_names=None):
+def _emit_expression(
+    expr: _Expression,
+    local_names: Iterable[str] | None = None,
+) -> tuple[str, int]:
     local_names = _normalize_local_names(local_names)
     if isinstance(expr, _Literal):
         return expr.value, _PRIMARY_PRECEDENCE
@@ -636,13 +672,11 @@ def _emit_expression(expr, local_names=None):
         target = _emit_child(expr.target, _POSTFIX_PRECEDENCE, local_names=local_names)
         index = _emit_expression(expr.index, local_names)[0]
         return f"{target}[{index}]", _POSTFIX_PRECEDENCE
-    if isinstance(expr, _Member):
-        target = _emit_child(expr.target, _POSTFIX_PRECEDENCE, local_names=local_names)
-        return f"{target}.{expr.member}", _POSTFIX_PRECEDENCE
-    raise GMLTranspileError("Unknown expression node")
+    target = _emit_child(expr.target, _POSTFIX_PRECEDENCE, local_names=local_names)
+    return f"{target}.{expr.member}", _POSTFIX_PRECEDENCE
 
 
-def _emit_builtin_call(expr, local_names):
+def _emit_builtin_call(expr: _Call, local_names: Iterable[str]) -> str | None:
     if isinstance(expr.callee, _Name) and expr.callee.value == "keyboard_check" and len(expr.args) == 1:
         key = expr.args[0]
         if isinstance(key, _Name) and key.value in _VIRTUAL_KEY_ACTIONS:
@@ -659,7 +693,7 @@ def _emit_builtin_call(expr, local_names):
     return None
 
 
-def _emit_binary(expr, local_names):
+def _emit_binary(expr: _Binary, local_names: Iterable[str]) -> tuple[str, int]:
     operator = _OPERATOR_REPLACEMENTS.get(expr.operator, expr.operator)
 
     if expr.operator == "div":
@@ -689,7 +723,13 @@ def _emit_binary(expr, local_names):
     return f"{left} {operator} {right}", precedence
 
 
-def _emit_child(expr, parent_precedence, is_right_child=False, parent_operator=None, local_names=None):
+def _emit_child(
+    expr: _Expression,
+    parent_precedence: int,
+    is_right_child: bool = False,
+    parent_operator: str | None = None,
+    local_names: Iterable[str] | None = None,
+) -> str:
     text, precedence = _emit_expression(expr, local_names)
     needs_parentheses = precedence < parent_precedence
     if is_right_child and precedence == parent_precedence and parent_operator not in _RIGHT_ASSOCIATIVE:
@@ -699,10 +739,10 @@ def _emit_child(expr, parent_precedence, is_right_child=False, parent_operator=N
     return text
 
 
-def _strip_comments(source):
-    result = []
+def _strip_comments(source: str) -> str:
+    result: list[str] = []
     index = 0
-    in_string = None
+    in_string: str | None = None
     escaped = False
     while index < len(source):
         char = source[index]
@@ -742,11 +782,11 @@ def _strip_comments(source):
     return "".join(result)
 
 
-def _split_statements(source):
-    statements = []
+def _split_statements(source: str) -> list[str]:  # pyright: ignore[reportUnusedFunction]
+    statements: list[str] = []
     start = 0
     depth = 0
-    in_string = None
+    in_string: str | None = None
     escaped = False
 
     for index, char in enumerate(source):
@@ -778,7 +818,11 @@ def _split_statements(source):
     return [statement for statement in statements if statement.strip()]
 
 
-def _transpile_statement(statement, local_names=None, instance_variables=None):
+def _transpile_statement(
+    statement: str,
+    local_names: MutableSet[str] | None = None,
+    instance_variables: MutableSet[str] | None = None,
+) -> list[str]:
     if not statement:
         return []
 
@@ -808,7 +852,11 @@ def _transpile_statement(statement, local_names=None, instance_variables=None):
     return [transpile_gml_expression(statement, local_names)]
 
 
-def _record_instance_assignment(target, local_names, instance_variables):
+def _record_instance_assignment(
+    target: str,
+    local_names: Iterable[str],
+    instance_variables: MutableSet[str] | None,
+) -> None:
     if instance_variables is None:
         return
 
@@ -822,8 +870,11 @@ def _record_instance_assignment(target, local_names, instance_variables):
     instance_variables.add(name)
 
 
-def _transpile_var_statement(statement, local_names=None):
-    lines = []
+def _transpile_var_statement(
+    statement: str,
+    local_names: MutableSet[str] | None = None,
+) -> list[str]:
+    lines: list[str] = []
     if local_names is None:
         local_names = set()
     for declaration in _split_top_level(statement, ","):
@@ -845,7 +896,7 @@ def _transpile_var_statement(statement, local_names=None):
     return lines
 
 
-def _parse_increment_statement(statement):
+def _parse_increment_statement(statement: str) -> tuple[str, _IncrementDelta] | None:
     stripped = statement.strip()
     if stripped.endswith("++"):
         return stripped[:-2].strip(), 1
@@ -858,9 +909,9 @@ def _parse_increment_statement(statement):
     return None
 
 
-def _split_assignment(statement):
+def _split_assignment(statement: str) -> tuple[str, _AssignmentOperator, str] | None:
     depth = 0
-    in_string = None
+    in_string: str | None = None
     escaped = False
     index = 0
 
@@ -902,17 +953,17 @@ def _split_assignment(statement):
     return None
 
 
-def _is_comparison_assignment_false_positive(statement, index):
+def _is_comparison_assignment_false_positive(statement: str, index: int) -> bool:
     previous_char = statement[index - 1] if index > 0 else ""
     next_char = statement[index + 1] if index + 1 < len(statement) else ""
     return previous_char in "!<>=?" or next_char == "="
 
 
-def _split_top_level(source, separator):
-    parts = []
+def _split_top_level(source: str, separator: str) -> list[str]:
+    parts: list[str] = []
     start = 0
     depth = 0
-    in_string = None
+    in_string: str | None = None
     escaped = False
 
     for index, char in enumerate(source):

--- a/src/conversion/included_files.py
+++ b/src/conversion/included_files.py
@@ -1,24 +1,29 @@
+from __future__ import annotations
+
 import os
 import shutil
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
+from src.conversion.type_defs import ConversionRunning, LogCallback, ProgressCallback, StrPath
 
 
 class IncludedFilesConverter(BaseConverter):
-    def __init__(self, gm_project_path, godot_project_path, log_callback=print, progress_callback=None, conversion_running=None,
-                 update_log_callback=None, compact_logging=False, max_workers=None):
+    def __init__(self, gm_project_path: StrPath, godot_project_path: StrPath, log_callback: LogCallback = print,
+                 progress_callback: ProgressCallback | None = None, conversion_running: ConversionRunning | None = None,
+                 update_log_callback: LogCallback | None = None, compact_logging: bool = False,
+                 max_workers: int | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback, progress_callback, conversion_running,
                          update_log_callback, compact_logging, max_workers=max_workers)
 
-    def _process_file(self, gm_file_path, godot_file_path, rel_path):
+    def _process_file(self, gm_file_path: str, godot_file_path: str, rel_path: str) -> str | None:
         if not self.conversion_running():
             return None
         shutil.copy2(gm_file_path, godot_file_path)
         return rel_path
 
-    def convert_included_files(self):
+    def convert_included_files(self) -> None:
         gm_datafiles_path = os.path.join(self.gm_project_path, "datafiles")
         godot_included_path = os.path.join(self.godot_project_path, "included_files")
 
@@ -29,8 +34,8 @@ class IncludedFilesConverter(BaseConverter):
         os.makedirs(godot_included_path, exist_ok=True)
 
         # Collect all files, skipping .yy metadata files
-        all_files = []
-        for root, dirs, files in os.walk(gm_datafiles_path):
+        all_files: list[str] = []
+        for root, _, files in os.walk(gm_datafiles_path):
             for file in files:
                 if not file.endswith('.yy'):
                     all_files.append(os.path.join(root, file))
@@ -49,7 +54,7 @@ class IncludedFilesConverter(BaseConverter):
         processed_files = 0
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            futures_map = {}
+            futures_map: dict[Future[str | None], str] = {}
             for gm_file_path in all_files:
                 rel_path = os.path.relpath(gm_file_path, gm_datafiles_path)
                 godot_file_path = os.path.join(godot_included_path, rel_path)
@@ -69,5 +74,5 @@ class IncludedFilesConverter(BaseConverter):
                     self._safe_log(get_localized("Console_Convertor_IncludedFiles_Copied").format(path=result))
                 self._safe_progress(int((processed_files / total_files) * 100))
 
-    def convert_all(self):
+    def convert_all(self) -> None:
         self.convert_included_files()

--- a/src/conversion/notes.py
+++ b/src/conversion/notes.py
@@ -1,24 +1,29 @@
+from __future__ import annotations
+
 import os
 import shutil
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
+from src.conversion.type_defs import ConversionRunning, LogCallback, ProgressCallback, StrPath
 
 
 class NoteConverter(BaseConverter):
-    def __init__(self, gm_project_path, godot_project_path, log_callback=print, progress_callback=None, conversion_running=None,
-                 update_log_callback=None, compact_logging=False, max_workers=None):
+    def __init__(self, gm_project_path: StrPath, godot_project_path: StrPath, log_callback: LogCallback = print,
+                 progress_callback: ProgressCallback | None = None, conversion_running: ConversionRunning | None = None,
+                 update_log_callback: LogCallback | None = None, compact_logging: bool = False,
+                 max_workers: int | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback, progress_callback, conversion_running,
                          update_log_callback, compact_logging, max_workers=max_workers)
 
-    def _process_note(self, src_file, dst_file, note_name):
+    def _process_note(self, src_file: str, dst_file: str, note_name: str) -> str | None:
         if not self.conversion_running():
             return None
         shutil.copy2(src_file, dst_file)
         return note_name
 
-    def convert_notes(self):
+    def convert_notes(self) -> None:
         gm_notes_path = os.path.join(self.gm_project_path, "notes")
         godot_notes_path = os.path.join(self.godot_project_path, "notes")
 
@@ -29,9 +34,9 @@ class NoteConverter(BaseConverter):
         os.makedirs(godot_notes_path, exist_ok=True)
 
         # Collect all note files and their subfolders
-        note_files = []
-        note_subfolders = {}
-        for root, dirs, files in os.walk(gm_notes_path):
+        note_files: list[str] = []
+        note_subfolders: dict[str, str] = {}
+        for root, _, files in os.walk(gm_notes_path):
             for file in files:
                 if file.endswith('.txt'):
                     src_path = os.path.join(root, file)
@@ -58,7 +63,7 @@ class NoteConverter(BaseConverter):
         processed_notes = 0
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            futures_map = {}
+            futures_map: dict[Future[str | None], str] = {}
             for src_file in note_files:
                 note_name = os.path.splitext(os.path.basename(src_file))[0]
                 subfolder = note_subfolders.get(src_file, "")
@@ -82,5 +87,5 @@ class NoteConverter(BaseConverter):
                     self._safe_log(get_localized("Console_Convertor_Notes_Copied").format(note_name=result))
                 self._safe_progress(int((processed_notes / total_notes) * 100))
 
-    def convert_all(self):
+    def convert_all(self) -> None:
         self.convert_notes()

--- a/src/conversion/objects.py
+++ b/src/conversion/objects.py
@@ -2,6 +2,7 @@ import os
 import re
 import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import TypedDict, cast
 
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
@@ -9,16 +10,33 @@ from src.conversion.event_mapping import map_event
 from src.conversion.gml_runtime import write_gml_runtime
 from src.conversion.gml_transpiler import GMLTranspileError, transpile_gml_code
 from src.conversion.script_generator import generate_script_content
+from src.conversion.type_defs import ConversionRunning, JsonDict, LogCallback, ProgressCallback, StrPath
+
+
+class ParsedObject(TypedDict):
+    sprite_name: str | None
+    event_list: list[JsonDict]
+
+
+class ObjectProcessResult(TypedDict):
+    success: bool
+    name: str
+    has_sprite: bool
+    sprite_name: str | None
+    event_count: int
 
 
 class ObjectConverter(BaseConverter):
-    def __init__(self, gm_project_path, godot_project_path, log_callback=print, progress_callback=None, conversion_running=None,
-                 update_log_callback=None, compact_logging=False, max_workers=None):
+    def __init__(self, gm_project_path: StrPath, godot_project_path: StrPath,
+                 log_callback: LogCallback = print, progress_callback: ProgressCallback | None = None,
+                 conversion_running: ConversionRunning | None = None,
+                 update_log_callback: LogCallback | None = None, compact_logging: bool = False,
+                 max_workers: int | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback, progress_callback, conversion_running,
                          update_log_callback, compact_logging, max_workers=max_workers)
         self.godot_objects_path = os.path.join(self.godot_project_path, 'objects')
 
-    def _get_valid_object_names(self):
+    def _get_valid_object_names(self) -> dict[str, str] | None:
         """Parse the .yyp project file and return a dict of object name -> subfolder.
 
         Returns None if the .yyp file cannot be found or parsed, allowing
@@ -34,14 +52,14 @@ class ObjectConverter(BaseConverter):
                 content = f.read()
 
             cleaned = re.sub(r',\s*([}\]])', r'\1', content)
-            data = json.loads(cleaned)
+            data = cast(JsonDict, json.loads(cleaned))
 
-            valid_objects = {}
-            for resource in data.get('resources', []):
-                res_id = resource.get('id', {})
-                path = res_id.get('path', '')
+            valid_objects: dict[str, str] = {}
+            for resource in cast(list[JsonDict], data.get('resources', [])):
+                res_id = cast(JsonDict, resource.get('id', {}))
+                path = cast(str, res_id.get('path', ''))
                 if path.startswith('objects/'):
-                    name = res_id.get('name', '')
+                    name = cast(str, res_id.get('name', ''))
                     yy_path = os.path.join(self.gm_project_path, 'objects', name, name + '.yy')
                     valid_objects[name] = self._get_subfolder_from_yy(yy_path)
 
@@ -50,7 +68,7 @@ class ObjectConverter(BaseConverter):
             self._safe_log(get_localized("Console_Convertor_Objects_YYPFilterWarning"))
             return None
 
-    def _parse_object_yy(self, object_name):
+    def _parse_object_yy(self, object_name: str) -> ParsedObject | None:
         """Parse an object .yy file and extract the sprite reference and event list.
 
         Returns a dict with 'sprite_name' (str or None) and 'event_list' (list)
@@ -61,14 +79,15 @@ class ObjectConverter(BaseConverter):
             with open(yy_path, 'r', encoding='utf-8') as f:
                 content = f.read()
             cleaned = re.sub(r',\s*([}\]])', r'\1', content)
-            data = json.loads(cleaned)
+            data = cast(JsonDict, json.loads(cleaned))
 
             sprite_id = data.get('spriteId')
-            sprite_name = None
-            if sprite_id is not None:
-                sprite_name = sprite_id.get('name', None)
+            sprite_name: str | None = None
+            if isinstance(sprite_id, dict):
+                sprite_data = cast(JsonDict, sprite_id)
+                sprite_name = cast(str | None, sprite_data.get('name', None))
 
-            event_list = data.get('eventList', [])
+            event_list = cast(list[JsonDict], data.get('eventList', []))
 
             return {"sprite_name": sprite_name, "event_list": event_list}
         except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
@@ -76,12 +95,12 @@ class ObjectConverter(BaseConverter):
                 yy_path=yy_path, object_name=object_name))
             return None
 
-    def _get_sprite_subfolder(self, sprite_name):
+    def _get_sprite_subfolder(self, sprite_name: str) -> str:
         """Resolve a sprite's subfolder by reading its .yy file from the GM project."""
         yy_path = os.path.join(self.gm_project_path, 'sprites', sprite_name, sprite_name + '.yy')
         return self._get_subfolder_from_yy(yy_path)
 
-    def _sprite_scene_exists(self, sprite_name, sprite_subfolder=""):
+    def _sprite_scene_exists(self, sprite_name: str, sprite_subfolder: str = "") -> bool:
         """Check whether the converted sprite scene exists in the Godot project."""
         if sprite_subfolder:
             tscn_path = os.path.join(self.godot_project_path, 'sprites', sprite_subfolder, sprite_name, sprite_name + '.tscn')
@@ -89,7 +108,8 @@ class ObjectConverter(BaseConverter):
             tscn_path = os.path.join(self.godot_project_path, 'sprites', sprite_name, sprite_name + '.tscn')
         return os.path.isfile(tscn_path)
 
-    def _generate_object_scene(self, object_name, sprite_name, sprite_subfolder="", script_res_path=None):
+    def _generate_object_scene(self, object_name: str, sprite_name: str | None,
+                               sprite_subfolder: str = "", script_res_path: str | None = None) -> str:
         """Build the .tscn content string for an object scene.
 
         If sprite_name is not None, the scene instances the sprite's scene as a child.
@@ -132,9 +152,9 @@ class ObjectConverter(BaseConverter):
 
         return ''.join(parts)
 
-    def _load_event_code_bodies(self, object_name, event_list):
-        code_bodies = {}
-        instance_variables = set()
+    def _load_event_code_bodies(self, object_name: str, event_list: list[JsonDict]) -> tuple[dict[str, str], set[str]]:
+        code_bodies: dict[str, str] = {}
+        instance_variables: set[str] = set()
         object_dir = os.path.join(self.gm_project_path, 'objects', object_name)
 
         for event in event_list or []:
@@ -171,7 +191,7 @@ class ObjectConverter(BaseConverter):
 
         return code_bodies, instance_variables
 
-    def _process_object(self, object_name, subfolder=""):
+    def _process_object(self, object_name: str, subfolder: str = "") -> ObjectProcessResult | None:
         """Process a single object: parse .yy, generate scene and script, write files.
 
         Returns a result dict or None if conversion was stopped.
@@ -181,7 +201,7 @@ class ObjectConverter(BaseConverter):
 
         parsed = self._parse_object_yy(object_name)
         if parsed is None:
-            return {"success": False, "name": object_name}
+            return {"success": False, "name": object_name, "has_sprite": False, "sprite_name": None, "event_count": 0}
 
         sprite_name = parsed["sprite_name"]
         event_list = parsed["event_list"]
@@ -222,7 +242,7 @@ class ObjectConverter(BaseConverter):
         return {"success": True, "name": object_name, "has_sprite": sprite_name is not None,
                 "sprite_name": sprite_name, "event_count": len(event_list)}
 
-    def convert_objects(self):
+    def convert_objects(self) -> None:
         os.makedirs(self.godot_objects_path, exist_ok=True)
 
         gm_objects_path = os.path.join(self.gm_project_path, 'objects')
@@ -284,5 +304,5 @@ class ObjectConverter(BaseConverter):
 
         self.log_callback(get_localized("Console_Convertor_Objects_Complete"))
 
-    def convert_all(self):
+    def convert_all(self) -> None:
         self.convert_objects()

--- a/src/conversion/project_godot.py
+++ b/src/conversion/project_godot.py
@@ -1,17 +1,18 @@
 import os
+from typing import Any
 
 
 class GodotProjectFile:
     """Line-preserving helper for small `project.godot` setting updates."""
 
-    def __init__(self, project_godot_path):
+    def __init__(self, project_godot_path: str) -> None:
         self.project_godot_path = project_godot_path
 
-    def set_main_scene(self, scene_path):
+    def set_main_scene(self, scene_path: str) -> bool:
         """Set [application] run/main_scene while preserving unrelated settings."""
         return self.set_setting("application", "run/main_scene", scene_path)
 
-    def set_setting(self, section, key, value):
+    def set_setting(self, section: str, key: str, value: Any) -> bool:
         if not os.path.isfile(self.project_godot_path):
             return False
 
@@ -25,7 +26,7 @@ class GodotProjectFile:
         return True
 
     @staticmethod
-    def _format_value(value):
+    def _format_value(value: Any) -> str:
         if isinstance(value, str):
             escaped = value.replace("\\", "\\\\").replace('"', '\\"')
             return f'"{escaped}"'
@@ -34,7 +35,9 @@ class GodotProjectFile:
         return str(value)
 
     @classmethod
-    def _set_setting(cls, content, section, key, formatted_value):
+    def _set_setting(
+        cls, content: str, section: str, key: str, formatted_value: str
+    ) -> str:
         lines = content.splitlines(keepends=True)
         newline = cls._detect_newline(content)
         section_header = f"[{section}]"
@@ -70,7 +73,9 @@ class GodotProjectFile:
         return "".join(lines)
 
     @staticmethod
-    def _append_section(content, section_header, setting_line, newline):
+    def _append_section(
+        content: str, section_header: str, setting_line: str, newline: str
+    ) -> str:
         if not content:
             return f"{section_header}{newline}{setting_line}{newline}"
 
@@ -78,15 +83,15 @@ class GodotProjectFile:
         return f"{content}{separator}{newline}{section_header}{newline}{setting_line}{newline}"
 
     @staticmethod
-    def _is_section_header(stripped_line):
+    def _is_section_header(stripped_line: str) -> bool:
         return stripped_line.startswith("[") and stripped_line.endswith("]")
 
     @staticmethod
-    def _detect_newline(content):
+    def _detect_newline(content: str) -> str:
         return "\r\n" if "\r\n" in content else "\n"
 
     @staticmethod
-    def _line_ending(line, default_newline):
+    def _line_ending(line: str, default_newline: str) -> str:
         if line.endswith("\r\n"):
             return "\r\n"
         if line.endswith("\n"):
@@ -94,11 +99,13 @@ class GodotProjectFile:
         return default_newline
 
     @staticmethod
-    def _ends_with_newline(line):
+    def _ends_with_newline(line: str) -> bool:
         return line.endswith(("\n", "\r"))
 
     @staticmethod
-    def _setting_insert_index(lines, section_start, section_end):
+    def _setting_insert_index(
+        lines: list[str], section_start: int, section_end: int
+    ) -> int:
         insert_at = section_end
         while insert_at > section_start + 1 and not lines[insert_at - 1].strip():
             insert_at -= 1

--- a/src/conversion/project_settings.py
+++ b/src/conversion/project_settings.py
@@ -1,19 +1,21 @@
 import os
 import shutil
 import re
-import json
 from PIL import Image
-from typing import Optional, List, Callable
+from typing import Optional, List
 
 # Import localization manager
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
+from src.conversion.type_defs import ConversionRunning, LogCallback, ProgressCallback
 
 class ProjectSettingsConverter(BaseConverter):
-    def __init__(self, gm_project_path, godot_project_path,
-                 log_callback=print, progress_callback=None,
-                 conversion_running=None, gm_platform='windows',
-                 max_workers=None):
+    def __init__(self, gm_project_path: str, godot_project_path: str,
+                 log_callback: LogCallback = print,
+                 progress_callback: ProgressCallback | None = None,
+                 conversion_running: ConversionRunning | None = None,
+                 gm_platform: str = 'windows',
+                 max_workers: int | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path,
                          log_callback, progress_callback, conversion_running,
                          max_workers=max_workers)
@@ -254,7 +256,7 @@ class ProjectSettingsConverter(BaseConverter):
         except Exception as e:
             self.log_callback(get_localized("Console_Convertor_AudioBus_Error_GroupNotGenerated").format(error=str(e)))
 
-    def convert_all(self):
+    def convert_all(self) -> None:
         self.convert_icon()
         self.update_project_name()
         self.update_project_settings()

--- a/src/conversion/resource_index.py
+++ b/src/conversion/resource_index.py
@@ -1,8 +1,23 @@
 import os
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import ClassVar, cast
 
 from src.conversion.base_converter import BaseConverter
+from src.conversion.type_defs import (
+    ConversionRunning,
+    JsonDict,
+    JsonList,
+    LogCallback,
+    ProgressCallback,
+)
+
+
+def _empty_json_dict() -> JsonDict:
+    return cast(JsonDict, {})
+
+
+def _empty_json_list() -> JsonList:
+    return cast(JsonList, [])
 
 
 @dataclass(frozen=True)
@@ -26,51 +41,54 @@ class IndexedRoom:
     yyp_path: str
     godot_path: str
     subfolder: str = ""
-    room_settings: Dict = field(default_factory=dict)
-    physics_settings: Dict = field(default_factory=dict)
-    view_settings: Dict = field(default_factory=dict)
-    views: List = field(default_factory=list)
-    layers: List = field(default_factory=list)
-    instance_creation_order: List = field(default_factory=list)
-    parent_room: Optional[Dict] = None
+    room_settings: JsonDict = field(default_factory=_empty_json_dict)
+    physics_settings: JsonDict = field(default_factory=_empty_json_dict)
+    view_settings: JsonDict = field(default_factory=_empty_json_dict)
+    views: JsonList = field(default_factory=_empty_json_list)
+    layers: JsonList = field(default_factory=_empty_json_list)
+    instance_creation_order: JsonList = field(default_factory=_empty_json_list)
+    parent_room: JsonDict | None = None
     creation_code_file: str = ""
     inherit_code: bool = False
     inherit_creation_order: bool = False
     inherit_layers: bool = False
     is_dnd: bool = False
-    raw_data: Dict = field(default_factory=dict)
+    raw_data: JsonDict = field(default_factory=_empty_json_dict)
 
 
 class GameMakerResourceIndex(BaseConverter):
     """Index GameMaker project resources for converters that need cross references."""
 
-    RESOURCE_EXTENSIONS = {
+    RESOURCE_EXTENSIONS: ClassVar[dict[str, str]] = {
         "rooms": ".tscn",
         "objects": ".tscn",
         "sprites": ".tscn",
         "tilesets": ".tres",
     }
 
-    def __init__(self, gm_project_path, godot_project_path, log_callback=print,
-                 progress_callback=None, conversion_running=None,
-                 update_log_callback=None, compact_logging=False,
-                 max_workers=None):
+    def __init__(self, gm_project_path: str, godot_project_path: str,
+                 log_callback: LogCallback = print,
+                 progress_callback: ProgressCallback | None = None,
+                 conversion_running: ConversionRunning | None = None,
+                 update_log_callback: LogCallback | None = None,
+                 compact_logging: bool = False,
+                 max_workers: int | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback,
                          progress_callback, conversion_running,
                          update_log_callback, compact_logging,
                          max_workers=max_workers)
-        self.yyp_path = None
-        self.yyp_data = None
-        self.resources = self._empty_resources()
-        self.rooms = {}
-        self.room_order = []
+        self.yyp_path: str | None = None
+        self.yyp_data: JsonDict | None = None
+        self.resources: dict[str, dict[str, IndexedResource]] = self._empty_resources()
+        self.rooms: dict[str, IndexedRoom] = {}
+        self.room_order: list[str] = []
         self.used_room_order_fallback = False
 
-    def convert_all(self):
+    def convert_all(self) -> "GameMakerResourceIndex":
         """Build the in-memory index. No Godot files are written."""
         return self.build()
 
-    def build(self):
+    def build(self) -> "GameMakerResourceIndex":
         """Build and return this resource index."""
         self.resources = self._empty_resources()
         self.rooms = {}
@@ -99,7 +117,7 @@ class GameMakerResourceIndex(BaseConverter):
 
         return self
 
-    def find_yyp_path(self):
+    def find_yyp_path(self) -> str | None:
         """Return the first .yyp path in the GameMaker project, if any."""
         try:
             yyp_files = sorted(
@@ -113,41 +131,41 @@ class GameMakerResourceIndex(BaseConverter):
             return None
         return os.path.join(self.gm_project_path, yyp_files[0])
 
-    def get_resource(self, kind, name):
+    def get_resource(self, kind: str, name: str) -> IndexedResource | None:
         """Return an indexed non-room resource, or a room resource, by kind/name."""
         return self.resources.get(kind, {}).get(name)
 
-    def get_resources(self, kind):
+    def get_resources(self, kind: str) -> dict[str, IndexedResource]:
         """Return all indexed resources for a supported kind."""
         return dict(self.resources.get(kind, {}))
 
-    def get_room(self, name):
+    def get_room(self, name: str) -> IndexedRoom | None:
         """Return normalized room data by name."""
         return self.rooms.get(name)
 
-    def ordered_rooms(self):
+    def ordered_rooms(self) -> list[IndexedRoom]:
         """Return normalized rooms in GameMaker room order when available."""
         return [self.rooms[name] for name in self.room_order if name in self.rooms]
 
-    def first_room(self):
+    def first_room(self) -> IndexedRoom | None:
         """Return the first GameMaker room, or None when no room is indexed."""
         ordered = self.ordered_rooms()
         return ordered[0] if ordered else None
 
-    def resolve_gm_path(self, kind, name):
+    def resolve_gm_path(self, kind: str, name: str) -> str | None:
         """Return the source GameMaker .yy path for a resource, if indexed."""
         resource = self.get_resource(kind, name)
         return resource.yy_path if resource else None
 
-    def resolve_godot_path(self, kind, name):
+    def resolve_godot_path(self, kind: str, name: str) -> str | None:
         """Return the generated res:// path for a resource, if indexed."""
         resource = self.get_resource(kind, name)
         return resource.godot_path if resource else None
 
-    def _empty_resources(self):
+    def _empty_resources(self) -> dict[str, dict[str, IndexedResource]]:
         return {kind: {} for kind in self.RESOURCE_EXTENSIONS}
 
-    def _index_yyp_resources(self, yyp_data):
+    def _index_yyp_resources(self, yyp_data: JsonDict) -> None:
         for resource_entry in yyp_data.get("resources", []):
             res_id = resource_entry.get("id", {})
             yyp_path = res_id.get("path", "")
@@ -168,7 +186,7 @@ class GameMakerResourceIndex(BaseConverter):
 
             self.resources[kind][name] = self._make_resource(kind, name, yy_path, yyp_path)
 
-    def _index_disk_resources(self):
+    def _index_disk_resources(self) -> None:
         for kind in self.RESOURCE_EXTENSIONS:
             kind_dir = os.path.join(self.gm_project_path, kind)
             if not os.path.isdir(kind_dir):
@@ -184,13 +202,13 @@ class GameMakerResourceIndex(BaseConverter):
                     kind, name, yy_path, yyp_path
                 )
 
-    def _parse_indexed_rooms(self):
+    def _parse_indexed_rooms(self) -> None:
         for name, resource in self.resources["rooms"].items():
             room = self._parse_room(resource)
             if room is not None:
                 self.rooms[name] = room
 
-    def _parse_room(self, resource):
+    def _parse_room(self, resource: IndexedResource) -> IndexedRoom | None:
         data = self._read_yy_file(resource.yy_path)
         if data is None:
             self._safe_log(
@@ -219,7 +237,7 @@ class GameMakerResourceIndex(BaseConverter):
             raw_data=data,
         )
 
-    def _apply_yyp_room_order(self, yyp_data):
+    def _apply_yyp_room_order(self, yyp_data: JsonDict) -> None:
         if "RoomOrderNodes" not in yyp_data:
             self.used_room_order_fallback = True
             self._safe_log(
@@ -228,7 +246,7 @@ class GameMakerResourceIndex(BaseConverter):
             self.room_order = sorted(self.rooms)
             return
 
-        ordered = []
+        ordered: list[str] = []
         for room_node in yyp_data.get("RoomOrderNodes", []):
             room_id = room_node.get("roomId", {})
             name = room_id.get("name") or self._name_from_yyp_path(room_id.get("path", ""))
@@ -241,7 +259,9 @@ class GameMakerResourceIndex(BaseConverter):
 
         self.room_order = ordered
 
-    def _make_resource(self, kind, name, yy_path, yyp_path):
+    def _make_resource(
+        self, kind: str, name: str, yy_path: str, yyp_path: str
+    ) -> IndexedResource:
         subfolder = self._get_subfolder_from_yy(yy_path)
         return IndexedResource(
             kind=kind,
@@ -253,7 +273,7 @@ class GameMakerResourceIndex(BaseConverter):
         )
 
     @classmethod
-    def godot_res_path(cls, kind, name, subfolder=""):
+    def godot_res_path(cls, kind: str, name: str, subfolder: str = "") -> str:
         """Build a generated res:// path using existing converter conventions."""
         extension = cls.RESOURCE_EXTENSIONS[kind]
         path_parts = ["res:/", kind]
@@ -263,13 +283,13 @@ class GameMakerResourceIndex(BaseConverter):
         return "/".join(path_parts)
 
     @staticmethod
-    def _kind_from_yyp_path(yyp_path):
+    def _kind_from_yyp_path(yyp_path: str) -> str:
         if not yyp_path or "/" not in yyp_path:
             return ""
         return yyp_path.split("/", 1)[0]
 
     @staticmethod
-    def _name_from_yyp_path(yyp_path):
+    def _name_from_yyp_path(yyp_path: str) -> str:
         if not yyp_path:
             return ""
         filename = os.path.basename(yyp_path)

--- a/src/conversion/room_creation_code.py
+++ b/src/conversion/room_creation_code.py
@@ -1,5 +1,27 @@
+from __future__ import annotations
+
 import os
 from dataclasses import dataclass
+from typing import Protocol, cast
+
+from src.conversion.type_defs import JsonDict, JsonList, LogCallback
+
+
+class RoomCreationCodeRoom(Protocol):
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def yy_path(self) -> str: ...
+
+    @property
+    def creation_code_file(self) -> str: ...
+
+    @property
+    def inherit_code(self) -> bool: ...
+
+    @property
+    def instance_creation_order(self) -> JsonList: ...
 
 
 ROOM_EXECUTION_ORDER = [
@@ -21,7 +43,11 @@ class CreationCodeMetadata:
     execution_phase_index: int
 
 
-def resolve_room_creation_code(room, gm_project_path, warn_callback=None):
+def resolve_room_creation_code(
+    room: RoomCreationCodeRoom,
+    gm_project_path: str,
+    warn_callback: LogCallback | None = None,
+) -> CreationCodeMetadata:
     """Resolve room creation-code metadata without transpiling GML."""
     source_file = room.creation_code_file or ""
     source_path = _resolve_room_creation_code_path(room, gm_project_path, source_file)
@@ -46,7 +72,11 @@ def resolve_room_creation_code(room, gm_project_path, warn_callback=None):
     return metadata
 
 
-def resolve_instance_creation_code(room, instance, warn_callback=None):
+def resolve_instance_creation_code(
+    room: RoomCreationCodeRoom,
+    instance: JsonDict,
+    warn_callback: LogCallback | None = None,
+) -> CreationCodeMetadata:
     """Resolve per-instance creation-code metadata without transpiling GML."""
     instance_name = _instance_name(instance)
     has_code = bool(instance.get("hasCreationCode", False))
@@ -80,17 +110,22 @@ def resolve_instance_creation_code(room, instance, warn_callback=None):
     return metadata
 
 
-def instance_creation_order_names(room):
-    names = []
+def instance_creation_order_names(room: RoomCreationCodeRoom) -> list[str]:
+    names: list[str] = []
     for entry in room.instance_creation_order:
         if isinstance(entry, dict):
-            name = entry.get("%Name") or entry.get("name")
-            if name:
+            entry_dict = cast(JsonDict, entry)
+            name = entry_dict.get("%Name") or entry_dict.get("name")
+            if isinstance(name, str) and name:
                 names.append(name)
     return names
 
 
-def _resolve_room_creation_code_path(room, gm_project_path, source_file):
+def _resolve_room_creation_code_path(
+    room: RoomCreationCodeRoom,
+    gm_project_path: str,
+    source_file: str,
+) -> str:
     if not source_file:
         return ""
 
@@ -107,5 +142,6 @@ def _resolve_room_creation_code_path(room, gm_project_path, source_file):
     return os.path.normpath(os.path.join(os.path.dirname(room.yy_path), normalized))
 
 
-def _instance_name(instance):
-    return instance.get("%Name") or instance.get("name") or "Instance"
+def _instance_name(instance: JsonDict) -> str:
+    name = instance.get("%Name") or instance.get("name")
+    return name if isinstance(name, str) and name else "Instance"

--- a/src/conversion/room_layers.py
+++ b/src/conversion/room_layers.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import json
 import os
 import re
-from dataclasses import dataclass, field
+from typing import Protocol, cast
 
 from src.conversion.room_creation_code import resolve_instance_creation_code
+from src.conversion.type_defs import JsonDict, JsonList, JsonValue, LogCallback
 
 
 KNOWN_LAYER_TYPES = {
@@ -15,44 +18,81 @@ KNOWN_LAYER_TYPES = {
 }
 
 
-def godot_string(value):
+class RoomLayerRoom(Protocol):
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def yy_path(self) -> str: ...
+
+    @property
+    def creation_code_file(self) -> str: ...
+
+    @property
+    def inherit_code(self) -> bool: ...
+
+    @property
+    def room_settings(self) -> JsonDict: ...
+
+    @property
+    def layers(self) -> JsonList: ...
+
+    @property
+    def instance_creation_order(self) -> JsonList: ...
+
+
+class RoomLayerResourceIndex(Protocol):
+    godot_project_path: str
+
+    def resolve_godot_path(self, kind: str, name: str) -> str | None: ...
+
+
+def godot_string(value: JsonValue) -> str:
     """Format a Python value as a quoted Godot string literal."""
     return json.dumps(str(value))
 
 
-def godot_value(value):
+def godot_value(value: JsonValue) -> str:
     """Format simple JSON-compatible values as Godot text-scene values."""
     return json.dumps(value)
 
 
-@dataclass
 class SerializedRoomLayers:
-    ext_resource_lines: list = field(default_factory=list)
-    node_lines: list = field(default_factory=list)
+    def __init__(
+        self, ext_resource_lines: list[str] | None = None, node_lines: list[str] | None = None
+    ) -> None:
+        self.ext_resource_lines = ext_resource_lines or []
+        self.node_lines = node_lines or []
 
 
 class RoomLayerSerializationContext:
-    def __init__(self, room, gm_project_path=None, resource_index=None, warn_callback=None):
+    def __init__(
+        self,
+        room: RoomLayerRoom,
+        gm_project_path: str | None = None,
+        resource_index: RoomLayerResourceIndex | None = None,
+        warn_callback: LogCallback | None = None,
+    ) -> None:
         self.room = room
         self.gm_project_path = gm_project_path
         self.resource_index = resource_index
         self.warn_callback = warn_callback
-        self.ext_resource_ids = {}
+        self.ext_resource_ids: dict[tuple[str, str], str] = {}
         self.creation_order = _instance_creation_order(room)
 
-    def ext_resource_id(self, resource_type, resource_path):
+    def ext_resource_id(self, resource_type: str, resource_path: str) -> str:
         key = (resource_type, resource_path)
         if key not in self.ext_resource_ids:
             self.ext_resource_ids[key] = str(len(self.ext_resource_ids) + 1)
         return self.ext_resource_ids[key]
 
-    def object_scene_ext_resource_id(self, object_name):
+    def object_scene_ext_resource_id(self, object_name: str | None) -> str | None:
         scene_path = self.object_scene_path(object_name)
         if scene_path is None:
             return None
         return self.ext_resource_id("PackedScene", scene_path)
 
-    def object_scene_path(self, object_name):
+    def object_scene_path(self, object_name: str | None) -> str | None:
         if not object_name or self.resource_index is None:
             return None
         scene_path = self.resource_index.resolve_godot_path("objects", object_name)
@@ -62,13 +102,13 @@ class RoomLayerSerializationContext:
             return None
         return scene_path
 
-    def sprite_scene_ext_resource_id(self, sprite_name):
+    def sprite_scene_ext_resource_id(self, sprite_name: str | None) -> str | None:
         scene_path = self.sprite_scene_path(sprite_name)
         if scene_path is None:
             return None
         return self.ext_resource_id("PackedScene", scene_path)
 
-    def sprite_scene_path(self, sprite_name):
+    def sprite_scene_path(self, sprite_name: str | None) -> str | None:
         if not sprite_name or self.resource_index is None:
             return None
         scene_path = self.resource_index.resolve_godot_path("sprites", sprite_name)
@@ -78,11 +118,11 @@ class RoomLayerSerializationContext:
             return None
         return scene_path
 
-    def warn(self, message):
+    def warn(self, message: str) -> None:
         if self.warn_callback is not None:
             self.warn_callback(message)
 
-    def ext_resource_lines(self):
+    def ext_resource_lines(self) -> list[str]:
         return [
             '[ext_resource type="{resource_type}" path={path} id="{resource_id}"]'.format(
                 resource_type=resource_type,
@@ -92,28 +132,43 @@ class RoomLayerSerializationContext:
             for (resource_type, path), resource_id in self.ext_resource_ids.items()
         ]
 
-    def _scene_path_exists(self, scene_path):
+    def _scene_path_exists(self, scene_path: str) -> bool:
         if not scene_path.startswith("res://"):
             return False
         relative_path = scene_path[len("res://"):]
+        resource_index = self.resource_index
+        if resource_index is None:
+            return False
         filesystem_path = os.path.join(
-            self.resource_index.godot_project_path,
+            resource_index.godot_project_path,
             *relative_path.split("/"),
         )
         return os.path.isfile(filesystem_path)
 
 
-def serialize_room_layers(room, gm_project_path=None, resource_index=None, warn_callback=None):
+def serialize_room_layers(
+    room: RoomLayerRoom,
+    gm_project_path: str | None = None,
+    resource_index: RoomLayerResourceIndex | None = None,
+    warn_callback: LogCallback | None = None,
+) -> SerializedRoomLayers:
     """Serialize GameMaker room layers and supported layer children."""
     context = RoomLayerSerializationContext(room, gm_project_path, resource_index, warn_callback)
-    node_lines = []
-    used_names = {}
+    node_lines: list[str] = []
+    used_names: dict[str, int] = {}
     for layer in room.layers:
-        _serialize_layer(layer, ".", used_names, node_lines, context)
+        if isinstance(layer, dict):
+            _serialize_layer(cast(JsonDict, layer), ".", used_names, node_lines, context)
     return SerializedRoomLayers(context.ext_resource_lines(), node_lines)
 
 
-def _serialize_layer(layer, parent_path, sibling_names, lines, context):
+def _serialize_layer(
+    layer: JsonDict,
+    parent_path: str,
+    sibling_names: dict[str, int],
+    lines: list[str],
+    context: RoomLayerSerializationContext,
+) -> None:
     original_name = _layer_name(layer)
     node_name = _unique_name(_sanitize_node_name(original_name), sibling_names)
     resource_type = _layer_resource_type(layer)
@@ -138,7 +193,7 @@ def _serialize_layer(layer, parent_path, sibling_names, lines, context):
     if resource_type == "GMRInstanceLayer":
         lines.extend(_instance_node_lines(layer, child_parent_path, original_name, context))
 
-    child_names = {}
+    child_names: dict[str, int] = {}
     for child_layer in _child_layers(layer):
         _serialize_layer(
             child_layer,
@@ -149,7 +204,13 @@ def _serialize_layer(layer, parent_path, sibling_names, lines, context):
         )
 
 
-def _layer_node_lines(layer, node_name, parent_path, original_name, resource_type):
+def _layer_node_lines(
+    layer: JsonDict,
+    node_name: str,
+    parent_path: str,
+    original_name: str,
+    resource_type: str,
+) -> list[str]:
     visible = bool(layer.get("visible", True))
     depth = _coerce_int(layer.get("depth", 0))
     z_index = -depth
@@ -185,25 +246,25 @@ def _layer_node_lines(layer, node_name, parent_path, original_name, resource_typ
         )
 
     if resource_type == "GMRInstanceLayer":
-        instances = layer.get("instances") or []
+        instances = _dict_items(layer.get("instances"))
         lines.append(f"metadata/gamemaker_instance_count = {len(instances)}")
         lines.append(
             f"metadata/gamemaker_instance_names = {godot_value(_item_names(instances))}"
         )
     elif resource_type == "GMRAssetLayer":
-        assets = layer.get("assets") or []
+        assets = _dict_items(layer.get("assets"))
         lines.append(f"metadata/gamemaker_asset_count = {len(assets)}")
         lines.append(f"metadata/gamemaker_asset_names = {godot_value(_item_names(assets))}")
     elif resource_type == "GMRBackgroundLayer":
-        sprite_id = layer.get("spriteId") or {}
+        sprite_id = _dict_value(layer.get("spriteId"))
         lines.append(
             f"metadata/gamemaker_background_sprite = {godot_value(sprite_id.get('name'))}"
         )
         for key in ("colour", "htiled", "vtiled", "hspeed", "vspeed", "stretch"):
             _append_optional_metadata(lines, layer, key, f"gamemaker_background_{key}")
     elif resource_type == "GMRTileLayer":
-        tileset_id = layer.get("tilesetId") or {}
-        tiles = layer.get("tiles") or {}
+        tileset_id = _dict_value(layer.get("tilesetId"))
+        tiles = _dict_value(layer.get("tiles"))
         lines.append(f"metadata/gamemaker_tileset = {godot_value(tileset_id.get('name'))}")
         _append_optional_metadata(lines, tiles, "SerialiseWidth", "gamemaker_tile_serialise_width")
         _append_optional_metadata(lines, tiles, "SerialiseHeight", "gamemaker_tile_serialise_height")
@@ -221,12 +282,19 @@ def _layer_node_lines(layer, node_name, parent_path, original_name, resource_typ
     return lines
 
 
-def _append_optional_metadata(lines, source, source_key, metadata_key):
+def _append_optional_metadata(
+    lines: list[str], source: JsonDict, source_key: str, metadata_key: str
+) -> None:
     if source_key in source:
         lines.append(f"metadata/{metadata_key} = {godot_value(source.get(source_key))}")
 
 
-def _background_visual_lines(layer, parent_path, layer_name, context):
+def _background_visual_lines(
+    layer: JsonDict,
+    parent_path: str,
+    layer_name: str,
+    context: RoomLayerSerializationContext,
+) -> list[str]:
     sprite_name = _background_sprite_name(layer)
     if sprite_name:
         ext_resource_id = context.sprite_scene_ext_resource_id(sprite_name)
@@ -245,7 +313,9 @@ def _background_visual_lines(layer, parent_path, layer_name, context):
     return _background_color_lines(layer, parent_path, context)
 
 
-def _background_color_lines(layer, parent_path, context):
+def _background_color_lines(
+    layer: JsonDict, parent_path: str, context: RoomLayerSerializationContext
+) -> list[str]:
     width, height = _room_size(context)
     lines = [
         f'[node name="BackgroundVisual" type="ColorRect" parent={godot_string(parent_path)}]',
@@ -266,7 +336,13 @@ def _background_color_lines(layer, parent_path, context):
     return lines
 
 
-def _background_sprite_lines(layer, parent_path, sprite_name, ext_resource_id, context):
+def _background_sprite_lines(
+    layer: JsonDict,
+    parent_path: str,
+    sprite_name: str,
+    ext_resource_id: str,
+    context: RoomLayerSerializationContext,
+) -> list[str]:
     node_name = _sanitize_node_name(sprite_name) or "BackgroundSprite"
     lines = [
         '[node name={name} parent={parent} instance=ExtResource("{resource_id}")]'.format(
@@ -287,7 +363,7 @@ def _background_sprite_lines(layer, parent_path, sprite_name, ext_resource_id, c
     return lines
 
 
-def _background_metadata_lines(layer, visual_type):
+def _background_metadata_lines(layer: JsonDict, visual_type: str) -> list[str]:
     colour = layer.get("colour")
     lines = [
         "metadata/gamemaker_background_visual = true",
@@ -312,7 +388,9 @@ def _background_metadata_lines(layer, visual_type):
     return lines
 
 
-def _warn_background_runtime_requirements(layer, context):
+def _warn_background_runtime_requirements(
+    layer: JsonDict, context: RoomLayerSerializationContext
+) -> None:
     if not (_truthy(layer.get("htiled")) or _truthy(layer.get("vtiled"))
             or _nonzero(layer.get("hspeed")) or _nonzero(layer.get("vspeed"))):
         return
@@ -325,17 +403,18 @@ def _warn_background_runtime_requirements(layer, context):
     )
 
 
-def _background_sprite_name(layer):
-    sprite_id = layer.get("spriteId") or {}
-    return sprite_id.get("name") if isinstance(sprite_id, dict) else None
+def _background_sprite_name(layer: JsonDict) -> str | None:
+    sprite_id = _dict_value(layer.get("spriteId"))
+    name = sprite_id.get("name")
+    return name if isinstance(name, str) else None
 
 
-def _room_size(context):
+def _room_size(context: RoomLayerSerializationContext) -> tuple[JsonValue, JsonValue]:
     settings = context.room.room_settings or {}
     return settings.get("Width", 1024), settings.get("Height", 768)
 
 
-def _godot_color(value):
+def _godot_color(value: JsonValue) -> str:
     r, g, b, a = _decode_gamemaker_colour(value)
     return "Color({r}, {g}, {b}, {a})".format(
         r=_format_color_component(r),
@@ -345,7 +424,7 @@ def _godot_color(value):
     )
 
 
-def _decode_gamemaker_colour(value):
+def _decode_gamemaker_colour(value: JsonValue) -> list[float]:
     try:
         packed = int(value)
     except (TypeError, ValueError):
@@ -359,7 +438,7 @@ def _decode_gamemaker_colour(value):
     ]
 
 
-def _format_color_component(value):
+def _format_color_component(value: float) -> str:
     if value == 0:
         return "0"
     if value == 1:
@@ -367,15 +446,21 @@ def _format_color_component(value):
     return ("{:.6f}".format(value)).rstrip("0").rstrip(".")
 
 
-def _instance_node_lines(layer, parent_path, layer_name, context):
-    lines = []
-    instances = layer.get("instances") or []
+def _instance_node_lines(
+    layer: JsonDict,
+    parent_path: str,
+    layer_name: str,
+    context: RoomLayerSerializationContext,
+) -> list[str]:
+    lines: list[str] = []
+    instances = _dict_items(layer.get("instances"))
     ordered_instances = _ordered_instances(instances, context.creation_order)
-    sibling_names = {}
+    sibling_names: dict[str, int] = {}
     for instance, order_index, _original_index in ordered_instances:
         instance_name = _instance_name(instance)
-        object_id = instance.get("objectId") or {}
-        object_name = object_id.get("name")
+        object_id = _dict_value(instance.get("objectId"))
+        raw_object_name = object_id.get("name")
+        object_name = raw_object_name if isinstance(raw_object_name, str) else None
 
         if instance.get("ignore") is True:
             context.warn(
@@ -417,8 +502,16 @@ def _instance_node_lines(layer, parent_path, layer_name, context):
     return lines
 
 
-def _instance_scene_lines(instance, node_name, parent_path, instance_name, object_name,
-                          ext_resource_id, order_index, context):
+def _instance_scene_lines(
+    instance: JsonDict,
+    node_name: str,
+    parent_path: str,
+    instance_name: str,
+    object_name: str | None,
+    ext_resource_id: str | None,
+    order_index: int | None,
+    context: RoomLayerSerializationContext,
+) -> list[str]:
     creation_code = resolve_instance_creation_code(
         context.room,
         instance,
@@ -474,8 +567,10 @@ def _instance_scene_lines(instance, node_name, parent_path, instance_name, objec
     return lines
 
 
-def _ordered_instances(instances, creation_order):
-    indexed = []
+def _ordered_instances(
+    instances: list[JsonDict], creation_order: dict[str, int]
+) -> list[tuple[JsonDict, int | None, int]]:
+    indexed: list[tuple[int, int, JsonDict, int | None]] = []
     for original_index, instance in enumerate(instances):
         order_index = creation_order.get(_instance_name(instance))
         sort_order = order_index if order_index is not None else len(creation_order) + original_index
@@ -484,26 +579,29 @@ def _ordered_instances(instances, creation_order):
     return [(instance, order_index, original_index) for _sort, original_index, instance, order_index in indexed]
 
 
-def _instance_creation_order(room):
-    order = {}
+def _instance_creation_order(room: RoomLayerRoom) -> dict[str, int]:
+    order: dict[str, int] = {}
     for index, entry in enumerate(room.instance_creation_order):
         if not isinstance(entry, dict):
             continue
-        name = entry.get("%Name") or entry.get("name")
-        if name and name not in order:
+        entry_dict = cast(JsonDict, entry)
+        name = entry_dict.get("%Name") or entry_dict.get("name")
+        if isinstance(name, str) and name and name not in order:
             order[name] = index
     return order
 
 
-def _instance_name(instance):
-    return instance.get("%Name") or instance.get("name") or "Instance"
+def _instance_name(instance: JsonDict) -> str:
+    name = instance.get("%Name") or instance.get("name")
+    return name if isinstance(name, str) and name else "Instance"
 
 
-def _layer_name(layer):
-    return layer.get("%Name") or layer.get("name") or "Layer"
+def _layer_name(layer: JsonDict) -> str:
+    name = layer.get("%Name") or layer.get("name")
+    return name if isinstance(name, str) and name else "Layer"
 
 
-def _layer_resource_type(layer):
+def _layer_resource_type(layer: JsonDict) -> str:
     resource_type = layer.get("resourceType")
     if resource_type:
         return resource_type
@@ -513,27 +611,28 @@ def _layer_resource_type(layer):
     return "UnknownLayer"
 
 
-def _child_layers(layer):
-    children = layer.get("layers") or layer.get("children") or []
-    return children if isinstance(children, list) else []
+def _child_layers(layer: JsonDict) -> list[JsonDict]:
+    children: JsonValue = layer.get("layers") or layer.get("children") or []
+    return _dict_items(children)
 
 
-def _item_names(items):
-    names = []
+def _item_names(items: list[JsonDict]) -> list[str]:
+    names: list[str] = []
     for item in items:
-        if isinstance(item, dict):
-            names.append(item.get("%Name") or item.get("name") or "")
+        name = item.get("%Name") or item.get("name") or ""
+        if isinstance(name, str):
+            names.append(name)
     return [name for name in names if name]
 
 
-def _coerce_int(value):
+def _coerce_int(value: JsonValue) -> int:
     try:
         return int(float(value))
     except (TypeError, ValueError):
         return 0
 
 
-def _format_number(value):
+def _format_number(value: JsonValue) -> str:
     try:
         number = float(value)
     except (TypeError, ValueError):
@@ -543,26 +642,37 @@ def _format_number(value):
     return str(number)
 
 
-def _truthy(value):
+def _truthy(value: JsonValue) -> bool:
     return bool(value)
 
 
-def _nonzero(value):
+def _nonzero(value: JsonValue) -> bool:
     try:
         return float(value) != 0.0
     except (TypeError, ValueError):
         return False
 
 
-def _sanitize_node_name(name):
+def _sanitize_node_name(name: JsonValue) -> str:
     sanitized = str(name).replace("/", "_").replace('"', "_").replace("\\", "_")
     sanitized = re.sub(r"\s+", " ", sanitized).strip()
     return sanitized or "Layer"
 
 
-def _unique_name(base_name, used_names):
+def _unique_name(base_name: str, used_names: dict[str, int]) -> str:
     count = used_names.get(base_name, 0) + 1
     used_names[base_name] = count
     if count == 1:
         return base_name
     return f"{base_name}_{count}"
+
+
+def _dict_value(value: JsonValue) -> JsonDict:
+    return cast(JsonDict, value) if isinstance(value, dict) else {}
+
+
+def _dict_items(value: JsonValue) -> list[JsonDict]:
+    if not isinstance(value, list):
+        return []
+    items = cast(list[JsonValue], value)
+    return [cast(JsonDict, item) for item in items if isinstance(item, dict)]

--- a/src/conversion/rooms.py
+++ b/src/conversion/rooms.py
@@ -1,25 +1,41 @@
+from __future__ import annotations
+
 import json
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import TypedDict
 
 from src.conversion.base_converter import BaseConverter
 from src.conversion.project_godot import GodotProjectFile
+from src.conversion.resource_index import GameMakerResourceIndex, IndexedRoom
 from src.conversion.room_creation_code import (
     ROOM_EXECUTION_ORDER,
     instance_creation_order_names,
     resolve_room_creation_code,
 )
 from src.conversion.room_layers import godot_string, serialize_room_layers
-from src.conversion.resource_index import GameMakerResourceIndex
+from src.conversion.type_defs import ConversionRunning, LogCallback, ProgressCallback, StrPath
+
+
+class RoomProcessResult(TypedDict):
+    success: bool
+    name: str
+    width: object
+    height: object
+    scene_path: str
 
 
 class RoomConverter(BaseConverter):
     """Convert GameMaker rooms into minimal Godot room scenes."""
 
-    def __init__(self, gm_project_path, godot_project_path, log_callback=print,
-                 progress_callback=None, conversion_running=None,
-                 update_log_callback=None, compact_logging=False,
-                 max_workers=None, resource_index=None):
+    def __init__(self, gm_project_path: StrPath, godot_project_path: StrPath,
+                  log_callback: LogCallback = print,
+                  progress_callback: ProgressCallback | None = None,
+                  conversion_running: ConversionRunning | None = None,
+                  update_log_callback: LogCallback | None = None,
+                  compact_logging: bool = False,
+                  max_workers: int | None = None,
+                  resource_index: GameMakerResourceIndex | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback,
                          progress_callback, conversion_running,
                          update_log_callback, compact_logging,
@@ -27,7 +43,7 @@ class RoomConverter(BaseConverter):
         self.godot_rooms_path = os.path.join(self.godot_project_path, "rooms")
         self.resource_index = resource_index
 
-    def _build_resource_index(self):
+    def _build_resource_index(self) -> GameMakerResourceIndex:
         if self.resource_index is not None:
             return self.resource_index
         return GameMakerResourceIndex(
@@ -41,7 +57,9 @@ class RoomConverter(BaseConverter):
             max_workers=self.max_workers,
         ).build()
 
-    def _generate_room_scene(self, room, resource_index=None):
+    def _generate_room_scene(
+        self, room: IndexedRoom, resource_index: GameMakerResourceIndex | None = None
+    ) -> str:
         room_settings = room.room_settings
         physics_settings = room.physics_settings
         room_creation_code = resolve_room_creation_code(
@@ -95,7 +113,7 @@ class RoomConverter(BaseConverter):
         lines.extend(serialized_layers.node_lines)
         return "\n".join(lines)
 
-    def _room_output_path(self, room):
+    def _room_output_path(self, room: IndexedRoom) -> str:
         if room.godot_path.startswith("res://"):
             relative_path = room.godot_path[len("res://"):]
             return os.path.join(self.godot_project_path, *relative_path.split("/"))
@@ -106,7 +124,9 @@ class RoomConverter(BaseConverter):
             )
         return os.path.join(self.godot_rooms_path, room.name, room.name + ".tscn")
 
-    def _process_room(self, room, resource_index=None):
+    def _process_room(
+        self, room: IndexedRoom, resource_index: GameMakerResourceIndex | None = None
+    ) -> RoomProcessResult | None:
         if not self.conversion_running():
             return None
 
@@ -125,7 +145,9 @@ class RoomConverter(BaseConverter):
             "scene_path": room.godot_path,
         }
 
-    def _set_startup_scene(self, index, generated_scene_paths):
+    def _set_startup_scene(
+        self, index: GameMakerResourceIndex, generated_scene_paths: dict[str, str]
+    ) -> None:
         if not generated_scene_paths:
             self.log_callback(
                 "Warning: No room scene generated; leaving project.godot main_scene unchanged."
@@ -155,7 +177,7 @@ class RoomConverter(BaseConverter):
                 "Warning: project.godot not found; could not set startup scene."
             )
 
-    def convert_rooms(self):
+    def convert_rooms(self) -> None:
         index = self._build_resource_index()
         rooms = index.ordered_rooms()
         if not rooms:
@@ -165,7 +187,7 @@ class RoomConverter(BaseConverter):
 
         total = len(rooms)
         processed = 0
-        generated_scene_paths = {}
+        generated_scene_paths: dict[str, str] = {}
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             futures_map = {
@@ -197,5 +219,5 @@ class RoomConverter(BaseConverter):
         self._set_startup_scene(index, generated_scene_paths)
         self.log_callback("Room conversion completed.")
 
-    def convert_all(self):
+    def convert_all(self) -> None:
         self.convert_rooms()

--- a/src/conversion/script_generator.py
+++ b/src/conversion/script_generator.py
@@ -1,26 +1,41 @@
 import re
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Callable, TypeAlias, cast
 
-from src.conversion.event_mapping import map_event, is_input_event, INPUT_MERGED_MAPPING
+from src.conversion.event_mapping import INPUT_MERGED_MAPPING, is_input_event, map_event
+from src.conversion.events.base import EventMapping
 from src.conversion.events.features import get_script_features
 from src.conversion.gml_runtime import GML_RUNTIME_RESOURCE_PATH
+from src.conversion.type_defs import JsonDict
+
+
+_CodeBodies: TypeAlias = Mapping[str, str]
+_MapEvent: TypeAlias = Callable[[JsonDict], EventMapping | None]
+_IsInputEvent: TypeAlias = Callable[[JsonDict], bool]
+_GetAdditionalFunctions: TypeAlias = Callable[[set[str]], list[EventMapping]]
+_EmitPrelude: TypeAlias = Callable[[list[str], set[str]], None]
+_WrapBody: TypeAlias = Callable[[EventMapping, str, set[str]], str]
+
+_map_event = cast(_MapEvent, map_event)
+_is_input_event = cast(_IsInputEvent, is_input_event)
 
 
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
-def _uses_gml_runtime(code_bodies):
+def _uses_gml_runtime(code_bodies: _CodeBodies | None) -> bool:
     return any("GMRuntime." in body for body in (code_bodies or {}).values())
 
 
-def _get_function_body(func, code_bodies):
+def _get_function_body(func: EventMapping, code_bodies: _CodeBodies | None) -> str:
     if code_bodies and func.godot_func in code_bodies:
         return code_bodies[func.godot_func]
     return "\tpass"
 
 
-def _deduplicate_functions(functions):
-    seen = set()
-    unique_functions = []
+def _deduplicate_functions(functions: Iterable[EventMapping]) -> list[EventMapping]:
+    seen: set[str] = set()
+    unique_functions: list[EventMapping] = []
     for func in functions:
         if func.godot_func not in seen:
             seen.add(func.godot_func)
@@ -28,7 +43,7 @@ def _deduplicate_functions(functions):
     return unique_functions
 
 
-def _valid_instance_variables(instance_variables):
+def _valid_instance_variables(instance_variables: Iterable[str] | None) -> list[str]:
     if not instance_variables:
         return []
     return sorted(
@@ -37,7 +52,11 @@ def _valid_instance_variables(instance_variables):
     )
 
 
-def generate_script_content(event_list, code_bodies=None, instance_variables=None):
+def generate_script_content(
+    event_list: Sequence[JsonDict] | None,
+    code_bodies: _CodeBodies | None = None,
+    instance_variables: Iterable[str] | None = None,
+) -> str:
     """Generate .gd script content with function stubs for each event.
 
     Events are mapped to Godot callback functions. Input events (mouse,
@@ -58,15 +77,15 @@ def generate_script_content(event_list, code_bodies=None, instance_variables=Non
     if not event_list:
         return "extends Node2D\n"
 
-    functions = []
+    functions: list[EventMapping] = []
     has_input = False
 
     for event in event_list:
-        if is_input_event(event):
+        if _is_input_event(event):
             has_input = True
             continue
 
-        mapping = map_event(event)
+        mapping = _map_event(event)
         if mapping is not None:
             functions.append(mapping)
 
@@ -78,7 +97,10 @@ def generate_script_content(event_list, code_bodies=None, instance_variables=Non
     script_features = get_script_features()
 
     for feature in script_features:
-        get_additional_functions = getattr(feature, "get_additional_functions", None)
+        get_additional_functions = cast(
+            _GetAdditionalFunctions | None,
+            getattr(feature, "get_additional_functions", None),
+        )
         if get_additional_functions is None:
             continue
 
@@ -96,7 +118,7 @@ def generate_script_content(event_list, code_bodies=None, instance_variables=Non
     if _uses_gml_runtime(code_bodies):
         lines.append(f'\n\nconst GMRuntime = preload("{GML_RUNTIME_RESOURCE_PATH}")\n')
     for feature in script_features:
-        emit_prelude = getattr(feature, "emit_prelude", None)
+        emit_prelude = cast(_EmitPrelude | None, getattr(feature, "emit_prelude", None))
         if emit_prelude is not None:
             emit_prelude(lines, function_names)
     for variable_name in _valid_instance_variables(instance_variables):
@@ -105,7 +127,7 @@ def generate_script_content(event_list, code_bodies=None, instance_variables=Non
     for func in unique_functions:
         body = _get_function_body(func, code_bodies)
         for feature in script_features:
-            wrap_body = getattr(feature, "wrap_body", None)
+            wrap_body = cast(_WrapBody | None, getattr(feature, "wrap_body", None))
             if wrap_body is not None:
                 body = wrap_body(func, body, function_names)
         lines.append(f"\n\nfunc {func.godot_func}({func.params}):")

--- a/src/conversion/shaders.py
+++ b/src/conversion/shaders.py
@@ -1,23 +1,26 @@
+from __future__ import annotations
+
 import os
 import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from src.conversion.base_converter import BaseConverter
+from src.conversion.type_defs import ConversionRunning, LogCallback, ProgressCallback, StrPath
 from src.localization import get_localized
 
 
 class ShaderConverter(BaseConverter):
-    def __init__(self, gm_project_path, godot_project_path,
-                 log_callback=print, progress_callback=None,
-                 conversion_running=None,
-                 update_log_callback=None, compact_logging=False,
-                 max_workers=None):
+    def __init__(self, gm_project_path: StrPath, godot_project_path: StrPath,
+                 log_callback: LogCallback = print, progress_callback: ProgressCallback | None = None,
+                 conversion_running: ConversionRunning | None = None,
+                 update_log_callback: LogCallback | None = None, compact_logging: bool = False,
+                 max_workers: int | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path,
                          log_callback, progress_callback, conversion_running,
                          update_log_callback, compact_logging, max_workers=max_workers)
         self.godot_shaders_path = os.path.join(self.godot_project_path, 'shaders')
 
-    def convert_shader(self, input_file, output_file):
+    def convert_shader(self, input_file: str, output_file: str) -> None:
         with open(input_file, 'r', encoding='utf-8') as f:
             content = f.read()
 
@@ -58,7 +61,7 @@ class ShaderConverter(BaseConverter):
         with open(output_file, 'w', encoding='utf-8') as f:
             f.write(content)
 
-    def _process_shader(self, input_path, subfolder=""):
+    def _process_shader(self, input_path: str, subfolder: str = "") -> tuple[str, str] | None:
         if not self.conversion_running():
             return None
         filename = os.path.basename(input_path)
@@ -72,7 +75,7 @@ class ShaderConverter(BaseConverter):
         self.convert_shader(input_path, output_path)
         return (filename, output_name)
 
-    def convert_all(self):
+    def convert_all(self) -> None:
         gm_shaders_path = os.path.join(self.gm_project_path, 'shaders')
 
         if not os.path.exists(gm_shaders_path):
@@ -82,8 +85,8 @@ class ShaderConverter(BaseConverter):
         os.makedirs(self.godot_shaders_path, exist_ok=True)
 
         # Collect shader files with their subfolder info
-        shader_files = []
-        shader_subfolders = {}
+        shader_files: list[str] = []
+        shader_subfolders: dict[str, str] = {}
         for root, _, files in os.walk(gm_shaders_path):
             for f in files:
                 if f.endswith(('.vsh', '.fsh')):

--- a/src/conversion/sounds.py
+++ b/src/conversion/sounds.py
@@ -1,25 +1,50 @@
+from __future__ import annotations
+
 import json
 import math
 import os
 import shutil
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from typing import TypedDict, cast
 
 # Import localization manager
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
+from src.conversion.type_defs import ConversionRunning, JsonDict, LogCallback, ProgressCallback, StrPath
+
+
+class SoundData(TypedDict):
+    name: str
+    soundFile: str
+    volume: float
+    type: int
+    bitDepth: int
+    bitRate: int
+    sampleRate: int
+    compression: int
+    preload: bool
+    audioGroupId: str
+    duration: float
+
+
+class SoundResult(TypedDict):
+    success: bool
+    name: str
+    audio_group: str
 
 class SoundConverter(BaseConverter):
-    def __init__(self, gm_project_path, godot_project_path, log_callback=print, progress_callback=None, conversion_running=None,
-                 update_log_callback=None, compact_logging=False, max_workers=None,
-                 organize_by_audio_group=False):
+    def __init__(self, gm_project_path: StrPath, godot_project_path: StrPath, log_callback: LogCallback = print,
+                 progress_callback: ProgressCallback | None = None, conversion_running: ConversionRunning | None = None,
+                 update_log_callback: LogCallback | None = None, compact_logging: bool = False, max_workers: int | None = None,
+                 organize_by_audio_group: bool = False) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback, progress_callback, conversion_running,
                          update_log_callback, compact_logging, max_workers=max_workers)
         self.godot_sounds_path = os.path.join(self.godot_project_path, 'sounds')
         self.organize_by_audio_group = bool(organize_by_audio_group)
 
-    def find_sound_files(self):
+    def find_sound_files(self) -> list[str]:
         sound_folder = os.path.join(self.gm_project_path, 'sounds')
-        sound_files = []
+        sound_files: list[str] = []
         for root, _, files in os.walk(sound_folder):
             sound_files.extend(
                 os.path.join(root, file)
@@ -28,7 +53,7 @@ class SoundConverter(BaseConverter):
             )
         return sound_files
 
-    def _parse_sound_yy(self, yy_path):
+    def _parse_sound_yy(self, yy_path: str) -> SoundData | None:
         data = self._read_yy_file(yy_path)
         if data is None:
             self._safe_log(get_localized("Console_Convertor_Sounds_ParseError").format(yy_path=yy_path))
@@ -36,8 +61,8 @@ class SoundConverter(BaseConverter):
 
         try:
             return {
-                'name': data['name'],
-                'soundFile': data.get('soundFile', ''),
+                'name': str(data['name']),
+                'soundFile': str(data.get('soundFile', '')),
                 'volume': float(data.get('volume', 1.0)),
                 'type': int(data.get('type', 0)),
                 'bitDepth': int(data.get('bitDepth', 16)),
@@ -45,7 +70,7 @@ class SoundConverter(BaseConverter):
                 'sampleRate': int(data.get('sampleRate', 44100)),
                 'compression': int(data.get('compression', 0)),
                 'preload': bool(data.get('preload', True)),
-                'audioGroupId': data.get('audioGroupId', {}).get('name', 'audiogroup_default'),
+                'audioGroupId': str(cast(JsonDict, data.get('audioGroupId', {})).get('name', 'audiogroup_default')),
                 'duration': float(data.get('duration', 0.0)),
             }
         except (KeyError, TypeError, ValueError):
@@ -53,13 +78,13 @@ class SoundConverter(BaseConverter):
             return None
 
     @staticmethod
-    def _volume_to_db(volume):
+    def _volume_to_db(volume: float) -> float:
         if volume <= 0.0:
             return -80.0
         return 20.0 * math.log10(volume)
 
-    def _build_output_paths(self, sound_name, subfolder, audio_group):
-        output_parts = []
+    def _build_output_paths(self, sound_name: str, subfolder: str, audio_group: str) -> tuple[str, str]:
+        output_parts: list[str] = []
 
         if self.organize_by_audio_group:
             output_parts.append(audio_group or 'audiogroup_default')
@@ -73,7 +98,7 @@ class SoundConverter(BaseConverter):
         res_subfolder = '/'.join(output_parts)
         return output_dir, res_subfolder
 
-    def _write_audio_group_map(self, audio_group_map):
+    def _write_audio_group_map(self, audio_group_map: dict[str, str]) -> None:
         map_path = os.path.join(self.godot_sounds_path, 'audio_group_map.json')
         ordered_map = {name: audio_group_map[name] for name in sorted(audio_group_map)}
         payload = {
@@ -89,7 +114,7 @@ class SoundConverter(BaseConverter):
             self._safe_log(get_localized("Console_Convertor_Sounds_MapGenerated").format(
                 map_path='sounds/audio_group_map.json', sounds_num=len(ordered_map)))
 
-    def _generate_import_file(self, sound_file, subfolder=""):
+    def _generate_import_file(self, sound_file: str, subfolder: str = "") -> str | None:
         ext = os.path.splitext(sound_file)[1].lower()
 
         if subfolder:
@@ -161,7 +186,7 @@ class SoundConverter(BaseConverter):
             )
         return None
 
-    def _process_sound(self, yy_path):
+    def _process_sound(self, yy_path: str) -> SoundResult | None:
         if not self.conversion_running():
             return None
 
@@ -213,7 +238,7 @@ class SoundConverter(BaseConverter):
 
         return {'success': True, 'name': sound_name, 'audio_group': audio_group}
 
-    def convert_sounds(self):
+    def convert_sounds(self) -> None:
         os.makedirs(self.godot_project_path, exist_ok=True)
         os.makedirs(self.godot_sounds_path, exist_ok=True)
 
@@ -231,10 +256,10 @@ class SoundConverter(BaseConverter):
 
         total_sounds = len(sound_files)
         processed_sounds = 0
-        audio_group_map = {}
+        audio_group_map: dict[str, str] = {}
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            futures_map = {executor.submit(self._process_sound, sf): sf for sf in sound_files}
+            futures_map: dict[Future[SoundResult | None], str] = {executor.submit(self._process_sound, sf): sf for sf in sound_files}
             for future in as_completed(futures_map):
                 result = future.result()
                 if result is None:
@@ -254,5 +279,5 @@ class SoundConverter(BaseConverter):
 
         self.log_callback(get_localized("Console_Convertor_Sounds_Complete"))
 
-    def convert_all(self):
+    def convert_all(self) -> None:
         self.convert_sounds()

--- a/src/conversion/sprites.py
+++ b/src/conversion/sprites.py
@@ -1,22 +1,53 @@
+from __future__ import annotations
+
 import os
 import re
 import json
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from PIL import Image
 from collections import defaultdict
+from typing import TypedDict, cast
 
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
+from src.conversion.type_defs import ConversionRunning, JsonDict, LogCallback, ProgressCallback, StrPath
+
+
+class CollisionData(TypedDict):
+    collisionKind: int
+    bboxMode: int
+    bbox_left: int
+    bbox_right: int
+    bbox_top: int
+    bbox_bottom: int
+    width: int
+    height: int
+    origin: int
+    xorigin: int
+    yorigin: int
+
+
+class AnimationData(TypedDict):
+    playbackSpeed: float
+    playbackSpeedType: int
+    loop: bool
+    frame_durations: list[float]
+
+
+SpriteParseResult = tuple[list[str], list[str]]
+SpriteProcessResult = tuple[str, int, int, str, str]
 
 
 class SpriteConverter(BaseConverter):
-    def __init__(self, gm_project_path, godot_project_path, log_callback=print, progress_callback=None, conversion_running=None,
-                 update_log_callback=None, compact_logging=False, max_workers=None):
+    def __init__(self, gm_project_path: StrPath, godot_project_path: StrPath, log_callback: LogCallback = print,
+                 progress_callback: ProgressCallback | None = None, conversion_running: ConversionRunning | None = None,
+                 update_log_callback: LogCallback | None = None, compact_logging: bool = False,
+                 max_workers: int | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback, progress_callback, conversion_running,
                          update_log_callback, compact_logging, max_workers=max_workers)
         self.godot_sprites_path = os.path.join(self.godot_project_path, 'sprites')
 
-    def _get_valid_sprite_names(self):
+    def _get_valid_sprite_names(self) -> dict[str, str] | None:
         """Parse the .yyp project file and return a dict of sprite name -> subfolder.
 
         Returns None if the .yyp file cannot be found or parsed, allowing
@@ -32,14 +63,14 @@ class SpriteConverter(BaseConverter):
                 content = f.read()
 
             cleaned = re.sub(r',\s*([}\]])', r'\1', content)
-            data = json.loads(cleaned)
+            data = cast(JsonDict, json.loads(cleaned))
 
-            valid_sprites = {}
-            for resource in data.get('resources', []):
-                res_id = resource.get('id', {})
-                path = res_id.get('path', '')
+            valid_sprites: dict[str, str] = {}
+            for resource in cast(list[JsonDict], data.get('resources', [])):
+                res_id = cast(JsonDict, resource.get('id', {}))
+                path = str(res_id.get('path', ''))
                 if path.startswith('sprites/'):
-                    name = res_id.get('name', '')
+                    name = str(res_id.get('name', ''))
                     yy_path = os.path.join(self.gm_project_path, 'sprites', name, name + '.yy')
                     valid_sprites[name] = self._get_subfolder_from_yy(yy_path)
 
@@ -49,15 +80,15 @@ class SpriteConverter(BaseConverter):
             return None
 
     @staticmethod
-    def _sprite_res_path(subfolder, sprite_name):
+    def _sprite_res_path(subfolder: str, sprite_name: str) -> str:
         """Build a res://sprites/... path, avoiding double slashes."""
         if subfolder:
             return f"res://sprites/{subfolder}/{sprite_name}"
         return f"res://sprites/{sprite_name}"
 
-    def _find_all_sprite_images(self):
+    def _find_all_sprite_images(self) -> defaultdict[str, list[str]]:
         sprite_folder = os.path.join(self.gm_project_path, 'sprites')
-        image_files = defaultdict(list)
+        image_files: defaultdict[str, list[str]] = defaultdict(list)
         for root, _, files in os.walk(sprite_folder):
             if 'layers' in root.split(os.path.sep):
                 sprite_name = root.split(os.path.sep)[-3]
@@ -68,7 +99,7 @@ class SpriteConverter(BaseConverter):
                 )
         return image_files
 
-    def _parse_collision_data(self, sprite_name):
+    def _parse_collision_data(self, sprite_name: str) -> CollisionData | None:
         """Parse collision mask properties from a sprite .yy file.
 
         Returns a dict with collision fields or None if parsing fails.
@@ -78,7 +109,7 @@ class SpriteConverter(BaseConverter):
             with open(yy_path, 'r', encoding='utf-8') as f:
                 content = f.read()
             cleaned = re.sub(r',\s*([}\]])', r'\1', content)
-            data = json.loads(cleaned)
+            data = cast(JsonDict, json.loads(cleaned))
 
             return {
                 "collisionKind": int(data.get("collisionKind", 1)),
@@ -96,7 +127,7 @@ class SpriteConverter(BaseConverter):
         except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
             return None
 
-    def _parse_animation_data(self, sprite_name):
+    def _parse_animation_data(self, sprite_name: str) -> AnimationData | None:
         """Parse animation metadata from a sprite .yy file's sequence object.
 
         Returns a dict with animation fields or None if parsing fails.
@@ -106,21 +137,22 @@ class SpriteConverter(BaseConverter):
             with open(yy_path, 'r', encoding='utf-8') as f:
                 content = f.read()
             cleaned = re.sub(r',\s*([}\]])', r'\1', content)
-            data = json.loads(cleaned)
+            data = cast(JsonDict, json.loads(cleaned))
 
             sequence = data.get("sequence")
-            if sequence is None:
+            if not isinstance(sequence, dict):
                 return None
+            sequence_data = cast(JsonDict, sequence)
 
-            playback_speed = float(sequence.get("playbackSpeed", 30.0))
-            playback_speed_type = int(sequence.get("playbackSpeedType", 0))
-            loop = int(sequence.get("playback", 1)) == 1
+            playback_speed = float(sequence_data.get("playbackSpeed", 30.0))
+            playback_speed_type = int(sequence_data.get("playbackSpeedType", 0))
+            loop = int(sequence_data.get("playback", 1)) == 1
 
-            frame_durations = []
-            tracks = sequence.get("tracks", [])
+            frame_durations: list[float] = []
+            tracks = cast(list[JsonDict], sequence_data.get("tracks", []))
             if tracks:
-                keyframes_store = tracks[0].get("keyframes", {})
-                keyframes = keyframes_store.get("Keyframes", [])
+                keyframes_store = cast(JsonDict, tracks[0].get("keyframes", {}))
+                keyframes = cast(list[JsonDict], keyframes_store.get("Keyframes", []))
                 sorted_kf = sorted(keyframes, key=lambda kf: float(kf.get("Key", 0)))
                 frame_durations = [float(kf.get("Length", 1.0)) for kf in sorted_kf]
 
@@ -134,7 +166,7 @@ class SpriteConverter(BaseConverter):
             return None
 
     @staticmethod
-    def _compute_godot_fps(animation_data):
+    def _compute_godot_fps(animation_data: AnimationData) -> float:
         """Convert GameMaker playback speed to Godot FPS.
 
         Type 0 (FPS): use value directly.
@@ -145,7 +177,7 @@ class SpriteConverter(BaseConverter):
             return speed * 60.0
         return speed
 
-    def _compute_origin_offset(self, collision_data):
+    def _compute_origin_offset(self, collision_data: CollisionData) -> tuple[float, float] | tuple[int, int]:
         """Compute the sprite origin position in pixels.
 
         Returns (origin_x, origin_y) based on the origin preset or custom values.
@@ -154,7 +186,7 @@ class SpriteConverter(BaseConverter):
         h = collision_data["height"]
         origin = collision_data["origin"]
 
-        origin_map = {
+        origin_map: dict[int, tuple[float, float] | tuple[int, int]] = {
             0: (0, 0),
             1: (w / 2, 0),
             2: (w, 0),
@@ -170,7 +202,7 @@ class SpriteConverter(BaseConverter):
             return (collision_data["xorigin"], collision_data["yorigin"])
         return origin_map.get(origin, (0, 0))
 
-    def _build_collision_block(self, collision_data):
+    def _build_collision_block(self, collision_data: CollisionData | None) -> tuple[str | None, str | None, str | None]:
         """Build collision sub_resource text, shape id, and node text from collision data.
 
         Returns (sub_resource_text, shape_id, node_text) or (None, None, None)
@@ -248,7 +280,8 @@ class SpriteConverter(BaseConverter):
 
         return (sub_resource_text, shape_id, node_text)
 
-    def _write_static_scene(self, sprite_name, collision_sub, collision_node, subfolder=""):
+    def _write_static_scene(self, sprite_name: str, collision_sub: str | None, collision_node: str | None,
+                            subfolder: str = "") -> None:
         """Generate a Sprite2D .tscn scene file.
 
         Creates the file at godot_sprites_path/{subfolder}/{sprite_name}/{sprite_name}.tscn.
@@ -257,7 +290,7 @@ class SpriteConverter(BaseConverter):
         load_steps = 2 if has_collision else 1
         res_prefix = self._sprite_res_path(subfolder, sprite_name)
 
-        parts = [f'[gd_scene format=3 load_steps={load_steps}]\n']
+        parts: list[str] = [f'[gd_scene format=3 load_steps={load_steps}]\n']
         parts.append(f'\n[ext_resource type="Texture2D" path="{res_prefix}/{sprite_name}.png" id="1"]\n')
 
         if has_collision:
@@ -278,7 +311,8 @@ class SpriteConverter(BaseConverter):
         with open(tscn_path, 'w', encoding='utf-8') as f:
             f.write(tscn_content)
 
-    def _write_animated_scene(self, sprite_name, frame_count, animation_data, collision_sub, collision_node, subfolder=""):
+    def _write_animated_scene(self, sprite_name: str, frame_count: int, animation_data: AnimationData,
+                              collision_sub: str | None, collision_node: str | None, subfolder: str = "") -> None:
         """Generate an AnimatedSprite2D .tscn scene file with embedded SpriteFrames.
 
         Creates the file at godot_sprites_path/{subfolder}/{sprite_name}/{sprite_name}.tscn.
@@ -296,7 +330,7 @@ class SpriteConverter(BaseConverter):
 
         # Build frame entries for the SpriteFrames animation array
         durations = animation_data.get("frame_durations", [])
-        frame_entries = []
+        frame_entries: list[str] = []
         for i in range(1, frame_count + 1):
             duration = durations[i - 1] if i - 1 < len(durations) else 1.0
             frame_entries.append(
@@ -331,7 +365,8 @@ class SpriteConverter(BaseConverter):
         with open(tscn_path, 'w', encoding='utf-8') as f:
             f.write(tscn_content)
 
-    def _generate_sprite_scene(self, sprite_name, collision_data, frame_count, animation_data=None, subfolder=""):
+    def _generate_sprite_scene(self, sprite_name: str, collision_data: CollisionData | None, frame_count: int,
+                               animation_data: AnimationData | None = None, subfolder: str = "") -> None:
         """Generate a .tscn scene file for a sprite.
 
         Creates either an AnimatedSprite2D scene (multi-frame with animation data)
@@ -339,30 +374,32 @@ class SpriteConverter(BaseConverter):
 
         Creates the file at godot_sprites_path/{subfolder}/{sprite_name}/{sprite_name}.tscn.
         """
-        collision_sub, shape_id, collision_node = self._build_collision_block(collision_data)
+        collision_sub, _, collision_node = self._build_collision_block(collision_data)
 
         if frame_count > 1 and animation_data is not None:
             self._write_animated_scene(sprite_name, frame_count, animation_data, collision_sub, collision_node, subfolder)
         else:
             self._write_static_scene(sprite_name, collision_sub, collision_node, subfolder)
 
-    def _parse_sprite_yy(self, sprite_name):
+    def _parse_sprite_yy(self, sprite_name: str) -> SpriteParseResult | None:
         yy_path = os.path.join(self.gm_project_path, 'sprites', sprite_name, sprite_name + '.yy')
         try:
             with open(yy_path, 'r', encoding='utf-8') as f:
                 content = f.read()
             cleaned = re.sub(r',\s*([}\]])', r'\1', content)
-            data = json.loads(cleaned)
+            data = cast(JsonDict, json.loads(cleaned))
 
-            frame_guids = [frame['name'] for frame in data['frames']]
+            frames = cast(list[JsonDict], data['frames'])
+            frame_guids = [str(frame['name']) for frame in frames]
 
+            layers = cast(list[JsonDict], data.get('layers', []))
             visible_layer_guids = [
-                layer['name']
-                for layer in data.get('layers', [])
+                str(layer['name'])
+                for layer in layers
                 if layer.get('visible', True)
             ]
-            if not visible_layer_guids and data.get('layers'):
-                visible_layer_guids = [data['layers'][0]['name']]
+            if not visible_layer_guids and layers:
+                visible_layer_guids = [str(layers[0]['name'])]
 
             return (frame_guids, visible_layer_guids)
         except (OSError, json.JSONDecodeError, KeyError, TypeError, IndexError):
@@ -370,21 +407,21 @@ class SpriteConverter(BaseConverter):
                 yy_path=yy_path, sprite_name=sprite_name))
             return None
 
-    def _build_ordered_frame_list(self, sprite_name, all_image_paths):
+    def _build_ordered_frame_list(self, sprite_name: str, all_image_paths: list[str]) -> list[list[str]]:
         result = self._parse_sprite_yy(sprite_name)
         if result is None:
             return [[path] for path in sorted(all_image_paths)]
 
         frame_guids, layer_guids = result
 
-        path_index = {}
+        path_index: dict[str, dict[str, str]] = {}
         for path in all_image_paths:
             parts = path.replace('\\', '/').split('/')
             frame_guid = parts[-2]
             filename = parts[-1]
             path_index.setdefault(frame_guid, {})[filename] = path
 
-        ordered = []
+        ordered: list[list[str]] = []
         for guid in frame_guids:
             frame_files = path_index.get(guid, {})
             if not frame_files:
@@ -401,7 +438,8 @@ class SpriteConverter(BaseConverter):
 
         return ordered if ordered else [[path] for path in sorted(all_image_paths)]
 
-    def _process_sprite(self, sprite_name, index, gm_sprite_paths, images_count, subfolder=""):
+    def _process_sprite(self, sprite_name: str, index: int, gm_sprite_paths: list[str], images_count: int,
+                        subfolder: str = "") -> SpriteProcessResult | None:
         if not self.conversion_running():
             return None
 
@@ -420,19 +458,20 @@ class SpriteConverter(BaseConverter):
                 if composed is None:
                     composed = Image.new('RGBA', layer.size, (0, 0, 0, 0))
                 composed.alpha_composite(layer)
+            assert composed is not None
             composed.save(godot_sprite_path, 'PNG')
 
         return (sprite_name, index, images_count, gm_sprite_paths[0], new_filename)
 
-    def convert_sprites(self):
+    def convert_sprites(self) -> None:
         os.makedirs(self.godot_sprites_path, exist_ok=True)
 
         sprite_images = self._find_all_sprite_images()
 
         valid_names = self._get_valid_sprite_names()
-        sprite_subfolders = {}
+        sprite_subfolders: dict[str, str] = {}
         if valid_names is not None:
-            filtered = {}
+            filtered: defaultdict[str, list[str]] = defaultdict(list)
             for name, images in sprite_images.items():
                 if name in valid_names:
                     filtered[name] = images
@@ -457,7 +496,7 @@ class SpriteConverter(BaseConverter):
             os.makedirs(sprite_dir, exist_ok=True)
 
         # Flatten all work items
-        work_items = []
+        work_items: list[tuple[str, int, list[str], int, str]] = []
         for sprite_name, images in sprite_images.items():
             ordered_images = self._build_ordered_frame_list(sprite_name, images)
             subfolder = sprite_subfolders.get(sprite_name, "")
@@ -468,7 +507,7 @@ class SpriteConverter(BaseConverter):
         processed_images = 0
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            futures_map = {
+            futures_map: dict[Future[SpriteProcessResult | None], tuple[str, int, list[str], int, str]] = {
                 executor.submit(self._process_sprite, name, idx, path, count, sub): (name, idx, path, count, sub)
                 for name, idx, path, count, sub in work_items
             }
@@ -478,7 +517,7 @@ class SpriteConverter(BaseConverter):
                     self.log_callback(get_localized("Console_Convertor_Sprites_Stopped"))
                     return
 
-                sprite_name, index, images_count, gm_sprite_path, new_filename = result
+                sprite_name, _index, _images_count, gm_sprite_path, new_filename = result
                 processed_images += 1
 
                 if self.compact_logging:
@@ -513,5 +552,5 @@ class SpriteConverter(BaseConverter):
 
         self.log_callback(get_localized("Console_Convertor_Sprites_Complete"))
 
-    def convert_all(self):
+    def convert_all(self) -> None:
         self.convert_sprites()

--- a/src/conversion/tilesets.py
+++ b/src/conversion/tilesets.py
@@ -1,23 +1,56 @@
+from __future__ import annotations
+
 import os
 import re
 import json
 import shutil
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from typing import Literal, NotRequired, TypedDict, cast
 
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
+from src.conversion.type_defs import ConversionRunning, JsonDict, LogCallback, ProgressCallback, StrPath
+
+
+class TilesetData(TypedDict):
+    sprite_name: str
+    sprite_path: str
+    tileWidth: int
+    tileHeight: int
+    tilehsep: int
+    tilevsep: int
+    tilexoff: int
+    tileyoff: int
+    tile_count: int
+
+
+class TilesetSuccess(TypedDict):
+    success: Literal[True]
+    name: str
+    tileset_data: TilesetData
+
+
+class TilesetFailure(TypedDict):
+    success: Literal[False]
+    name: str
+    error: str
+    sprite_name: NotRequired[str]
+
+
+TilesetResult = TilesetSuccess | TilesetFailure
 
 
 class TileSetConverter(BaseConverter):
-    def __init__(self, gm_project_path, godot_project_path, log_callback=print,
-                 progress_callback=None, conversion_running=None,
-                 update_log_callback=None, compact_logging=False, max_workers=None):
+    def __init__(self, gm_project_path: StrPath, godot_project_path: StrPath, log_callback: LogCallback = print,
+                 progress_callback: ProgressCallback | None = None, conversion_running: ConversionRunning | None = None,
+                 update_log_callback: LogCallback | None = None, compact_logging: bool = False,
+                 max_workers: int | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback,
                          progress_callback, conversion_running,
                          update_log_callback, compact_logging, max_workers=max_workers)
         self.godot_tilesets_path = os.path.join(self.godot_project_path, 'tilesets')
 
-    def _get_valid_tileset_names(self):
+    def _get_valid_tileset_names(self) -> dict[str, str] | None:
         """Parse the .yyp project file and return a dict of tileset name -> subfolder.
 
         Returns None if the .yyp file cannot be found or parsed, allowing
@@ -33,14 +66,14 @@ class TileSetConverter(BaseConverter):
                 content = f.read()
 
             cleaned = re.sub(r',\s*([}\]])', r'\1', content)
-            data = json.loads(cleaned)
+            data = cast(JsonDict, json.loads(cleaned))
 
-            valid_tilesets = {}
-            for resource in data.get('resources', []):
-                res_id = resource.get('id', {})
-                path = res_id.get('path', '')
+            valid_tilesets: dict[str, str] = {}
+            for resource in cast(list[JsonDict], data.get('resources', [])):
+                res_id = cast(JsonDict, resource.get('id', {}))
+                path = str(res_id.get('path', ''))
                 if path.startswith('tilesets/'):
-                    name = res_id.get('name', '')
+                    name = str(res_id.get('name', ''))
                     yy_path = os.path.join(self.gm_project_path, 'tilesets', name, name + '.yy')
                     valid_tilesets[name] = self._get_subfolder_from_yy(yy_path)
 
@@ -48,7 +81,7 @@ class TileSetConverter(BaseConverter):
         except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
             return None
 
-    def _parse_tileset_yy(self, tileset_name):
+    def _parse_tileset_yy(self, tileset_name: str) -> TilesetData | None:
         """Read and parse a tileset .yy file.
 
         Returns a dict with tileset properties, or None on failure.
@@ -58,12 +91,12 @@ class TileSetConverter(BaseConverter):
             with open(yy_path, 'r', encoding='utf-8') as f:
                 content = f.read()
             cleaned = re.sub(r',\s*([}\]])', r'\1', content)
-            data = json.loads(cleaned)
+            data = cast(JsonDict, json.loads(cleaned))
 
-            sprite_id = data.get('spriteId', {})
+            sprite_id = cast(JsonDict, data.get('spriteId', {}))
             return {
-                "sprite_name": sprite_id.get('name', ''),
-                "sprite_path": sprite_id.get('path', ''),
+                "sprite_name": str(sprite_id.get('name', '')),
+                "sprite_path": str(sprite_id.get('path', '')),
                 "tileWidth": int(data.get('tileWidth', 16)),
                 "tileHeight": int(data.get('tileHeight', 16)),
                 "tilehsep": int(data.get('tilehsep', 0)),
@@ -75,7 +108,7 @@ class TileSetConverter(BaseConverter):
         except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
             return None
 
-    def _find_sprite_image(self, sprite_name):
+    def _find_sprite_image(self, sprite_name: str) -> str | None:
         """Find the primary layer image for a sprite referenced by a tileset.
 
         Parses the sprite's .yy to identify the first visible layer, then
@@ -89,22 +122,23 @@ class TileSetConverter(BaseConverter):
             with open(yy_path, 'r', encoding='utf-8') as f:
                 content = f.read()
             cleaned = re.sub(r',\s*([}\]])', r'\1', content)
-            data = json.loads(cleaned)
+            data = cast(JsonDict, json.loads(cleaned))
 
             # Get the first frame GUID
-            frames = data.get('frames', [])
+            frames = cast(list[JsonDict], data.get('frames', []))
             if not frames:
                 return None
-            frame_guid = frames[0].get('name', '')
+            frame_guid = str(frames[0].get('name', ''))
 
             # Get the primary visible layer GUID
             primary_layer_guid = None
-            for layer in data.get('layers', []):
+            layers = cast(list[JsonDict], data.get('layers', []))
+            for layer in layers:
                 if layer.get('visible', True):
-                    primary_layer_guid = layer.get('name', '')
+                    primary_layer_guid = str(layer.get('name', ''))
                     break
-            if primary_layer_guid is None and data.get('layers'):
-                primary_layer_guid = data['layers'][0].get('name', '')
+            if primary_layer_guid is None and layers:
+                primary_layer_guid = str(layers[0].get('name', ''))
 
             if not frame_guid or not primary_layer_guid:
                 return None
@@ -127,7 +161,7 @@ class TileSetConverter(BaseConverter):
 
         return None
 
-    def _generate_tileset_tres(self, tileset_name, tileset_data, subfolder=""):
+    def _generate_tileset_tres(self, tileset_name: str, tileset_data: TilesetData, subfolder: str = "") -> str:
         """Generate a Godot TileSet .tres resource string."""
         tile_w = tileset_data["tileWidth"]
         tile_h = tileset_data["tileHeight"]
@@ -141,7 +175,7 @@ class TileSetConverter(BaseConverter):
         else:
             res_path = f"res://tilesets/{tileset_name}/{tileset_name}.png"
 
-        lines = []
+        lines: list[str] = []
         lines.append('[gd_resource type="TileSet" format=3]')
         lines.append('')
         lines.append(f'[ext_resource type="Texture2D" path="{res_path}" id="1"]')
@@ -163,7 +197,7 @@ class TileSetConverter(BaseConverter):
 
         return '\n'.join(lines)
 
-    def _process_tileset(self, tileset_name, subfolder=""):
+    def _process_tileset(self, tileset_name: str, subfolder: str = "") -> TilesetResult | None:
         """Process a single tileset: parse, copy image, generate .tres.
 
         Returns a dict with conversion results, or None if stopped.
@@ -202,7 +236,7 @@ class TileSetConverter(BaseConverter):
 
         return {"success": True, "name": tileset_name, "tileset_data": tileset_data}
 
-    def convert_tilesets(self):
+    def convert_tilesets(self) -> None:
         """Main tileset conversion method."""
         os.makedirs(self.godot_project_path, exist_ok=True)
         os.makedirs(self.godot_tilesets_path, exist_ok=True)
@@ -215,7 +249,7 @@ class TileSetConverter(BaseConverter):
             return
 
         # Discover tileset directories by walking the tilesets folder
-        tileset_names = []
+        tileset_names: list[str] = []
         for entry in os.listdir(gm_tilesets_path):
             entry_path = os.path.join(gm_tilesets_path, entry)
             yy_path = os.path.join(entry_path, entry + '.yy')
@@ -224,7 +258,7 @@ class TileSetConverter(BaseConverter):
 
         # Filter against .yyp if available
         valid_names = self._get_valid_tileset_names()
-        tileset_subfolders = {}
+        tileset_subfolders: dict[str, str] = {}
         if valid_names is not None:
             tileset_names = [n for n in tileset_names if n in valid_names]
             tileset_subfolders = {n: valid_names[n] for n in tileset_names}
@@ -241,7 +275,7 @@ class TileSetConverter(BaseConverter):
         processed_tilesets = 0
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            futures_map = {
+            futures_map: dict[Future[TilesetResult | None], str] = {
                 executor.submit(self._process_tileset, name, tileset_subfolders.get(name, "")): name
                 for name in tileset_names
             }
@@ -254,12 +288,13 @@ class TileSetConverter(BaseConverter):
                 processed_tilesets += 1
 
                 if result["success"]:
-                    td = result["tileset_data"]
+                    success_result = cast(TilesetSuccess, result)
+                    td = success_result["tileset_data"]
                     if self.compact_logging:
-                        self._safe_log_progress(result["name"], processed_tilesets, total_tilesets)
+                        self._safe_log_progress(success_result["name"], processed_tilesets, total_tilesets)
                     else:
                         self._safe_log(get_localized("Console_Convertor_Tilesets_Converted").format(
-                            name=result["name"],
+                            name=success_result["name"],
                             tile_count=td["tile_count"],
                             tileWidth=td["tileWidth"],
                             tileHeight=td["tileHeight"]))
@@ -268,5 +303,5 @@ class TileSetConverter(BaseConverter):
 
         self.log_callback(get_localized("Console_Convertor_Tilesets_Complete"))
 
-    def convert_all(self):
+    def convert_all(self) -> None:
         self.convert_tilesets()

--- a/src/conversion/type_defs.py
+++ b/src/conversion/type_defs.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from os import PathLike
+from typing import Any, Callable, Protocol, TypeAlias
+
+
+JsonDict: TypeAlias = dict[str, Any]
+JsonList: TypeAlias = list[Any]
+JsonValue: TypeAlias = Any
+StrPath: TypeAlias = str | PathLike[str]
+
+LogCallback: TypeAlias = Callable[[str], None]
+ProgressCallback: TypeAlias = Callable[[int | float], None]
+ConversionRunning: TypeAlias = Callable[[], bool]
+
+
+class BoolSetting(Protocol):
+    def get(self) -> bool: ...

--- a/src/gui/dialogs/about_dialog.py
+++ b/src/gui/dialogs/about_dialog.py
@@ -1,5 +1,7 @@
 import webbrowser
 from datetime import datetime
+from collections.abc import Mapping
+from typing import Any, cast
 
 import requests
 from PySide6.QtCore import Qt
@@ -14,13 +16,13 @@ from src.localization import get_localized
 
 
 class AboutDialog(QDialog):
-    def __init__(self, parent=None):
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setWindowTitle(get_localized("About_Title"))
         self.resize(600, 700)
         self._init_ui()
 
-    def _init_ui(self):
+    def _init_ui(self) -> None:
         layout = QVBoxLayout(self)
         layout.setContentsMargins(20, 20, 20, 20)
         layout.setSpacing(10)
@@ -74,7 +76,7 @@ class AboutDialog(QDialog):
             )
             link.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
             link.setAlignment(Qt.AlignmentFlag.AlignCenter)
-            link.mousePressEvent = lambda e, u=url: webbrowser.open_new(u)
+            link.mousePressEvent = lambda e, u=url: webbrowser.open_new(u)  # type: ignore[method-assign]
             layout.addWidget(link)
 
         # Copyright
@@ -84,7 +86,7 @@ class AboutDialog(QDialog):
         copyright_label.setStyleSheet(f"color: {THEME['fg_white']};")
         layout.addWidget(copyright_label)
 
-    def _load_contributors(self):
+    def _load_contributors(self) -> None:
         try:
             response = requests.get(
                 "https://api.github.com/repos/Infiland/GM2Godot/contributors",
@@ -92,7 +94,7 @@ class AboutDialog(QDialog):
                 timeout=10,
             )
             response.raise_for_status()
-            for contributor in response.json():
+            for contributor in cast(list[Mapping[str, Any]], response.json()):
                 self._add_contributor(contributor)
         except Exception as e:
             error_label = QLabel(
@@ -101,8 +103,8 @@ class AboutDialog(QDialog):
             error_label.setStyleSheet(f"color: {THEME['fg_white']};")
             self._contrib_layout.addWidget(error_label)
 
-    def _add_contributor(self, contributor):
-        url = contributor["html_url"]
+    def _add_contributor(self, contributor: Mapping[str, Any]) -> None:
+        url = str(contributor["html_url"])
 
         # Clickable frame wrapping the entire row
         frame = QFrame()
@@ -111,31 +113,31 @@ class AboutDialog(QDialog):
             f"QFrame:hover {{ background-color: {THEME['bg_tertiary']}; }}"
         )
         frame.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
-        frame.mousePressEvent = lambda e, u=url: webbrowser.open_new(u)
+        frame.mousePressEvent = lambda e, u=url: webbrowser.open_new(u)  # type: ignore[method-assign]
 
         row = QHBoxLayout(frame)
         row.setContentsMargins(6, 6, 6, 6)
 
         # Avatar
         try:
-            resp = requests.get(contributor["avatar_url"], timeout=10)
+            resp = requests.get(str(contributor["avatar_url"]), timeout=10)
             pixmap = QPixmap()
             pixmap.loadFromData(resp.content)
             avatar = QLabel()
             avatar.setPixmap(pixmap.scaled(40, 40))
             avatar.setFixedSize(40, 40)
             avatar.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
-            avatar.mousePressEvent = lambda e, u=url: webbrowser.open_new(u)
+            avatar.mousePressEvent = lambda e, u=url: webbrowser.open_new(u)  # type: ignore[method-assign]
             row.addWidget(avatar)
         except Exception:
             pass
 
         # Info
         info_layout = QVBoxLayout()
-        name = QLabel(contributor["login"])
+        name = QLabel(str(contributor["login"]))
         name.setStyleSheet(f"color: {THEME['accent_link']};")
         name.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
-        name.mousePressEvent = lambda e, u=url: webbrowser.open_new(u)
+        name.mousePressEvent = lambda e, u=url: webbrowser.open_new(u)  # type: ignore[method-assign]
         info_layout.addWidget(name)
 
         contribs = QLabel(f"{contributor['contributions']} contributions")

--- a/src/gui/dialogs/language_dialog.py
+++ b/src/gui/dialogs/language_dialog.py
@@ -2,27 +2,28 @@ import glob
 import json
 import os
 import sys
+from typing import Any, cast
 
 from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QComboBox, QPushButton,
+    QDialog, QVBoxLayout, QHBoxLayout, QComboBox, QPushButton, QWidget,
 )
 
 from src.localization import get_localized
 
 
-def _base_path():
+def _base_path() -> str:
     if getattr(sys, 'frozen', False):
-        return sys._MEIPASS
+        return cast(str, getattr(sys, '_MEIPASS'))
     return os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 
 class LanguageDialog(QDialog):
-    def __init__(self, parent=None):
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setWindowTitle(get_localized("Language_Select_Title"))
         self.resize(300, 150)
 
-        self._language_keys = []
+        self._language_keys: list[str] = []
         self._current_index = 0
 
         layout = QVBoxLayout(self)
@@ -44,7 +45,7 @@ class LanguageDialog(QDialog):
 
         layout.addLayout(btn_row)
 
-    def _load_languages(self):
+    def _load_languages(self) -> None:
         base = _base_path()
         lang_files = glob.glob(os.path.join(base, "Languages", "*.json"))
 
@@ -58,9 +59,9 @@ class LanguageDialog(QDialog):
         for i, path in enumerate(lang_files):
             try:
                 with open(path, "r", encoding="utf-8") as f:
-                    data = json.load(f)
-                    self._language_keys.append(data["Language_Code"])
-                    self._combo.addItem(data["Language"])
+                    data = cast(dict[str, Any], json.load(f))
+                    self._language_keys.append(str(data["Language_Code"]))
+                    self._combo.addItem(str(data["Language"]))
                     if data["Language_Code"] == current_key:
                         self._current_index = i
             except Exception:
@@ -68,7 +69,7 @@ class LanguageDialog(QDialog):
 
         self._combo.setCurrentIndex(self._current_index)
 
-    def _apply(self):
+    def _apply(self) -> None:
         base = _base_path()
         idx = self._combo.currentIndex()
         lang_code = self._language_keys[idx] if idx < len(self._language_keys) else "eng"

--- a/src/gui/dialogs/release_notes_dialog.py
+++ b/src/gui/dialogs/release_notes_dialog.py
@@ -1,17 +1,18 @@
 import requests
-import markdown2
+import markdown2  # type: ignore[reportMissingTypeStubs]
+from typing import Any, cast
 
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QTextBrowser, QMessageBox
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QTextBrowser, QMessageBox, QWidget
 
 from src.gui.theme import THEME
 from src.localization import get_localized
 
 
 class ReleaseNotesDialog:
-    def __init__(self, parent):
+    def __init__(self, parent: QWidget) -> None:
         self._parent = parent
 
-    def show(self):
+    def show(self) -> None:
         notes = self._fetch()
         if notes:
             self._display(notes)
@@ -19,20 +20,21 @@ class ReleaseNotesDialog:
             errors = get_localized("ReleaseNotes_Error_NoInternet")
             QMessageBox.critical(self._parent, errors[0], errors[1])
 
-    def _fetch(self):
+    def _fetch(self) -> str | None:
         try:
             response = requests.get(
                 "https://api.github.com/repos/Infiland/GM2Godot/releases/latest",
                 timeout=10,
             )
             if response.status_code == 200:
-                return response.json()["body"]
+                data = cast(dict[str, Any], response.json())
+                return str(data["body"])
             return None
         except Exception as e:
             print(get_localized("ReleaseNotes_Error_Generic").format(error=e))
             return None
 
-    def _display(self, notes):
+    def _display(self, notes: str) -> None:
         dialog = QDialog(self._parent)
         dialog.setWindowTitle(get_localized("ReleaseNotes_Title"))
         dialog.resize(750, 600)
@@ -47,7 +49,7 @@ class ReleaseNotesDialog:
             f"color: {THEME['fg_white']}; "
             f"border: none; border-radius: 6px; padding: 10px;"
         )
-        html = markdown2.markdown(notes, extras=["fenced-code-blocks"])
+        html = cast(str, markdown2.markdown(notes, extras=["fenced-code-blocks"]))
         browser.setHtml(html)
         layout.addWidget(browser)
 

--- a/src/gui/dialogs/settings_dialog.py
+++ b/src/gui/dialogs/settings_dialog.py
@@ -1,4 +1,5 @@
 import multiprocessing
+from typing import cast
 
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
@@ -7,21 +8,29 @@ from PySide6.QtWidgets import (
 )
 
 from src.gui.theme import THEME
+from src.gui.setting_value import SettingValue
 from src.conversion.converter import CONVERSION_CATEGORIES
 from src.localization import get_localized
 
 
 class SettingsDialog(QDialog):
-    def __init__(self, conversion_settings, compact_logging, platform_value, max_workers, parent=None):
+    def __init__(
+        self,
+        conversion_settings: dict[str, SettingValue],
+        compact_logging: SettingValue,
+        platform_value: str,
+        max_workers: int,
+        parent: QWidget | None = None,
+    ) -> None:
         super().__init__(parent)
         self._settings = conversion_settings
         self._compact_logging = compact_logging
         self._platform = platform_value
         self._max_workers = max_workers
-        self._checkboxes = {}
+        self._checkboxes: dict[str, QCheckBox] = {}
         self._init_ui()
 
-    def _init_ui(self):
+    def _init_ui(self) -> None:
         self.setWindowTitle(get_localized("Settings_Title"))
         self.resize(800, 500)
 
@@ -42,11 +51,11 @@ class SettingsDialog(QDialog):
         grid = QGridLayout(categories_widget)
         grid.setSpacing(20)
 
-        labels = get_localized("Settings_Labels")
-        headings = get_localized("Settings_Categories_Headings")
+        labels = cast(dict[str, str], get_localized("Settings_Labels"))
+        headings = cast(list[str], get_localized("Settings_Categories_Headings"))
         categories_items = list(CONVERSION_CATEGORIES.items())
 
-        for col, (cat_key, setting_keys) in enumerate(categories_items):
+        for col, (_cat_key, setting_keys) in enumerate(categories_items):
             col_layout = QVBoxLayout()
 
             cat_heading = QLabel(headings[col])
@@ -59,7 +68,7 @@ class SettingsDialog(QDialog):
                 display_name = labels.get(key, key.replace("_", " ").title())
                 cb = QCheckBox(display_name)
                 cb.setChecked(self._settings[key].get())
-                cb.toggled.connect(lambda checked, k=key: self._settings[k].set(checked))
+                cb.toggled.connect(lambda checked=False, k=key: self._settings[k].set(checked))
                 col_layout.addWidget(cb)
                 self._checkboxes[key] = cb
 
@@ -136,16 +145,16 @@ class SettingsDialog(QDialog):
 
         layout.addLayout(btn_row)
 
-    def _select_all(self):
-        for key, cb in self._checkboxes.items():
+    def _select_all(self) -> None:
+        for cb in self._checkboxes.values():
             cb.setChecked(True)
 
-    def _deselect_all(self):
-        for key, cb in self._checkboxes.items():
+    def _deselect_all(self) -> None:
+        for cb in self._checkboxes.values():
             cb.setChecked(False)
 
-    def selected_platform(self):
+    def selected_platform(self) -> str:
         return self._platform_combo.currentText()
 
-    def selected_max_workers(self):
+    def selected_max_workers(self) -> int:
         return self._workers_spin.value()

--- a/src/gui/dialogs/update_dialog.py
+++ b/src/gui/dialogs/update_dialog.py
@@ -1,9 +1,12 @@
 import webbrowser
-import markdown2
+from typing import cast
+
+import markdown2  # type: ignore[reportMissingTypeStubs]
 
 from PySide6.QtCore import Qt, QThread, Signal, QObject
+from PySide6.QtGui import QCloseEvent
 from PySide6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QWidget,
     QTextBrowser, QProgressBar, QFileDialog, QMessageBox,
 )
 
@@ -18,12 +21,12 @@ class DownloadWorker(QObject):
     progress = Signal(int)
     finished = Signal(bool)
 
-    def __init__(self, url, dest_path):
+    def __init__(self, url: str, dest_path: str) -> None:
         super().__init__()
         self.url = url
         self.dest_path = dest_path
 
-    def run(self):
+    def run(self) -> None:
         success = UpdateChecker.download_update(
             self.url, self.dest_path,
             progress_callback=self.progress.emit
@@ -32,16 +35,16 @@ class DownloadWorker(QObject):
 
 
 class UpdateDialog(QDialog):
-    def __init__(self, update_info: UpdateInfo, parent=None):
+    def __init__(self, update_info: UpdateInfo, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._info = update_info
-        self._download_thread = None
-        self._worker = None
+        self._download_thread: QThread | None = None
+        self._worker: DownloadWorker | None = None
         self.setWindowTitle(get_localized("Update_Available_Title"))
         self.resize(600, 500)
         self._init_ui()
 
-    def _init_ui(self):
+    def _init_ui(self) -> None:
         layout = QVBoxLayout(self)
         layout.setContentsMargins(20, 20, 20, 20)
         layout.setSpacing(10)
@@ -79,7 +82,7 @@ class UpdateDialog(QDialog):
                 f"color: {THEME['fg_white']}; "
                 f"border: none; border-radius: 6px; padding: 10px;"
             )
-            html = markdown2.markdown(self._info.release_notes, extras=["fenced-code-blocks"])
+            html = cast(str, markdown2.markdown(self._info.release_notes, extras=["fenced-code-blocks"]))
             browser.setHtml(html)
             layout.addWidget(browser, stretch=1)
 
@@ -122,8 +125,12 @@ class UpdateDialog(QDialog):
 
         layout.addLayout(btn_layout)
 
-    def _start_download(self):
+    def _start_download(self) -> None:
         """Open file dialog and start download."""
+        download_url = self._info.download_url
+        if download_url is None:
+            return
+
         suggested_name = self._info.asset_name or f"GM2Godot-{self._info.latest_version}"
         dest_path, _ = QFileDialog.getSaveFileName(
             self, get_localized("Update_Button_Download"),
@@ -138,20 +145,20 @@ class UpdateDialog(QDialog):
         self._status_label.setVisible(True)
         self._status_label.setText(get_localized("Update_Download_Progress").format(percent=0))
 
-        self._worker = DownloadWorker(self._info.download_url, dest_path)
+        self._worker = DownloadWorker(download_url, dest_path)
         self._download_thread = QThread()
         self._worker.moveToThread(self._download_thread)
 
         self._worker.progress.connect(self._on_download_progress)
-        self._worker.finished.connect(lambda success: self._on_download_finished(success, dest_path))
+        self._worker.finished.connect(lambda success=False: self._on_download_finished(success, dest_path))
         self._download_thread.started.connect(self._worker.run)
         self._download_thread.start()
 
-    def _on_download_progress(self, percent):
+    def _on_download_progress(self, percent: int) -> None:
         self._progress_bar.setValue(percent)
         self._status_label.setText(get_localized("Update_Download_Progress").format(percent=percent))
 
-    def _on_download_finished(self, success, dest_path):
+    def _on_download_finished(self, success: bool, dest_path: str) -> None:
         if self._download_thread:
             self._download_thread.quit()
             self._download_thread.wait()
@@ -170,11 +177,11 @@ class UpdateDialog(QDialog):
             self._status_label.setText(get_localized("Update_Error_Download").format(error="Download failed"))
             self._download_btn.setEnabled(True)
 
-    def _skip_version(self):
+    def _skip_version(self) -> None:
         UpdateChecker.set_skipped_version(self._info.latest_version)
         self.reject()
 
-    def closeEvent(self, event):
+    def closeEvent(self, event: QCloseEvent) -> None:
         if self._download_thread and self._download_thread.isRunning():
             self._download_thread.quit()
             self._download_thread.wait(3000)

--- a/src/gui/icons.py
+++ b/src/gui/icons.py
@@ -1,18 +1,19 @@
 import os
 import sys
+from typing import cast
 
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon, QPixmap
 
 
-def _base_path():
+def _base_path() -> str:
     if getattr(sys, 'frozen', False):
-        return sys._MEIPASS
+        return cast(str, getattr(sys, '_MEIPASS'))
     return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 class AppIcons:
-    def __init__(self):
+    def __init__(self) -> None:
         base = _base_path()
         self._app = QIcon(os.path.join(base, "img", "Logo.png"))
         self._gamemaker = QPixmap(os.path.join(base, "img", "Gamemaker.png")).scaled(
@@ -25,14 +26,14 @@ class AppIcons:
             24, 24, mode=Qt.TransformationMode.SmoothTransformation
         )
 
-    def app_icon(self):
+    def app_icon(self) -> QIcon:
         return self._app
 
-    def gamemaker_icon(self):
+    def gamemaker_icon(self) -> QPixmap:
         return self._gamemaker
 
-    def godot_icon(self):
+    def godot_icon(self) -> QPixmap:
         return self._godot
 
-    def language_icon(self):
+    def language_icon(self) -> QPixmap:
         return self._language

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -5,9 +5,9 @@ import time
 import webbrowser
 import multiprocessing
 
-from PySide6.QtCore import Qt, QThread, QTimer, Signal, QObject
-from PySide6.QtGui import QIcon
-from PySide6.QtWidgets import QMainWindow, QWidget, QVBoxLayout, QMessageBox, QApplication
+from PySide6.QtCore import QThread, QTimer, Signal, QObject
+from PySide6.QtGui import QCloseEvent, QIcon
+from PySide6.QtWidgets import QMainWindow, QWidget, QVBoxLayout, QMessageBox
 
 from src.gui.icons import AppIcons
 from src.gui.setting_value import SettingValue
@@ -25,13 +25,14 @@ from src.conversion.converter import CONVERSION_CATEGORIES
 from src.version import get_version
 from src.localization import get_localized
 from src.update_checker import UpdateChecker
+from src.update_checker import UpdateInfo
 from src.gui.dialogs.update_dialog import UpdateDialog
 
 
 class UpdateCheckWorker(QObject):
     update_available = Signal(object)  # emits UpdateInfo
 
-    def run(self):
+    def run(self) -> None:
         checker = UpdateChecker()
         info = checker.check_for_update()
         if info and info.available:
@@ -39,7 +40,7 @@ class UpdateCheckWorker(QObject):
 
 
 class MainWindow(QMainWindow):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle(get_localized("Menu_Title").format(version=get_version()))
         self.resize(800, 600)
@@ -50,8 +51,10 @@ class MainWindow(QMainWindow):
 
         self._setup_conversion_settings()
         self._conversion_running = threading.Event()
-        self._conversion_thread = None
-        self._worker = None
+        self._conversion_thread: QThread | None = None
+        self._worker: ConversionWorker | None = None
+        self._update_thread: QThread | None = None
+        self._update_worker: UpdateCheckWorker | None = None
         self._timer_running = False
         self._start_time = 0
 
@@ -65,9 +68,9 @@ class MainWindow(QMainWindow):
         self._timer.setInterval(1000)
         self._timer.timeout.connect(self._update_timer)
 
-    def _setup_conversion_settings(self):
+    def _setup_conversion_settings(self) -> None:
         all_keys = [key for keys in CONVERSION_CATEGORIES.values() for key in keys]
-        self._conversion_settings = {key: SettingValue(True) for key in all_keys}
+        self._conversion_settings: dict[str, SettingValue] = {key: SettingValue(True) for key in all_keys}
         self._conversion_settings["notes"].set(False)
         self._conversion_settings["sound_group_folders"].set(False)
         self._compact_logging = SettingValue(True)
@@ -81,7 +84,7 @@ class MainWindow(QMainWindow):
             case _:
                 self._gm_platform = "windows"
 
-    def _init_ui(self):
+    def _init_ui(self) -> None:
         central = QWidget()
         self.setCentralWidget(central)
         layout = QVBoxLayout(central)
@@ -116,7 +119,7 @@ class MainWindow(QMainWindow):
         )
         layout.addWidget(self._info_bar)
 
-    def _create_menu(self):
+    def _create_menu(self) -> None:
         menu_bar = self.menuBar()
         help_menu = menu_bar.addMenu("Help")
         help_menu.addAction("About GM2Godot", self._show_about)
@@ -137,10 +140,10 @@ class MainWindow(QMainWindow):
 
     # --- Actions ---
 
-    def _show_about(self):
+    def _show_about(self) -> None:
         AboutDialog(self).exec()
 
-    def _check_for_updates_on_startup(self):
+    def _check_for_updates_on_startup(self) -> None:
         self._update_worker = UpdateCheckWorker()
         self._update_thread = QThread()
         self._update_worker.moveToThread(self._update_thread)
@@ -148,7 +151,7 @@ class MainWindow(QMainWindow):
         self._update_thread.started.connect(self._update_worker.run)
         self._update_thread.start()
 
-    def _on_update_available(self, info):
+    def _on_update_available(self, info: UpdateInfo) -> None:
         if self._update_thread:
             self._update_thread.quit()
             self._update_thread.wait()
@@ -161,7 +164,7 @@ class MainWindow(QMainWindow):
 
         UpdateDialog(info, self).exec()
 
-    def _check_for_updates(self):
+    def _check_for_updates(self) -> None:
         checker = UpdateChecker()
         info = checker.check_for_update()
         if info is None:
@@ -172,7 +175,7 @@ class MainWindow(QMainWindow):
         else:
             QMessageBox.information(self, "GM2Godot", get_localized("Update_UpToDate"))
 
-    def _open_settings(self):
+    def _open_settings(self) -> None:
         dialog = SettingsDialog(
             self._conversion_settings,
             self._compact_logging,
@@ -184,16 +187,16 @@ class MainWindow(QMainWindow):
             self._gm_platform = dialog.selected_platform()
             self._max_workers = dialog.selected_max_workers()
 
-    def _open_language(self):
+    def _open_language(self) -> None:
         LanguageDialog(self).exec()
 
-    def _on_path_selected(self, key, folder):
+    def _on_path_selected(self, key: str, folder: str) -> None:
         if key == "gamemaker":
             self._check_project_file(folder, ".yyp", "GameMaker")
         else:
             self._check_project_file(folder, "project.godot", "Godot")
 
-    def _check_project_file(self, folder, file_extension, file_name):
+    def _check_project_file(self, folder: str, file_extension: str, file_name: str) -> None:
         try:
             files = [f for f in os.listdir(folder) if f.endswith(file_extension)]
         except OSError:
@@ -221,7 +224,7 @@ class MainWindow(QMainWindow):
 
     # --- Conversion ---
 
-    def _start_conversion(self):
+    def _start_conversion(self) -> None:
         gm_path = self._path_panel.gamemaker_path()
         godot_path = self._path_panel.godot_path()
 
@@ -258,7 +261,7 @@ class MainWindow(QMainWindow):
 
         self._start_timer()
 
-    def _validate_projects(self, gm_path, godot_path):
+    def _validate_projects(self, gm_path: str, godot_path: str) -> bool:
         try:
             yyp_files = [f for f in os.listdir(gm_path) if f.endswith(".yyp")]
         except OSError:
@@ -282,7 +285,7 @@ class MainWindow(QMainWindow):
             return False
         return True
 
-    def _prepare_for_conversion(self):
+    def _prepare_for_conversion(self) -> None:
         self._action_panel.convert_button.setEnabled(False)
         self._action_panel.stop_button.setEnabled(True)
         self._action_panel.settings_button.setEnabled(False)
@@ -291,13 +294,13 @@ class MainWindow(QMainWindow):
         self._progress.progress_bar.set_progress(0)
         self._console.append_log(get_localized("Console_ConversionStart"))
 
-    def _stop_conversion(self):
+    def _stop_conversion(self) -> None:
         if self._conversion_running.is_set():
             self._conversion_running.clear()
             self._console.append_log(get_localized("Console_ConversionStopping"))
             self._action_panel.stop_button.setEnabled(False)
 
-    def _conversion_complete(self):
+    def _conversion_complete(self) -> None:
         self._progress.progress_bar.set_progress(100)
         self._progress.status_label.setText(get_localized("Console_ConversionComplete"))
 
@@ -320,16 +323,16 @@ class MainWindow(QMainWindow):
 
     # --- Timer ---
 
-    def _start_timer(self):
+    def _start_timer(self) -> None:
         self._timer_running = True
         self._start_time = time.time()
         self._timer.start()
 
-    def _stop_timer(self):
+    def _stop_timer(self) -> None:
         self._timer_running = False
         self._timer.stop()
 
-    def _update_timer(self):
+    def _update_timer(self) -> None:
         elapsed = int(time.time() - self._start_time)
         h, remainder = divmod(elapsed, 3600)
         m, s = divmod(remainder, 60)
@@ -339,12 +342,12 @@ class MainWindow(QMainWindow):
 
     # --- Close ---
 
-    def closeEvent(self, event):
+    def closeEvent(self, event: QCloseEvent) -> None:
         if self._conversion_thread and self._conversion_thread.isRunning():
             self._conversion_running.clear()
             self._conversion_thread.quit()
             self._conversion_thread.wait(5000)
-        if hasattr(self, '_update_thread') and self._update_thread and self._update_thread.isRunning():
+        if self._update_thread and self._update_thread.isRunning():
             self._update_thread.quit()
             self._update_thread.wait(3000)
         event.accept()

--- a/src/gui/panels/action_panel.py
+++ b/src/gui/panels/action_panel.py
@@ -1,15 +1,14 @@
-from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QWidget, QHBoxLayout, QPushButton
 
 from src.localization import get_localized
 
 
 class ActionPanel(QWidget):
-    def __init__(self, parent=None):
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._init_ui()
 
-    def _init_ui(self):
+    def _init_ui(self) -> None:
         layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addStretch()

--- a/src/gui/panels/console_panel.py
+++ b/src/gui/panels/console_panel.py
@@ -5,7 +5,7 @@ from src.gui.theme import THEME
 
 
 class ConsolePanel(QWidget):
-    def __init__(self, parent=None):
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -26,7 +26,7 @@ class ConsolePanel(QWidget):
         self._success_format = QTextCharFormat()
         self._success_format.setForeground(QColor(THEME["log_success"]))
 
-    def _get_format(self, message):
+    def _get_format(self, message: str) -> QTextCharFormat:
         msg_lower = message.lower()
         if msg_lower.startswith("warning:") or ": warning:" in msg_lower:
             return self._warning_format
@@ -34,7 +34,7 @@ class ConsolePanel(QWidget):
             return self._error_format
         return self._default_format
 
-    def append_log(self, message, success=False):
+    def append_log(self, message: str, success: bool = False) -> None:
         fmt = self._success_format if success else self._get_format(message)
         cursor = self._text_edit.textCursor()
         cursor.movePosition(QTextCursor.MoveOperation.End)
@@ -44,7 +44,7 @@ class ConsolePanel(QWidget):
         cursor.insertText(message)
         self._text_edit.moveCursor(QTextCursor.MoveOperation.End)
 
-    def update_last_line(self, message):
+    def update_last_line(self, message: str) -> None:
         fmt = self._get_format(message)
         cursor = self._text_edit.textCursor()
         cursor.movePosition(QTextCursor.MoveOperation.End)
@@ -54,5 +54,5 @@ class ConsolePanel(QWidget):
         cursor.insertText(message)
         self._text_edit.moveCursor(QTextCursor.MoveOperation.End)
 
-    def clear(self):
+    def clear(self) -> None:
         self._text_edit.clear()

--- a/src/gui/panels/info_bar.py
+++ b/src/gui/panels/info_bar.py
@@ -1,7 +1,8 @@
 import webbrowser
+from collections.abc import Callable
 
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QCursor
+from PySide6.QtCore import Qt, QEvent
+from PySide6.QtGui import QCursor, QEnterEvent, QIcon, QMouseEvent
 from PySide6.QtWidgets import QWidget, QHBoxLayout, QLabel, QPushButton
 
 from src.gui.theme import THEME
@@ -10,7 +11,7 @@ from src.localization import get_localized
 
 
 class ClickableLabel(QLabel):
-    def __init__(self, text, callback, parent=None):
+    def __init__(self, text: str, callback: Callable[[], object], parent: QWidget | None = None) -> None:
         super().__init__(text, parent)
         self._callback = callback
         self._default_color = THEME["fg_primary"]
@@ -18,24 +19,30 @@ class ClickableLabel(QLabel):
         self.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
         self.setStyleSheet(f"font-size: {THEME['font_size_small']}pt;")
 
-    def enterEvent(self, event):
+    def enterEvent(self, event: QEnterEvent) -> None:
         self.setStyleSheet(
             f"color: {self._hover_color}; font-size: {THEME['font_size_small']}pt;"
         )
         super().enterEvent(event)
 
-    def leaveEvent(self, event):
+    def leaveEvent(self, event: QEvent) -> None:
         self.setStyleSheet(f"font-size: {THEME['font_size_small']}pt;")
         super().leaveEvent(event)
 
-    def mousePressEvent(self, event):
+    def mousePressEvent(self, event: QMouseEvent) -> None:
         if event.button() == Qt.MouseButton.LeftButton:
             self._callback()
         super().mousePressEvent(event)
 
 
 class InfoBar(QWidget):
-    def __init__(self, on_version_click, on_language_click, language_icon, parent=None):
+    def __init__(
+        self,
+        on_version_click: Callable[[], object],
+        on_language_click: Callable[[], object],
+        language_icon: QIcon,
+        parent: QWidget | None = None,
+    ) -> None:
         super().__init__(parent)
         layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)

--- a/src/gui/panels/path_panel.py
+++ b/src/gui/panels/path_panel.py
@@ -3,21 +3,21 @@ from PySide6.QtWidgets import (
     QWidget, QHBoxLayout, QVBoxLayout, QLabel, QLineEdit, QPushButton,
     QFileDialog,
 )
-from PySide6.QtGui import QPixmap
 
+from src.gui.icons import AppIcons
 from src.localization import get_localized
 
 
 class PathPanel(QWidget):
     path_selected = Signal(str, str)  # (key, folder_path)
 
-    def __init__(self, icons, parent=None):
+    def __init__(self, icons: AppIcons, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._icons = icons
-        self._entries = {}
+        self._entries: dict[str, QLineEdit] = {}
         self._init_ui()
 
-    def _init_ui(self):
+    def _init_ui(self) -> None:
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(15)
@@ -51,20 +51,20 @@ class PathPanel(QWidget):
             browse_btn = QPushButton(
                 get_localized("Menu_UI_Directory_Button").format(Game_Engine=engine_name)
             )
-            browse_btn.clicked.connect(lambda checked, k=key: self._browse(k))
+            browse_btn.clicked.connect(lambda checked=False, k=key: self._browse(k))
             row.addWidget(browse_btn)
 
             self._entries[key] = entry
             layout.addLayout(row)
 
-    def _browse(self, key):
+    def _browse(self, key: str) -> None:
         folder = QFileDialog.getExistingDirectory(self, get_localized(f"Prompt_Path_{'GameMaker' if key == 'gamemaker' else 'Godot'}"))
         if folder:
             self._entries[key].setText(folder)
             self.path_selected.emit(key, folder)
 
-    def gamemaker_path(self):
+    def gamemaker_path(self) -> str:
         return self._entries["gamemaker"].text().strip()
 
-    def godot_path(self):
+    def godot_path(self) -> str:
         return self._entries["godot"].text().strip()

--- a/src/gui/panels/progress_panel.py
+++ b/src/gui/panels/progress_panel.py
@@ -1,7 +1,7 @@
 import colorsys
 
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QColor, QPainter, QPen, QBrush, QFont
+from PySide6.QtGui import QColor, QPainter, QFont, QPaintEvent
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLabel
 
 from src.gui.theme import THEME
@@ -9,21 +9,21 @@ from src.localization import get_localized
 
 
 class GradientProgressBar(QWidget):
-    def __init__(self, parent=None):
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._progress = 0
         self.setFixedHeight(30)
 
-    def set_progress(self, value):
+    def set_progress(self, value: int) -> None:
         self._progress = max(0, min(100, value))
         self.update()
 
-    def _get_progress_color(self, progress_fraction):
+    def _get_progress_color(self, progress_fraction: float) -> QColor:
         hue = progress_fraction * 120 / 360
         r, g, b = colorsys.hsv_to_rgb(hue, 0.8, 0.9)
         return QColor(int(r * 255), int(g * 255), int(b * 255))
 
-    def paintEvent(self, event):
+    def paintEvent(self, event: QPaintEvent) -> None:
         painter = QPainter(self)
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
 
@@ -45,7 +45,7 @@ class GradientProgressBar(QWidget):
 
         # Text
         painter.setPen(QColor(THEME["fg_white"]))
-        font = QFont(THEME["font_family"], THEME["font_size_large"])
+        font = QFont(str(THEME["font_family"]), int(THEME["font_size_large"]))
         font.setBold(True)
         painter.setFont(font)
         painter.drawText(0, 0, w, h, Qt.AlignmentFlag.AlignCenter, f"{self._progress}%")
@@ -54,7 +54,7 @@ class GradientProgressBar(QWidget):
 
 
 class ProgressPanel(QWidget):
-    def __init__(self, parent=None):
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)

--- a/src/gui/setting_value.py
+++ b/src/gui/setting_value.py
@@ -1,11 +1,11 @@
 class SettingValue:
     """Drop-in replacement for tk.BooleanVar, compatible with converter.py's .get() interface."""
 
-    def __init__(self, value=True):
+    def __init__(self, value: bool = True) -> None:
         self._value = bool(value)
 
-    def get(self):
+    def get(self) -> bool:
         return self._value
 
-    def set(self, value):
+    def set(self, value: bool) -> None:
         self._value = bool(value)

--- a/src/gui/workers.py
+++ b/src/gui/workers.py
@@ -1,6 +1,21 @@
+import threading
+from typing import Protocol, cast
+
 from PySide6.QtCore import QObject, Signal
 
 from src.conversion.converter import Converter
+from src.gui.setting_value import SettingValue
+
+
+class _ConverterProtocol(Protocol):
+    def convert(
+        self,
+        gm_path: str,
+        gm_platform: str,
+        godot_path: str,
+        settings: dict[str, SettingValue],
+    ) -> None:
+        ...
 
 
 class ConversionWorker(QObject):
@@ -10,8 +25,10 @@ class ConversionWorker(QObject):
     status_updated = Signal(str)
     conversion_finished = Signal()
 
-    def __init__(self, gm_path, gm_platform, godot_path, conversion_settings,
-                 compact_logging, conversion_running, max_workers=None):
+    def __init__(self, gm_path: str, gm_platform: str, godot_path: str,
+                 conversion_settings: dict[str, SettingValue],
+                 compact_logging: bool, conversion_running: threading.Event,
+                 max_workers: int | None = None) -> None:
         super().__init__()
         self._gm_path = gm_path
         self._gm_platform = gm_platform
@@ -21,16 +38,19 @@ class ConversionWorker(QObject):
         self._conversion_running = conversion_running
         self._max_workers = max_workers
 
-    def run(self):
+    def run(self) -> None:
         try:
-            converter = Converter(
-                self.log_message.emit,
-                self.progress_updated.emit,
-                self.status_updated.emit,
-                self._conversion_running,
-                update_log_callback=self.update_log_message.emit,
-                compact_logging=self._compact_logging,
-                max_workers=self._max_workers,
+            converter = cast(
+                _ConverterProtocol,
+                Converter(
+                    self.log_message.emit,
+                    self.progress_updated.emit,
+                    self.status_updated.emit,
+                    self._conversion_running,
+                    update_log_callback=self.update_log_message.emit,
+                    compact_logging=self._compact_logging,
+                    max_workers=self._max_workers,
+                ),
             )
             converter.convert(
                 self._gm_path,

--- a/src/localization.py
+++ b/src/localization.py
@@ -1,27 +1,40 @@
-import json, string, os, sys
+from __future__ import annotations
 
-def get_base_path():
+import json
+import os
+import sys
+from typing import Any, cast
+
+def get_base_path() -> str:
     if getattr(sys, 'frozen', False):
-        return sys._MEIPASS
+        return cast(str, getattr(sys, '_MEIPASS'))
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-def get_localized(key):
+def _load_language_value(path: str, key: str) -> str | None:
+    with open(path, 'r', encoding='utf-8') as file:
+        data = cast(dict[str, Any], json.load(file))
+    value = data.get(key)
+    return value if isinstance(value, str) else None
+
+
+def get_localized(key: str) -> str:
     base_path = get_base_path()
     lang_file = os.path.join(base_path, 'Current Language')
     with open(lang_file, 'r', encoding='utf-8') as file:
         language = file.readline().strip()
 
     json_path = os.path.join(base_path, 'Languages', f'{language}.json')
-    with open(json_path, 'r', encoding='utf-8') as file:
-        try :
-            return json.load(file)[key]
-        except :
-            pass
+    try:
+        value = _load_language_value(json_path, key)
+        if value is not None:
+            return value
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        pass
 
     # If an exception is thrown, the script will attempt to load the key from eng.json
-    with open(os.path.join(base_path, 'Languages', 'eng.json'), 'r', encoding='utf-8') as file:
-        try :
-            return json.load(file)[key]
-        except :
-            return ""
+    try:
+        value = _load_language_value(os.path.join(base_path, 'Languages', 'eng.json'), key)
+        return value or ""
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return ""
     # Finally, if eng.json fails, the script will return a blank string

--- a/src/update_checker.py
+++ b/src/update_checker.py
@@ -2,7 +2,8 @@ import os
 import platform
 import requests
 from dataclasses import dataclass
-from typing import Optional
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, Optional, cast
 
 from src.version import get_version
 
@@ -29,23 +30,24 @@ class UpdateChecker:
                 timeout=10,
             )
             response.raise_for_status()
-            data = response.json()
+            data = cast(Mapping[str, Any], response.json())
 
-            latest_tag = data.get("tag_name", "").lstrip("v")
+            latest_tag = str(data.get("tag_name", "")).lstrip("v")
             current = get_version()
 
             available = self._is_newer(latest_tag, current)
 
             # Find platform-appropriate asset
-            download_url, asset_name = self._find_platform_asset(data.get("assets", []))
+            assets = cast(Sequence[Mapping[str, Any]], data.get("assets", []))
+            download_url, asset_name = self._find_platform_asset(assets)
 
             return UpdateInfo(
                 available=available,
                 latest_version=latest_tag,
-                release_notes=data.get("body", ""),
+                release_notes=str(data.get("body", "")),
                 download_url=download_url,
                 asset_name=asset_name,
-                release_page_url=data.get("html_url", "https://github.com/Infiland/GM2Godot/releases"),
+                release_page_url=str(data.get("html_url", "https://github.com/Infiland/GM2Godot/releases")),
             )
         except Exception:
             return None
@@ -61,7 +63,7 @@ class UpdateChecker:
             return False
 
     @staticmethod
-    def _find_platform_asset(assets: list) -> tuple:
+    def _find_platform_asset(assets: Sequence[Mapping[str, Any]]) -> tuple[Optional[str], Optional[str]]:
         """Find the download URL for the current platform."""
         system = platform.system().lower()
         platform_keywords = {
@@ -72,14 +74,21 @@ class UpdateChecker:
         keywords = platform_keywords.get(system, [])
 
         for asset in assets:
-            name = asset.get("name", "").lower()
+            name = str(asset.get("name", "")).lower()
             if any(kw in name for kw in keywords):
-                return asset.get("browser_download_url"), asset.get("name")
+                return (
+                    cast(Optional[str], asset.get("browser_download_url")),
+                    cast(Optional[str], asset.get("name")),
+                )
 
         return None, None
 
     @staticmethod
-    def download_update(url: str, dest_path: str, progress_callback=None) -> bool:
+    def download_update(
+        url: str,
+        dest_path: str,
+        progress_callback: Callable[[int], None] | None = None,
+    ) -> bool:
         """Download the update binary with progress reporting."""
         try:
             response = requests.get(url, stream=True, timeout=60)
@@ -111,7 +120,7 @@ class UpdateChecker:
             return None
 
     @staticmethod
-    def set_skipped_version(version: str):
+    def set_skipped_version(version: str) -> None:
         """Save a version to skip."""
         config_dir = os.path.join(os.path.expanduser("~"), ".gm2godot")
         os.makedirs(config_dir, exist_ok=True)

--- a/tests/conversion/events/test_alarm_events.py
+++ b/tests/conversion/events/test_alarm_events.py
@@ -15,6 +15,7 @@ class TestAlarmEvents(unittest.TestCase):
         for alarm_index in range(12):
             with self.subTest(alarm_index=alarm_index):
                 mapping = map_event({"eventType": 2, "eventNum": alarm_index})
+                assert mapping is not None
 
                 self.assertEqual(mapping.godot_func, f"_on_alarm_{alarm_index}")
                 self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_animation_events.py
+++ b/tests/conversion/events/test_animation_events.py
@@ -21,6 +21,7 @@ class TestAnimationEvents(unittest.TestCase):
         for event_num, godot_func, gml_filename in cases:
             with self.subTest(event_num=event_num):
                 mapping = map_event({"eventType": 7, "eventNum": event_num})
+                assert mapping is not None
 
                 self.assertEqual(mapping.godot_func, godot_func)
                 self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_async_audio.py
+++ b/tests/conversion/events/test_async_audio.py
@@ -13,6 +13,7 @@ from src.conversion.script_generator import generate_script_content
 class TestAsyncAudioEvents(unittest.TestCase):
     def test_maps_async_audio_recording_event(self):
         mapping = map_event({"eventType": 7, "eventNum": 73})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_audio_recording_async")
         self.assertEqual(mapping.params, "")
@@ -21,6 +22,7 @@ class TestAsyncAudioEvents(unittest.TestCase):
 
     def test_maps_async_audio_playback_event(self):
         mapping = map_event({"eventType": 7, "eventNum": 74})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_audio_playback_async")
         self.assertEqual(mapping.params, "")
@@ -29,6 +31,7 @@ class TestAsyncAudioEvents(unittest.TestCase):
 
     def test_maps_async_audio_playback_ended_event(self):
         mapping = map_event({"eventType": 7, "eventNum": 80})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_audio_playback_ended_async")
         self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_async_dialog.py
+++ b/tests/conversion/events/test_async_dialog.py
@@ -13,6 +13,7 @@ from src.conversion.script_generator import generate_script_content
 class TestAsyncDialogEvent(unittest.TestCase):
     def test_maps_async_dialog_event(self):
         mapping = map_event({"eventType": 7, "eventNum": 63})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_async_dialog")
         self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_async_http.py
+++ b/tests/conversion/events/test_async_http.py
@@ -13,6 +13,7 @@ from src.conversion.script_generator import generate_script_content
 class TestAsyncHttpEvent(unittest.TestCase):
     def test_maps_async_http_event(self):
         mapping = map_event({"eventType": 7, "eventNum": 62})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_http_request_completed")
         self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_async_image_loaded.py
+++ b/tests/conversion/events/test_async_image_loaded.py
@@ -13,6 +13,7 @@ from src.conversion.script_generator import generate_script_content
 class TestAsyncImageLoadedEvent(unittest.TestCase):
     def test_maps_async_image_loaded_event(self):
         mapping = map_event({"eventType": 7, "eventNum": 60})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_async_image_loaded")
         self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_async_networking.py
+++ b/tests/conversion/events/test_async_networking.py
@@ -13,6 +13,7 @@ from src.conversion.script_generator import generate_script_content
 class TestAsyncNetworkingEvent(unittest.TestCase):
     def test_maps_async_networking_event(self):
         mapping = map_event({"eventType": 7, "eventNum": 68})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_async_networking")
         self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_async_platform_events.py
+++ b/tests/conversion/events/test_async_platform_events.py
@@ -23,6 +23,7 @@ class TestAsyncPlatformEvents(unittest.TestCase):
         for event_num, godot_func, gml_filename in ASYNC_PLATFORM_EVENTS:
             with self.subTest(event_num=event_num):
                 mapping = map_event({"eventType": 7, "eventNum": event_num})
+                assert mapping is not None
 
                 self.assertEqual(mapping.godot_func, godot_func)
                 self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_async_save_load.py
+++ b/tests/conversion/events/test_async_save_load.py
@@ -13,6 +13,7 @@ from src.conversion.script_generator import generate_script_content
 class TestAsyncSaveLoadEvent(unittest.TestCase):
     def test_maps_async_save_load_event(self):
         mapping = map_event({"eventType": 7, "eventNum": 72})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_async_save_load")
         self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_async_sound_loaded.py
+++ b/tests/conversion/events/test_async_sound_loaded.py
@@ -13,6 +13,7 @@ from src.conversion.script_generator import generate_script_content
 class TestAsyncSoundLoadedEvent(unittest.TestCase):
     def test_maps_async_sound_loaded_event(self):
         mapping = map_event({"eventType": 7, "eventNum": 61})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_async_sound_loaded")
         self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_async_steam.py
+++ b/tests/conversion/events/test_async_steam.py
@@ -13,6 +13,7 @@ from src.conversion.script_generator import generate_script_content
 class TestAsyncSteamEvent(unittest.TestCase):
     def test_maps_other_async_steam_event(self):
         mapping = map_event({"eventType": 7, "eventNum": 69})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_async_steam")
         self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_async_system.py
+++ b/tests/conversion/events/test_async_system.py
@@ -13,6 +13,7 @@ from src.conversion.script_generator import generate_script_content
 class TestAsyncSystemEvent(unittest.TestCase):
     def test_maps_async_system_event(self):
         mapping = map_event({"eventType": 7, "eventNum": 75})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_async_system")
         self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_broadcast_message.py
+++ b/tests/conversion/events/test_broadcast_message.py
@@ -13,6 +13,7 @@ from src.conversion.script_generator import generate_script_content
 class TestBroadcastMessageEvent(unittest.TestCase):
     def test_maps_broadcast_message_event(self):
         mapping = map_event({"eventType": 7, "eventNum": 76})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_broadcast_message")
         self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_cleanup_event.py
+++ b/tests/conversion/events/test_cleanup_event.py
@@ -13,6 +13,7 @@ from src.conversion.script_generator import generate_script_content
 class TestCleanupEvent(unittest.TestCase):
     def test_maps_cleanup_event_to_exit_tree(self):
         mapping = map_event({"eventType": 12, "eventNum": 0})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_exit_tree")
         self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_collision_events.py
+++ b/tests/conversion/events/test_collision_events.py
@@ -17,6 +17,7 @@ class TestCollisionEvents(unittest.TestCase):
             "eventNum": 0,
             "collisionObjectId": {"name": "o_enemy"},
         })
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_collision_o_enemy")
         self.assertEqual(mapping.params, "")
@@ -25,6 +26,7 @@ class TestCollisionEvents(unittest.TestCase):
 
     def test_maps_collision_without_target_object(self):
         mapping = map_event({"eventType": 4, "eventNum": 0})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_collision")
         self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_create_event.py
+++ b/tests/conversion/events/test_create_event.py
@@ -13,6 +13,7 @@ from src.conversion.script_generator import generate_script_content
 class TestCreateEvent(unittest.TestCase):
     def test_maps_create_event_to_ready(self):
         mapping = map_event({"eventType": 0, "eventNum": 0})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_ready")
         self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_destroy_event.py
+++ b/tests/conversion/events/test_destroy_event.py
@@ -13,6 +13,7 @@ from src.conversion.script_generator import generate_script_content
 class TestDestroyEvent(unittest.TestCase):
     def test_maps_destroy_event_to_destroy_callback(self):
         mapping = map_event({"eventType": 1, "eventNum": 0})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_destroy")
         self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_draw_events.py
+++ b/tests/conversion/events/test_draw_events.py
@@ -27,6 +27,7 @@ class TestDrawEvents(unittest.TestCase):
         for event_num, godot_func, sort_key, gml_filename in cases:
             with self.subTest(event_num=event_num):
                 mapping = map_event({"eventType": 8, "eventNum": event_num})
+                assert mapping is not None
 
                 self.assertEqual(mapping.godot_func, godot_func)
                 self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_lifecycle_events.py
+++ b/tests/conversion/events/test_lifecycle_events.py
@@ -22,6 +22,7 @@ class TestLifecycleEvents(unittest.TestCase):
         for event_num, godot_func, gml_filename in cases:
             with self.subTest(event_num=event_num):
                 mapping = map_event({"eventType": 7, "eventNum": event_num})
+                assert mapping is not None
 
                 self.assertEqual(mapping.godot_func, godot_func)
                 self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_path_ended.py
+++ b/tests/conversion/events/test_path_ended.py
@@ -13,6 +13,7 @@ from src.conversion.script_generator import generate_script_content
 class TestPathEndedEvent(unittest.TestCase):
     def test_maps_path_ended_event(self):
         mapping = map_event({"eventType": 7, "eventNum": 8})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_path_ended")
         self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_registry.py
+++ b/tests/conversion/events/test_registry.py
@@ -17,6 +17,8 @@ class TestEventRegistry(unittest.TestCase):
     def test_loads_static_mapping_modules(self):
         close_button = map_event({"eventType": 7, "eventNum": 30})
         legacy_lives = map_event({"eventType": 7, "eventNum": 6})
+        assert close_button is not None
+        assert legacy_lives is not None
 
         self.assertEqual(close_button.godot_func, "_notification")
         self.assertEqual(legacy_lives.godot_func, "_on_no_more_lives")
@@ -24,6 +26,8 @@ class TestEventRegistry(unittest.TestCase):
     def test_keeps_dynamic_handlers(self):
         alarm = map_event({"eventType": 2, "eventNum": 3})
         other = map_event({"eventType": 7, "eventNum": 26})
+        assert alarm is not None
+        assert other is not None
 
         self.assertEqual(alarm.godot_func, "_on_alarm_3")
         self.assertEqual(other.godot_func, "_on_other_26")

--- a/tests/conversion/events/test_room_boundary_mappings.py
+++ b/tests/conversion/events/test_room_boundary_mappings.py
@@ -13,6 +13,7 @@ from src.conversion.script_generator import generate_script_content
 class TestRoomBoundaryMappings(unittest.TestCase):
     def test_outside_room_mapping(self):
         mapping = map_event({"eventType": 7, "eventNum": 0})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_outside_room")
         self.assertEqual(mapping.params, "")
@@ -21,6 +22,7 @@ class TestRoomBoundaryMappings(unittest.TestCase):
 
     def test_intersect_boundary_mapping(self):
         mapping = map_event({"eventType": 7, "eventNum": 1})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_intersect_boundary")
         self.assertEqual(mapping.params, "")
@@ -29,6 +31,7 @@ class TestRoomBoundaryMappings(unittest.TestCase):
 
     def test_outside_view_mapping(self):
         mapping = map_event({"eventType": 7, "eventNum": 43})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_outside_view_3")
         self.assertEqual(mapping.params, "")
@@ -37,6 +40,7 @@ class TestRoomBoundaryMappings(unittest.TestCase):
 
     def test_intersect_view_boundary_mapping(self):
         mapping = map_event({"eventType": 7, "eventNum": 56})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_on_intersect_view_6_boundary")
         self.assertEqual(mapping.params, "")

--- a/tests/conversion/events/test_step_events.py
+++ b/tests/conversion/events/test_step_events.py
@@ -21,6 +21,7 @@ class TestStepEvents(unittest.TestCase):
         for event_num, godot_func, params, sort_key, gml_filename in cases:
             with self.subTest(event_num=event_num):
                 mapping = map_event({"eventType": 3, "eventNum": event_num})
+                assert mapping is not None
 
                 self.assertEqual(mapping.godot_func, godot_func)
                 self.assertEqual(mapping.params, params)

--- a/tests/conversion/events/test_user_events.py
+++ b/tests/conversion/events/test_user_events.py
@@ -13,6 +13,7 @@ from src.conversion.script_generator import generate_script_content
 class TestUserEventMappings(unittest.TestCase):
     def test_user_event_lower_bound(self):
         mapping = map_event({"eventType": 7, "eventNum": 10})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_user_event_0")
         self.assertEqual(mapping.params, "")
@@ -21,12 +22,14 @@ class TestUserEventMappings(unittest.TestCase):
 
     def test_user_event_middle(self):
         mapping = map_event({"eventType": 7, "eventNum": 17})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_user_event_7")
         self.assertEqual(mapping.gml_filename, "Other_17.gml")
 
     def test_user_event_upper_bound(self):
         mapping = map_event({"eventType": 7, "eventNum": 25})
+        assert mapping is not None
 
         self.assertEqual(mapping.godot_func, "_user_event_15")
         self.assertEqual(mapping.gml_filename, "Other_25.gml")

--- a/tests/conversion/events/test_wallpaper_events.py
+++ b/tests/conversion/events/test_wallpaper_events.py
@@ -21,6 +21,7 @@ class TestWallpaperEvents(unittest.TestCase):
         for event_num, godot_func, gml_filename in WALLPAPER_EVENTS:
             with self.subTest(event_num=event_num):
                 mapping = map_event({"eventType": 7, "eventNum": event_num})
+                assert mapping is not None
 
                 self.assertEqual(mapping.godot_func, godot_func)
                 self.assertEqual(mapping.params, "")

--- a/tests/test_base_converter.py
+++ b/tests/test_base_converter.py
@@ -1,3 +1,7 @@
+# pyright: reportAbstractUsage=false, reportPrivateUsage=false
+
+from __future__ import annotations
+
 import os
 import shutil
 import sys
@@ -34,7 +38,7 @@ class TestBaseConverterAbstract(unittest.TestCase):
         """A proper subclass that implements convert_all should work."""
 
         class GoodConverter(BaseConverter):
-            def convert_all(self):
+            def convert_all(self) -> None:
                 pass
 
         converter = GoodConverter("/gm", "/godot")
@@ -46,10 +50,10 @@ class TestBaseConverterDefaults(unittest.TestCase):
 
     def setUp(self):
         class StubConverter(BaseConverter):
-            def convert_all(self):
+            def convert_all(self) -> None:
                 pass
 
-        self.converter = StubConverter("/gm", "/godot")
+        self.converter: BaseConverter = StubConverter("/gm", "/godot")
 
     def test_log_callback_defaults_to_print(self):
         self.assertIs(self.converter.log_callback, print)
@@ -68,11 +72,11 @@ class TestBaseConverterThreadSafety(unittest.TestCase):
 
     def setUp(self):
         class StubConverter(BaseConverter):
-            def convert_all(self):
+            def convert_all(self) -> None:
                 pass
 
-        self.messages = []
-        self.progress_values = []
+        self.messages: list[str] = []
+        self.progress_values: list[int | float] = []
 
         self.converter = StubConverter(
             "/gm", "/godot",
@@ -81,9 +85,9 @@ class TestBaseConverterThreadSafety(unittest.TestCase):
         )
 
     def test_safe_log_thread_safety(self):
-        errors = []
+        errors: list[Exception] = []
 
-        def log_many(start):
+        def log_many(start: int) -> None:
             try:
                 for i in range(50):
                     self.converter._safe_log(f"thread-{start}-msg-{i}")
@@ -100,9 +104,9 @@ class TestBaseConverterThreadSafety(unittest.TestCase):
         self.assertEqual(len(self.messages), 200)
 
     def test_safe_progress_thread_safety(self):
-        errors = []
+        errors: list[Exception] = []
 
-        def progress_many(start):
+        def progress_many(start: int) -> None:
             try:
                 for i in range(50):
                     self.converter._safe_progress(start * 100 + i)
@@ -124,11 +128,11 @@ class TestBaseConverterCompactLogging(unittest.TestCase):
 
     def setUp(self):
         class StubConverter(BaseConverter):
-            def convert_all(self):
+            def convert_all(self) -> None:
                 pass
 
-        self.log_messages = []
-        self.update_messages = []
+        self.log_messages: list[str] = []
+        self.update_messages: list[str] = []
         self.converter = StubConverter(
             "/gm", "/godot",
             log_callback=lambda msg: self.log_messages.append(msg),
@@ -163,10 +167,10 @@ class TestBaseConverterCompactLogging(unittest.TestCase):
     def test_update_log_defaults_to_log_callback(self):
         """When update_log_callback is not provided, it falls back to log_callback."""
         class StubConverter(BaseConverter):
-            def convert_all(self):
+            def convert_all(self) -> None:
                 pass
 
-        messages = []
+        messages: list[str] = []
         converter = StubConverter(
             "/gm", "/godot",
             log_callback=lambda msg: messages.append(msg),
@@ -182,10 +186,10 @@ class TestReadYYFile(unittest.TestCase):
 
     def setUp(self):
         class StubConverter(BaseConverter):
-            def convert_all(self):
+            def convert_all(self) -> None:
                 pass
 
-        self.converter = StubConverter("/gm", "/godot")
+        self.converter: BaseConverter = StubConverter("/gm", "/godot")
         self.tmp_dir = tempfile.mkdtemp()
 
     def tearDown(self):
@@ -204,6 +208,7 @@ class TestReadYYFile(unittest.TestCase):
             f.write('{"name": "test", "items": [1, 2, 3,],}')
         result = self.converter._read_yy_file(yy_path)
         self.assertIsNotNone(result)
+        assert result is not None
         self.assertEqual(result["items"], [1, 2, 3])
 
     def test_returns_none_for_missing_file(self):
@@ -223,16 +228,16 @@ class TestGetSubfolderFromYY(unittest.TestCase):
 
     def setUp(self):
         class StubConverter(BaseConverter):
-            def convert_all(self):
+            def convert_all(self) -> None:
                 pass
 
-        self.converter = StubConverter("/gm", "/godot")
+        self.converter: BaseConverter = StubConverter("/gm", "/godot")
         self.tmp_dir = tempfile.mkdtemp()
 
     def tearDown(self):
         shutil.rmtree(self.tmp_dir)
 
-    def _write_yy(self, parent_path):
+    def _write_yy(self, parent_path: str) -> str:
         yy_path = os.path.join(self.tmp_dir, "test.yy")
         content = '{{"name": "test", "parent": {{"name": "folder", "path": "{path}",}},}}'.format(
             path=parent_path)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 import threading
@@ -39,10 +41,10 @@ class TestConversionCategories(unittest.TestCase):
 
 class _FakeBooleanVar:
     """Mimics tkinter BooleanVar for testing."""
-    def __init__(self, value):
+    def __init__(self, value: bool) -> None:
         self._value = value
 
-    def get(self):
+    def get(self) -> bool:
         return self._value
 
 
@@ -52,8 +54,8 @@ class TestConverterSkipsDisabled(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
-        self.statuses = []
+        self.logs: list[str] = []
+        self.statuses: list[str] = []
 
         # Create minimal GM project structure
         with open(os.path.join(self.gm_dir, "Test.yyp"), "w", encoding="utf-8") as f:
@@ -99,8 +101,8 @@ class TestConverterRespectsRunningFlag(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
-        self.statuses = []
+        self.logs: list[str] = []
+        self.statuses: list[str] = []
 
         with open(os.path.join(self.gm_dir, "Test.yyp"), "w", encoding="utf-8") as f:
             f.write('{ "%Name": "Test" }')

--- a/tests/test_event_mapping.py
+++ b/tests/test_event_mapping.py
@@ -1,15 +1,25 @@
 import os
 import sys
 import unittest
+from typing import cast
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from src.conversion.event_mapping import (
-    EventMapping, map_event, is_input_event,
-    INPUT_EVENT_TYPES, INPUT_MERGED_MAPPING,
+    EventMapping, map_event as _map_event, is_input_event,
+    INPUT_MERGED_MAPPING,
 )
+from src.conversion.type_defs import JsonDict
+
+
+def map_event(event: JsonDict) -> EventMapping:
+    return cast(EventMapping, _map_event(event))
+
+
+def map_event_optional(event: JsonDict) -> EventMapping | None:
+    return _map_event(event)
 
 
 class TestIsInputEvent(unittest.TestCase):
@@ -196,26 +206,26 @@ class TestMapEventInputReturnsNone(unittest.TestCase):
     """Input events should return None (they are merged by the script generator)."""
 
     def test_mouse_returns_none(self):
-        self.assertIsNone(map_event({"eventType": 6, "eventNum": 4}))
+        self.assertIsNone(map_event_optional({"eventType": 6, "eventNum": 4}))
 
     def test_mouse_variants_return_none(self):
         for event_num in (0, 11, 50, 58, 60, 61):
             with self.subTest(event_num=event_num):
-                self.assertIsNone(map_event({"eventType": 6, "eventNum": event_num}))
+                self.assertIsNone(map_event_optional({"eventType": 6, "eventNum": event_num}))
 
     def test_keyboard_returns_none(self):
-        self.assertIsNone(map_event({"eventType": 5, "eventNum": 65}))
+        self.assertIsNone(map_event_optional({"eventType": 5, "eventNum": 65}))
 
     def test_key_press_returns_none(self):
-        self.assertIsNone(map_event({"eventType": 9, "eventNum": 32}))
+        self.assertIsNone(map_event_optional({"eventType": 9, "eventNum": 32}))
 
     def test_key_release_returns_none(self):
-        self.assertIsNone(map_event({"eventType": 10, "eventNum": 13}))
+        self.assertIsNone(map_event_optional({"eventType": 10, "eventNum": 13}))
 
     def test_gesture_returns_none(self):
         for event_num in range(13):
             with self.subTest(event_num=event_num):
-                self.assertIsNone(map_event({"eventType": 13, "eventNum": event_num}))
+                self.assertIsNone(map_event_optional({"eventType": 13, "eventNum": event_num}))
 
 
 class TestMapEventUnknown(unittest.TestCase):
@@ -246,7 +256,7 @@ class TestEventMappingFrozen(unittest.TestCase):
     def test_cannot_modify(self):
         m = map_event({"eventType": 0, "eventNum": 0})
         with self.assertRaises(AttributeError):
-            m.godot_func = "changed"
+            setattr(m, "godot_func", "changed")
 
     def test_input_merged_mapping(self):
         self.assertEqual(INPUT_MERGED_MAPPING.godot_func, "_input")

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -1,10 +1,13 @@
+# pyright: reportPrivateUsage=false
+
 import json
 import os
 import sys
 import shutil
 import tempfile
 import unittest
-from unittest.mock import patch
+from typing import TypeAlias
+from unittest.mock import Mock, patch
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
@@ -13,7 +16,10 @@ if PROJECT_ROOT not in sys.path:
 from src.conversion.fonts import FontConverter, _find_system_font
 
 
-MINIMAL_FONT_YY = {
+FontYY: TypeAlias = dict[str, object]
+
+
+MINIMAL_FONT_YY: FontYY = {
     "$GMFont": "",
     "%Name": "fnt_test",
     "AntiAlias": 1,
@@ -46,7 +52,7 @@ MINIMAL_FONT_YY = {
 }
 
 
-def _make_font_yy(base_dir, font_name, overrides=None):
+def _make_font_yy(base_dir: str, font_name: str, overrides: FontYY | None = None) -> str:
     """Create a font .yy file in the standard GM directory structure."""
     font_dir = os.path.join(base_dir, "fonts", font_name)
     os.makedirs(font_dir, exist_ok=True)
@@ -67,7 +73,7 @@ class TestFontConverterSystemFont(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
         _make_font_yy(self.gm_dir, "fnt_test", {
             "fontName": "NonExistentTestFont99999", "size": 16.0,
         })
@@ -117,7 +123,7 @@ class TestFontConverterBold(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
         _make_font_yy(self.gm_dir, "fnt_bold", {
             "fontName": "NonExistentTestFont99999", "bold": True,
         })
@@ -146,7 +152,7 @@ class TestFontConverterTTF(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
         yy_path = _make_font_yy(self.gm_dir, "fnt_custom", {
             "fontName": "CustomFont",
             "includeTTF": True,
@@ -191,7 +197,7 @@ class TestFontConverterTTFMissing(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
         _make_font_yy(self.gm_dir, "fnt_missing_ttf", {
             "fontName": "NonExistentTestFont99999",
             "includeTTF": True,
@@ -225,7 +231,7 @@ class TestFontConverterSystemFontLookup(unittest.TestCase):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
         self.fake_font_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
         # Create a fake system font file
         self.fake_ttf = os.path.join(self.fake_font_dir, "TestFont.ttf")
@@ -240,7 +246,7 @@ class TestFontConverterSystemFontLookup(unittest.TestCase):
         shutil.rmtree(self.fake_font_dir)
 
     @patch('src.conversion.fonts._get_system_font_dirs')
-    def test_copies_system_font(self, mock_dirs):
+    def test_copies_system_font(self, mock_dirs: Mock) -> None:
         mock_dirs.return_value = [self.fake_font_dir]
         converter = FontConverter(
             self.gm_dir, self.godot_dir,
@@ -254,7 +260,7 @@ class TestFontConverterSystemFontLookup(unittest.TestCase):
                         f"Expected system font copied to {expected}")
 
     @patch('src.conversion.fonts._get_system_font_dirs')
-    def test_no_tres_when_system_font_found(self, mock_dirs):
+    def test_no_tres_when_system_font_found(self, mock_dirs: Mock) -> None:
         mock_dirs.return_value = [self.fake_font_dir]
         converter = FontConverter(
             self.gm_dir, self.godot_dir,
@@ -281,19 +287,19 @@ class TestFindSystemFont(unittest.TestCase):
         shutil.rmtree(self.font_dir)
 
     @patch('src.conversion.fonts._get_system_font_dirs')
-    def test_finds_exact_match(self, mock_dirs):
+    def test_finds_exact_match(self, mock_dirs: Mock) -> None:
         mock_dirs.return_value = [self.font_dir]
         result = _find_system_font("MyFont")
         self.assertEqual(result, self.font_file)
 
     @patch('src.conversion.fonts._get_system_font_dirs')
-    def test_finds_case_insensitive(self, mock_dirs):
+    def test_finds_case_insensitive(self, mock_dirs: Mock) -> None:
         mock_dirs.return_value = [self.font_dir]
         result = _find_system_font("myfont")
         self.assertEqual(result, self.font_file)
 
     @patch('src.conversion.fonts._get_system_font_dirs')
-    def test_finds_with_regular_suffix(self, mock_dirs):
+    def test_finds_with_regular_suffix(self, mock_dirs: Mock) -> None:
         regular_font = os.path.join(self.font_dir, "TestFont-Regular.ttf")
         with open(regular_font, "wb") as f:
             f.write(b"\x00" * 32)
@@ -302,7 +308,7 @@ class TestFindSystemFont(unittest.TestCase):
         self.assertEqual(result, regular_font)
 
     @patch('src.conversion.fonts._get_system_font_dirs')
-    def test_returns_none_when_not_found(self, mock_dirs):
+    def test_returns_none_when_not_found(self, mock_dirs: Mock) -> None:
         mock_dirs.return_value = [self.font_dir]
         result = _find_system_font("NoSuchFont")
         self.assertIsNone(result)
@@ -314,7 +320,7 @@ class TestFontConverterMissingFolder(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
     def tearDown(self):
         shutil.rmtree(self.gm_dir)
@@ -338,7 +344,7 @@ class TestFontConverterEmptyFolder(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
         os.makedirs(os.path.join(self.gm_dir, "fonts"))
 
     def tearDown(self):
@@ -363,7 +369,7 @@ class TestFontConverterSubfolders(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
         _make_font_yy(self.gm_dir, "fnt_ui", {
             "fontName": "NonExistentTestFont99999",
             "parent": {"name": "UI", "path": "folders/Fonts/UI.yy"},

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -206,7 +206,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
         )
 
     def test_collects_assigned_instance_variables(self):
-        instance_variables = set()
+        instance_variables: set[str] = set()
 
         self.assertEqual(
             transpile_gml_code(

--- a/tests/test_included_files.py
+++ b/tests/test_included_files.py
@@ -17,7 +17,7 @@ class TestIncludedFilesConverterBasic(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
         datafiles_dir = os.path.join(self.gm_dir, "datafiles")
         os.makedirs(datafiles_dir)
@@ -70,7 +70,7 @@ class TestIncludedFilesConverterNestedDirs(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
         # Create nested structure like the Asteroids++ project
         langs_dir = os.path.join(self.gm_dir, "datafiles", "Languages")
@@ -117,7 +117,7 @@ class TestIncludedFilesConverterSkipsYY(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
         datafiles_dir = os.path.join(self.gm_dir, "datafiles")
         os.makedirs(datafiles_dir)
@@ -151,7 +151,7 @@ class TestIncludedFilesConverterMissingFolder(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
     def tearDown(self):
         shutil.rmtree(self.gm_dir)

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -17,7 +17,7 @@ class TestNoteConverterBasic(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
         notes_dir = os.path.join(self.gm_dir, "notes")
         os.makedirs(notes_dir)
@@ -71,7 +71,7 @@ class TestNoteConverterMissingFolder(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
         # Deliberately do NOT create a notes folder
 
     def tearDown(self):
@@ -96,7 +96,7 @@ class TestNoteConverterSubfolders(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
         # Create a note with a .yy file that specifies a subfolder
         note_dir = os.path.join(self.gm_dir, "notes", "my_note")

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,17 +1,22 @@
 import os
+# pyright: reportPrivateUsage=false
 import sys
 import shutil
 import tempfile
 import unittest
+from typing import cast
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from src.conversion.objects import ObjectConverter
+from src.conversion.type_defs import JsonDict
 
 
-def _make_object_yy_content(name, sprite_name=None, parent_path="folders/Objects.yy", event_list=None):
+def _make_object_yy_content(name: str, sprite_name: str | None = None,
+                            parent_path: str = "folders/Objects.yy",
+                            event_list: list[JsonDict] | None = None) -> str:
     """Build a GameMaker object .yy file string."""
     if sprite_name is not None:
         sprite_id = (
@@ -23,11 +28,11 @@ def _make_object_yy_content(name, sprite_name=None, parent_path="folders/Objects
 
     if event_list is None:
         event_list = []
-    event_entries = []
+    event_entries: list[str] = []
     for evt in event_list:
         collision_id = "null"
         if evt.get("collisionObjectId") is not None:
-            col = evt["collisionObjectId"]
+            col = cast(JsonDict, evt["collisionObjectId"])
             collision_id = '{{"name": "{name}", "path": "objects/{name}/{name}.yy",}}'.format(name=col["name"])
         entry = (
             '{{"isDnD":false,"eventNum":{eventNum},"eventType":{eventType},'
@@ -66,7 +71,7 @@ def _make_object_yy_content(name, sprite_name=None, parent_path="folders/Objects
     ).format(name=name, sprite_id=sprite_id, parent_path=parent_path, event_list_str=event_list_str)
 
 
-def _create_fake_sprite_scene(godot_dir, sprite_name, subfolder=""):
+def _create_fake_sprite_scene(godot_dir: str, sprite_name: str, subfolder: str = "") -> None:
     """Create a minimal sprite .tscn file in the Godot project."""
     if subfolder:
         sprite_dir = os.path.join(godot_dir, "sprites", subfolder, sprite_name)
@@ -78,7 +83,7 @@ def _create_fake_sprite_scene(godot_dir, sprite_name, subfolder=""):
         f.write('[gd_scene format=3]\n\n[node name="{}" type="Area2D"]\n'.format(sprite_name))
 
 
-def _make_sprite_yy_content(sprite_name, parent_path="folders/Sprites.yy"):
+def _make_sprite_yy_content(sprite_name: str, parent_path: str = "folders/Sprites.yy") -> str:
     """Build a minimal sprite .yy file with parent folder info."""
     return (
         '{{\n'
@@ -93,9 +98,9 @@ class TestObjectConverterBasic(unittest.TestCase):
     """Test ObjectConverter with a minimal fake GameMaker project."""
 
     def setUp(self):
-        self.gm_dir = tempfile.mkdtemp()
-        self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.gm_dir: str = tempfile.mkdtemp()
+        self.godot_dir: str = tempfile.mkdtemp()
+        self.logs: list[str] = []
 
         # Create an object with a sprite reference
         obj_dir = os.path.join(self.gm_dir, "objects", "o_player")
@@ -118,7 +123,7 @@ class TestObjectConverterBasic(unittest.TestCase):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_converter(self):
+    def _make_converter(self) -> ObjectConverter:
         return ObjectConverter(
             self.gm_dir, self.godot_dir,
             log_callback=lambda msg: self.logs.append(msg),
@@ -175,9 +180,9 @@ class TestObjectConverterEmpty(unittest.TestCase):
     """Edge cases: missing objects dir and missing sprites."""
 
     def setUp(self):
-        self.gm_dir = tempfile.mkdtemp()
-        self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.gm_dir: str = tempfile.mkdtemp()
+        self.godot_dir: str = tempfile.mkdtemp()
+        self.logs: list[str] = []
 
     def tearDown(self):
         shutil.rmtree(self.gm_dir)
@@ -229,8 +234,8 @@ class TestParseObjectYY(unittest.TestCase):
     """Test _parse_object_yy directly."""
 
     def setUp(self):
-        self.gm_dir = tempfile.mkdtemp()
-        self.godot_dir = tempfile.mkdtemp()
+        self.gm_dir: str = tempfile.mkdtemp()
+        self.godot_dir: str = tempfile.mkdtemp()
         self.converter = ObjectConverter(
             self.gm_dir, self.godot_dir,
             log_callback=lambda msg: None,
@@ -242,7 +247,7 @@ class TestParseObjectYY(unittest.TestCase):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _write_object_yy(self, object_name, content):
+    def _write_object_yy(self, object_name: str, content: str) -> None:
         obj_dir = os.path.join(self.gm_dir, "objects", object_name)
         os.makedirs(obj_dir, exist_ok=True)
         with open(os.path.join(obj_dir, object_name + ".yy"), "w") as f:
@@ -254,6 +259,7 @@ class TestParseObjectYY(unittest.TestCase):
 
         result = self.converter._parse_object_yy("o_test")
         self.assertIsNotNone(result)
+        assert result is not None
         self.assertEqual(result["sprite_name"], "s_test")
 
     def test_parses_valid_object_without_sprite(self):
@@ -262,6 +268,7 @@ class TestParseObjectYY(unittest.TestCase):
 
         result = self.converter._parse_object_yy("o_empty")
         self.assertIsNotNone(result)
+        assert result is not None
         self.assertIsNone(result["sprite_name"])
 
     def test_returns_none_for_missing(self):
@@ -280,6 +287,7 @@ class TestParseObjectYY(unittest.TestCase):
 
         result = self.converter._parse_object_yy("o_tc")
         self.assertIsNotNone(result)
+        assert result is not None
         self.assertEqual(result["sprite_name"], "s_tc")
 
 
@@ -287,9 +295,9 @@ class TestObjectConverterYYPFiltering(unittest.TestCase):
     """Test that objects are filtered against the .yyp project file."""
 
     def setUp(self):
-        self.gm_dir = tempfile.mkdtemp()
-        self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.gm_dir: str = tempfile.mkdtemp()
+        self.godot_dir: str = tempfile.mkdtemp()
+        self.logs: list[str] = []
 
         # Create two objects on disk
         for name in ["o_listed", "o_unlisted"]:
@@ -336,15 +344,15 @@ class TestObjectConverterSubfolders(unittest.TestCase):
     """Test that objects respect GameMaker's folder hierarchy."""
 
     def setUp(self):
-        self.gm_dir = tempfile.mkdtemp()
-        self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.gm_dir: str = tempfile.mkdtemp()
+        self.godot_dir: str = tempfile.mkdtemp()
+        self.logs: list[str] = []
 
     def tearDown(self):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_converter(self):
+    def _make_converter(self) -> ObjectConverter:
         return ObjectConverter(
             self.gm_dir, self.godot_dir,
             log_callback=lambda msg: self.logs.append(msg),
@@ -418,15 +426,15 @@ class TestScriptGeneration(unittest.TestCase):
     """Test .gd script file generation for objects."""
 
     def setUp(self):
-        self.gm_dir = tempfile.mkdtemp()
-        self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.gm_dir: str = tempfile.mkdtemp()
+        self.godot_dir: str = tempfile.mkdtemp()
+        self.logs: list[str] = []
 
     def tearDown(self):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_converter(self):
+    def _make_converter(self) -> ObjectConverter:
         return ObjectConverter(
             self.gm_dir, self.godot_dir,
             log_callback=lambda msg: self.logs.append(msg),
@@ -434,7 +442,8 @@ class TestScriptGeneration(unittest.TestCase):
             conversion_running=lambda: True,
         )
 
-    def _setup_object(self, name, sprite_name=None, event_list=None):
+    def _setup_object(self, name: str, sprite_name: str | None = None,
+                      event_list: list[JsonDict] | None = None) -> None:
         obj_dir = os.path.join(self.gm_dir, "objects", name)
         os.makedirs(obj_dir)
         yy_content = _make_object_yy_content(name, sprite_name=sprite_name, event_list=event_list)
@@ -844,8 +853,8 @@ class TestParseObjectYYEvents(unittest.TestCase):
     """Test that _parse_object_yy extracts event lists."""
 
     def setUp(self):
-        self.gm_dir = tempfile.mkdtemp()
-        self.godot_dir = tempfile.mkdtemp()
+        self.gm_dir: str = tempfile.mkdtemp()
+        self.godot_dir: str = tempfile.mkdtemp()
         self.converter = ObjectConverter(
             self.gm_dir, self.godot_dir,
             log_callback=lambda msg: None,
@@ -857,7 +866,7 @@ class TestParseObjectYYEvents(unittest.TestCase):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _write_object_yy(self, object_name, content):
+    def _write_object_yy(self, object_name: str, content: str) -> None:
         obj_dir = os.path.join(self.gm_dir, "objects", object_name)
         os.makedirs(obj_dir, exist_ok=True)
         with open(os.path.join(obj_dir, object_name + ".yy"), "w") as f:
@@ -873,6 +882,7 @@ class TestParseObjectYYEvents(unittest.TestCase):
 
         result = self.converter._parse_object_yy("o_test")
         self.assertIsNotNone(result)
+        assert result is not None
         self.assertEqual(len(result["event_list"]), 2)
         self.assertEqual(result["event_list"][0]["eventType"], 0)
         self.assertEqual(result["event_list"][1]["eventType"], 3)
@@ -884,6 +894,7 @@ class TestParseObjectYYEvents(unittest.TestCase):
 
         result = self.converter._parse_object_yy("o_test")
         self.assertIsNotNone(result)
+        assert result is not None
         self.assertEqual(result["event_list"], [])
 
     def test_event_with_collision_object(self):
@@ -895,6 +906,7 @@ class TestParseObjectYYEvents(unittest.TestCase):
 
         result = self.converter._parse_object_yy("o_test")
         self.assertIsNotNone(result)
+        assert result is not None
         self.assertEqual(len(result["event_list"]), 1)
         self.assertEqual(result["event_list"][0]["collisionObjectId"]["name"], "o_enemy")
 

--- a/tests/test_project_godot.py
+++ b/tests/test_project_godot.py
@@ -11,25 +11,25 @@ if PROJECT_ROOT not in sys.path:
 from src.conversion.project_godot import GodotProjectFile
 
 
-def _write_file(path, content):
+def _write_file(path: str, content: str) -> None:
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w", encoding="utf-8") as f:
         f.write(content)
 
 
 class TestGodotProjectFile(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.godot_dir = tempfile.mkdtemp()
         self.project_path = os.path.join(self.godot_dir, "project.godot")
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.godot_dir)
 
-    def _read_project(self):
+    def _read_project(self) -> str:
         with open(self.project_path, "r", encoding="utf-8") as f:
             return f.read()
 
-    def test_set_main_scene_replaces_existing_and_preserves_settings(self):
+    def test_set_main_scene_replaces_existing_and_preserves_settings(self) -> None:
         _write_file(self.project_path, (
             '[application]\n'
             'config/name="Existing"\n'
@@ -53,7 +53,7 @@ class TestGodotProjectFile(unittest.TestCase):
         self.assertIn('[rendering]', content)
         self.assertIn('renderer/rendering_method="gl_compatibility"', content)
 
-    def test_set_main_scene_adds_to_existing_application_section(self):
+    def test_set_main_scene_adds_to_existing_application_section(self) -> None:
         _write_file(self.project_path, (
             '[application]\n'
             'config/name="Existing"\n'
@@ -74,7 +74,7 @@ class TestGodotProjectFile(unittest.TestCase):
         self.assertIn('[display]', content)
         self.assertIn('window/size/viewport_width=1280', content)
 
-    def test_set_main_scene_adds_application_section_when_missing(self):
+    def test_set_main_scene_adds_application_section_when_missing(self) -> None:
         _write_file(self.project_path, (
             '[rendering]\n'
             'quality/driver="GLES3"\n'
@@ -91,7 +91,7 @@ class TestGodotProjectFile(unittest.TestCase):
         self.assertIn('[rendering]', content)
         self.assertIn('quality/driver="GLES3"', content)
 
-    def test_set_main_scene_does_not_change_other_sections(self):
+    def test_set_main_scene_does_not_change_other_sections(self) -> None:
         _write_file(self.project_path, (
             '[other]\n'
             'run/main_scene="res://other.tscn"\n'
@@ -109,7 +109,7 @@ class TestGodotProjectFile(unittest.TestCase):
         self.assertIn('[other]\nrun/main_scene="res://other.tscn"', content)
         self.assertIn('run/main_scene="res://rooms/r_a/r_a.tscn"', content)
 
-    def test_set_main_scene_returns_false_when_project_missing(self):
+    def test_set_main_scene_returns_false_when_project_missing(self) -> None:
         result = GodotProjectFile(self.project_path).set_main_scene(
             "res://rooms/r_a/r_a.tscn"
         )

--- a/tests/test_project_settings.py
+++ b/tests/test_project_settings.py
@@ -33,21 +33,21 @@ config/icon="res://old_icon.png"
 class TestGetGmProjectName(unittest.TestCase):
     """Test ProjectSettingsConverter.get_gm_project_name()."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
         # Write a fake .yyp file
         self.yyp_path = os.path.join(self.gm_dir, "TestProject.yyp")
         with open(self.yyp_path, "w", encoding="utf-8") as f:
             f.write(SAMPLE_YYP)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_converter(self):
+    def _make_converter(self) -> ProjectSettingsConverter:
         return ProjectSettingsConverter(
             self.gm_dir, self.godot_dir,
             log_callback=lambda msg: self.logs.append(msg),
@@ -55,12 +55,12 @@ class TestGetGmProjectName(unittest.TestCase):
             conversion_running=lambda: True,
         )
 
-    def test_returns_project_name(self):
+    def test_returns_project_name(self) -> None:
         converter = self._make_converter()
         name = converter.get_gm_project_name()
         self.assertEqual(name, "TestProject")
 
-    def test_returns_none_when_no_yyp(self):
+    def test_returns_none_when_no_yyp(self) -> None:
         os.remove(self.yyp_path)
         converter = self._make_converter()
         name = converter.get_gm_project_name()
@@ -70,10 +70,10 @@ class TestGetGmProjectName(unittest.TestCase):
 class TestUpdateProjectName(unittest.TestCase):
     """Test ProjectSettingsConverter.update_project_name()."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
         # .yyp in GM dir
         with open(os.path.join(self.gm_dir, "MyGame.yyp"), "w", encoding="utf-8") as f:
@@ -84,11 +84,11 @@ class TestUpdateProjectName(unittest.TestCase):
         with open(self.project_godot, "w", encoding="utf-8") as f:
             f.write(SAMPLE_PROJECT_GODOT)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_converter(self):
+    def _make_converter(self) -> ProjectSettingsConverter:
         return ProjectSettingsConverter(
             self.gm_dir, self.godot_dir,
             log_callback=lambda msg: self.logs.append(msg),
@@ -96,7 +96,7 @@ class TestUpdateProjectName(unittest.TestCase):
             conversion_running=lambda: True,
         )
 
-    def test_updates_name_in_project_godot(self):
+    def test_updates_name_in_project_godot(self) -> None:
         converter = self._make_converter()
         converter.update_project_name()
 
@@ -106,7 +106,7 @@ class TestUpdateProjectName(unittest.TestCase):
         self.assertIn('config/name="MyGame"', content)
         self.assertNotIn("Placeholder", content)
 
-    def test_missing_project_godot_no_crash(self):
+    def test_missing_project_godot_no_crash(self) -> None:
         os.remove(self.project_godot)
         converter = self._make_converter()
         converter.update_project_name()  # should not raise
@@ -116,19 +116,19 @@ class TestUpdateProjectName(unittest.TestCase):
 class TestReadAudioGroups(unittest.TestCase):
     """Test ProjectSettingsConverter.read_audio_groups()."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
         with open(os.path.join(self.gm_dir, "Game.yyp"), "w", encoding="utf-8") as f:
             f.write(SAMPLE_YYP)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_converter(self):
+    def _make_converter(self) -> ProjectSettingsConverter:
         return ProjectSettingsConverter(
             self.gm_dir, self.godot_dir,
             log_callback=lambda msg: self.logs.append(msg),
@@ -136,12 +136,12 @@ class TestReadAudioGroups(unittest.TestCase):
             conversion_running=lambda: True,
         )
 
-    def test_reads_audio_groups(self):
+    def test_reads_audio_groups(self) -> None:
         converter = self._make_converter()
         groups = converter.read_audio_groups()
         self.assertEqual(groups, ["audiogroup_default", "audiogroup_music"])
 
-    def test_empty_audio_groups(self):
+    def test_empty_audio_groups(self) -> None:
         # Overwrite with a .yyp that has no AudioGroups section
         with open(os.path.join(self.gm_dir, "Game.yyp"), "w", encoding="utf-8") as f:
             f.write('{ "%Name": "Game" }')
@@ -154,16 +154,16 @@ class TestReadAudioGroups(unittest.TestCase):
 class TestConvertIconFallback(unittest.TestCase):
     """Test that convert_icon falls back to other platforms when the selected platform has no icons."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_converter(self, platform='linux'):
+    def _make_converter(self, platform: str = 'linux') -> ProjectSettingsConverter:
         return ProjectSettingsConverter(
             self.gm_dir, self.godot_dir,
             log_callback=lambda msg: self.logs.append(msg),
@@ -172,7 +172,7 @@ class TestConvertIconFallback(unittest.TestCase):
             gm_platform=platform,
         )
 
-    def _create_icon(self, platform):
+    def _create_icon(self, platform: str) -> None:
         """Create a minimal .ico file under options/<platform>/icons/."""
         from PIL import Image
         icons_dir = os.path.join(self.gm_dir, 'options', platform, 'icons')
@@ -180,7 +180,7 @@ class TestConvertIconFallback(unittest.TestCase):
         img = Image.new("RGBA", (16, 16), "blue")
         img.save(os.path.join(icons_dir, "icon.ico"), "PNG")
 
-    def test_uses_fallback_platform_when_selected_missing(self):
+    def test_uses_fallback_platform_when_selected_missing(self) -> None:
         self._create_icon('windows')
         converter = self._make_converter(platform='linux')
         result = converter.convert_icon()
@@ -190,7 +190,7 @@ class TestConvertIconFallback(unittest.TestCase):
         fallback_logs = [l for l in self.logs if 'windows' in l]
         self.assertTrue(len(fallback_logs) > 0, "Should log which platform was used as fallback")
 
-    def test_uses_selected_platform_when_available(self):
+    def test_uses_selected_platform_when_available(self) -> None:
         self._create_icon('linux')
         self._create_icon('windows')
         converter = self._make_converter(platform='linux')
@@ -200,7 +200,7 @@ class TestConvertIconFallback(unittest.TestCase):
         fallback_logs = [l for l in self.logs if 'Fallback' in l or 'instead' in l]
         self.assertEqual(len(fallback_logs), 0, "Should not fall back when selected platform has icons")
 
-    def test_returns_false_when_no_platform_has_icons(self):
+    def test_returns_false_when_no_platform_has_icons(self) -> None:
         converter = self._make_converter(platform='linux')
         result = converter.convert_icon()
 

--- a/tests/test_resource_index.py
+++ b/tests/test_resource_index.py
@@ -3,6 +3,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+from typing import Iterable
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
@@ -11,27 +12,29 @@ if PROJECT_ROOT not in sys.path:
 from src.conversion.resource_index import GameMakerResourceIndex
 
 
-def _write_file(path, content):
+def _write_file(path: str, content: str) -> None:
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w", encoding="utf-8") as f:
         f.write(content)
 
 
-def _resource_entry(kind, name):
+def _resource_entry(kind: str, name: str) -> str:
     return (
         '    {{"id":{{"name":"{name}",'
         '"path":"{kind}/{name}/{name}.yy",}},}}'
     ).format(kind=kind, name=name)
 
 
-def _room_order_entry(name):
+def _room_order_entry(name: str) -> str:
     return (
         '    {{"roomId":{{"name":"{name}",'
         '"path":"rooms/{name}/{name}.yy",}},}}'
     ).format(name=name)
 
 
-def _make_yyp(resources, room_order=None):
+def _make_yyp(
+    resources: Iterable[tuple[str, str]], room_order: Iterable[str] | None = None
+) -> str:
     room_order = room_order or []
     resource_lines = ",\n".join(
         _resource_entry(kind, name) for kind, name in resources
@@ -46,7 +49,7 @@ def _make_yyp(resources, room_order=None):
     )
 
 
-def _make_room_yy(name, parent_path="folders/Rooms.yy"):
+def _make_room_yy(name: str, parent_path: str = "folders/Rooms.yy") -> str:
     return (
         '{{\n'
         '  "$GMRoom":"v1",\n'
@@ -70,7 +73,9 @@ def _make_room_yy(name, parent_path="folders/Rooms.yy"):
     ).format(name=name, parent_path=parent_path)
 
 
-def _make_minimal_yy(name, resource_type, parent_name, parent_path):
+def _make_minimal_yy(
+    name: str, resource_type: str, parent_name: str, parent_path: str
+) -> str:
     return (
         '{{\n'
         '  "name":"{name}",\n'
@@ -86,16 +91,16 @@ def _make_minimal_yy(name, resource_type, parent_name, parent_path):
 
 
 class TestGameMakerResourceIndex(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _build_index(self):
+    def _build_index(self) -> GameMakerResourceIndex:
         index = GameMakerResourceIndex(
             self.gm_dir,
             self.godot_dir,
@@ -105,26 +110,32 @@ class TestGameMakerResourceIndex(unittest.TestCase):
         )
         return index.build()
 
-    def _write_yyp(self, resources, room_order=None):
+    def _write_yyp(
+        self, resources: Iterable[tuple[str, str]], room_order: Iterable[str] | None = None
+    ) -> None:
         _write_file(
             os.path.join(self.gm_dir, "TestProject.yyp"),
             _make_yyp(resources, room_order),
         )
 
-    def _write_room(self, name, parent_path="folders/Rooms.yy", content=None):
+    def _write_room(
+        self, name: str, parent_path: str = "folders/Rooms.yy", content: str | None = None
+    ) -> None:
         _write_file(
             os.path.join(self.gm_dir, "rooms", name, name + ".yy"),
             content if content is not None else _make_room_yy(name, parent_path),
         )
 
-    def _write_resource(self, kind, name, parent_path, resource_type):
+    def _write_resource(
+        self, kind: str, name: str, parent_path: str, resource_type: str
+    ) -> None:
         parent_name = kind.capitalize()
         _write_file(
             os.path.join(self.gm_dir, kind, name, name + ".yy"),
             _make_minimal_yy(name, resource_type, parent_name, parent_path),
         )
 
-    def test_indexes_yyp_resources_and_preserves_room_order(self):
+    def test_indexes_yyp_resources_and_preserves_room_order(self) -> None:
         self._write_yyp(
             [("rooms", "r_second"), ("rooms", "r_first")],
             room_order=["r_first", "r_second"],
@@ -138,13 +149,15 @@ class TestGameMakerResourceIndex(unittest.TestCase):
             [room.name for room in index.ordered_rooms()],
             ["r_first", "r_second"],
         )
-        self.assertEqual(index.first_room().name, "r_first")
+        first_room = index.first_room()
+        assert first_room is not None
+        self.assertEqual(first_room.name, "r_first")
         self.assertEqual(
             index.resolve_gm_path("rooms", "r_first"),
             os.path.join(self.gm_dir, "rooms", "r_first", "r_first.yy"),
         )
 
-    def test_resolves_resource_gm_paths_for_supported_kinds(self):
+    def test_resolves_resource_gm_paths_for_supported_kinds(self) -> None:
         self._write_yyp([
             ("rooms", "r_test"),
             ("objects", "o_player"),
@@ -158,20 +171,29 @@ class TestGameMakerResourceIndex(unittest.TestCase):
 
         index = self._build_index()
 
-        self.assertTrue(index.resolve_gm_path("rooms", "r_test").endswith(
+        room_path = index.resolve_gm_path("rooms", "r_test")
+        object_path = index.resolve_gm_path("objects", "o_player")
+        sprite_path = index.resolve_gm_path("sprites", "s_player")
+        tileset_path = index.resolve_gm_path("tilesets", "ts_ground")
+
+        assert room_path is not None
+        assert object_path is not None
+        assert sprite_path is not None
+        assert tileset_path is not None
+        self.assertTrue(room_path.endswith(
             os.path.join("rooms", "r_test", "r_test.yy")
         ))
-        self.assertTrue(index.resolve_gm_path("objects", "o_player").endswith(
+        self.assertTrue(object_path.endswith(
             os.path.join("objects", "o_player", "o_player.yy")
         ))
-        self.assertTrue(index.resolve_gm_path("sprites", "s_player").endswith(
+        self.assertTrue(sprite_path.endswith(
             os.path.join("sprites", "s_player", "s_player.yy")
         ))
-        self.assertTrue(index.resolve_gm_path("tilesets", "ts_ground").endswith(
+        self.assertTrue(tileset_path.endswith(
             os.path.join("tilesets", "ts_ground", "ts_ground.yy")
         ))
 
-    def test_computes_godot_paths_with_subfolders(self):
+    def test_computes_godot_paths_with_subfolders(self) -> None:
         self._write_yyp([
             ("rooms", "r_intro"),
             ("objects", "o_player"),
@@ -208,18 +230,18 @@ class TestGameMakerResourceIndex(unittest.TestCase):
             "res://tilesets/World/ts_ground/ts_ground.tres",
         )
 
-    def test_handles_trailing_commas_in_yyp_and_room_yy(self):
+    def test_handles_trailing_commas_in_yyp_and_room_yy(self) -> None:
         self._write_yyp([("rooms", "r_trailing")], room_order=["r_trailing"])
         self._write_room("r_trailing")
 
         index = self._build_index()
         room = index.get_room("r_trailing")
 
-        self.assertIsNotNone(room)
+        assert room is not None
         self.assertEqual(room.room_settings["Width"], 640)
         self.assertEqual(room.room_settings["Height"], 480)
 
-    def test_indexes_room_creation_code_metadata(self):
+    def test_indexes_room_creation_code_metadata(self) -> None:
         content = _make_room_yy("r_code").replace(
             '"creationCodeFile":"",',
             '"creationCodeFile":"rooms/r_code/RoomCreationCode.gml",',
@@ -236,11 +258,12 @@ class TestGameMakerResourceIndex(unittest.TestCase):
         index = self._build_index()
         room = index.get_room("r_code")
 
+        assert room is not None
         self.assertEqual(room.creation_code_file, "rooms/r_code/RoomCreationCode.gml")
         self.assertTrue(room.inherit_code)
         self.assertTrue(room.is_dnd)
 
-    def test_missing_yyp_falls_back_to_disk_scan(self):
+    def test_missing_yyp_falls_back_to_disk_scan(self) -> None:
         self._write_room("r_disk")
         self._write_resource("objects", "o_disk", "folders/Objects.yy", "GMObject")
         self._write_resource("sprites", "s_disk", "folders/Sprites.yy", "GMSprite")
@@ -254,7 +277,7 @@ class TestGameMakerResourceIndex(unittest.TestCase):
         self.assertIsNotNone(index.get_resource("tilesets", "ts_disk"))
         self.assertEqual([room.name for room in index.ordered_rooms()], ["r_disk"])
 
-    def test_malformed_yyp_falls_back_to_disk_scan(self):
+    def test_malformed_yyp_falls_back_to_disk_scan(self) -> None:
         _write_file(os.path.join(self.gm_dir, "BadProject.yyp"), "not valid json {{{")
         self._write_room("r_disk")
 
@@ -263,7 +286,7 @@ class TestGameMakerResourceIndex(unittest.TestCase):
         self.assertIsNotNone(index.get_room("r_disk"))
         self.assertTrue(any("falling back" in msg for msg in self.logs))
 
-    def test_missing_room_order_nodes_uses_sorted_fallback_and_logs_warning(self):
+    def test_missing_room_order_nodes_uses_sorted_fallback_and_logs_warning(self) -> None:
         _write_file(
             os.path.join(self.gm_dir, "TestProject.yyp"),
             "{\n"
@@ -280,12 +303,14 @@ class TestGameMakerResourceIndex(unittest.TestCase):
         index = self._build_index()
 
         self.assertEqual([room.name for room in index.ordered_rooms()], ["r_a", "r_z"])
-        self.assertEqual(index.first_room().name, "r_a")
+        first_room = index.first_room()
+        assert first_room is not None
+        self.assertEqual(first_room.name, "r_a")
         self.assertTrue(index.used_room_order_fallback)
         self.assertTrue(any("RoomOrderNodes missing" in msg for msg in self.logs))
         self.assertTrue(any("fallback" in msg.lower() for msg in self.logs))
 
-    def test_malformed_room_is_skipped_and_logged(self):
+    def test_malformed_room_is_skipped_and_logged(self) -> None:
         self._write_yyp([("rooms", "r_bad")], room_order=["r_bad"])
         self._write_room("r_bad", content="not valid json {{{")
 
@@ -294,7 +319,7 @@ class TestGameMakerResourceIndex(unittest.TestCase):
         self.assertIsNone(index.get_room("r_bad"))
         self.assertTrue(any("r_bad" in msg for msg in self.logs))
 
-    def test_missing_optional_room_fields_do_not_crash(self):
+    def test_missing_optional_room_fields_do_not_crash(self) -> None:
         self._write_yyp([("rooms", "r_minimal")], room_order=["r_minimal"])
         self._write_room(
             "r_minimal",
@@ -304,6 +329,7 @@ class TestGameMakerResourceIndex(unittest.TestCase):
         index = self._build_index()
         room = index.get_room("r_minimal")
 
+        assert room is not None
         self.assertEqual(room.room_settings, {})
         self.assertEqual(room.physics_settings, {})
         self.assertEqual(room.view_settings, {})
@@ -313,7 +339,7 @@ class TestGameMakerResourceIndex(unittest.TestCase):
         self.assertIsNone(room.parent_room)
         self.assertEqual(room.creation_code_file, "")
 
-    def test_no_scene_output_is_written(self):
+    def test_no_scene_output_is_written(self) -> None:
         self._write_yyp([("rooms", "r_empty")], room_order=["r_empty"])
         self._write_room("r_empty")
 

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import json
 import os
 import shutil
 import sys
 import tempfile
 import unittest
+from typing import Any, Callable
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
@@ -12,16 +15,20 @@ if PROJECT_ROOT not in sys.path:
 from src.conversion.rooms import RoomConverter
 
 
-def _write_file(path, content):
+def _write_file(path: str, content: str) -> None:
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w", encoding="utf-8") as f:
         f.write(content)
 
 
-def _make_yyp(room_names, room_order=None, extra_resources=None):
+def _make_yyp(
+    room_names: list[str],
+    room_order: list[str] | None = None,
+    extra_resources: list[tuple[str, str]] | None = None,
+) -> str:
     room_order = room_order or room_names
     extra_resources = extra_resources or []
-    resources = []
+    resources: list[str] = []
     for name in room_names:
         resources.append(
             '    {{"id":{{"name":"{name}",'
@@ -32,7 +39,7 @@ def _make_yyp(room_names, room_order=None, extra_resources=None):
             '    {{"id":{{"name":"{name}",'
             '"path":"{kind}/{name}/{name}.yy",}},}}'.format(kind=kind, name=name)
         )
-    order_entries = []
+    order_entries: list[str] = []
     for name in room_order:
         order_entries.append(
             '    {{"roomId":{{"name":"{name}",'
@@ -48,10 +55,12 @@ def _make_yyp(room_names, room_order=None, extra_resources=None):
     )
 
 
-def _make_room_yy(name, parent_path="folders/Rooms.yy", width=1024, height=768,
-                  persistent=False, volume=1.0, physics_world=False, layers=None,
-                  instance_creation_order=None, creation_code_file="",
-                  inherit_code=False, is_dnd=False):
+def _make_room_yy(name: str, parent_path: str = "folders/Rooms.yy", width: int = 1024,
+                  height: int = 768, persistent: bool = False, volume: float = 1.0,
+                  physics_world: bool = False, layers: list[dict[str, Any]] | None = None,
+                  instance_creation_order: list[dict[str, Any]] | None = None,
+                  creation_code_file: str = "", inherit_code: bool = False,
+                  is_dnd: bool = False) -> str:
     persistent_value = "true" if persistent else "false"
     physics_world_value = "true" if physics_world else "false"
     inherit_code_value = "true" if inherit_code else "false"
@@ -104,7 +113,7 @@ def _make_room_yy(name, parent_path="folders/Rooms.yy", width=1024, height=768,
     )
 
 
-def _make_object_yy(name, parent_path="folders/Objects.yy"):
+def _make_object_yy(name: str, parent_path: str = "folders/Objects.yy") -> str:
     return (
         '{{\n'
         '  "$GMObject":"",\n'
@@ -117,7 +126,7 @@ def _make_object_yy(name, parent_path="folders/Objects.yy"):
     ).format(name=name, parent_path=parent_path)
 
 
-def _make_sprite_yy(name, parent_path="folders/Sprites.yy"):
+def _make_sprite_yy(name: str, parent_path: str = "folders/Sprites.yy") -> str:
     return (
         '{{\n'
         '  "$GMSprite":"",\n'
@@ -130,17 +139,19 @@ def _make_sprite_yy(name, parent_path="folders/Sprites.yy"):
 
 
 class TestRoomConverter(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
-        self.progress = []
+        self.logs: list[str] = []
+        self.progress: list[int | float] = []
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_converter(self, conversion_running=lambda: True):
+    def _make_converter(
+        self, conversion_running: Callable[[], bool] = lambda: True
+    ) -> RoomConverter:
         return RoomConverter(
             self.gm_dir,
             self.godot_dir,
@@ -150,26 +161,33 @@ class TestRoomConverter(unittest.TestCase):
             max_workers=1,
         )
 
-    def _write_yyp(self, room_names, room_order=None, extra_resources=None):
+    def _write_yyp(
+        self,
+        room_names: list[str],
+        room_order: list[str] | None = None,
+        extra_resources: list[tuple[str, str]] | None = None,
+    ) -> None:
         _write_file(
             os.path.join(self.gm_dir, "TestProject.yyp"),
             _make_yyp(room_names, room_order, extra_resources),
         )
 
-    def _write_project_godot(self, content='[application]\nconfig/name="Existing"\n'):
+    def _write_project_godot(
+        self, content: str = '[application]\nconfig/name="Existing"\n'
+    ) -> None:
         _write_file(os.path.join(self.godot_dir, "project.godot"), content)
 
-    def _write_room(self, name, **kwargs):
+    def _write_room(self, name: str, **kwargs: Any) -> str:
         room_path = os.path.join(self.gm_dir, "rooms", name, name + ".yy")
         _write_file(room_path, _make_room_yy(name, **kwargs))
         return room_path
 
-    def _write_object(self, name, parent_path="folders/Objects.yy"):
+    def _write_object(self, name: str, parent_path: str = "folders/Objects.yy") -> str:
         object_path = os.path.join(self.gm_dir, "objects", name, name + ".yy")
         _write_file(object_path, _make_object_yy(name, parent_path))
         return object_path
 
-    def _write_object_scene(self, name, *subfolders):
+    def _write_object_scene(self, name: str, *subfolders: str) -> str:
         scene_path = os.path.join(
             self.godot_dir,
             "objects",
@@ -180,12 +198,12 @@ class TestRoomConverter(unittest.TestCase):
         _write_file(scene_path, '[gd_scene format=3]\n\n[node name="{}" type="Node2D"]\n'.format(name))
         return scene_path
 
-    def _write_sprite(self, name, parent_path="folders/Sprites.yy"):
+    def _write_sprite(self, name: str, parent_path: str = "folders/Sprites.yy") -> str:
         sprite_path = os.path.join(self.gm_dir, "sprites", name, name + ".yy")
         _write_file(sprite_path, _make_sprite_yy(name, parent_path))
         return sprite_path
 
-    def _write_sprite_scene(self, name, *subfolders):
+    def _write_sprite_scene(self, name: str, *subfolders: str) -> str:
         scene_path = os.path.join(
             self.godot_dir,
             "sprites",
@@ -196,7 +214,7 @@ class TestRoomConverter(unittest.TestCase):
         _write_file(scene_path, '[gd_scene format=3]\n\n[node name="{}" type="Area2D"]\n'.format(name))
         return scene_path
 
-    def _read_scene(self, room_name, *subfolders):
+    def _read_scene(self, room_name: str, *subfolders: str) -> str:
         tscn_path = os.path.join(
             self.godot_dir,
             "rooms",

--- a/tests/test_shaders.py
+++ b/tests/test_shaders.py
@@ -30,7 +30,7 @@ class TestShaderConverterBasic(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
         shaders_dir = os.path.join(self.gm_dir, "shaders")
         os.makedirs(shaders_dir)
@@ -121,7 +121,7 @@ class TestShaderConverterEmpty(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
         # No shaders directory created
 
     def tearDown(self):
@@ -146,7 +146,7 @@ class TestShaderConverterSubfolders(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
         # Create a shader in a named directory with a .yy specifying subfolder
         shader_dir = os.path.join(self.gm_dir, "shaders", "sh_blur")

--- a/tests/test_simple_topdown_conversion.py
+++ b/tests/test_simple_topdown_conversion.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import shutil
 import sys
@@ -5,6 +7,7 @@ import tempfile
 import threading
 import unittest
 from datetime import date
+from typing import Any, ClassVar, cast
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
@@ -28,6 +31,10 @@ def _get_simple_topdown_path():
 )
 class TestSimpleTopDownConversion(unittest.TestCase):
     """Integration test: convert the SimpleTopDown GameMaker test project."""
+
+    project_path: ClassVar[str | None]
+    godot_dir: ClassVar[str]
+    logs: ClassVar[list[str]]
 
     @classmethod
     def setUpClass(cls):
@@ -54,28 +61,37 @@ class TestSimpleTopDownConversion(unittest.TestCase):
         conversion_running = threading.Event()
         conversion_running.set()
 
-        converter = Converter(
-            log_callback=lambda msg: cls.logs.append(msg),
-            progress_callback=lambda v: None,
-            status_callback=lambda msg: None,
+        def log_message(msg: object) -> None:
+            cls.logs.append(str(msg))
+
+        def ignore_progress(_value: object) -> None:
+            return None
+
+        def ignore_status(_msg: object) -> None:
+            return None
+
+        converter = cast(Any, Converter)(
+            log_callback=log_message,
+            progress_callback=ignore_progress,
+            status_callback=ignore_status,
             conversion_running=conversion_running,
             compact_logging=True,
         )
         converter.convert(cls.project_path, "windows", cls.godot_dir, settings)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         if hasattr(cls, "godot_dir") and os.path.isdir(cls.godot_dir):
             shutil.rmtree(cls.godot_dir)
 
-    def _find_generated_file(self, resource_dir, filename):
+    def _find_generated_file(self, resource_dir: str, filename: str) -> str:
         root_dir = os.path.join(self.godot_dir, resource_dir)
         for root, _dirs, files in os.walk(root_dir):
             if filename in files:
                 return os.path.join(root, filename)
         self.fail(f"Expected {filename} somewhere under {resource_dir}/")
 
-    def _read_generated_file(self, resource_dir, filename):
+    def _read_generated_file(self, resource_dir: str, filename: str) -> str:
         path = self._find_generated_file(resource_dir, filename)
         with open(path, "r", encoding="utf-8") as f:
             return f.read()

--- a/tests/test_sounds.py
+++ b/tests/test_sounds.py
@@ -1,18 +1,32 @@
+# pyright: reportPrivateUsage=false
+
 import json
 import os
 import sys
 import shutil
 import tempfile
 import unittest
+from typing import NotRequired, TypeAlias, TypedDict, Unpack, cast
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from src.conversion.sounds import SoundConverter
+from src.conversion.type_defs import ConversionRunning, LogCallback, ProgressCallback
 
 
-MINIMAL_SOUND_YY = {
+SoundYY: TypeAlias = dict[str, object]
+
+
+class SoundConverterKwargs(TypedDict, total=False):
+    log_callback: LogCallback
+    progress_callback: ProgressCallback
+    conversion_running: ConversionRunning
+    organize_by_audio_group: NotRequired[bool]
+
+
+MINIMAL_SOUND_YY: SoundYY = {
     "$GMSound": "",
     "%Name": "snd_test",
     "name": "snd_test",
@@ -32,7 +46,7 @@ MINIMAL_SOUND_YY = {
 }
 
 
-def _make_sound_yy(base_dir, sound_name, overrides=None):
+def _make_sound_yy(base_dir: str, sound_name: str, overrides: SoundYY | None = None) -> str:
     """Create a sound .yy file + placeholder audio in standard GM structure."""
     sound_dir = os.path.join(base_dir, "sounds", sound_name)
     os.makedirs(sound_dir, exist_ok=True)
@@ -46,7 +60,9 @@ def _make_sound_yy(base_dir, sound_name, overrides=None):
     with open(yy_path, "w", encoding="utf-8") as f:
         json.dump(data, f)
     # Create placeholder audio file
-    audio_path = os.path.join(sound_dir, data["soundFile"])
+    sound_file = data["soundFile"]
+    assert isinstance(sound_file, str)
+    audio_path = os.path.join(sound_dir, sound_file)
     with open(audio_path, "wb") as f:
         f.write(b"\x00" * 64)
     return yy_path
@@ -58,19 +74,19 @@ class TestSoundConverterBasic(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
         _make_sound_yy(self.gm_dir, "jump")
 
     def tearDown(self):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_converter(self, **kwargs):
-        defaults = dict(
-            log_callback=lambda msg: self.logs.append(msg),
-            progress_callback=lambda v: None,
-            conversion_running=lambda: True,
-        )
+    def _make_converter(self, **kwargs: Unpack[SoundConverterKwargs]) -> SoundConverter:
+        defaults: SoundConverterKwargs = {
+            "log_callback": lambda msg: self.logs.append(msg),
+            "progress_callback": lambda v: None,
+            "conversion_running": lambda: True,
+        }
         defaults.update(kwargs)
         return SoundConverter(self.gm_dir, self.godot_dir, **defaults)
 
@@ -110,7 +126,7 @@ class TestSoundConverterFormats(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
     def tearDown(self):
         shutil.rmtree(self.gm_dir)
@@ -176,7 +192,7 @@ class TestSoundConverterMetadata(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
     def tearDown(self):
         shutil.rmtree(self.gm_dir)
@@ -244,8 +260,11 @@ class TestSoundConverterMetadata(unittest.TestCase):
         result = converter._parse_sound_yy(yy_path)
 
         self.assertIsNotNone(result)
+        result = cast(dict[str, str | int | float], result)
+        volume = result["volume"]
+        assert isinstance(volume, (int, float))
         self.assertEqual(result['name'], "test_parse")
-        self.assertAlmostEqual(result['volume'], 0.7)
+        self.assertAlmostEqual(volume, 0.7)
         self.assertEqual(result['sampleRate'], 22050)
         self.assertEqual(result['bitDepth'], 8)
         self.assertEqual(result['audioGroupId'], "audiogroup_sfx")
@@ -257,19 +276,19 @@ class TestSoundConverterAudioGroupMap(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
     def tearDown(self):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_converter(self, **kwargs):
-        defaults = dict(
-            log_callback=lambda msg: self.logs.append(msg),
-            progress_callback=lambda v: None,
-            conversion_running=lambda: True,
-            organize_by_audio_group=False,
-        )
+    def _make_converter(self, **kwargs: Unpack[SoundConverterKwargs]) -> SoundConverter:
+        defaults: SoundConverterKwargs = {
+            "log_callback": lambda msg: self.logs.append(msg),
+            "progress_callback": lambda v: None,
+            "conversion_running": lambda: True,
+            "organize_by_audio_group": False,
+        }
         defaults.update(kwargs)
         return SoundConverter(self.gm_dir, self.godot_dir, **defaults)
 
@@ -286,11 +305,12 @@ class TestSoundConverterAudioGroupMap(unittest.TestCase):
         self.assertTrue(os.path.isfile(map_path))
 
         with open(map_path, "r", encoding="utf-8") as f:
-            data = json.load(f)
+            data = cast(dict[str, object], json.load(f))
+        sounds = cast(dict[str, str], data["sounds"])
 
         self.assertEqual(data.get("format_version"), 1)
-        self.assertEqual(data["sounds"]["snd_music"], "audiogroup_music")
-        self.assertEqual(data["sounds"]["snd_click"], "audiogroup_default")
+        self.assertEqual(sounds["snd_music"], "audiogroup_music")
+        self.assertEqual(sounds["snd_click"], "audiogroup_default")
 
     def test_map_skips_failed_sound_entries(self):
         _make_sound_yy(self.gm_dir, "ok")
@@ -310,7 +330,8 @@ class TestSoundConverterAudioGroupMap(unittest.TestCase):
 
         map_path = os.path.join(self.godot_dir, "sounds", "audio_group_map.json")
         with open(map_path, "r", encoding="utf-8") as f:
-            exported = json.load(f)["sounds"]
+            map_data = cast(dict[str, object], json.load(f))
+        exported = cast(dict[str, str], map_data["sounds"])
 
         self.assertIn("ok", exported)
         self.assertNotIn("ghost", exported)
@@ -338,19 +359,19 @@ class TestSoundConverterSubfolders(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
     def tearDown(self):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_converter(self, **kwargs):
-        defaults = dict(
-            log_callback=lambda msg: self.logs.append(msg),
-            progress_callback=lambda v: None,
-            conversion_running=lambda: True,
-            organize_by_audio_group=False,
-        )
+    def _make_converter(self, **kwargs: Unpack[SoundConverterKwargs]) -> SoundConverter:
+        defaults: SoundConverterKwargs = {
+            "log_callback": lambda msg: self.logs.append(msg),
+            "progress_callback": lambda v: None,
+            "conversion_running": lambda: True,
+            "organize_by_audio_group": False,
+        }
         defaults.update(kwargs)
         return SoundConverter(self.gm_dir, self.godot_dir, **defaults)
 
@@ -432,7 +453,7 @@ class TestSoundConverterEdgeCases(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
     def tearDown(self):
         shutil.rmtree(self.gm_dir)

--- a/tests/test_sprites.py
+++ b/tests/test_sprites.py
@@ -1,15 +1,18 @@
+# pyright: reportPrivateUsage=false
+
 import os
 import sys
 import shutil
 import tempfile
 import unittest
+from typing import cast
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from PIL import Image
-from src.conversion.sprites import SpriteConverter
+from src.conversion.sprites import AnimationData, CollisionData, SpriteConverter, SpriteParseResult
 
 
 class TestSpriteConverterBasic(unittest.TestCase):
@@ -18,7 +21,7 @@ class TestSpriteConverterBasic(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
         # Build a fake GM sprite directory structure:
         # sprites/test_sprite/layers/<layer_id>/
@@ -80,8 +83,8 @@ class TestSpriteConverterCompactLogging(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.log_messages = []
-        self.update_messages = []
+        self.log_messages: list[str] = []
+        self.update_messages: list[str] = []
 
         # Build two sprites with 2 frames each
         for sprite_name in ["sprite_a", "sprite_b"]:
@@ -120,7 +123,7 @@ class TestSpriteConverterCompactLogging(unittest.TestCase):
                         "Expected compact progress messages")
 
     def test_verbose_logging_when_compact_disabled(self):
-        logs = []
+        logs: list[str] = []
         converter = SpriteConverter(
             self.gm_dir, self.godot_dir,
             log_callback=lambda msg: logs.append(msg),
@@ -141,7 +144,7 @@ class TestSpriteConverterEmpty(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
         # Create the sprites folder but leave it empty
         os.makedirs(os.path.join(self.gm_dir, "sprites"))
@@ -160,13 +163,13 @@ class TestSpriteConverterEmpty(unittest.TestCase):
         converter.convert_all()  # should not raise
 
         # Should log the "not found" message
-        joined = " ".join(self.logs)
         self.assertTrue(len(self.logs) > 0,
                         "Expected at least one log message for empty sprites folder")
 
 
 # Helper to create a minimal .yy file with trailing commas (like real GameMaker files)
-def _make_yy_content(sprite_name, frame_guids, layer_guids, layer_visible=None):
+def _make_yy_content(sprite_name: str, frame_guids: list[str], layer_guids: list[str],
+                     layer_visible: list[bool] | None = None) -> str:
     """Build a .yy file string with the given frames and layers."""
     if layer_visible is None:
         layer_visible = [True] * len(layer_guids)
@@ -198,7 +201,7 @@ class TestSpriteConverterFrameOrdering(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
         sprite_dir = os.path.join(self.gm_dir, "sprites", "ordered_sprite")
         os.makedirs(sprite_dir)
@@ -238,8 +241,11 @@ class TestSpriteConverterFrameOrdering(unittest.TestCase):
             path = os.path.join(godot_dir, f"ordered_sprite_{idx}.png")
             self.assertTrue(os.path.exists(path), f"Missing {path}")
             with Image.open(path) as img:
-                pixel = img.getpixel((0, 0))[:3]
-            expected_rgb = Image.new("RGBA", (1, 1), expected_color).getpixel((0, 0))[:3]
+                pixel = cast(tuple[int, int, int, int], img.getpixel((0, 0)))[:3]
+            expected_rgb = cast(
+                tuple[int, int, int, int],
+                Image.new("RGBA", (1, 1), expected_color).getpixel((0, 0)),
+            )[:3]
             self.assertEqual(pixel, expected_rgb,
                              f"Frame {idx} has wrong color: {pixel} != {expected_rgb}")
 
@@ -289,7 +295,7 @@ class TestSpriteConverterMultiLayer(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
         sprite_dir = os.path.join(self.gm_dir, "sprites", "multi_layer")
         os.makedirs(sprite_dir)
@@ -337,7 +343,7 @@ class TestSpriteConverterMultiLayer(unittest.TestCase):
             converted = img.convert("RGBA")
             self.assertEqual(converted.getpixel((0, 0)), (0, 255, 0, 255))
             self.assertEqual(converted.getpixel((1, 0)), (0, 0, 255, 255))
-            self.assertEqual(converted.getpixel((1, 1))[3], 0)
+            self.assertEqual(cast(tuple[int, int, int, int], converted.getpixel((1, 1)))[3], 0)
 
 
 class TestParseSpriteYY(unittest.TestCase):
@@ -357,7 +363,7 @@ class TestParseSpriteYY(unittest.TestCase):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _write_yy(self, sprite_name, content):
+    def _write_yy(self, sprite_name: str, content: str) -> None:
         sprite_dir = os.path.join(self.gm_dir, "sprites", sprite_name)
         os.makedirs(sprite_dir, exist_ok=True)
         with open(os.path.join(sprite_dir, sprite_name + ".yy"), "w") as f:
@@ -369,6 +375,7 @@ class TestParseSpriteYY(unittest.TestCase):
 
         result = self.converter._parse_sprite_yy("test_spr")
         self.assertIsNotNone(result)
+        result = cast(SpriteParseResult, result)
         frame_guids, layer_guids = result
         self.assertEqual(frame_guids, guids)
         self.assertEqual(layer_guids, ["layer1"])
@@ -380,6 +387,7 @@ class TestParseSpriteYY(unittest.TestCase):
 
         result = self.converter._parse_sprite_yy("tc")
         self.assertIsNotNone(result)
+        result = cast(SpriteParseResult, result)
         self.assertEqual(result[0], ["frame1"])
 
     def test_returns_none_for_missing_file(self):
@@ -398,13 +406,14 @@ class TestParseSpriteYY(unittest.TestCase):
                                                  layer_visible=[False, True]))
         result = self.converter._parse_sprite_yy("vis")
         self.assertIsNotNone(result)
+        result = cast(SpriteParseResult, result)
         _, layer_guids = result
         self.assertEqual(layer_guids, ["visible_layer"])
 
 
-def _make_yyp_content(sprite_names, extra_resources=None):
+def _make_yyp_content(sprite_names: list[str], extra_resources: list[str] | None = None) -> str:
     """Build a minimal .yyp file string with the given sprite names in the resources array."""
-    resources = []
+    resources: list[str] = []
     for name in sprite_names:
         resources.append(
             '{{"id":{{"name":"{name}","path":"sprites/{name}/{name}.yy",}},}}'.format(name=name)
@@ -415,7 +424,8 @@ def _make_yyp_content(sprite_names, extra_resources=None):
     return '{{\n  "%Name": "TestProject",\n  "resources": [\n    {res}\n  ],\n}}'.format(res=res_str)
 
 
-def _make_sprite_on_disk(gm_dir, sprite_name, layer_guid="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"):
+def _make_sprite_on_disk(gm_dir: str, sprite_name: str,
+                         layer_guid: str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee") -> None:
     """Create a minimal sprite folder structure with a single-frame PNG."""
     layer_dir = os.path.join(gm_dir, "sprites", sprite_name, "layers", layer_guid)
     os.makedirs(layer_dir, exist_ok=True)
@@ -450,6 +460,7 @@ class TestGetValidSpriteNames(unittest.TestCase):
 
         converter = self._make_converter()
         result = converter._get_valid_sprite_names()
+        result = cast(dict[str, str], result)
         self.assertEqual(set(result.keys()), {"s_player", "s_enemy", "s_bullet"})
 
     def test_handles_trailing_commas(self):
@@ -460,6 +471,7 @@ class TestGetValidSpriteNames(unittest.TestCase):
 
         converter = self._make_converter()
         result = converter._get_valid_sprite_names()
+        result = cast(dict[str, str], result)
         self.assertEqual(set(result.keys()), {"s_test"})
 
     def test_returns_none_when_no_yyp(self):
@@ -493,7 +505,7 @@ class TestSpriteConverterFiltering(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
     def tearDown(self):
         shutil.rmtree(self.gm_dir)
@@ -520,7 +532,7 @@ class TestSpriteConverterFiltering(unittest.TestCase):
         converter.convert_all()
 
         godot_sprites = os.path.join(self.godot_dir, "sprites")
-        converted = set(os.listdir(godot_sprites)) if os.path.exists(godot_sprites) else set()
+        converted: set[str] = set(os.listdir(godot_sprites)) if os.path.exists(godot_sprites) else set()
         self.assertIn("s_valid1", converted)
         self.assertIn("s_valid2", converted)
         self.assertNotIn("s_orphan", converted)
@@ -575,13 +587,13 @@ class TestSpriteConverterFiltering(unittest.TestCase):
         self.assertIn("s_n", converted)
 
 
-def _make_yy_content_with_collision(sprite_name, frame_guids, layer_guids,
-                                    collision_kind=1, bbox_mode=0,
-                                    bbox_left=0, bbox_right=31,
-                                    bbox_top=0, bbox_bottom=31,
-                                    width=32, height=32,
-                                    origin=0, xorigin=0, yorigin=0,
-                                    layer_visible=None):
+def _make_yy_content_with_collision(sprite_name: str, frame_guids: list[str], layer_guids: list[str],
+                                    collision_kind: int = 1, bbox_mode: int = 0,
+                                    bbox_left: int = 0, bbox_right: int = 31,
+                                    bbox_top: int = 0, bbox_bottom: int = 31,
+                                    width: int = 32, height: int = 32,
+                                    origin: int = 0, xorigin: int = 0, yorigin: int = 0,
+                                    layer_visible: list[bool] | None = None) -> str:
     """Build a .yy file string with collision mask fields."""
     if layer_visible is None:
         layer_visible = [True] * len(layer_guids)
@@ -621,15 +633,15 @@ def _make_yy_content_with_collision(sprite_name, frame_guids, layer_guids,
     )
 
 
-def _make_yy_content_with_sequence(sprite_name, frame_guids, layer_guids,
-                                    collision_kind=1, bbox_mode=0,
-                                    bbox_left=0, bbox_right=31,
-                                    bbox_top=0, bbox_bottom=31,
-                                    width=32, height=32,
-                                    origin=0, xorigin=0, yorigin=0,
-                                    layer_visible=None,
-                                    playback_speed=30.0, playback_speed_type=0,
-                                    playback=1, frame_lengths=None):
+def _make_yy_content_with_sequence(sprite_name: str, frame_guids: list[str], layer_guids: list[str],
+                                     collision_kind: int = 1, bbox_mode: int = 0,
+                                     bbox_left: int = 0, bbox_right: int = 31,
+                                     bbox_top: int = 0, bbox_bottom: int = 31,
+                                     width: int = 32, height: int = 32,
+                                     origin: int = 0, xorigin: int = 0, yorigin: int = 0,
+                                     layer_visible: list[bool] | None = None,
+                                     playback_speed: float = 30.0, playback_speed_type: int = 0,
+                                     playback: int = 1, frame_lengths: list[float] | None = None) -> str:
     """Build a .yy file string with collision fields AND sequence animation data."""
     if layer_visible is None:
         layer_visible = [True] * len(layer_guids)
@@ -645,7 +657,7 @@ def _make_yy_content_with_sequence(sprite_name, frame_guids, layer_guids,
         for i, (g, v) in enumerate(zip(layer_guids, layer_visible))
     )
     # Build sequence keyframes
-    keyframes = []
+    keyframes: list[str] = []
     for idx, (guid, length) in enumerate(zip(frame_guids, frame_lengths)):
         keyframes.append(
             '{{"Key": {key}, "Length": {length}, "Channels": {{"0": {{"Id": {{"name": "{guid}"}}}}}}}}'.format(
@@ -710,7 +722,7 @@ class TestParseCollisionData(unittest.TestCase):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _write_yy(self, sprite_name, content):
+    def _write_yy(self, sprite_name: str, content: str) -> None:
         sprite_dir = os.path.join(self.gm_dir, "sprites", sprite_name)
         os.makedirs(sprite_dir, exist_ok=True)
         with open(os.path.join(sprite_dir, sprite_name + ".yy"), "w") as f:
@@ -728,6 +740,7 @@ class TestParseCollisionData(unittest.TestCase):
 
         result = self.converter._parse_collision_data("spr_test")
         self.assertIsNotNone(result)
+        result = cast(CollisionData, result)
         self.assertEqual(result["collisionKind"], 1)
         self.assertEqual(result["bboxMode"], 2)
         self.assertEqual(result["bbox_left"], 5)
@@ -748,6 +761,7 @@ class TestParseCollisionData(unittest.TestCase):
 
         result = self.converter._parse_collision_data("spr_custom")
         self.assertIsNotNone(result)
+        result = cast(CollisionData, result)
         self.assertEqual(result["origin"], 9)
         self.assertEqual(result["xorigin"], 10)
         self.assertEqual(result["yorigin"], 20)
@@ -773,8 +787,12 @@ class TestComputeOriginOffset(unittest.TestCase):
             conversion_running=lambda: True,
         )
 
-    def _make_data(self, origin, w=64, h=32, xorigin=0, yorigin=0):
+    def _make_data(self, origin: int, w: int = 64, h: int = 32,
+                   xorigin: int = 0, yorigin: int = 0) -> CollisionData:
         return {
+            "collisionKind": 1, "bboxMode": 0,
+            "bbox_left": 0, "bbox_right": w - 1,
+            "bbox_top": 0, "bbox_bottom": h - 1,
             "width": w, "height": h,
             "origin": origin,
             "xorigin": xorigin, "yorigin": yorigin,
@@ -831,9 +849,9 @@ class TestGenerateSpriteScene(unittest.TestCase):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_collision_data(self, collision_kind=1, bbox_left=0, bbox_right=31,
-                              bbox_top=0, bbox_bottom=31, width=32, height=32,
-                              origin=0, xorigin=0, yorigin=0):
+    def _make_collision_data(self, collision_kind: int = 1, bbox_left: int = 0, bbox_right: int = 31,
+                              bbox_top: int = 0, bbox_bottom: int = 31, width: int = 32, height: int = 32,
+                              origin: int = 0, xorigin: int = 0, yorigin: int = 0) -> CollisionData:
         return {
             "collisionKind": collision_kind,
             "bboxMode": 0,
@@ -877,8 +895,8 @@ class TestGenerateSpriteScene(unittest.TestCase):
 
     def test_multiframe_references_first_frame(self):
         data = self._make_collision_data(collision_kind=1)
-        anim_data = {"playbackSpeed": 30.0, "playbackSpeedType": 0,
-                     "loop": True, "frame_durations": [1.0, 1.0, 1.0]}
+        anim_data: AnimationData = {"playbackSpeed": 30.0, "playbackSpeedType": 0,
+                                    "loop": True, "frame_durations": [1.0, 1.0, 1.0]}
         self.converter._generate_sprite_scene("spr_anim", data, 3, anim_data)
 
         tscn_path = os.path.join(self.godot_dir, "sprites", "spr_anim", "spr_anim.tscn")
@@ -954,7 +972,7 @@ class TestParseAnimationData(unittest.TestCase):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _write_yy(self, sprite_name, content):
+    def _write_yy(self, sprite_name: str, content: str) -> None:
         sprite_dir = os.path.join(self.gm_dir, "sprites", sprite_name)
         os.makedirs(sprite_dir, exist_ok=True)
         with open(os.path.join(sprite_dir, sprite_name + ".yy"), "w") as f:
@@ -968,6 +986,7 @@ class TestParseAnimationData(unittest.TestCase):
         self._write_yy("spr_fps", content)
         result = self.converter._parse_animation_data("spr_fps")
         self.assertIsNotNone(result)
+        result = cast(AnimationData, result)
         self.assertEqual(result["playbackSpeed"], 30.0)
         self.assertEqual(result["playbackSpeedType"], 0)
         self.assertTrue(result["loop"])
@@ -980,6 +999,7 @@ class TestParseAnimationData(unittest.TestCase):
         self._write_yy("spr_pgf", content)
         result = self.converter._parse_animation_data("spr_pgf")
         self.assertIsNotNone(result)
+        result = cast(AnimationData, result)
         self.assertEqual(result["playbackSpeed"], 1.0)
         self.assertEqual(result["playbackSpeedType"], 1)
 
@@ -991,6 +1011,7 @@ class TestParseAnimationData(unittest.TestCase):
         self._write_yy("spr_noloop", content)
         result = self.converter._parse_animation_data("spr_noloop")
         self.assertIsNotNone(result)
+        result = cast(AnimationData, result)
         self.assertFalse(result["loop"])
 
     def test_parses_custom_frame_durations(self):
@@ -1001,6 +1022,7 @@ class TestParseAnimationData(unittest.TestCase):
         self._write_yy("spr_dur", content)
         result = self.converter._parse_animation_data("spr_dur")
         self.assertIsNotNone(result)
+        result = cast(AnimationData, result)
         self.assertEqual(result["frame_durations"], [1.0, 2.0, 0.5])
 
     def test_returns_none_for_missing_file(self):
@@ -1021,27 +1043,27 @@ class TestComputeGodotFps(unittest.TestCase):
     """Test _compute_godot_fps() static method."""
 
     def test_fps_type_passthrough(self):
-        data = {"playbackSpeed": 30.0, "playbackSpeedType": 0}
+        data: AnimationData = {"playbackSpeed": 30.0, "playbackSpeedType": 0, "loop": True, "frame_durations": [1.0]}
         self.assertEqual(SpriteConverter._compute_godot_fps(data), 30.0)
 
     def test_fps_type_sixty(self):
-        data = {"playbackSpeed": 60.0, "playbackSpeedType": 0}
+        data: AnimationData = {"playbackSpeed": 60.0, "playbackSpeedType": 0, "loop": True, "frame_durations": [1.0]}
         self.assertEqual(SpriteConverter._compute_godot_fps(data), 60.0)
 
     def test_per_game_frame_one(self):
-        data = {"playbackSpeed": 1.0, "playbackSpeedType": 1}
+        data: AnimationData = {"playbackSpeed": 1.0, "playbackSpeedType": 1, "loop": True, "frame_durations": [1.0]}
         self.assertEqual(SpriteConverter._compute_godot_fps(data), 60.0)
 
     def test_per_game_frame_half(self):
-        data = {"playbackSpeed": 0.5, "playbackSpeedType": 1}
+        data: AnimationData = {"playbackSpeed": 0.5, "playbackSpeedType": 1, "loop": True, "frame_durations": [1.0]}
         self.assertEqual(SpriteConverter._compute_godot_fps(data), 30.0)
 
     def test_per_game_frame_zero(self):
-        data = {"playbackSpeed": 0.0, "playbackSpeedType": 1}
+        data: AnimationData = {"playbackSpeed": 0.0, "playbackSpeedType": 1, "loop": True, "frame_durations": [1.0]}
         self.assertEqual(SpriteConverter._compute_godot_fps(data), 0.0)
 
     def test_zero_fps(self):
-        data = {"playbackSpeed": 0.0, "playbackSpeedType": 0}
+        data: AnimationData = {"playbackSpeed": 0.0, "playbackSpeedType": 0, "loop": True, "frame_durations": [1.0]}
         self.assertEqual(SpriteConverter._compute_godot_fps(data), 0.0)
 
 
@@ -1062,9 +1084,9 @@ class TestGenerateAnimatedScene(unittest.TestCase):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_collision_data(self, collision_kind=1, bbox_left=0, bbox_right=31,
-                              bbox_top=0, bbox_bottom=31, width=32, height=32,
-                              origin=0, xorigin=0, yorigin=0):
+    def _make_collision_data(self, collision_kind: int = 1, bbox_left: int = 0, bbox_right: int = 31,
+                              bbox_top: int = 0, bbox_bottom: int = 31, width: int = 32, height: int = 32,
+                              origin: int = 0, xorigin: int = 0, yorigin: int = 0) -> CollisionData:
         return {
             "collisionKind": collision_kind,
             "bboxMode": 0,
@@ -1074,7 +1096,8 @@ class TestGenerateAnimatedScene(unittest.TestCase):
             "origin": origin, "xorigin": xorigin, "yorigin": yorigin,
         }
 
-    def _make_anim_data(self, speed=30.0, speed_type=0, loop=True, durations=None):
+    def _make_anim_data(self, speed: float = 30.0, speed_type: int = 0,
+                        loop: bool = True, durations: list[float] | None = None) -> AnimationData:
         if durations is None:
             durations = [1.0]
         return {
@@ -1084,7 +1107,7 @@ class TestGenerateAnimatedScene(unittest.TestCase):
             "frame_durations": durations,
         }
 
-    def _read_tscn(self, sprite_name):
+    def _read_tscn(self, sprite_name: str) -> str:
         tscn_path = os.path.join(self.godot_dir, "sprites", sprite_name, sprite_name + ".tscn")
         with open(tscn_path, "r") as f:
             return f.read()

--- a/tests/test_tcc_conversion.py
+++ b/tests/test_tcc_conversion.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 import shutil
@@ -5,6 +7,7 @@ import tempfile
 import threading
 import unittest
 from datetime import date
+from typing import Any, ClassVar, cast
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
@@ -25,6 +28,10 @@ def _get_tcc_path():
 @unittest.skipUnless(_get_tcc_path(), "TCC_PROJECT_PATH not set or not a valid directory")
 class TestTCCConversion(unittest.TestCase):
     """Integration test: convert The Colorful Creature project to Godot."""
+
+    tcc_path: ClassVar[str | None]
+    godot_dir: ClassVar[str]
+    logs: ClassVar[list[str]]
 
     @classmethod
     def setUpClass(cls):
@@ -53,10 +60,19 @@ class TestTCCConversion(unittest.TestCase):
         conversion_running = threading.Event()
         conversion_running.set()
 
-        converter = Converter(
-            log_callback=lambda msg: cls.logs.append(msg),
-            progress_callback=lambda v: None,
-            status_callback=lambda msg: None,
+        def log_message(msg: object) -> None:
+            cls.logs.append(str(msg))
+
+        def ignore_progress(_value: object) -> None:
+            return None
+
+        def ignore_status(_msg: object) -> None:
+            return None
+
+        converter = cast(Any, Converter)(
+            log_callback=log_message,
+            progress_callback=ignore_progress,
+            status_callback=ignore_status,
             conversion_running=conversion_running,
             compact_logging=True,
         )
@@ -64,7 +80,7 @@ class TestTCCConversion(unittest.TestCase):
         converter.convert(cls.tcc_path, "windows", cls.godot_dir, settings)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         if hasattr(cls, "godot_dir") and os.path.isdir(cls.godot_dir):
             shutil.rmtree(cls.godot_dir)
 
@@ -75,8 +91,8 @@ class TestTCCConversion(unittest.TestCase):
 
     def test_known_sprites_exist(self):
         sprites_dir = os.path.join(self.godot_dir, "sprites")
-        all_dirs = set()
-        for root, dirs, _ in os.walk(sprites_dir):
+        all_dirs: set[str] = set()
+        for _root, dirs, _ in os.walk(sprites_dir):
             all_dirs.update(dirs)
         for name in ("s_C1AIcon", "s_C2AIcon", "s_C3AIcon"):
             self.assertIn(name, all_dirs, f"Expected sprites/{name}/ directory (nested)")
@@ -94,8 +110,8 @@ class TestTCCConversion(unittest.TestCase):
 
     def test_sprites_count(self):
         sprites_dir = os.path.join(self.godot_dir, "sprites")
-        sprite_dirs = []
-        for root, dirs, files in os.walk(sprites_dir):
+        sprite_dirs: list[str] = []
+        for root, _dirs, files in os.walk(sprites_dir):
             if any(f.endswith(".png") for f in files):
                 sprite_dirs.append(root)
         self.assertGreater(len(sprite_dirs), 800, f"Expected 800+ sprite directories, got {len(sprite_dirs)}")
@@ -108,7 +124,7 @@ class TestTCCConversion(unittest.TestCase):
     def test_known_sound_exists(self):
         sounds_dir = os.path.join(self.godot_dir, "sounds")
         found = False
-        for root, _, files in os.walk(sounds_dir):
+        for _root, _, files in os.walk(sounds_dir):
             if "m_ahoy.wav" in files:
                 found = True
                 break
@@ -116,8 +132,8 @@ class TestTCCConversion(unittest.TestCase):
 
     def test_sounds_count(self):
         sounds_dir = os.path.join(self.godot_dir, "sounds")
-        sound_files = []
-        for root, _, files in os.walk(sounds_dir):
+        sound_files: list[str] = []
+        for _root, _, files in os.walk(sounds_dir):
             sound_files.extend(f for f in files if f.endswith((".wav", ".mp3", ".ogg")))
         self.assertGreater(len(sound_files), 50, f"Expected 50+ sound files, got {len(sound_files)}")
 
@@ -137,7 +153,7 @@ class TestTCCConversion(unittest.TestCase):
 
     def test_known_notes_converted(self):
         notes_dir = os.path.join(self.godot_dir, "notes")
-        all_files = {}
+        all_files: dict[str, str] = {}
         for root, _, files in os.walk(notes_dir):
             for f in files:
                 all_files[f] = os.path.join(root, f)

--- a/tests/test_tilesets.py
+++ b/tests/test_tilesets.py
@@ -1,21 +1,24 @@
+# pyright: reportPrivateUsage=false
+
 import os
 import sys
 import shutil
 import tempfile
 import unittest
+from typing import cast
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from PIL import Image
-from src.conversion.tilesets import TileSetConverter
+from src.conversion.tilesets import TileSetConverter, TilesetData
 
 
-def _make_tileset_yy_content(name, sprite_name, tile_width=16, tile_height=16,
-                              tilehsep=0, tilevsep=0, tilexoff=0, tileyoff=0,
-                              tile_count=2, out_columns=1,
-                              parent_path="folders/Tilesets.yy"):
+def _make_tileset_yy_content(name: str, sprite_name: str, tile_width: int = 16, tile_height: int = 16,
+                              tilehsep: int = 0, tilevsep: int = 0, tilexoff: int = 0, tileyoff: int = 0,
+                              tile_count: int = 2, out_columns: int = 1,
+                              parent_path: str = "folders/Tilesets.yy") -> str:
     """Build a GameMaker tileset .yy file string."""
     return (
         '{{\n'
@@ -46,7 +49,7 @@ def _make_tileset_yy_content(name, sprite_name, tile_width=16, tile_height=16,
     )
 
 
-def _make_sprite_for_tileset(gm_dir, sprite_name, width=64, height=64):
+def _make_sprite_for_tileset(gm_dir: str, sprite_name: str, width: int = 64, height: int = 64) -> None:
     """Create a minimal sprite directory with a .yy and a single-frame PNG image.
 
     The structure matches what TileSetConverter._find_sprite_image expects:
@@ -92,7 +95,7 @@ class TestTileSetConverterBasic(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
         # Create a tileset that references a sprite
         tileset_dir = os.path.join(self.gm_dir, "tilesets", "ts_ground")
@@ -155,7 +158,7 @@ class TestTileSetConverterEmpty(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
     def tearDown(self):
         shutil.rmtree(self.gm_dir)
@@ -171,7 +174,6 @@ class TestTileSetConverterEmpty(unittest.TestCase):
         )
         converter.convert_all()  # should not raise
 
-        joined = " ".join(self.logs)
         self.assertTrue(len(self.logs) > 0,
                         "Expected at least one log message for missing tilesets folder")
 
@@ -214,7 +216,7 @@ class TestParseTilesetYY(unittest.TestCase):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _write_tileset_yy(self, tileset_name, content):
+    def _write_tileset_yy(self, tileset_name: str, content: str) -> None:
         tileset_dir = os.path.join(self.gm_dir, "tilesets", tileset_name)
         os.makedirs(tileset_dir, exist_ok=True)
         with open(os.path.join(tileset_dir, tileset_name + ".yy"), "w") as f:
@@ -228,6 +230,7 @@ class TestParseTilesetYY(unittest.TestCase):
 
         result = self.converter._parse_tileset_yy("ts_test")
         self.assertIsNotNone(result)
+        result = cast(TilesetData, result)
         self.assertEqual(result["sprite_name"], "s_test")
         self.assertEqual(result["tileWidth"], 32)
         self.assertEqual(result["tileHeight"], 32)
@@ -255,6 +258,7 @@ class TestParseTilesetYY(unittest.TestCase):
 
         result = self.converter._parse_tileset_yy("ts_tc")
         self.assertIsNotNone(result)
+        result = cast(TilesetData, result)
         self.assertEqual(result["sprite_name"], "s_tc")
         self.assertEqual(result["tileWidth"], 16)
 
@@ -265,7 +269,7 @@ class TestTileSetConverterSubfolders(unittest.TestCase):
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
-        self.logs = []
+        self.logs: list[str] = []
 
         tileset_dir = os.path.join(self.gm_dir, "tilesets", "ts_terrain")
         os.makedirs(tileset_dir)


### PR DESCRIPTION
Add static typing across the codebase and include a pyrightconfig.json for strict type checking. Introduce src/conversion/type_defs.py and apply type annotations, TypeAlias/TypedDict definitions and casts in many modules (conversion, events, fonts, gml_transpiler, registry, base_converter, converter, etc.). Small API and safety tweaks: annotate return/param types (e.g. main(), write_gml_runtime), ensure os.fspath usage for paths, tighten thread-safe callbacks, default max_workers fallback, and improve JSON parsing/casting for .yy files. These changes prepare the project for stricter static analysis and improve type-safety without altering runtime behavior.