### PR TITLE
Parse GML real number literals

### DIFF
--- a/src/conversion/gml_transpiler.py
+++ b/src/conversion/gml_transpiler.py
@@ -43,6 +43,12 @@ class _Literal:
 
 
 @dataclass(frozen=True)
+class _NumberLiteral:
+    value: str
+    is_float_like: bool
+
+
+@dataclass(frozen=True)
 class _Unary:
     operator: str
     operand: _Expression
@@ -85,7 +91,18 @@ class _Grouped:
     expr: _Expression
 
 
-_Expression: TypeAlias = _Name | _Literal | _Unary | _Binary | _Ternary | _Call | _Index | _Member | _Grouped
+_Expression: TypeAlias = (
+    _Name
+    | _Literal
+    | _NumberLiteral
+    | _Unary
+    | _Binary
+    | _Ternary
+    | _Call
+    | _Index
+    | _Member
+    | _Grouped
+)
 
 
 _EOF = _Token("EOF", "")
@@ -347,7 +364,9 @@ class _ExpressionParser:
 
     def _parse_primary(self) -> _Expression:
         token = self._advance()
-        if token.kind == "NUMBER" or token.kind == "STRING":
+        if token.kind == "NUMBER":
+            return _NumberLiteral(token.value, _is_float_like_number(token.value))
+        if token.kind == "STRING":
             return _Literal(token.value)
         if token.kind == "IDENT":
             return _Name(_NAME_REPLACEMENTS.get(token.value, token.value))
@@ -597,16 +616,10 @@ def _tokenize(source: str) -> list[_Token]:
             index += 1
             continue
 
-        if char.isdigit():
-            start = index
-            if source[index:index + 2].lower() == "0x":
-                index += 2
-                while index < len(source) and source[index].lower() in "0123456789abcdef":
-                    index += 1
-            else:
-                while index < len(source) and (source[index].isdigit() or source[index] == "."):
-                    index += 1
-            tokens.append(_Token("NUMBER", source[start:index]))
+        if char.isdigit() or (char == "." and index + 1 < len(source) and source[index + 1].isdigit()):
+            number_end = _read_number(source, index)
+            tokens.append(_Token("NUMBER", source[index:number_end]))
+            index = number_end
             continue
 
         if char == '"' or char == "'":
@@ -647,6 +660,29 @@ def _expression_tokens(source: str) -> list[_Token]:
     return [token for token in _tokenize(source) if token.kind != "NEWLINE"]
 
 
+def _read_number(source: str, start: int) -> int:
+    index = start
+    if source.startswith(("0x", "0X"), start):
+        index += 2
+        while index < len(source) and source[index].lower() in "0123456789abcdef":
+            index += 1
+        return index
+
+    while index < len(source) and source[index].isdigit():
+        index += 1
+
+    if index < len(source) and source[index] == ".":
+        index += 1
+        while index < len(source) and source[index].isdigit():
+            index += 1
+
+    return index
+
+
+def _is_float_like_number(value: str) -> bool:
+    return "." in value
+
+
 def _read_string(source: str, start: int) -> str:
     quote = source[start]
     index = start + 1
@@ -680,7 +716,7 @@ def _emit_expression(
     local_names: Iterable[str] | None = None,
 ) -> tuple[str, int]:
     local_names = _normalize_local_names(local_names)
-    if isinstance(expr, _Literal):
+    if isinstance(expr, _Literal | _NumberLiteral):
         return expr.value, _PRIMARY_PRECEDENCE
     if isinstance(expr, _Name):
         value = expr.value

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -31,6 +31,8 @@ RUNTIME_VALUE_PARITY_CASES = (
         "GMRuntime.is_undefined(GMRuntime.gml_undefined())",
     ),
     RuntimeValueParityCase("is_nan(NaN)", "GMRuntime.is_nan_value(NAN)"),
+    RuntimeValueParityCase("0.5", "0.5"),
+    RuntimeValueParityCase("1.5 / 2", "GMRuntime.gml_div(1.5, 2)"),
     RuntimeValueParityCase("5 / 2", "GMRuntime.gml_div(5, 2)"),
     RuntimeValueParityCase("5 div 2", "GMRuntime.gml_int_div(5, 2)"),
     RuntimeValueParityCase("!0.5", "not GMRuntime.gml_bool(0.5)"),

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -1,3 +1,4 @@
+# pyright: reportPrivateUsage=false
 import os
 import sys
 import unittest
@@ -6,13 +7,45 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
-from src.conversion.gml_transpiler import transpile_gml_code, transpile_gml_expression
+from src.conversion.gml_transpiler import (
+    GMLTranspileError,
+    _ExpressionParser,
+    _NumberLiteral,
+    _expression_tokens,
+    transpile_gml_code,
+    transpile_gml_expression,
+)
 
 
 class TestGMLExpressionTranspiler(unittest.TestCase):
     def test_preserves_arithmetic_precedence(self):
         self.assertEqual(transpile_gml_expression("a + b * c"), "a + b * c")
         self.assertEqual(transpile_gml_expression("(a + b) * c"), "(a + b) * c")
+
+    def test_parses_numeric_real_literals(self):
+        self.assertEqual(transpile_gml_expression("42"), "42")
+        self.assertEqual(transpile_gml_expression("0.5"), "0.5")
+        self.assertEqual(transpile_gml_expression(".5"), ".5")
+        self.assertEqual(transpile_gml_expression("5."), "5.")
+        self.assertEqual(
+            transpile_gml_expression("1.5 / 2"),
+            "GMRuntime.gml_div(1.5, 2)",
+        )
+
+    def test_preserves_numeric_literal_float_metadata(self):
+        integer_literal = _ExpressionParser(_expression_tokens("42")).parse()
+        decimal_literal = _ExpressionParser(_expression_tokens("3.5")).parse()
+
+        self.assertIsInstance(integer_literal, _NumberLiteral)
+        self.assertIsInstance(decimal_literal, _NumberLiteral)
+        assert isinstance(integer_literal, _NumberLiteral)
+        assert isinstance(decimal_literal, _NumberLiteral)
+        self.assertFalse(integer_literal.is_float_like)
+        self.assertTrue(decimal_literal.is_float_like)
+
+    def test_rejects_malformed_numeric_literals(self):
+        with self.assertRaises(GMLTranspileError):
+            transpile_gml_expression("1.2.3")
 
     def test_transpiles_logical_operators(self):
         self.assertEqual(


### PR DESCRIPTION
## Summary
- Adds explicit numeric literal AST nodes that preserve whether the source looked float-like.
- Tightens decimal number tokenization so malformed values like `1.2.3` are rejected instead of accepted as one token.
- Adds focused transpiler/runtime fixtures for integer-looking and decimal real literals.

## Docs
- Used Context7 Godot docs for GDScript numeric literals, Variant int/float behavior, and 64-bit float precision.
- Used Context7 GameMaker manual docs for GML real numeric literals and separated underscore/hex/binary coverage into their existing sibling issues.

## Verification
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest tests.test_gml_transpiler tests.test_gml_runtime
- ./venv/bin/python -m unittest

Part of #338
Closes #361