### PR TITLE
Add registry-driven GML function dispatch

### DIFF
--- a/src/conversion/gml_transpiler.py
+++ b/src/conversion/gml_transpiler.py
@@ -22,6 +22,12 @@ from src.conversion.gml_transpiler_parts.gml_api_manifest import (
     is_known_gml_api,
     iter_gml_api_entries,
 )
+from src.conversion.gml_transpiler_parts.gml_function_dispatch import (
+    GMLFunctionDescriptor,
+    get_gml_function_descriptor,
+    iter_gml_function_descriptors,
+    validate_gml_function_arity,
+)
 from src.conversion.gml_transpiler_parts.model import (
     GMLTranspileError,
     _ArrayLiteral,
@@ -55,6 +61,7 @@ __all__ = [
     "GMLTranspileError",
     "GMLAPICategoryReport",
     "GMLAPIEntry",
+    "GMLFunctionDescriptor",
     "_ArrayLiteral",
     "_Binary",
     "_BuiltinVariableMetadata",
@@ -88,10 +95,13 @@ __all__ = [
     "diagnostic_for_unimplemented_gml_api",
     "generate_gml_api_compatibility_report",
     "get_gml_api_entry",
+    "get_gml_function_descriptor",
     "godot_docs_root",
     "is_known_gml_api",
     "iter_gml_api_entries",
+    "iter_gml_function_descriptors",
     "transpile_gml_code",
     "transpile_gml_condition",
     "transpile_gml_expression",
+    "validate_gml_function_arity",
 ]

--- a/src/conversion/gml_transpiler_parts/emitter.py
+++ b/src/conversion/gml_transpiler_parts/emitter.py
@@ -6,7 +6,6 @@ from typing import Iterable
 
 from .constants import (
     _ARITHMETIC_RUNTIME_FUNCTIONS,
-    _ARRAY_RUNTIME_FUNCTIONS,
     _BINARY_PRECEDENCE,
     _BITWISE_RUNTIME_FUNCTIONS,
     _BOOLEAN_RESULT_BINARY_OPERATORS,
@@ -15,7 +14,6 @@ from .constants import (
     _BUILTIN_GLOBAL_VARIABLES,
     _BUILTIN_INSTANCE_VARIABLES,
     _DIRECT_MEMBER_TARGETS,
-    _DS_MAP_RUNTIME_FUNCTIONS,
     _GML_BUILTIN_CONSTANT_IDENTIFIERS,
     _GML_LITERAL_IDENTIFIERS,
     _INSTANCE_NAME_REPLACEMENTS,
@@ -24,13 +22,15 @@ from .constants import (
     _POSTFIX_PRECEDENCE,
     _PRIMARY_PRECEDENCE,
     _RIGHT_ASSOCIATIVE,
-    _RUNTIME_FUNCTIONS,
-    _STRUCT_RUNTIME_FUNCTIONS,
     _TERNARY_PRECEDENCE,
     _UNARY_PRECEDENCE,
-    _VARIABLE_RUNTIME_FUNCTIONS,
     _VIRTUAL_KEY_ACTIONS,
     _VIRTUAL_KEY_CONSTANTS,
+)
+from .gml_function_dispatch import (
+    GMLFunctionDescriptor,
+    get_gml_function_descriptor,
+    validate_gml_function_arity,
 )
 from .gml_api_manifest import diagnostic_for_unimplemented_gml_api
 from .identifiers import _is_plain_identifier, _sanitize_gdscript_identifier
@@ -354,89 +354,86 @@ def _emit_builtin_call(
     scope_context: _ScopeContext | None = None,
 ) -> str | None:
     scope_context = _normalize_scope_context(scope_context)
-    if isinstance(expr.callee, _Name) and expr.callee.value == "keyboard_check" and len(expr.args) == 1:
-        key = expr.args[0]
+    if not isinstance(expr.callee, _Name):
+        return None
+
+    descriptor = get_gml_function_descriptor(expr.callee.value)
+    if descriptor is not None:
+        return _emit_descriptor_call(
+            descriptor,
+            expr.args,
+            local_names,
+            scope_context=scope_context,
+        )
+
+    diagnostic = diagnostic_for_unimplemented_gml_api(expr.callee.value)
+    if diagnostic is not None:
+        raise GMLTranspileError(diagnostic)
+    return None
+
+
+def _emit_descriptor_call(
+    descriptor: GMLFunctionDescriptor,
+    args: tuple[_Expression, ...],
+    local_names: Iterable[str],
+    scope_context: _ScopeContext,
+) -> str:
+    arity_diagnostic = validate_gml_function_arity(descriptor, len(args))
+    if arity_diagnostic is not None:
+        raise GMLTranspileError(arity_diagnostic)
+
+    if descriptor.lowering_kind == "keyboard_check":
+        key = args[0]
         if isinstance(key, _Name) and key.value in _VIRTUAL_KEY_ACTIONS:
             return f'Input.is_action_pressed("{_VIRTUAL_KEY_ACTIONS[key.value]}")'
         if isinstance(key, _Name) and key.value in _VIRTUAL_KEY_CONSTANTS:
             return f"Input.is_key_pressed({_VIRTUAL_KEY_CONSTANTS[key.value]})"
-    if isinstance(expr.callee, _Name) and expr.callee.value == "method" and len(expr.args) == 2:
-        scope = _emit_expression(expr.args[0], local_names, scope_context=scope_context)[0]
+        raise GMLTranspileError(
+            "GML API 'keyboard_check' currently supports mapped vk_* constants only; "
+            f"tracked by #{descriptor.issue_number}."
+        )
+
+    if descriptor.lowering_kind == "method":
+        scope = _emit_expression(args[0], local_names, scope_context=scope_context)[0]
         if scope == _NAME_REPLACEMENTS["undefined"]:
             scope = scope_context.self_expression
         function_value = _emit_expression(
-            expr.args[1],
+            args[1],
             local_names,
             scope_context=scope_context,
         )[0]
-        return f"GMRuntime.gml_method({scope}, {function_value})"
-    if isinstance(expr.callee, _Name) and expr.callee.value == "with_targets" and len(expr.args) == 1:
+        return f"GMRuntime.{descriptor.lowering_target}({scope}, {function_value})"
+
+    if descriptor.lowering_kind == "with_targets":
         target = _emit_instance_keyword_argument(
-            expr.args[0],
+            args[0],
             local_names,
             scope_context=scope_context,
         )
-        return f"GMRuntime.gml_with_targets({target})"
-    if (
-        isinstance(expr.callee, _Name)
-        and expr.callee.value == "show_debug_message"
-        and len(expr.args) == 1
-    ):
-        arg = _emit_expression(expr.args[0], local_names, scope_context=scope_context)[0]
-        return f"print({arg})"
-    if isinstance(expr.callee, _Name) and expr.callee.value in _STRUCT_RUNTIME_FUNCTIONS:
-        args = ", ".join(
-            _emit_expression(arg, local_names, scope_context=scope_context)[0]
-            for arg in expr.args
-        )
-        return f"GMRuntime.{_STRUCT_RUNTIME_FUNCTIONS[expr.callee.value]}({args})"
-    if (
-        isinstance(expr.callee, _Name)
-        and expr.callee.value in _VARIABLE_RUNTIME_FUNCTIONS
-        and expr.callee.value.startswith("variable_instance_")
-        and expr.args
-    ):
+        return f"GMRuntime.{descriptor.lowering_target}({target})"
+
+    if descriptor.lowering_kind == "print":
+        arg = _emit_expression(args[0], local_names, scope_context=scope_context)[0]
+        return f"{descriptor.lowering_target}({arg})"
+
+    if descriptor.lowering_kind == "runtime_instance_keyword_first_arg":
         first_arg = _emit_instance_keyword_argument(
-            expr.args[0],
+            args[0],
             local_names,
             scope_context=scope_context,
         )
         remaining_args = [
             _emit_expression(arg, local_names, scope_context=scope_context)[0]
-            for arg in expr.args[1:]
+            for arg in args[1:]
         ]
-        args = ", ".join([first_arg, *remaining_args])
-        return f"GMRuntime.{_VARIABLE_RUNTIME_FUNCTIONS[expr.callee.value]}({args})"
-    if isinstance(expr.callee, _Name) and expr.callee.value in _VARIABLE_RUNTIME_FUNCTIONS:
-        args = ", ".join(
-            _emit_expression(arg, local_names, scope_context=scope_context)[0]
-            for arg in expr.args
-        )
-        return f"GMRuntime.{_VARIABLE_RUNTIME_FUNCTIONS[expr.callee.value]}({args})"
-    if isinstance(expr.callee, _Name) and expr.callee.value in _DS_MAP_RUNTIME_FUNCTIONS:
-        args = ", ".join(
-            _emit_expression(arg, local_names, scope_context=scope_context)[0]
-            for arg in expr.args
-        )
-        return f"GMRuntime.{_DS_MAP_RUNTIME_FUNCTIONS[expr.callee.value]}({args})"
-    if isinstance(expr.callee, _Name) and expr.callee.value in _ARRAY_RUNTIME_FUNCTIONS:
-        args = ", ".join(
-            _emit_expression(arg, local_names, scope_context=scope_context)[0]
-            for arg in expr.args
-        )
-        return f"GMRuntime.{_ARRAY_RUNTIME_FUNCTIONS[expr.callee.value]}({args})"
-    if (
-        isinstance(expr.callee, _Name)
-        and expr.callee.value in _RUNTIME_FUNCTIONS
-        and len(expr.args) == 1
-    ):
-        arg = _emit_expression(expr.args[0], local_names, scope_context=scope_context)[0]
-        return f"GMRuntime.{_RUNTIME_FUNCTIONS[expr.callee.value]}({arg})"
-    if isinstance(expr.callee, _Name):
-        diagnostic = diagnostic_for_unimplemented_gml_api(expr.callee.value)
-        if diagnostic is not None:
-            raise GMLTranspileError(diagnostic)
-    return None
+        emitted_args = ", ".join([first_arg, *remaining_args])
+        return f"GMRuntime.{descriptor.lowering_target}({emitted_args})"
+
+    emitted_args = ", ".join(
+        _emit_expression(arg, local_names, scope_context=scope_context)[0]
+        for arg in args
+    )
+    return f"GMRuntime.{descriptor.lowering_target}({emitted_args})"
 
 
 def _emit_instance_keyword_argument(

--- a/src/conversion/gml_transpiler_parts/gml_function_dispatch.py
+++ b/src/conversion/gml_transpiler_parts/gml_function_dispatch.py
@@ -1,0 +1,216 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, TypeAlias
+
+from .constants import (
+    _ARRAY_RUNTIME_FUNCTIONS,
+    _DS_MAP_RUNTIME_FUNCTIONS,
+    _RUNTIME_FUNCTIONS,
+    _STRUCT_RUNTIME_FUNCTIONS,
+    _VARIABLE_RUNTIME_FUNCTIONS,
+)
+from .gml_api_manifest import get_gml_api_entry
+
+GMLFunctionLoweringKind: TypeAlias = Literal[
+    "keyboard_check",
+    "method",
+    "print",
+    "runtime",
+    "runtime_instance_keyword_first_arg",
+    "with_targets",
+]
+
+
+@dataclass(frozen=True)
+class GMLFunctionDescriptor:
+    name: str
+    category: str
+    min_args: int
+    max_args: int | None
+    lowering_kind: GMLFunctionLoweringKind
+    lowering_target: str
+    issue_number: int
+    docs_url: str
+
+    @property
+    def issue_url(self) -> str:
+        return f"https://github.com/Infiland/GM2Godot/issues/{self.issue_number}"
+
+    def arity_description(self) -> str:
+        if self.max_args is None:
+            return f"at least {self.min_args}"
+        if self.min_args == self.max_args:
+            return str(self.min_args)
+        return f"{self.min_args} to {self.max_args}"
+
+
+_DEFAULT_CATEGORY = "Runtime Function Dispatch"
+_DEFAULT_ISSUE_NUMBER = 483
+_DEFAULT_DOCS_URL = (
+    "https://manual.gamemaker.io/monthly/en/"
+    "GameMaker_Language/GML_Reference/GML_Reference.htm"
+)
+
+_STRUCT_ARITY: dict[str, tuple[int, int | None]] = {
+    "struct_exists": (2, 2),
+    "struct_get": (2, 2),
+    "struct_get_names": (1, 1),
+    "struct_names_count": (1, 1),
+    "struct_set": (3, 3),
+    "struct_remove": (2, 2),
+    "struct_foreach": (2, 2),
+    "static_get": (1, 1),
+    "static_set": (2, 2),
+    "is_instanceof": (2, 2),
+    "instanceof": (1, 1),
+    "variable_get_hash": (1, 1),
+    "struct_get_from_hash": (2, 2),
+    "struct_set_from_hash": (3, 3),
+    "struct_exists_from_hash": (2, 2),
+    "struct_remove_from_hash": (2, 2),
+}
+
+_VARIABLE_ARITY: dict[str, tuple[int, int | None]] = {
+    "method_call": (1, 4),
+    "method": (2, 2),
+    "ref_create": (2, 3),
+    "variable_clone": (1, 2),
+    "variable_instance_exists": (2, 2),
+    "variable_instance_get": (2, 2),
+    "variable_instance_set": (3, 3),
+    "variable_instance_get_names": (1, 1),
+    "variable_instance_names_count": (1, 1),
+    "variable_global_exists": (1, 1),
+    "variable_global_get": (1, 1),
+    "variable_global_set": (2, 2),
+    "variable_struct_get": (2, 2),
+}
+
+_DS_MAP_ARITY: dict[str, tuple[int, int | None]] = {
+    "ds_map_exists": (2, 2),
+    "ds_map_find_value": (2, 2),
+}
+
+_ARRAY_ARITY: dict[str, tuple[int, int | None]] = {
+    "array_equals": (2, 2),
+    "array_push": (2, None),
+}
+
+
+def get_gml_function_descriptor(name: str) -> GMLFunctionDescriptor | None:
+    return _GML_FUNCTION_DESCRIPTORS.get(name)
+
+
+def iter_gml_function_descriptors() -> tuple[GMLFunctionDescriptor, ...]:
+    return tuple(_GML_FUNCTION_DESCRIPTORS.values())
+
+
+def validate_gml_function_arity(
+    descriptor: GMLFunctionDescriptor,
+    arg_count: int,
+) -> str | None:
+    if arg_count < descriptor.min_args:
+        return _arity_error(descriptor, arg_count)
+    if descriptor.max_args is not None and arg_count > descriptor.max_args:
+        return _arity_error(descriptor, arg_count)
+    return None
+
+
+def _arity_error(descriptor: GMLFunctionDescriptor, arg_count: int) -> str:
+    return (
+        f"GML API '{descriptor.name}' expects {descriptor.arity_description()} "
+        f"argument(s), got {arg_count}; tracked by #{descriptor.issue_number}."
+    )
+
+
+def _descriptor(
+    name: str,
+    min_args: int,
+    max_args: int | None,
+    lowering_kind: GMLFunctionLoweringKind,
+    lowering_target: str,
+) -> GMLFunctionDescriptor:
+    manifest_entry = get_gml_api_entry(name)
+    return GMLFunctionDescriptor(
+        name=name,
+        category=manifest_entry.category if manifest_entry is not None else _DEFAULT_CATEGORY,
+        min_args=min_args,
+        max_args=max_args,
+        lowering_kind=lowering_kind,
+        lowering_target=lowering_target,
+        issue_number=(
+            manifest_entry.issue_number if manifest_entry is not None else _DEFAULT_ISSUE_NUMBER
+        ),
+        docs_url=manifest_entry.docs_url if manifest_entry is not None else _DEFAULT_DOCS_URL,
+    )
+
+
+def _build_function_descriptors() -> dict[str, GMLFunctionDescriptor]:
+    descriptors: dict[str, GMLFunctionDescriptor] = {}
+
+    for name, target in _RUNTIME_FUNCTIONS.items():
+        if name == "with_targets":
+            continue
+        descriptors[name] = _descriptor(name, 1, 1, "runtime", target)
+
+    for name, target in _STRUCT_RUNTIME_FUNCTIONS.items():
+        min_args, max_args = _STRUCT_ARITY[name]
+        descriptors[name] = _descriptor(name, min_args, max_args, "runtime", target)
+
+    for name, target in _VARIABLE_RUNTIME_FUNCTIONS.items():
+        min_args, max_args = _VARIABLE_ARITY[name]
+        descriptors[name] = _descriptor(name, min_args, max_args, "runtime", target)
+
+    for name, target in _DS_MAP_RUNTIME_FUNCTIONS.items():
+        min_args, max_args = _DS_MAP_ARITY[name]
+        descriptors[name] = _descriptor(name, min_args, max_args, "runtime", target)
+
+    for name, target in _ARRAY_RUNTIME_FUNCTIONS.items():
+        min_args, max_args = _ARRAY_ARITY[name]
+        descriptors[name] = _descriptor(name, min_args, max_args, "runtime", target)
+
+    descriptors["keyboard_check"] = _descriptor(
+        "keyboard_check",
+        1,
+        1,
+        "keyboard_check",
+        "Input",
+    )
+    descriptors["method"] = _descriptor("method", 2, 2, "method", "gml_method")
+    descriptors["with_targets"] = _descriptor(
+        "with_targets",
+        1,
+        1,
+        "with_targets",
+        "gml_with_targets",
+    )
+    descriptors["show_debug_message"] = _descriptor(
+        "show_debug_message",
+        1,
+        1,
+        "print",
+        "print",
+    )
+
+    for name in (
+        "variable_instance_exists",
+        "variable_instance_get",
+        "variable_instance_set",
+        "variable_instance_get_names",
+        "variable_instance_names_count",
+    ):
+        current = descriptors[name]
+        descriptors[name] = _descriptor(
+            current.name,
+            current.min_args,
+            current.max_args,
+            "runtime_instance_keyword_first_arg",
+            current.lowering_target,
+        )
+
+    return descriptors
+
+
+_GML_FUNCTION_DESCRIPTORS = _build_function_descriptors()

--- a/tests/test_gml_api_manifest.py
+++ b/tests/test_gml_api_manifest.py
@@ -13,10 +13,13 @@ from src.conversion.gml_transpiler import (
     diagnostic_for_unimplemented_gml_api,
     generate_gml_api_compatibility_report,
     get_gml_api_entry,
+    get_gml_function_descriptor,
     godot_docs_root,
     is_known_gml_api,
     iter_gml_api_entries,
+    iter_gml_function_descriptors,
     transpile_gml_expression,
+    validate_gml_function_arity,
 )
 
 
@@ -76,9 +79,55 @@ class TestGMLAPIManifest(unittest.TestCase):
         self.assertIn("draw_sprite", diagnostic)
         self.assertIn("#491", diagnostic)
 
+    def test_function_descriptors_include_lowering_metadata_and_issue_urls(self):
+        descriptor = get_gml_function_descriptor("array_push")
+
+        self.assertIsNotNone(descriptor)
+        assert descriptor is not None
+        self.assertEqual(descriptor.category, "Arrays")
+        self.assertEqual(descriptor.min_args, 2)
+        self.assertIsNone(descriptor.max_args)
+        self.assertEqual(descriptor.lowering_kind, "runtime")
+        self.assertEqual(descriptor.lowering_target, "gml_array_push")
+        self.assertEqual(descriptor.issue_url, "https://github.com/Infiland/GM2Godot/issues/502")
+
+    def test_function_descriptors_cover_current_implemented_call_helpers(self):
+        descriptor_names = {descriptor.name for descriptor in iter_gml_function_descriptors()}
+
+        for name in (
+            "array_push",
+            "bool",
+            "keyboard_check",
+            "method",
+            "show_debug_message",
+            "struct_get",
+            "variable_instance_get",
+        ):
+            with self.subTest(name=name):
+                self.assertIn(name, descriptor_names)
+
+    def test_function_descriptor_arity_validation_is_deterministic(self):
+        descriptor = get_gml_function_descriptor("struct_set")
+
+        self.assertIsNotNone(descriptor)
+        assert descriptor is not None
+        diagnostic = validate_gml_function_arity(descriptor, 2)
+
+        self.assertIsNotNone(diagnostic)
+        assert diagnostic is not None
+        self.assertIn("struct_set", diagnostic)
+        self.assertIn("expects 3", diagnostic)
+        self.assertIn("#483", diagnostic)
+
     def test_transpiler_rejects_known_unimplemented_gml_builtin_calls(self):
         with self.assertRaisesRegex(GMLTranspileError, "draw_sprite.*#491"):
             transpile_gml_expression("draw_sprite(spr_player, 0, x, y)")
+
+    def test_transpiler_rejects_wrong_arity_for_known_helpers(self):
+        with self.assertRaisesRegex(GMLTranspileError, "real.*expects 1.*got 0"):
+            transpile_gml_expression("real()")
+        with self.assertRaisesRegex(GMLTranspileError, "array_push.*at least 2.*got 1"):
+            transpile_gml_expression("array_push(items)")
 
     def test_unknown_project_local_function_calls_still_pass_through(self):
         self.assertEqual(


### PR DESCRIPTION
Closes #483.

## Summary
- add typed GML function descriptors with category, arity, lowering target, docs, and issue metadata
- route known GML helper calls through the descriptor registry instead of scattered map checks in the emitter
- add deterministic arity diagnostics for known helpers while preserving unknown project-local function calls
- keep existing helper output stable for implemented PART 1 functionality

## Tests
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest