### PR TITLE
Add GML runtime value helpers

### DIFF
--- a/src/conversion/gml_runtime.py
+++ b/src/conversion/gml_runtime.py
@@ -6,56 +6,95 @@ GML_RUNTIME_RESOURCE_PATH = "res://gm2godot/gml_runtime.gd"
 
 GML_RUNTIME_SCRIPT = """extends RefCounted
 
+const GML_TYPE_UNDEFINED = "undefined"
+const GML_TYPE_BOOL = "bool"
+const GML_TYPE_NUMBER = "number"
+const GML_TYPE_STRING = "string"
+const GML_TYPE_ARRAY = "array"
+const GML_TYPE_STRUCT = "struct"
+const GML_TYPE_METHOD = "method"
+const GML_TYPE_UNKNOWN = "unknown"
+
+
+static func gml_undefined():
+	return null
+
+
+static func is_undefined(value):
+	return value == null
+
+
+static func is_number(value):
+	var value_type = typeof(value)
+	return value_type == TYPE_INT or value_type == TYPE_FLOAT
+
+
+static func is_nan_value(value):
+	return is_number(value) and is_nan(float(value))
+
+
+static func is_infinity(value):
+	return is_number(value) and is_inf(float(value))
+
+
 static func gml_div(left, right):
 	return float(left) / float(right)
 
 
-static func is_infinity(value):
-	return _is_number(value) and is_inf(float(value))
+static func gml_eq(left, right):
+	if is_undefined(left) or is_undefined(right):
+		return is_undefined(left) and is_undefined(right)
+	if is_nan_value(left) or is_nan_value(right):
+		return false
+	return left == right
+
+
+static func gml_ne(left, right):
+	return not gml_eq(left, right)
 
 
 static func gml_typeof(value):
+	if is_undefined(value):
+		return GML_TYPE_UNDEFINED
 	var value_type = typeof(value)
-	if value_type == TYPE_NIL:
-		return "undefined"
 	if value_type == TYPE_BOOL:
-		return "bool"
+		return GML_TYPE_BOOL
 	if value_type == TYPE_INT or value_type == TYPE_FLOAT:
-		return "number"
+		return GML_TYPE_NUMBER
 	if value_type == TYPE_STRING or value_type == TYPE_STRING_NAME:
-		return "string"
+		return GML_TYPE_STRING
 	if value_type == TYPE_ARRAY:
-		return "array"
+		return GML_TYPE_ARRAY
 	if value_type == TYPE_DICTIONARY:
-		return "struct"
+		return GML_TYPE_STRUCT
 	if value_type == TYPE_CALLABLE:
-		return "method"
+		return GML_TYPE_METHOD
 	if value_type == TYPE_OBJECT:
-		return "struct"
-	return "unknown"
+		return GML_TYPE_STRUCT
+	return GML_TYPE_UNKNOWN
 
 
 static func gml_string(value):
+	if is_undefined(value):
+		return GML_TYPE_UNDEFINED
 	if is_infinity(value):
 		return "-infinity" if float(value) < 0.0 else "infinity"
-	if _is_nan_number(value):
+	if is_nan_value(value):
 		return "NaN"
 	return str(value)
 
 
 static func gml_bool(value):
-	if _is_number(value):
+	if is_undefined(value):
+		return false
+	if is_number(value):
 		return float(value) > 0.5
 	return bool(value)
 
 
-static func _is_number(value):
-	var value_type = typeof(value)
-	return value_type == TYPE_INT or value_type == TYPE_FLOAT
-
-
-static func _is_nan_number(value):
-	return _is_number(value) and is_nan(float(value))
+static func gml_error(message):
+	push_error("GML runtime error: " + gml_string(message))
+	return gml_undefined()
 """
 
 

--- a/src/conversion/gml_transpiler.py
+++ b/src/conversion/gml_transpiler.py
@@ -175,7 +175,7 @@ _NAME_REPLACEMENTS = {
     "infinity": "INF",
     "NaN": "NAN",
     "nan": "NAN",
-    "undefined": "null",
+    "undefined": "GMRuntime.gml_undefined()",
 }
 
 _INSTANCE_NAME_REPLACEMENTS = {
@@ -202,6 +202,8 @@ _VIRTUAL_KEY_CONSTANTS = {
 
 _RUNTIME_FUNCTIONS = {
     "is_infinity": "is_infinity",
+    "is_nan": "is_nan_value",
+    "is_undefined": "is_undefined",
     "typeof": "gml_typeof",
     "string": "gml_string",
     "bool": "gml_bool",
@@ -710,7 +712,7 @@ def _emit_binary(expr: _Binary, local_names: Iterable[str]) -> tuple[str, int]:
     if expr.operator == "??":
         left = _emit_expression(expr.left, local_names)[0]
         right = _emit_child(expr.right, _TERNARY_PRECEDENCE, local_names=local_names)
-        return f"{left} if {left} != null else {right}", _TERNARY_PRECEDENCE
+        return f"{left} if not GMRuntime.is_undefined({left}) else {right}", _TERNARY_PRECEDENCE
 
     if expr.operator == "/":
         left = _emit_expression(expr.left, local_names)[0]
@@ -850,7 +852,7 @@ def _transpile_statement(
         target = transpile_gml_expression(target, local_names)
         value = transpile_gml_expression(value, local_names)
         if operator == "??=":
-            return [f"if {target} == null:", f"\t{target} = {value}"]
+            return [f"if GMRuntime.is_undefined({target}):", f"\t{target} = {value}"]
         if operator == "/=":
             return [f"{target} = GMRuntime.gml_div({target}, {value})"]
         return [f"{target} {operator} {value}"]

--- a/src/conversion/resource_index.py
+++ b/src/conversion/resource_index.py
@@ -343,7 +343,7 @@ class GameMakerResourceIndex(BaseConverter):
         for child_layer in self._dict_items_copy(child_layers):
             key = self._item_key(child_layer)
             if key and key in by_key:
-                parent_layer = cast(JsonDict, merged[by_key[key]])
+                parent_layer = merged[by_key[key]]
                 merged[by_key[key]] = self._merge_layer(parent_layer, child_layer)
             else:
                 merged.append(child_layer)
@@ -380,7 +380,7 @@ class GameMakerResourceIndex(BaseConverter):
         for child_item in self._dict_items_copy(child_items):
             key = self._item_key(child_item)
             if key and key in by_key:
-                parent_item = cast(JsonDict, merged[by_key[key]])
+                parent_item = merged[by_key[key]]
                 merged_item = copy.deepcopy(parent_item)
                 merged_item.update(copy.deepcopy(child_item))
                 merged[by_key[key]] = merged_item
@@ -422,7 +422,8 @@ class GameMakerResourceIndex(BaseConverter):
             if isinstance(value, str) and value:
                 return value
             if isinstance(value, dict):
-                name = value.get("name")
+                nested_value = cast(JsonDict, value)
+                name = nested_value.get("name")
                 if isinstance(name, str) and name:
                     return name
         return ""

--- a/src/conversion/room_layers.py
+++ b/src/conversion/room_layers.py
@@ -440,8 +440,10 @@ def _tile_map_layer_lines(
     width = _coerce_int(tiles.get("SerialiseWidth", 0))
     height = _coerce_int(tiles.get("SerialiseHeight", 0))
     tile_data_format = _coerce_int(tiles.get("TileDataFormat", 1))
-    compressed_data_value = tiles.get("TileCompressedData") or []
-    compressed_data = cast(list[JsonValue], compressed_data_value) if isinstance(compressed_data_value, list) else []
+    raw_compressed_data = tiles.get("TileCompressedData")
+    compressed_data: list[JsonValue] = []
+    if isinstance(raw_compressed_data, list):
+        compressed_data = cast(list[JsonValue], raw_compressed_data)
 
     try:
         decoded_tiles = decode_tile_compressed_data(

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -1,0 +1,85 @@
+import os
+import sys
+import tempfile
+import unittest
+from dataclasses import dataclass
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.gml_runtime import GML_RUNTIME_RELATIVE_PATH, GML_RUNTIME_SCRIPT, write_gml_runtime
+from src.conversion.gml_transpiler import transpile_gml_expression
+
+
+@dataclass(frozen=True)
+class RuntimeValueParityCase:
+    gml_expression: str
+    gdscript_expression: str
+
+
+RUNTIME_VALUE_PARITY_CASES = (
+    RuntimeValueParityCase("undefined", "GMRuntime.gml_undefined()"),
+    RuntimeValueParityCase("typeof(undefined)", "GMRuntime.gml_typeof(GMRuntime.gml_undefined())"),
+    RuntimeValueParityCase("string(undefined)", "GMRuntime.gml_string(GMRuntime.gml_undefined())"),
+    RuntimeValueParityCase("bool(undefined)", "GMRuntime.gml_bool(GMRuntime.gml_undefined())"),
+    RuntimeValueParityCase(
+        "is_undefined(undefined)",
+        "GMRuntime.is_undefined(GMRuntime.gml_undefined())",
+    ),
+    RuntimeValueParityCase("is_nan(NaN)", "GMRuntime.is_nan_value(NAN)"),
+    RuntimeValueParityCase(
+        "score ?? fallback",
+        "score if not GMRuntime.is_undefined(score) else fallback",
+    ),
+)
+
+
+class TestGMLRuntimeScript(unittest.TestCase):
+    def test_runtime_defines_shared_value_helpers(self):
+        for helper_name in (
+            "gml_undefined",
+            "is_undefined",
+            "is_number",
+            "is_nan_value",
+            "is_infinity",
+            "gml_eq",
+            "gml_ne",
+            "gml_typeof",
+            "gml_string",
+            "gml_bool",
+        ):
+            self.assertIn(f"static func {helper_name}", GML_RUNTIME_SCRIPT)
+
+    def test_runtime_helpers_keep_variant_backed_parameters(self):
+        self.assertIn("static func gml_typeof(value):", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_bool(value):", GML_RUNTIME_SCRIPT)
+        self.assertNotIn("static func gml_typeof(value:", GML_RUNTIME_SCRIPT)
+        self.assertNotIn("static func gml_bool(value:", GML_RUNTIME_SCRIPT)
+
+    def test_runtime_centralizes_error_reporting(self):
+        self.assertIn("static func gml_error(message):", GML_RUNTIME_SCRIPT)
+        self.assertIn("push_error", GML_RUNTIME_SCRIPT)
+        self.assertIn("return gml_undefined()", GML_RUNTIME_SCRIPT)
+
+    def test_write_gml_runtime_writes_support_script(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runtime_path = write_gml_runtime(tmpdir)
+
+            self.assertEqual(runtime_path, os.path.join(tmpdir, GML_RUNTIME_RELATIVE_PATH))
+            with open(runtime_path, encoding="utf-8") as runtime_file:
+                self.assertEqual(runtime_file.read(), GML_RUNTIME_SCRIPT)
+
+
+class TestGMLRuntimeParityFixtures(unittest.TestCase):
+    def test_runtime_value_expression_fixtures(self):
+        for parity_case in RUNTIME_VALUE_PARITY_CASES:
+            with self.subTest(gml_expression=parity_case.gml_expression):
+                self.assertEqual(
+                    transpile_gml_expression(parity_case.gml_expression),
+                    parity_case.gdscript_expression,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -53,7 +53,7 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
         )
         self.assertEqual(
             transpile_gml_expression("infinity == undefined"),
-            "INF == null",
+            "INF == GMRuntime.gml_undefined()",
         )
 
     def test_transpiles_single_equals_as_expression_equality(self):
@@ -80,6 +80,20 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
             "GMRuntime.gml_bool(INF)",
         )
 
+    def test_transpiles_shared_value_helpers(self):
+        self.assertEqual(
+            transpile_gml_expression("undefined"),
+            "GMRuntime.gml_undefined()",
+        )
+        self.assertEqual(
+            transpile_gml_expression("is_undefined(undefined)"),
+            "GMRuntime.is_undefined(GMRuntime.gml_undefined())",
+        )
+        self.assertEqual(
+            transpile_gml_expression("is_nan(NaN)"),
+            "GMRuntime.is_nan_value(NAN)",
+        )
+
     def test_transpiles_bitwise_operators(self):
         self.assertEqual(
             transpile_gml_expression("flags & mask | 4"),
@@ -90,7 +104,7 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
     def test_transpiles_nullish_operator(self):
         self.assertEqual(
             transpile_gml_expression("value ?? fallback"),
-            "value if value != null else fallback",
+            "value if not GMRuntime.is_undefined(value) else fallback",
         )
 
     def test_transpiles_ternary_operator(self):
@@ -140,7 +154,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
     def test_transpiles_nullish_assignment(self):
         self.assertEqual(
             transpile_gml_code("score ??= 10;", indent=""),
-            "if score == null:\n\tscore = 10",
+            "if GMRuntime.is_undefined(score):\n\tscore = 10",
         )
 
     def test_transpiles_increment_decrement_statements(self):
@@ -150,7 +164,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
     def test_transpiles_expression_statements(self):
         self.assertEqual(
             transpile_gml_code("show_debug_message(score ?? 0);", indent=""),
-            "show_debug_message(score if score != null else 0)",
+            "show_debug_message(score if not GMRuntime.is_undefined(score) else 0)",
         )
 
     def test_local_vars_shadow_instance_position_builtins(self):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -511,7 +511,7 @@ class TestScriptGeneration(unittest.TestCase):
 
         self.assertIn("func _ready():", content)
         self.assertIn("\tvar speed = base_speed * 2", content)
-        self.assertIn("\tif score == null:\n\t\tscore = 0", content)
+        self.assertIn("\tif GMRuntime.is_undefined(score):\n\t\tscore = 0", content)
         self.assertIn("\tscore += int(speed / 2)", content)
         self.assertNotIn("\tpass", content)
 


### PR DESCRIPTION
## Summary
- Adds shared GMRuntime helpers for GML undefined, type checks, string/bool conversion, equality, and centralized runtime errors.
- Routes undefined and nullish transpiler output through GMRuntime instead of raw null checks.
- Adds runtime value parity fixtures and keeps pyright clean with minimal typing fixes.

## Verification
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest

Closes #337
Closes #357
Closes #358
Closes #359
Closes #360