### PR TITLE
Add GML string runtime semantics

### DIFF
--- a/src/conversion/gml_runtime.py
+++ b/src/conversion/gml_runtime.py
@@ -39,6 +39,11 @@ static func is_bool(value):
 	return typeof(value) == TYPE_BOOL
 
 
+static func is_string(value):
+	var value_type = typeof(value)
+	return value_type == TYPE_STRING or value_type == TYPE_STRING_NAME
+
+
 static func is_number(value):
 	var value_type = typeof(value)
 	return value_type == TYPE_INT or value_type == TYPE_FLOAT
@@ -83,6 +88,12 @@ static func gml_int64(value):
 static func gml_add(left, right):
 	if is_numeric(left) and is_numeric(right):
 		return _to_real(left) + _to_real(right)
+	if is_string(left) and is_string(right):
+		return str(left) + str(right)
+	if is_string(right) and (is_numeric(left) or is_bool(left)):
+		return gml_string(left) + str(right)
+	if is_string(left) and (is_numeric(right) or is_bool(right)):
+		return gml_error("Invalid GML string concatenation")
 	return left + right
 
 
@@ -138,6 +149,10 @@ static func gml_typeof(value):
 static func gml_string(value):
 	if is_undefined(value):
 		return GML_TYPE_UNDEFINED
+	if is_string(value):
+		return str(value)
+	if is_bool(value):
+		return "true" if value else "false"
 	if is_int64(value):
 		return str(value.value)
 	if is_infinity(value):

--- a/src/conversion/gml_transpiler.py
+++ b/src/conversion/gml_transpiler.py
@@ -43,6 +43,11 @@ class _Literal:
 
 
 @dataclass(frozen=True)
+class _StringLiteral:
+    value: str
+
+
+@dataclass(frozen=True)
 class _NumberLiteral:
     value: str
     is_float_like: bool
@@ -94,6 +99,7 @@ class _Grouped:
 _Expression: TypeAlias = (
     _Name
     | _Literal
+    | _StringLiteral
     | _NumberLiteral
     | _Unary
     | _Binary
@@ -206,6 +212,7 @@ _BOOLEAN_RESULT_FUNCTIONS = frozenset({
     "is_nan",
     "is_numeric",
     "is_real",
+    "is_string",
     "is_undefined",
     "keyboard_check",
 })
@@ -270,6 +277,7 @@ _RUNTIME_FUNCTIONS = {
     "is_nan": "is_nan_value",
     "is_numeric": "is_numeric",
     "is_real": "is_real",
+    "is_string": "is_string",
     "is_undefined": "is_undefined",
     "real": "gml_real",
     "typeof": "gml_typeof",
@@ -391,7 +399,7 @@ class _ExpressionParser:
         if token.kind == "NUMBER":
             return _NumberLiteral(token.value, _is_float_like_number(token.value))
         if token.kind == "STRING":
-            return _Literal(token.value)
+            return _StringLiteral(token.value)
         if token.kind == "IDENT":
             return _Name(_NAME_REPLACEMENTS.get(token.value, token.value))
         if token.value == "(":
@@ -740,7 +748,7 @@ def _emit_expression(
     local_names: Iterable[str] | None = None,
 ) -> tuple[str, int]:
     local_names = _normalize_local_names(local_names)
-    if isinstance(expr, _Literal | _NumberLiteral):
+    if isinstance(expr, _Literal | _StringLiteral | _NumberLiteral):
         return expr.value, _PRIMARY_PRECEDENCE
     if isinstance(expr, _Name):
         value = expr.value

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -26,6 +26,9 @@ RUNTIME_VALUE_PARITY_CASES = (
     RuntimeValueParityCase("bool(0.5)", "GMRuntime.gml_bool(0.5)"),
     RuntimeValueParityCase("bool(0.50001)", "GMRuntime.gml_bool(0.50001)"),
     RuntimeValueParityCase("is_bool(true)", "GMRuntime.is_bool(true)"),
+    RuntimeValueParityCase('string("abc")', 'GMRuntime.gml_string("abc")'),
+    RuntimeValueParityCase('typeof("abc")', 'GMRuntime.gml_typeof("abc")'),
+    RuntimeValueParityCase('is_string("abc")', 'GMRuntime.is_string("abc")'),
     RuntimeValueParityCase("real(score)", "GMRuntime.gml_real(score)"),
     RuntimeValueParityCase("int64(score)", "GMRuntime.gml_int64(score)"),
     RuntimeValueParityCase("typeof(int64(score))", "GMRuntime.gml_typeof(GMRuntime.gml_int64(score))"),
@@ -44,6 +47,9 @@ RUNTIME_VALUE_PARITY_CASES = (
     RuntimeValueParityCase("5 / 2", "GMRuntime.gml_div(5, 2)"),
     RuntimeValueParityCase("5 div 2", "GMRuntime.gml_int_div(5, 2)"),
     RuntimeValueParityCase("a + b", "GMRuntime.gml_add(a, b)"),
+    RuntimeValueParityCase('"a" + "b"', 'GMRuntime.gml_add("a", "b")'),
+    RuntimeValueParityCase('1 + "px"', 'GMRuntime.gml_add(1, "px")'),
+    RuntimeValueParityCase('true + "!"', 'GMRuntime.gml_add(true, "!")'),
     RuntimeValueParityCase("a - b", "GMRuntime.gml_sub(a, b)"),
     RuntimeValueParityCase("a * b", "GMRuntime.gml_mul(a, b)"),
     RuntimeValueParityCase("a mod b", "GMRuntime.gml_mod(a, b)"),
@@ -65,6 +71,7 @@ class TestGMLRuntimeScript(unittest.TestCase):
             "gml_undefined",
             "is_undefined",
             "is_bool",
+            "is_string",
             "is_number",
             "is_real",
             "is_numeric",
@@ -105,6 +112,14 @@ class TestGMLRuntimeScript(unittest.TestCase):
         self.assertIn("static func gml_int64(value):", GML_RUNTIME_SCRIPT)
         self.assertIn("return value is GMLInt64", GML_RUNTIME_SCRIPT)
         self.assertIn("return GML_TYPE_INT64", GML_RUNTIME_SCRIPT)
+
+    def test_runtime_handles_string_conversion_and_concat_deliberately(self):
+        self.assertIn("static func is_string(value):", GML_RUNTIME_SCRIPT)
+        self.assertIn("return value_type == TYPE_STRING or value_type == TYPE_STRING_NAME", GML_RUNTIME_SCRIPT)
+        self.assertIn("return str(left) + str(right)", GML_RUNTIME_SCRIPT)
+        self.assertIn("return gml_string(left) + str(right)", GML_RUNTIME_SCRIPT)
+        self.assertIn("Invalid GML string concatenation", GML_RUNTIME_SCRIPT)
+        self.assertIn('return "true" if value else "false"', GML_RUNTIME_SCRIPT)
 
     def test_runtime_centralizes_error_reporting(self):
         self.assertIn("static func gml_error(message):", GML_RUNTIME_SCRIPT)

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -11,6 +11,7 @@ from src.conversion.gml_transpiler import (
     GMLTranspileError,
     _ExpressionParser,
     _NumberLiteral,
+    _StringLiteral,
     _expression_tokens,
     transpile_gml_code,
     transpile_gml_expression,
@@ -52,6 +53,24 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
     def test_rejects_malformed_numeric_literals(self):
         with self.assertRaises(GMLTranspileError):
             transpile_gml_expression("1.2.3")
+
+    def test_parses_string_literals(self):
+        self.assertEqual(transpile_gml_expression('"hello"'), '"hello"')
+        self.assertEqual(transpile_gml_expression("'hello'"), "'hello'")
+        self.assertEqual(transpile_gml_expression(r'"Hello\"World\""'), r'"Hello\"World\""')
+        self.assertEqual(transpile_gml_expression(r'"line\nnext"'), r'"line\nnext"')
+        self.assertEqual(transpile_gml_expression(r'"C:\\tmp"'), r'"C:\\tmp"')
+
+    def test_preserves_string_literal_metadata(self):
+        literal = _ExpressionParser(_expression_tokens('"hello"')).parse()
+
+        self.assertIsInstance(literal, _StringLiteral)
+        assert isinstance(literal, _StringLiteral)
+        self.assertEqual(literal.value, '"hello"')
+
+    def test_rejects_unterminated_string_literals(self):
+        with self.assertRaises(GMLTranspileError):
+            transpile_gml_expression('"unterminated')
 
     def test_transpiles_logical_operators(self):
         self.assertEqual(
@@ -106,6 +125,20 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
         self.assertEqual(transpile_gml_expression("a - b"), "GMRuntime.gml_sub(a, b)")
         self.assertEqual(transpile_gml_expression("a * b"), "GMRuntime.gml_mul(a, b)")
         self.assertEqual(transpile_gml_expression("a % b"), "GMRuntime.gml_mod(a, b)")
+
+    def test_transpiles_string_concatenation_through_runtime(self):
+        self.assertEqual(
+            transpile_gml_expression('"hello" + " world"'),
+            'GMRuntime.gml_add("hello", " world")',
+        )
+        self.assertEqual(
+            transpile_gml_expression('score + " pts"'),
+            'GMRuntime.gml_add(score, " pts")',
+        )
+        self.assertEqual(
+            transpile_gml_expression('"Score: " + string(score)'),
+            'GMRuntime.gml_add("Score: ", GMRuntime.gml_string(score))',
+        )
 
     def test_transpiles_infinity_and_nan_constants(self):
         self.assertEqual(transpile_gml_expression("infinity"), "INF")
@@ -187,6 +220,11 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
             transpile_gml_expression("is_int64(int64(score))"),
             "GMRuntime.is_int64(GMRuntime.gml_int64(score))",
         )
+
+    def test_transpiles_string_value_helpers(self):
+        self.assertEqual(transpile_gml_expression('string("abc")'), 'GMRuntime.gml_string("abc")')
+        self.assertEqual(transpile_gml_expression('typeof("abc")'), 'GMRuntime.gml_typeof("abc")')
+        self.assertEqual(transpile_gml_expression('is_string("abc")'), 'GMRuntime.is_string("abc")')
 
     def test_transpiles_bitwise_operators(self):
         self.assertEqual(

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -540,6 +540,27 @@ class TestScriptGeneration(unittest.TestCase):
         self.assertIn("\tvar ratio = GMRuntime.gml_div(1, 0)", content)
         self.assertIn("\tshow_debug_message(GMRuntime.gml_string(limit))", content)
 
+    def test_script_transpiles_string_runtime_support(self):
+        """String conversion and concatenation should use the shared runtime."""
+        self._setup_object("o_test", event_list=[{"eventType": 0, "eventNum": 0}])
+        source_path = os.path.join(self.gm_dir, "objects", "o_test", "Create_0.gml")
+        with open(source_path, "w", encoding="utf-8") as f:
+            f.write('var label = "Score: " + string(score); show_debug_message(label);')
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        gd_path = os.path.join(self.godot_dir, "objects", "o_test", "o_test.gd")
+        with open(gd_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        self.assertIn('const GMRuntime = preload("res://gm2godot/gml_runtime.gd")', content)
+        self.assertIn(
+            '\tvar label = GMRuntime.gml_add("Score: ", GMRuntime.gml_string(score))',
+            content,
+        )
+        self.assertIn("\tshow_debug_message(label)", content)
+
     def test_script_with_step_event(self):
         """eventType 3, eventNum 0 should produce func _process(delta)."""
         self._setup_object("o_test", event_list=[{"eventType": 3, "eventNum": 0}])


### PR DESCRIPTION
## Summary
- Adds explicit string literal AST metadata and focused parser coverage for quote/escape handling.
- Adds `GMRuntime.is_string()` and deliberate `gml_string()` handling for existing runtime values.
- Routes string concatenation through `GMRuntime.gml_add()` with GML-specific mixed string/numeric ordering behavior.

## Docs
- Used Context7 Godot docs for GDScript string literals, escape sequences, `str()`, String/Variant behavior, and mixed string concatenation requirements.
- Used Context7 GameMaker manual docs for strings, `string()`, `is_string()`, and documented string concatenation examples.

## Verification
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest tests.test_gml_transpiler tests.test_gml_runtime tests.test_objects
- ./venv/bin/python -m unittest

Closes #340
Closes #370
Closes #371
Closes #372
Closes #373
Part of #129