### PR TITLE
Add GML boolean semantics

### DIFF
--- a/src/conversion/gml_runtime.py
+++ b/src/conversion/gml_runtime.py
@@ -24,6 +24,10 @@ static func is_undefined(value):
 	return value == null
 
 
+static func is_bool(value):
+	return typeof(value) == TYPE_BOOL
+
+
 static func is_number(value):
 	var value_type = typeof(value)
 	return value_type == TYPE_INT or value_type == TYPE_FLOAT

--- a/src/conversion/gml_transpiler.py
+++ b/src/conversion/gml_transpiler.py
@@ -101,6 +101,7 @@ _MULTI_CHAR_OPERATORS = (
     "!=",
     "&&",
     "||",
+    "^^",
     "++",
     "--",
     "+=",
@@ -134,6 +135,7 @@ _BINARY_PRECEDENCE = {
     "??": 10,
     "or": 20,
     "||": 20,
+    "^^": 20,
     "and": 30,
     "&&": 30,
     "|": 40,
@@ -163,6 +165,30 @@ _PRIMARY_PRECEDENCE = 130
 _TERNARY_PRECEDENCE = 5
 
 _RIGHT_ASSOCIATIVE = {"??"}
+
+_BOOLEAN_RESULT_BINARY_OPERATORS = frozenset({
+    "&&",
+    "||",
+    "^^",
+    "and",
+    "or",
+    "=",
+    "==",
+    "!=",
+    "<",
+    "<=",
+    ">",
+    ">=",
+})
+
+_BOOLEAN_RESULT_FUNCTIONS = frozenset({
+    "bool",
+    "is_bool",
+    "is_infinity",
+    "is_nan",
+    "is_undefined",
+    "keyboard_check",
+})
 
 _OPERATOR_REPLACEMENTS = {
     "&&": "and",
@@ -201,6 +227,7 @@ _VIRTUAL_KEY_CONSTANTS = {
 }
 
 _RUNTIME_FUNCTIONS = {
+    "is_bool": "is_bool",
     "is_infinity": "is_infinity",
     "is_nan": "is_nan_value",
     "is_undefined": "is_undefined",
@@ -215,6 +242,13 @@ def transpile_gml_expression(source: str, local_names: Iterable[str] | None = No
     parser = _ExpressionParser(_expression_tokens(source))
     expr = parser.parse()
     return _emit_expression(expr, _normalize_local_names(local_names))[0]
+
+
+def transpile_gml_condition(source: str, local_names: Iterable[str] | None = None) -> str:
+    """Transpile a GML condition using GameMaker truthiness semantics."""
+    parser = _ExpressionParser(_expression_tokens(source))
+    expr = parser.parse()
+    return _emit_truthy_expression(expr, _normalize_local_names(local_names))
 
 
 def transpile_gml_code(
@@ -412,7 +446,7 @@ class _StatementParser:
         if not condition_tokens:
             raise GMLTranspileError("Expected if condition")
 
-        condition = transpile_gml_expression(
+        condition = transpile_gml_condition(
             _tokens_to_source(condition_tokens),
             local_names=self.local_names,
         )
@@ -656,16 +690,16 @@ def _emit_expression(
     if isinstance(expr, _Grouped):
         return f"({_emit_expression(expr.expr, local_names)[0]})", _PRIMARY_PRECEDENCE
     if isinstance(expr, _Unary):
-        operand = _emit_child(expr.operand, _UNARY_PRECEDENCE, local_names=local_names)
         if expr.operator == "!":
-            return f"not {operand}", _UNARY_PRECEDENCE
+            return f"not {_emit_truthy_expression(expr.operand, local_names)}", _UNARY_PRECEDENCE
         if expr.operator == "not":
-            return f"not {operand}", _UNARY_PRECEDENCE
+            return f"not {_emit_truthy_expression(expr.operand, local_names)}", _UNARY_PRECEDENCE
+        operand = _emit_child(expr.operand, _UNARY_PRECEDENCE, local_names=local_names)
         return f"{expr.operator}{operand}", _UNARY_PRECEDENCE
     if isinstance(expr, _Binary):
         return _emit_binary(expr, local_names)
     if isinstance(expr, _Ternary):
-        condition = _emit_child(expr.condition, _TERNARY_PRECEDENCE, local_names=local_names)
+        condition = _emit_truthy_expression(expr.condition, local_names)
         true_expr = _emit_child(expr.true_expr, _TERNARY_PRECEDENCE, local_names=local_names)
         false_expr = _emit_child(expr.false_expr, _TERNARY_PRECEDENCE, local_names=local_names)
         return f"{true_expr} if {condition} else {false_expr}", _TERNARY_PRECEDENCE
@@ -704,6 +738,17 @@ def _emit_builtin_call(expr: _Call, local_names: Iterable[str]) -> str | None:
 def _emit_binary(expr: _Binary, local_names: Iterable[str]) -> tuple[str, int]:
     operator = _OPERATOR_REPLACEMENTS.get(expr.operator, expr.operator)
 
+    if expr.operator in ("&&", "and", "||", "or"):
+        operator = "and" if expr.operator in ("&&", "and") else "or"
+        left = _emit_truthy_expression(expr.left, local_names)
+        right = _emit_truthy_expression(expr.right, local_names)
+        return f"{left} {operator} {right}", _BINARY_PRECEDENCE[expr.operator]
+
+    if expr.operator == "^^":
+        left = _emit_truthy_expression(expr.left, local_names)
+        right = _emit_truthy_expression(expr.right, local_names)
+        return f"{left} != {right}", _BINARY_PRECEDENCE[expr.operator]
+
     if expr.operator == "div":
         left = _emit_expression(expr.left, local_names)[0]
         right = _emit_expression(expr.right, local_names)[0]
@@ -729,6 +774,30 @@ def _emit_binary(expr: _Binary, local_names: Iterable[str]) -> tuple[str, int]:
         local_names=local_names,
     )
     return f"{left} {operator} {right}", precedence
+
+
+def _emit_truthy_expression(expr: _Expression, local_names: Iterable[str]) -> str:
+    if _emits_boolean_result(expr):
+        return _emit_expression(expr, local_names)[0]
+    return _gml_bool_call(_emit_expression(expr, local_names)[0])
+
+
+def _emits_boolean_result(expr: _Expression) -> bool:
+    if isinstance(expr, _Name):
+        return expr.value in ("true", "false")
+    if isinstance(expr, _Grouped):
+        return _emits_boolean_result(expr.expr)
+    if isinstance(expr, _Unary):
+        return expr.operator in ("!", "not")
+    if isinstance(expr, _Binary):
+        return expr.operator in _BOOLEAN_RESULT_BINARY_OPERATORS
+    if isinstance(expr, _Call) and isinstance(expr.callee, _Name):
+        return expr.callee.value in _BOOLEAN_RESULT_FUNCTIONS
+    return False
+
+
+def _gml_bool_call(expression: str) -> str:
+    return f"GMRuntime.gml_bool({expression})"
 
 
 def _emit_child(

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -23,11 +23,19 @@ RUNTIME_VALUE_PARITY_CASES = (
     RuntimeValueParityCase("typeof(undefined)", "GMRuntime.gml_typeof(GMRuntime.gml_undefined())"),
     RuntimeValueParityCase("string(undefined)", "GMRuntime.gml_string(GMRuntime.gml_undefined())"),
     RuntimeValueParityCase("bool(undefined)", "GMRuntime.gml_bool(GMRuntime.gml_undefined())"),
+    RuntimeValueParityCase("bool(0.5)", "GMRuntime.gml_bool(0.5)"),
+    RuntimeValueParityCase("bool(0.50001)", "GMRuntime.gml_bool(0.50001)"),
+    RuntimeValueParityCase("is_bool(true)", "GMRuntime.is_bool(true)"),
     RuntimeValueParityCase(
         "is_undefined(undefined)",
         "GMRuntime.is_undefined(GMRuntime.gml_undefined())",
     ),
     RuntimeValueParityCase("is_nan(NaN)", "GMRuntime.is_nan_value(NAN)"),
+    RuntimeValueParityCase("!0.5", "not GMRuntime.gml_bool(0.5)"),
+    RuntimeValueParityCase(
+        "0.25 || 1",
+        "GMRuntime.gml_bool(0.25) or GMRuntime.gml_bool(1)",
+    ),
     RuntimeValueParityCase(
         "score ?? fallback",
         "score if not GMRuntime.is_undefined(score) else fallback",
@@ -40,6 +48,7 @@ class TestGMLRuntimeScript(unittest.TestCase):
         for helper_name in (
             "gml_undefined",
             "is_undefined",
+            "is_bool",
             "is_number",
             "is_nan_value",
             "is_infinity",

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -17,11 +17,15 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
     def test_transpiles_logical_operators(self):
         self.assertEqual(
             transpile_gml_expression("a && !b || c"),
-            "a and not b or c",
+            "GMRuntime.gml_bool(a) and not GMRuntime.gml_bool(b) or GMRuntime.gml_bool(c)",
         )
         self.assertEqual(
             transpile_gml_expression("a and not b or c"),
-            "a and not b or c",
+            "GMRuntime.gml_bool(a) and not GMRuntime.gml_bool(b) or GMRuntime.gml_bool(c)",
+        )
+        self.assertEqual(
+            transpile_gml_expression("a ^^ b"),
+            "GMRuntime.gml_bool(a) != GMRuntime.gml_bool(b)",
         )
 
     def test_transpiles_div_and_mod(self):
@@ -94,6 +98,18 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
             "GMRuntime.is_nan_value(NAN)",
         )
 
+    def test_transpiles_boolean_value_helpers(self):
+        self.assertEqual(transpile_gml_expression("true"), "true")
+        self.assertEqual(transpile_gml_expression("false"), "false")
+        self.assertEqual(
+            transpile_gml_expression("bool(0.5)"),
+            "GMRuntime.gml_bool(0.5)",
+        )
+        self.assertEqual(
+            transpile_gml_expression("is_bool(true)"),
+            "GMRuntime.is_bool(true)",
+        )
+
     def test_transpiles_bitwise_operators(self):
         self.assertEqual(
             transpile_gml_expression("flags & mask | 4"),
@@ -110,7 +126,7 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
     def test_transpiles_ternary_operator(self):
         self.assertEqual(
             transpile_gml_expression("alive ? speed : 0"),
-            "speed if alive else 0",
+            "speed if GMRuntime.gml_bool(alive) else 0",
         )
 
     def test_transpiles_calls_indexes_and_members(self):
@@ -183,6 +199,16 @@ class TestGMLStatementTranspiler(unittest.TestCase):
         self.assertEqual(
             transpile_gml_code("if faster = true { superSpeed = 20 }", indent=""),
             "if faster == true:\n\tsuperSpeed = 20",
+        )
+
+    def test_transpiles_if_conditions_with_gml_numeric_truthiness(self):
+        self.assertEqual(
+            transpile_gml_code("if score { score = 1; }", indent=""),
+            "if GMRuntime.gml_bool(score):\n\tscore = 1",
+        )
+        self.assertEqual(
+            transpile_gml_code("if 0.5 { score = 1; }", indent=""),
+            "if GMRuntime.gml_bool(0.5):\n\tscore = 1",
         )
 
     def test_transpiles_shift_keyboard_check(self):


### PR DESCRIPTION
## Summary
- Adds `GMRuntime.is_bool` and maps GML `is_bool()` through the shared runtime layer.
- Lowers GML boolean contexts through GameMaker truthiness, including numeric conditions, unary `!`/`not`, ternary conditions, and logical `&&`, `||`, `and`, `or`, and `^^`.
- Adds focused runtime/transpiler parity fixtures for boolean constants, conversion, predicates, numeric truthiness, and logical operators.

## Docs
- Used Context7 Godot docs for GDScript boolean operators, short-circuiting, ternary expressions, `typeof()`, and Variant type constants.
- Used Context7 GameMaker manual docs for `bool()`, `is_bool()`, if/else truthiness, and logical operator behavior.

## Verification
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest tests.test_gml_runtime tests.test_gml_transpiler tests.test_script_generator tests.test_objects
- ./venv/bin/python -m unittest

Closes #339
Closes #366
Closes #367
Closes #368
Closes #369