### PR TITLE
Support sprite_index and image_index conversion

### DIFF
--- a/src/conversion/gml_transpiler.py
+++ b/src/conversion/gml_transpiler.py
@@ -183,6 +183,12 @@ _INSTANCE_NAME_REPLACEMENTS = {
     "y": "position.y",
 }
 
+_BUILTIN_INSTANCE_VARIABLES = frozenset({
+    *_INSTANCE_NAME_REPLACEMENTS,
+    "sprite_index",
+    "image_index",
+})
+
 _VIRTUAL_KEY_ACTIONS = {
     "vk_left": "ui_left",
     "vk_right": "ui_right",
@@ -865,7 +871,7 @@ def _record_instance_assignment(
         return
 
     name = tokens[0].value
-    if name in local_names or name in _INSTANCE_NAME_REPLACEMENTS:
+    if name in local_names or name in _BUILTIN_INSTANCE_VARIABLES:
         return
     instance_variables.add(name)
 

--- a/src/conversion/objects.py
+++ b/src/conversion/objects.py
@@ -2,6 +2,7 @@ import os
 import re
 import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from collections.abc import Mapping
 from typing import TypedDict, cast
 
 from src.localization import get_localized
@@ -9,7 +10,7 @@ from src.conversion.base_converter import BaseConverter
 from src.conversion.event_mapping import map_event
 from src.conversion.gml_runtime import write_gml_runtime
 from src.conversion.gml_transpiler import GMLTranspileError, transpile_gml_code
-from src.conversion.script_generator import generate_script_content
+from src.conversion.script_generator import SpriteRuntimeConfig, generate_script_content
 from src.conversion.type_defs import ConversionRunning, JsonDict, LogCallback, ProgressCallback, StrPath
 
 
@@ -108,6 +109,23 @@ class ObjectConverter(BaseConverter):
             tscn_path = os.path.join(self.godot_project_path, 'sprites', sprite_name, sprite_name + '.tscn')
         return os.path.isfile(tscn_path)
 
+    def _get_available_sprite_scene_paths(self) -> dict[str, str]:
+        """Return sprite resource names mapped to converted Godot scene paths."""
+        sprites_root = os.path.join(self.godot_project_path, 'sprites')
+        if not os.path.isdir(sprites_root):
+            return {}
+
+        scene_paths: dict[str, str] = {}
+        for dirpath, _, filenames in os.walk(sprites_root):
+            for filename in filenames:
+                if not filename.endswith('.tscn'):
+                    continue
+                sprite_name = os.path.splitext(filename)[0]
+                scene_path = os.path.join(dirpath, filename)
+                relative_path = os.path.relpath(scene_path, self.godot_project_path).replace(os.sep, '/')
+                scene_paths[sprite_name] = f"res://{relative_path}"
+        return scene_paths
+
     def _generate_object_scene(self, object_name: str, sprite_name: str | None,
                                sprite_subfolder: str = "", script_res_path: str | None = None) -> str:
         """Build the .tscn content string for an object scene.
@@ -191,7 +209,12 @@ class ObjectConverter(BaseConverter):
 
         return code_bodies, instance_variables
 
-    def _process_object(self, object_name: str, subfolder: str = "") -> ObjectProcessResult | None:
+    def _process_object(
+        self,
+        object_name: str,
+        subfolder: str = "",
+        sprite_scene_paths: Mapping[str, str] | None = None,
+    ) -> ObjectProcessResult | None:
         """Process a single object: parse .yy, generate scene and script, write files.
 
         Returns a result dict or None if conversion was stopped.
@@ -226,6 +249,10 @@ class ObjectConverter(BaseConverter):
             event_list,
             code_bodies=code_bodies,
             instance_variables=instance_variables,
+            sprite_runtime=SpriteRuntimeConfig(
+                initial_sprite_name=sprite_name,
+                sprite_scene_paths=sprite_scene_paths,
+            ),
         )
         scene_content = self._generate_object_scene(object_name, sprite_name, sprite_subfolder, script_res_path)
 
@@ -274,10 +301,11 @@ class ObjectConverter(BaseConverter):
 
         total = len(object_names)
         processed = 0
+        sprite_scene_paths = self._get_available_sprite_scene_paths()
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             futures_map = {
-                executor.submit(self._process_object, name, object_subfolders.get(name, "")): name
+                executor.submit(self._process_object, name, object_subfolders.get(name, ""), sprite_scene_paths): name
                 for name in object_names
             }
             for future in as_completed(futures_map):

--- a/src/conversion/script_generator.py
+++ b/src/conversion/script_generator.py
@@ -1,5 +1,7 @@
+import json
 import re
 from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
 from typing import Callable, TypeAlias, cast
 
 from src.conversion.event_mapping import INPUT_MERGED_MAPPING, is_input_event, map_event
@@ -21,10 +23,80 @@ _is_input_event = cast(_IsInputEvent, is_input_event)
 
 
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SPRITE_RUNTIME_IDENTIFIER_RE = re.compile(r"\b(?:sprite_index|image_index)\b")
+_SCRIPT_BUILTIN_VARIABLES = frozenset({"sprite_index", "image_index"})
+_SPRITE_RUNTIME_RESERVED_NAMES = _SCRIPT_BUILTIN_VARIABLES | frozenset({
+    "AnimatedSprite2D",
+    "GMRuntime",
+    "Node2D",
+    "Sprite2D",
+    "_GM_SPRITE_SCENES",
+    "_gm_apply_image_index",
+    "_gm_apply_sprite_index",
+    "_gm_clear_current_sprite",
+    "_gm_current_sprite_scene_root",
+    "_gm_initialize_sprite_runtime",
+    "_gm_sprite_visual_node",
+})
+_GDSCRIPT_RESERVED_WORDS = frozenset({
+    "and",
+    "as",
+    "assert",
+    "await",
+    "break",
+    "class",
+    "class_name",
+    "const",
+    "continue",
+    "elif",
+    "else",
+    "enum",
+    "extends",
+    "false",
+    "for",
+    "func",
+    "if",
+    "in",
+    "is",
+    "match",
+    "not",
+    "null",
+    "or",
+    "pass",
+    "return",
+    "self",
+    "signal",
+    "static",
+    "super",
+    "true",
+    "var",
+    "void",
+    "while",
+})
+
+
+@dataclass(frozen=True)
+class SpriteRuntimeConfig:
+    initial_sprite_name: str | None = None
+    sprite_scene_paths: Mapping[str, str] | None = None
 
 
 def _uses_gml_runtime(code_bodies: _CodeBodies | None) -> bool:
     return any("GMRuntime." in body for body in (code_bodies or {}).values())
+
+
+def _uses_sprite_runtime(
+    sprite_runtime: SpriteRuntimeConfig | None,
+    code_bodies: _CodeBodies | None,
+) -> bool:
+    if sprite_runtime is None:
+        return False
+    if sprite_runtime.initial_sprite_name is not None:
+        return True
+    return any(
+        _SPRITE_RUNTIME_IDENTIFIER_RE.search(body) is not None
+        for body in (code_bodies or {}).values()
+    )
 
 
 def _get_function_body(func: EventMapping, code_bodies: _CodeBodies | None) -> str:
@@ -48,14 +120,142 @@ def _valid_instance_variables(instance_variables: Iterable[str] | None) -> list[
         return []
     return sorted(
         name for name in instance_variables
-        if _IDENTIFIER_RE.match(name)
+        if _IDENTIFIER_RE.match(name) and name not in _SCRIPT_BUILTIN_VARIABLES
     )
+
+
+def _is_valid_gdscript_identifier(name: str) -> bool:
+    return (
+        _IDENTIFIER_RE.match(name) is not None
+        and name not in _GDSCRIPT_RESERVED_WORDS
+        and name not in _SPRITE_RUNTIME_RESERVED_NAMES
+    )
+
+
+def _gd_string(value: str) -> str:
+    return json.dumps(value)
+
+
+def _emit_sprite_runtime_prelude(lines: list[str], sprite_runtime: SpriteRuntimeConfig) -> None:
+    sprite_scene_paths = dict(sprite_runtime.sprite_scene_paths or {})
+    sprite_constants = [
+        sprite_name for sprite_name in sorted(sprite_scene_paths)
+        if _is_valid_gdscript_identifier(sprite_name)
+    ]
+
+    if sprite_constants:
+        lines.append("\n\n")
+        for sprite_name in sprite_constants:
+            lines.append(f"const {sprite_name} = {_gd_string(sprite_name)}\n")
+
+    lines.append("\n\nconst _GM_SPRITE_SCENES = {")
+    for sprite_name, scene_path in sorted(sprite_scene_paths.items()):
+        lines.append(f"\n\t{_gd_string(sprite_name)}: preload({_gd_string(scene_path)}),")
+    lines.append("\n}\n")
+
+    initial_sprite = "null"
+    if sprite_runtime.initial_sprite_name is not None:
+        initial_sprite = _gd_string(sprite_runtime.initial_sprite_name)
+
+    lines.append(
+        f"\nvar sprite_index = {initial_sprite}:"
+        "\n\tset(value):"
+        "\n\t\tsprite_index = value"
+        "\n\t\t_gm_apply_sprite_index()"
+        "\n\nvar image_index = 0.0:"
+        "\n\tset(value):"
+        "\n\t\timage_index = value"
+        "\n\t\t_gm_apply_image_index()"
+        "\n\nfunc _gm_initialize_sprite_runtime():"
+        "\n\t_gm_apply_sprite_index()"
+        "\n\tif has_meta(\"gamemaker_image_index\"):"
+        "\n\t\timage_index = get_meta(\"gamemaker_image_index\")"
+        "\n\telse:"
+        "\n\t\t_gm_apply_image_index()"
+        "\n\nfunc _gm_apply_sprite_index():"
+        "\n\tif sprite_index == null:"
+        "\n\t\t_gm_clear_current_sprite()"
+        "\n\t\treturn"
+        "\n\tvar sprite_index_type = typeof(sprite_index)"
+        "\n\tif (sprite_index_type == TYPE_INT or sprite_index_type == TYPE_FLOAT) and int(sprite_index) == -1:"
+        "\n\t\t_gm_clear_current_sprite()"
+        "\n\t\treturn"
+        "\n\tvar sprite_name = str(sprite_index)"
+        "\n\tvar current = _gm_current_sprite_scene_root()"
+        "\n\tif current != null and str(current.name) == sprite_name:"
+        "\n\t\t_gm_apply_image_index()"
+        "\n\t\treturn"
+        "\n\tvar scene = _GM_SPRITE_SCENES.get(sprite_name)"
+        "\n\tif scene == null:"
+        "\n\t\t_gm_apply_image_index()"
+        "\n\t\treturn"
+        "\n\tif current != null:"
+        "\n\t\tremove_child(current)"
+        "\n\t\tcurrent.queue_free()"
+        "\n\tvar instance = scene.instantiate()"
+        "\n\tinstance.name = sprite_name"
+        "\n\tadd_child(instance)"
+        "\n\tmove_child(instance, 0)"
+        "\n\t_gm_apply_image_index()"
+        "\n\nfunc _gm_apply_image_index():"
+        "\n\tvar sprite_node = _gm_sprite_visual_node()"
+        "\n\tif sprite_node == null:"
+        "\n\t\treturn"
+        "\n\tvar frame_index = max(int(image_index), 0)"
+        "\n\tif sprite_node is AnimatedSprite2D:"
+        "\n\t\tvar frame_count = 0"
+        "\n\t\tif sprite_node.sprite_frames != null and sprite_node.sprite_frames.has_animation(sprite_node.animation):"
+        "\n\t\t\tframe_count = sprite_node.sprite_frames.get_frame_count(sprite_node.animation)"
+        "\n\t\tif frame_count > 0:"
+        "\n\t\t\tframe_index = min(frame_index, frame_count - 1)"
+        "\n\t\tsprite_node.frame = frame_index"
+        "\n\t\tsprite_node.frame_progress = 0.0"
+        "\n\t\treturn"
+        "\n\tif sprite_node is Sprite2D:"
+        "\n\t\tvar frame_count = sprite_node.hframes * sprite_node.vframes"
+        "\n\t\tif frame_count > 1:"
+        "\n\t\t\tsprite_node.frame = min(frame_index, frame_count - 1)"
+        "\n\nfunc _gm_current_sprite_scene_root():"
+        "\n\tfor child in get_children():"
+        "\n\t\tif str(child.name) in _GM_SPRITE_SCENES:"
+        "\n\t\t\treturn child"
+        "\n\t\tif child is Sprite2D or child is AnimatedSprite2D:"
+        "\n\t\t\treturn child"
+        "\n\t\tif child.find_child(\"AnimatedSprite2D\", true, false) != null:"
+        "\n\t\t\treturn child"
+        "\n\t\tif child.find_child(\"Sprite2D\", true, false) != null:"
+        "\n\t\t\treturn child"
+        "\n\treturn null"
+        "\n\nfunc _gm_sprite_visual_node():"
+        "\n\tvar current = _gm_current_sprite_scene_root()"
+        "\n\tif current == null:"
+        "\n\t\treturn null"
+        "\n\tif current is AnimatedSprite2D or current is Sprite2D:"
+        "\n\t\treturn current"
+        "\n\tvar animated_sprite = current.find_child(\"AnimatedSprite2D\", true, false)"
+        "\n\tif animated_sprite != null:"
+        "\n\t\treturn animated_sprite"
+        "\n\treturn current.find_child(\"Sprite2D\", true, false)"
+        "\n\nfunc _gm_clear_current_sprite():"
+        "\n\tvar current = _gm_current_sprite_scene_root()"
+        "\n\tif current != null:"
+        "\n\t\tremove_child(current)"
+        "\n\t\tcurrent.queue_free()\n"
+    )
+
+
+def _prepend_sprite_runtime_ready_body(body: str) -> str:
+    init_body = "\t_gm_initialize_sprite_runtime()"
+    if body.strip() == "pass":
+        return init_body
+    return f"{init_body}\n{body}"
 
 
 def generate_script_content(
     event_list: Sequence[JsonDict] | None,
     code_bodies: _CodeBodies | None = None,
     instance_variables: Iterable[str] | None = None,
+    sprite_runtime: SpriteRuntimeConfig | None = None,
 ) -> str:
     """Generate .gd script content with function stubs for each event.
 
@@ -70,17 +270,20 @@ def generate_script_content(
             seam where a future transpiler injects converted GML code.
         instance_variables: Optional iterable of GameMaker instance variable
             names to declare as GDScript member variables.
+        sprite_runtime: Optional sprite runtime configuration for GameMaker
+            sprite_index and image_index compatibility.
 
     Returns:
         Complete .gd file content as a string.
     """
-    if not event_list:
+    uses_sprite_runtime = _uses_sprite_runtime(sprite_runtime, code_bodies)
+    if not event_list and not uses_sprite_runtime:
         return "extends Node2D\n"
 
     functions: list[EventMapping] = []
     has_input = False
 
-    for event in event_list:
+    for event in event_list or []:
         if _is_input_event(event):
             has_input = True
             continue
@@ -94,6 +297,9 @@ def generate_script_content(
 
     unique_functions = _deduplicate_functions(functions)
     function_names = {func.godot_func for func in unique_functions}
+    if uses_sprite_runtime and "_ready" not in function_names:
+        unique_functions = _deduplicate_functions(unique_functions + [EventMapping("_ready", "", 0, "")])
+        function_names = {func.godot_func for func in unique_functions}
     script_features = get_script_features()
 
     for feature in script_features:
@@ -121,6 +327,8 @@ def generate_script_content(
         emit_prelude = cast(_EmitPrelude | None, getattr(feature, "emit_prelude", None))
         if emit_prelude is not None:
             emit_prelude(lines, function_names)
+    if uses_sprite_runtime and sprite_runtime is not None:
+        _emit_sprite_runtime_prelude(lines, sprite_runtime)
     for variable_name in _valid_instance_variables(instance_variables):
         lines.append(f"\n\nvar {variable_name}\n")
 
@@ -130,6 +338,8 @@ def generate_script_content(
             wrap_body = cast(_WrapBody | None, getattr(feature, "wrap_body", None))
             if wrap_body is not None:
                 body = wrap_body(func, body, function_names)
+        if uses_sprite_runtime and func.godot_func == "_ready":
+            body = _prepend_sprite_runtime_ready_body(body)
         lines.append(f"\n\nfunc {func.godot_func}({func.params}):")
         lines.append(f"\n{body}\n")
 

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -218,6 +218,19 @@ class TestGMLStatementTranspiler(unittest.TestCase):
         )
         self.assertEqual(instance_variables, {"superSpeed"})
 
+    def test_sprite_builtins_are_not_collected_instance_variables(self):
+        instance_variables: set[str] = set()
+
+        self.assertEqual(
+            transpile_gml_code(
+                "sprite_index = s_enemy; image_index = 2; image_index += 1;",
+                indent="",
+                instance_variables=instance_variables,
+            ),
+            "sprite_index = s_enemy\nimage_index = 2\nimage_index += 1",
+        )
+        self.assertEqual(instance_variables, set())
+
     def test_transpiles_current_simple_topdown_step_body(self):
         source = """
         if keyboard_check(vk_shift) {

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -611,6 +611,39 @@ class TestScriptGeneration(unittest.TestCase):
         self.assertIn("\t\tposition.x -= superSpeed", content)
         self.assertNotIn("Could not transpile", "\n".join(str(msg) for msg in self.logs))
 
+    def test_script_supports_sprite_and_image_index(self):
+        """sprite_index and image_index should map to generated sprite runtime state."""
+        self._setup_object(
+            "o_player",
+            sprite_name="s_player",
+            event_list=[{"eventType": 0, "eventNum": 0}],
+        )
+        _create_fake_sprite_scene(self.godot_dir, "s_enemy")
+        source_path = os.path.join(self.gm_dir, "objects", "o_player", "Create_0.gml")
+        with open(source_path, "w", encoding="utf-8") as f:
+            f.write("image_index = 2; sprite_index = s_enemy;")
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        gd_path = os.path.join(self.godot_dir, "objects", "o_player", "o_player.gd")
+        with open(gd_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        self.assertIn('const s_enemy = "s_enemy"', content)
+        self.assertIn('const s_player = "s_player"', content)
+        self.assertIn('"s_enemy": preload("res://sprites/s_enemy/s_enemy.tscn")', content)
+        self.assertIn('"s_player": preload("res://sprites/s_player/s_player.tscn")', content)
+        self.assertIn('var sprite_index = "s_player":', content)
+        self.assertIn('var image_index = 0.0:', content)
+        self.assertIn('func _gm_apply_sprite_index():', content)
+        self.assertIn('func _gm_apply_image_index():', content)
+        self.assertIn('if has_meta("gamemaker_image_index"):', content)
+        self.assertIn("\t_gm_initialize_sprite_runtime()\n\timage_index = 2", content)
+        self.assertIn("\tsprite_index = s_enemy", content)
+        self.assertNotIn("\n\nvar image_index\n", content)
+        self.assertNotIn("\n\nvar sprite_index\n", content)
+
     def test_script_with_begin_step(self):
         """eventType 3, eventNum 1 should produce func _physics_process(delta)."""
         self._setup_object("o_test", event_list=[{"eventType": 3, "eventNum": 1}])

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -6,7 +6,7 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
-from src.conversion.script_generator import generate_script_content
+from src.conversion.script_generator import SpriteRuntimeConfig, generate_script_content
 
 
 class TestScriptGeneratorBasic(unittest.TestCase):
@@ -274,6 +274,49 @@ class TestScriptGeneratorCodeBodies(unittest.TestCase):
             code_bodies={},
         )
         self.assertIn("\tpass", content)
+
+
+class TestScriptGeneratorSpriteRuntime(unittest.TestCase):
+    """GameMaker sprite_index and image_index runtime support."""
+
+    def test_sprite_runtime_generates_ready_and_helpers_without_events(self):
+        content = generate_script_content(
+            [],
+            sprite_runtime=SpriteRuntimeConfig(
+                initial_sprite_name="s_player",
+                sprite_scene_paths={
+                    "s_enemy": "res://sprites/s_enemy/s_enemy.tscn",
+                    "s_player": "res://sprites/s_player/s_player.tscn",
+                },
+            ),
+        )
+
+        self.assertIn('const s_enemy = "s_enemy"', content)
+        self.assertIn('const s_player = "s_player"', content)
+        self.assertIn('"s_enemy": preload("res://sprites/s_enemy/s_enemy.tscn")', content)
+        self.assertIn('var sprite_index = "s_player":', content)
+        self.assertIn('var image_index = 0.0:', content)
+        self.assertIn('func _gm_apply_sprite_index():', content)
+        self.assertIn('func _gm_apply_image_index():', content)
+        self.assertIn('if has_meta("gamemaker_image_index"):', content)
+        self.assertIn('func _ready():\n\t_gm_initialize_sprite_runtime()', content)
+
+    def test_sprite_runtime_uses_gml_body_without_duplicate_builtin_vars(self):
+        content = generate_script_content(
+            [{"eventType": 0, "eventNum": 0}],
+            code_bodies={"_ready": "\timage_index = 2\n\tsprite_index = s_enemy"},
+            instance_variables={"image_index", "score", "sprite_index"},
+            sprite_runtime=SpriteRuntimeConfig(
+                sprite_scene_paths={"s_enemy": "res://sprites/s_enemy/s_enemy.tscn"},
+            ),
+        )
+
+        self.assertIn('const s_enemy = "s_enemy"', content)
+        self.assertIn("\t_gm_initialize_sprite_runtime()\n\timage_index = 2", content)
+        self.assertIn("\tsprite_index = s_enemy", content)
+        self.assertIn("\n\nvar score\n", content)
+        self.assertNotIn("\n\nvar image_index\n", content)
+        self.assertNotIn("\n\nvar sprite_index\n", content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add generated object-script runtime support for GameMaker `sprite_index` and `image_index`.
- Map converted sprite scenes into generated scripts so `sprite_index = s_name` can swap visuals and `image_index` can select sprite frames.
- Keep these GameMaker built-ins out of generic instance variable declarations and add focused tests.

## Tests
- `./venv/bin/pyright --warnings`
- `./venv/bin/python -m unittest tests.test_gml_transpiler tests.test_script_generator tests.test_objects`
- `./venv/bin/python -m unittest`

Closes #305
Refs #129