### PR TITLE
Add GML integer division runtime lowering

### DIFF
--- a/src/conversion/gml_runtime.py
+++ b/src/conversion/gml_runtime.py
@@ -45,6 +45,10 @@ static func gml_div(left, right):
 	return float(left) / float(right)
 
 
+static func gml_int_div(left, right):
+	return int(float(left) / float(right))
+
+
 static func gml_eq(left, right):
 	if is_undefined(left) or is_undefined(right):
 		return is_undefined(left) and is_undefined(right)

--- a/src/conversion/gml_transpiler.py
+++ b/src/conversion/gml_transpiler.py
@@ -752,7 +752,7 @@ def _emit_binary(expr: _Binary, local_names: Iterable[str]) -> tuple[str, int]:
     if expr.operator == "div":
         left = _emit_expression(expr.left, local_names)[0]
         right = _emit_expression(expr.right, local_names)[0]
-        return f"int({left} / {right})", _PRIMARY_PRECEDENCE
+        return f"GMRuntime.gml_int_div({left}, {right})", _POSTFIX_PRECEDENCE
 
     if expr.operator == "??":
         left = _emit_expression(expr.left, local_names)[0]

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -31,6 +31,8 @@ RUNTIME_VALUE_PARITY_CASES = (
         "GMRuntime.is_undefined(GMRuntime.gml_undefined())",
     ),
     RuntimeValueParityCase("is_nan(NaN)", "GMRuntime.is_nan_value(NAN)"),
+    RuntimeValueParityCase("5 / 2", "GMRuntime.gml_div(5, 2)"),
+    RuntimeValueParityCase("5 div 2", "GMRuntime.gml_int_div(5, 2)"),
     RuntimeValueParityCase("!0.5", "not GMRuntime.gml_bool(0.5)"),
     RuntimeValueParityCase(
         "0.25 || 1",
@@ -54,6 +56,8 @@ class TestGMLRuntimeScript(unittest.TestCase):
             "is_infinity",
             "gml_eq",
             "gml_ne",
+            "gml_div",
+            "gml_int_div",
             "gml_typeof",
             "gml_string",
             "gml_bool",

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -29,10 +29,17 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
         )
 
     def test_transpiles_div_and_mod(self):
-        self.assertEqual(transpile_gml_expression("score div 10"), "int(score / 10)")
+        self.assertEqual(
+            transpile_gml_expression("score div 10"),
+            "GMRuntime.gml_int_div(score, 10)",
+        )
         self.assertEqual(transpile_gml_expression("score mod 3"), "score % 3")
 
     def test_transpiles_runtime_safe_real_division(self):
+        self.assertEqual(
+            transpile_gml_expression("5 / 2"),
+            "GMRuntime.gml_div(5, 2)",
+        )
         self.assertEqual(
             transpile_gml_expression("1 / 0"),
             "GMRuntime.gml_div(1, 0)",
@@ -40,6 +47,16 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
         self.assertEqual(
             transpile_gml_expression("a / b + c"),
             "GMRuntime.gml_div(a, b) + c",
+        )
+
+    def test_transpiles_integer_division_through_runtime(self):
+        self.assertEqual(
+            transpile_gml_expression("5 div 2"),
+            "GMRuntime.gml_int_div(5, 2)",
+        )
+        self.assertEqual(
+            transpile_gml_expression("a div b + c"),
+            "GMRuntime.gml_int_div(a, b) + c",
         )
 
     def test_transpiles_infinity_and_nan_constants(self):
@@ -209,6 +226,10 @@ class TestGMLStatementTranspiler(unittest.TestCase):
         self.assertEqual(
             transpile_gml_code("if 0.5 { score = 1; }", indent=""),
             "if GMRuntime.gml_bool(0.5):\n\tscore = 1",
+        )
+        self.assertEqual(
+            transpile_gml_code("if score div 2 { score = 1; }", indent=""),
+            "if GMRuntime.gml_bool(GMRuntime.gml_int_div(score, 2)):\n\tscore = 1",
         )
 
     def test_transpiles_shift_keyboard_check(self):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -512,7 +512,7 @@ class TestScriptGeneration(unittest.TestCase):
         self.assertIn("func _ready():", content)
         self.assertIn("\tvar speed = base_speed * 2", content)
         self.assertIn("\tif GMRuntime.is_undefined(score):\n\t\tscore = 0", content)
-        self.assertIn("\tscore += int(speed / 2)", content)
+        self.assertIn("\tscore += GMRuntime.gml_int_div(speed, 2)", content)
         self.assertNotIn("\tpass", content)
 
     def test_script_transpiles_infinity_runtime_support(self):


### PR DESCRIPTION
## Summary
- Adds `GMRuntime.gml_int_div()` so GML `div` does not rely on raw GDScript `/` before truncation.
- Lowers GML `div` expressions through the shared runtime helper while keeping `/` on `GMRuntime.gml_div()` for real division.
- Adds focused transpiler/runtime/object coverage for integer division and the Godot int-division mismatch.

## Docs
- Used Context7 Godot docs for GDScript integer-vs-float division and `int()` truncation behavior.
- Used Context7 GameMaker manual docs for GML `div` and arithmetic operator behavior.

## Verification
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest tests.test_gml_runtime tests.test_gml_transpiler tests.test_objects
- ./venv/bin/python -m unittest

Part of #338
Closes #365