### PR TITLE
Add selector-aware cross-instance member access

### DIFF
--- a/src/conversion/gml_runtime_parts/segments/40_arrays_structs_variables.gd
+++ b/src/conversion/gml_runtime_parts/segments/40_arrays_structs_variables.gd
@@ -78,38 +78,85 @@ static func gml_variable_struct_get(struct_value, member_name):
 
 
 static func gml_variable_instance_get(instance_value, member_name):
-	var resolved_instance = _gml_resolve_instance(instance_value)
-	if resolved_instance == null:
-		return gml_undefined()
-	return gml_struct_get(resolved_instance, member_name)
+	return gml_selector_get(instance_value, member_name)
 
 
 static func gml_variable_instance_exists(instance_value, member_name):
-	var resolved_instance = _gml_resolve_instance(instance_value)
-	if resolved_instance == null:
-		return false
-	return gml_struct_exists(resolved_instance, member_name)
+	return gml_selector_exists(instance_value, member_name)
 
 
 static func gml_variable_instance_set(instance_value, member_name, value):
-	var resolved_instance = _gml_resolve_instance(instance_value)
-	if resolved_instance == null:
-		return gml_undefined()
-	return gml_struct_set(resolved_instance, member_name, value)
+	return gml_selector_set(instance_value, member_name, value)
 
 
 static func gml_variable_instance_get_names(instance_value):
-	var resolved_instance = _gml_resolve_instance(instance_value)
-	if resolved_instance == null:
-		return []
-	return gml_struct_get_names(resolved_instance)
+	return gml_selector_get_names(instance_value)
 
 
 static func gml_variable_instance_names_count(instance_value):
-	var resolved_instance = _gml_resolve_instance(instance_value)
-	if resolved_instance == null:
+	return gml_selector_names_count(instance_value)
+
+
+static func gml_selector_get(target, member_name, current_self = null, current_other = null):
+	var targets = gml_with_targets(target, current_self, current_other)
+	if targets.is_empty():
+		return gml_undefined()
+	return gml_struct_get(targets[0], member_name)
+
+
+static func gml_selector_exists(target, member_name, current_self = null, current_other = null):
+	for instance in gml_with_targets(target, current_self, current_other):
+		if gml_struct_exists(instance, member_name):
+			return true
+	return false
+
+
+static func gml_selector_set(target, member_name, value, current_self = null, current_other = null):
+	var targets = gml_with_targets(target, current_self, current_other)
+	if targets.is_empty():
+		return gml_undefined()
+	for instance in targets:
+		gml_struct_set(instance, member_name, value)
+	return value
+
+
+static func gml_selector_update(target, member_name, update_callable, current_self = null, current_other = null):
+	var targets = gml_with_targets(target, current_self, current_other)
+	if targets.is_empty():
+		return gml_undefined()
+	var result = gml_undefined()
+	for instance in targets:
+		result = update_callable.call(gml_struct_get(instance, member_name))
+		gml_struct_set(instance, member_name, result)
+	return result
+
+
+static func gml_selector_set_if_nullish(target, member_name, value_callable, current_self = null, current_other = null):
+	var targets = gml_with_targets(target, current_self, current_other)
+	if targets.is_empty():
+		return gml_undefined()
+	var result = gml_undefined()
+	for instance in targets:
+		var current_value = gml_struct_get(instance, member_name)
+		if gml_is_nullish(current_value):
+			result = gml_struct_set(instance, member_name, value_callable.call())
+		else:
+			result = current_value
+	return result
+
+
+static func gml_selector_get_names(target, current_self = null, current_other = null):
+	var targets = gml_with_targets(target, current_self, current_other)
+	if targets.is_empty():
+		return []
+	return gml_struct_get_names(targets[0])
+
+
+static func gml_selector_names_count(target, current_self = null, current_other = null):
+	var targets = gml_with_targets(target, current_self, current_other)
+	if targets.is_empty():
 		return -1
-	return gml_struct_names_count(resolved_instance)
+	return gml_struct_names_count(targets[0])
 
 
 static func gml_variable_global_exists(member_name):
@@ -239,5 +286,3 @@ static func gml_struct_remove_from_hash(struct_value, member_hash):
 	if is_undefined(member_name):
 		return member_name
 	return gml_struct_remove(struct_value, member_name)
-
-

--- a/src/conversion/gml_transpiler_parts/emitter.py
+++ b/src/conversion/gml_transpiler_parts/emitter.py
@@ -275,13 +275,12 @@ def _emit_expression(
             scope_context=scope_context,
         )
         return f"{target}.{_sanitize_gdscript_identifier(expr.member)}", _POSTFIX_PRECEDENCE
-    target = _emit_child(
+    target = _emit_instance_keyword_argument(
         expr.target,
-        _POSTFIX_PRECEDENCE,
-        local_names=local_names,
+        local_names,
         scope_context=scope_context,
     )
-    return f"GMRuntime.gml_struct_get({target}, {json.dumps(expr.member)})", _POSTFIX_PRECEDENCE
+    return f"GMRuntime.gml_selector_get({target}, {json.dumps(expr.member)})", _POSTFIX_PRECEDENCE
 
 
 def _uses_direct_member_access(
@@ -480,8 +479,9 @@ def _emit_instance_keyword_argument(
         return "GMRuntime.gml_instance_all()"
     if legacy_keyword == -4:
         return "GMRuntime.gml_instance_noone()"
-    if isinstance(expr, _Name) and expr.value in scope_context.asset_names:
-        return f"GMRuntime.gml_asset_get_index({json.dumps(expr.value)})"
+    unwrapped_expr = _unwrap_grouped_expression(expr)
+    if isinstance(unwrapped_expr, _Name) and unwrapped_expr.value in scope_context.asset_names:
+        return f"GMRuntime.gml_asset_get_index({json.dumps(unwrapped_expr.value)})"
     return _emit_expression(expr, local_names, scope_context=scope_context)[0]
 
 

--- a/src/conversion/gml_transpiler_parts/statement_parser.py
+++ b/src/conversion/gml_transpiler_parts/statement_parser.py
@@ -5,7 +5,9 @@ import json
 from typing import Iterable, MutableMapping, MutableSet
 
 from .constants import _EOF
+from .emitter import _emit_instance_keyword_argument
 from .enum_helpers import _evaluate_enum_value_tokens
+from .expression_parser import _parse_gml_expression
 from .expression_service import transpile_gml_condition, transpile_gml_expression
 from .identifiers import _sanitize_gdscript_identifier, _validate_gml_identifier, _reject_asset_identifier_name
 from .model import GMLTranspileError, _ScopeContext, _Token
@@ -256,13 +258,17 @@ class _StatementParser:
         if not target_tokens:
             raise GMLTranspileError("Expected with target")
 
-        target = transpile_gml_expression(
+        target_expr = _parse_gml_expression(
             _tokens_to_source(target_tokens),
-            local_names=self.local_names,
             enum_values=self.enum_values,
             enum_names=self.enum_names,
-            scope_context=self.scope_context,
             macro_values=self.macro_values,
+            scope_context=self.scope_context,
+        )
+        target = _emit_instance_keyword_argument(
+            target_expr,
+            self.local_names,
+            scope_context=self.scope_context,
         )
         with_target = self._next_generated_name("_gml_with_target")
         outer_scope_context = self.scope_context

--- a/src/conversion/gml_transpiler_parts/statements.py
+++ b/src/conversion/gml_transpiler_parts/statements.py
@@ -11,7 +11,12 @@ from .constants import (
     _COMPOUND_RUNTIME_FUNCTIONS,
     _GML_LITERAL_IDENTIFIERS,
 )
-from .emitter import _emit_expression, _name_resolves_to_global, _uses_direct_member_access
+from .emitter import (
+    _emit_expression,
+    _emit_instance_keyword_argument,
+    _name_resolves_to_global,
+    _uses_direct_member_access,
+)
 from .enum_helpers import (
     _reject_constant_assignment_target_name,
     _reject_constant_declaration_name,
@@ -222,6 +227,31 @@ def _transpile_statement(
                 "GMRuntime.gml_variable_instance_set("
                 f"{instance_target}, {member_name}, "
                 f"GMRuntime.{helper}({current_value}, 1))"
+            ]
+        selector_target = _selector_assignment_parts(
+            target_expr,
+            local_names,
+            scope_context=scope_context,
+        )
+        if selector_target is not None:
+            container, key = selector_target
+            prelude_lines: list[str] = []
+            if isinstance(target_expr, _Member):
+                container = _cache_assignment_part(
+                    prelude_lines,
+                    target_expr.target,
+                    container,
+                    generated_counter,
+                    "_gml_selector_target",
+                )
+            current_value = _next_generated_name_from_counter(
+                generated_counter,
+                "_gml_selector_value",
+            )
+            return [
+                *prelude_lines,
+                f"GMRuntime.gml_selector_update({container}, {key}, "
+                f"func({current_value}): return GMRuntime.{helper}({current_value}, 1))",
             ]
         if isinstance(target_expr, _Index):
             container = _emit_expression(
@@ -555,6 +585,42 @@ def _transpile_statement(
                     f"GMRuntime.{helper}({current_value}, {value}))"
                 ]
             raise GMLTranspileError("Unsupported DS map accessor assignment operator")
+        selector_target = _selector_assignment_parts(
+            target_expr,
+            local_names,
+            scope_context=scope_context,
+        )
+        if selector_target is not None:
+            container, key = selector_target
+            if operator in ("=", ":="):
+                return [f"GMRuntime.gml_selector_set({container}, {key}, {value})"]
+            prelude_lines = []
+            if isinstance(target_expr, _Member):
+                container = _cache_assignment_part(
+                    prelude_lines,
+                    target_expr.target,
+                    container,
+                    generated_counter,
+                    "_gml_selector_target",
+                )
+            if operator == "??=":
+                return [
+                    *prelude_lines,
+                    f"GMRuntime.gml_selector_set_if_nullish({container}, {key}, "
+                    f"func(): return {value})",
+                ]
+            if operator in _COMPOUND_RUNTIME_FUNCTIONS:
+                helper = _COMPOUND_RUNTIME_FUNCTIONS[operator]
+                current_value = _next_generated_name_from_counter(
+                    generated_counter,
+                    "_gml_selector_value",
+                )
+                return [
+                    *prelude_lines,
+                    f"GMRuntime.gml_selector_update({container}, {key}, "
+                    f"func({current_value}): return GMRuntime.{helper}({current_value}, {value}))",
+                ]
+            raise GMLTranspileError("Unsupported selector member assignment operator")
         struct_target = _struct_assignment_parts(
             target_expr,
             local_names,
@@ -943,6 +1009,14 @@ def _transpile_assignment_to_emitted_value(
     if ds_map_target is not None:
         container, key = ds_map_target
         return [f"GMRuntime.gml_ds_map_set({container}, {key}, {value})"]
+    selector_target = _selector_assignment_parts(
+        target_expr,
+        local_names,
+        scope_context=scope_context,
+    )
+    if selector_target is not None:
+        container, key = selector_target
+        return [f"GMRuntime.gml_selector_set({container}, {key}, {value})"]
     struct_target = _struct_assignment_parts(
         target_expr,
         local_names,
@@ -957,3 +1031,22 @@ def _transpile_assignment_to_emitted_value(
         scope_context=scope_context,
     )[0]
     return [f"{emitted_target} = {value}"]
+
+
+def _selector_assignment_parts(
+    target_expr: _Expression,
+    local_names: Iterable[str],
+    scope_context: _ScopeContext | None = None,
+) -> tuple[str, str] | None:
+    scope_context = _normalize_scope_context(scope_context)
+    if not isinstance(target_expr, _Member) or _uses_direct_member_access(
+        target_expr,
+        scope_context=scope_context,
+    ):
+        return None
+    container = _emit_instance_keyword_argument(
+        target_expr.target,
+        local_names,
+        scope_context=scope_context,
+    )
+    return container, json.dumps(target_expr.member)

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -37,6 +37,10 @@ RUNTIME_VALUE_PARITY_CASES = (
         "with_targets(o_enemy)",
         'GMRuntime.gml_with_targets(GMRuntime.gml_asset_get_index("o_enemy"))',
     ),
+    RuntimeValueParityCase(
+        "o_enemy.hp",
+        'GMRuntime.gml_selector_get(GMRuntime.gml_asset_get_index("o_enemy"), "hp")',
+    ),
     RuntimeValueParityCase("pointer_null", "GMRuntime.gml_pointer_null()"),
     RuntimeValueParityCase("pointer_invalid", "GMRuntime.gml_pointer_invalid()"),
     RuntimeValueParityCase("typeof(undefined)", "GMRuntime.gml_typeof(GMRuntime.gml_undefined())"),
@@ -276,7 +280,7 @@ RUNTIME_VALUE_PARITY_CASES = (
     RuntimeValueParityCase("instance_id_get(0)", "GMRuntime.gml_instance_id_get(0)"),
     RuntimeValueParityCase("items == other_items", "GMRuntime.gml_eq(items, other_items)"),
     RuntimeValueParityCase("{a: 1}", 'GMRuntime.gml_struct({"a": 1})'),
-    RuntimeValueParityCase("mystruct.a", 'GMRuntime.gml_struct_get(mystruct, "a")'),
+    RuntimeValueParityCase("mystruct.a", 'GMRuntime.gml_selector_get(mystruct, "a")'),
     RuntimeValueParityCase('mystruct[$ "x"]', 'GMRuntime.gml_struct_get(mystruct, "x")'),
     RuntimeValueParityCase('struct_exists(mystruct, "x")', 'GMRuntime.gml_struct_exists(mystruct, "x")'),
     RuntimeValueParityCase('struct_get(mystruct, "x")', 'GMRuntime.gml_struct_get(mystruct, "x")'),
@@ -319,7 +323,7 @@ RUNTIME_VALUE_PARITY_CASES = (
         'GMRuntime.gml_variable_instance_set(GMRuntime.gml_instance_noone(), "hp", 10)',
     ),
     RuntimeValueParityCase("global", "GMRuntime.gml_global_scope()"),
-    RuntimeValueParityCase("global.score", 'GMRuntime.gml_struct_get(GMRuntime.gml_global_scope(), "score")'),
+    RuntimeValueParityCase("global.score", 'GMRuntime.gml_selector_get(GMRuntime.gml_global_scope(), "score")'),
     RuntimeValueParityCase(
         'variable_instance_get(global, "score")',
         'GMRuntime.gml_variable_instance_get(GMRuntime.gml_global_scope(), "score")',
@@ -537,6 +541,13 @@ class TestGMLRuntimeScript(unittest.TestCase):
             "gml_instance_create_layer",
             "gml_instance_create_depth",
             "gml_with_targets",
+            "gml_selector_get",
+            "gml_selector_exists",
+            "gml_selector_set",
+            "gml_selector_update",
+            "gml_selector_set_if_nullish",
+            "gml_selector_get_names",
+            "gml_selector_names_count",
             "gml_handle_is_valid",
             "gml_handle_parse",
             "gml_ref_create",
@@ -758,6 +769,20 @@ class TestGMLRuntimeScript(unittest.TestCase):
         self.assertIn('targets.append(entry["instance"])', GML_RUNTIME_SCRIPT)
         self.assertIn("gml_handle_invalidate(handle)", GML_RUNTIME_SCRIPT)
         self.assertIn("if _gml_is_invalid_handle_index(handle_kind, handle_index):", GML_RUNTIME_SCRIPT)
+
+    def test_runtime_selector_helpers_use_with_targets(self):
+        self.assertIn("static func gml_selector_get(target, member_name, current_self = null, current_other = null):", GML_RUNTIME_SCRIPT)
+        self.assertIn("return gml_struct_get(targets[0], member_name)", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_selector_exists(target, member_name, current_self = null, current_other = null):", GML_RUNTIME_SCRIPT)
+        self.assertIn("if gml_struct_exists(instance, member_name):\n\t\t\treturn true", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_selector_set(target, member_name, value, current_self = null, current_other = null):", GML_RUNTIME_SCRIPT)
+        self.assertIn("for instance in targets:\n\t\tgml_struct_set(instance, member_name, value)", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_selector_update(target, member_name, update_callable, current_self = null, current_other = null):", GML_RUNTIME_SCRIPT)
+        self.assertIn("result = update_callable.call(gml_struct_get(instance, member_name))", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_selector_set_if_nullish(target, member_name, value_callable, current_self = null, current_other = null):", GML_RUNTIME_SCRIPT)
+        self.assertIn("result = gml_struct_set(instance, member_name, value_callable.call())", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_selector_get_names(target, current_self = null, current_other = null):", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_selector_names_count(target, current_self = null, current_other = null):", GML_RUNTIME_SCRIPT)
         self.assertIn("handle.reference = null", GML_RUNTIME_SCRIPT)
         self.assertIn("handle.index = _gml_invalid_handle_index(handle.kind)", GML_RUNTIME_SCRIPT)
         self.assertIn("handle.value = _gml_encode_handle_value(handle.type_id, handle.index)", GML_RUNTIME_SCRIPT)
@@ -1135,8 +1160,8 @@ class TestGMLRuntimeScript(unittest.TestCase):
         self.assertIn("static func gml_variable_struct_get(struct_value, member_name):", GML_RUNTIME_SCRIPT)
         self.assertIn("return gml_struct_get(struct_value, member_name)", GML_RUNTIME_SCRIPT)
         self.assertIn("static func gml_variable_instance_get(instance_value, member_name):", GML_RUNTIME_SCRIPT)
-        self.assertIn("var resolved_instance = _gml_resolve_instance(instance_value)", GML_RUNTIME_SCRIPT)
-        self.assertIn("if resolved_instance == null:\n\t\treturn gml_undefined()", GML_RUNTIME_SCRIPT)
+        self.assertIn("return gml_selector_get(instance_value, member_name)", GML_RUNTIME_SCRIPT)
+        self.assertIn("if targets.is_empty():\n\t\treturn gml_undefined()", GML_RUNTIME_SCRIPT)
         self.assertIn("static func gml_ds_map_find_value(map_value, key):", GML_RUNTIME_SCRIPT)
         self.assertIn("var resolved_map = _gml_resolve_ds_map(map_value)", GML_RUNTIME_SCRIPT)
         self.assertIn("if resolved_map.has(key):\n\t\t\treturn resolved_map[key]", GML_RUNTIME_SCRIPT)
@@ -1153,17 +1178,17 @@ class TestGMLRuntimeScript(unittest.TestCase):
         self.assertIn("static func gml_typeof(value):\n\tif is_undefined(value):\n\t\treturn GML_TYPE_UNDEFINED", GML_RUNTIME_SCRIPT)
         self.assertIn("static func gml_string(value):\n\tif is_undefined(value):\n\t\treturn GML_TYPE_UNDEFINED", GML_RUNTIME_SCRIPT)
         self.assertIn("static func gml_bool(value):\n\tif is_undefined(value):\n\t\treturn false", GML_RUNTIME_SCRIPT)
-        self.assertIn("if resolved_instance == null:\n\t\treturn gml_undefined()", GML_RUNTIME_SCRIPT)
+        self.assertIn("if targets.is_empty():\n\t\treturn gml_undefined()", GML_RUNTIME_SCRIPT)
         self.assertIn("if resolved_map.has(key):\n\t\t\treturn resolved_map[key]", GML_RUNTIME_SCRIPT)
         self.assertIn("return gml_undefined()", GML_RUNTIME_SCRIPT)
 
     def test_runtime_instance_variable_helpers_resolve_instances_and_invalid_ids(self):
         self.assertIn("static func gml_variable_instance_exists(instance_value, member_name):", GML_RUNTIME_SCRIPT)
-        self.assertIn("return gml_struct_exists(resolved_instance, member_name)", GML_RUNTIME_SCRIPT)
+        self.assertIn("return gml_selector_exists(instance_value, member_name)", GML_RUNTIME_SCRIPT)
         self.assertIn("static func gml_variable_instance_set(instance_value, member_name, value):", GML_RUNTIME_SCRIPT)
-        self.assertIn("return gml_struct_set(resolved_instance, member_name, value)", GML_RUNTIME_SCRIPT)
-        self.assertIn("if resolved_instance == null:\n\t\treturn false", GML_RUNTIME_SCRIPT)
-        self.assertIn("if resolved_instance == null:\n\t\treturn gml_undefined()", GML_RUNTIME_SCRIPT)
+        self.assertIn("return gml_selector_set(instance_value, member_name, value)", GML_RUNTIME_SCRIPT)
+        self.assertIn("for instance in gml_with_targets(target, current_self, current_other):", GML_RUNTIME_SCRIPT)
+        self.assertIn("for instance in targets:\n\t\tgml_struct_set(instance, member_name, value)", GML_RUNTIME_SCRIPT)
 
     def test_runtime_global_scope_is_a_shared_struct_for_instance_apis(self):
         self.assertIn("static var _gml_global_scope = {", GML_RUNTIME_SCRIPT)
@@ -1218,12 +1243,11 @@ class TestGMLRuntimeScript(unittest.TestCase):
 
     def test_runtime_instance_name_helpers_enumerate_visible_names_and_invalid_instances(self):
         self.assertIn("static func gml_variable_instance_get_names(instance_value):", GML_RUNTIME_SCRIPT)
-        self.assertIn("var resolved_instance = _gml_resolve_instance(instance_value)", GML_RUNTIME_SCRIPT)
-        self.assertIn("return gml_struct_get_names(resolved_instance)", GML_RUNTIME_SCRIPT)
+        self.assertIn("return gml_selector_get_names(instance_value)", GML_RUNTIME_SCRIPT)
         self.assertIn("static func gml_variable_instance_names_count(instance_value):", GML_RUNTIME_SCRIPT)
-        self.assertIn("return gml_struct_names_count(resolved_instance)", GML_RUNTIME_SCRIPT)
-        self.assertIn("if resolved_instance == null:\n\t\treturn []", GML_RUNTIME_SCRIPT)
-        self.assertIn("if resolved_instance == null:\n\t\treturn -1", GML_RUNTIME_SCRIPT)
+        self.assertIn("return gml_selector_names_count(instance_value)", GML_RUNTIME_SCRIPT)
+        self.assertIn("if targets.is_empty():\n\t\treturn []", GML_RUNTIME_SCRIPT)
+        self.assertIn("if targets.is_empty():\n\t\treturn -1", GML_RUNTIME_SCRIPT)
 
     def test_runtime_global_variable_helpers_use_shared_global_scope(self):
         self.assertIn("static func gml_variable_global_exists(member_name):", GML_RUNTIME_SCRIPT)

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -752,7 +752,7 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
         self.assertEqual(
             transpile_gml_code("enum RAINBOW { RED, ORANGE, GREEN }\ncolour = RAINBOW.GREEN", indent=""),
             'var RAINBOW = GMRuntime.gml_enum({"RED": 0, "ORANGE": 1, "GREEN": 2})\n'
-            'colour = GMRuntime.gml_struct_get(RAINBOW, "GREEN")',
+            'colour = GMRuntime.gml_selector_get(RAINBOW, "GREEN")',
         )
         self.assertEqual(
             transpile_gml_code(
@@ -854,7 +854,7 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
         self.assertEqual(
             transpile_gml_code("enum RAINBOW { GREEN }\nitems[RAINBOW.GREEN] = 2", indent=""),
             'var RAINBOW = GMRuntime.gml_enum({"GREEN": 0})\n'
-            'GMRuntime.gml_array_set(items, GMRuntime.gml_struct_get(RAINBOW, "GREEN"), 2)',
+            'GMRuntime.gml_array_set(items, GMRuntime.gml_selector_get(RAINBOW, "GREEN"), 2)',
         )
 
     def test_transpiles_nullish_operator(self):
@@ -979,11 +979,11 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
     def test_transpiles_struct_member_access_through_runtime(self):
         self.assertEqual(
             transpile_gml_expression("mystruct.a"),
-            'GMRuntime.gml_struct_get(mystruct, "a")',
+            'GMRuntime.gml_selector_get(mystruct, "a")',
         )
         self.assertEqual(
             transpile_gml_expression("{a: 1}.a"),
-            'GMRuntime.gml_struct_get(GMRuntime.gml_struct({"a": 1}), "a")',
+            'GMRuntime.gml_selector_get(GMRuntime.gml_struct({"a": 1}), "a")',
         )
         self.assertEqual(
             transpile_gml_expression('mystruct[$ "x"]'),
@@ -1090,11 +1090,11 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
         self.assertEqual(transpile_gml_expression("global"), "GMRuntime.gml_global_scope()")
         self.assertEqual(
             transpile_gml_expression("global.score"),
-            'GMRuntime.gml_struct_get(GMRuntime.gml_global_scope(), "score")',
+            'GMRuntime.gml_selector_get(GMRuntime.gml_global_scope(), "score")',
         )
         self.assertEqual(
             transpile_gml_code("global.score = 10", indent=""),
-            'GMRuntime.gml_struct_set(GMRuntime.gml_global_scope(), "score", 10)',
+            'GMRuntime.gml_selector_set(GMRuntime.gml_global_scope(), "score", 10)',
         )
         self.assertEqual(
             transpile_gml_expression('variable_instance_get(global, "score")'),
@@ -1243,7 +1243,7 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
         )
         self.assertEqual(
             transpile_gml_expression("new factory.Point(name, )"),
-            'GMRuntime.gml_new(GMRuntime.gml_struct_get(factory, "Point"), '
+            'GMRuntime.gml_new(GMRuntime.gml_selector_get(factory, "Point"), '
             "[name, GMRuntime.gml_undefined()])",
         )
 
@@ -1529,7 +1529,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             "if GMRuntime.is_gml_exception(_gml_try_exception_0):\n"
             "\tvar err = GMRuntime.gml_exception_struct(_gml_try_exception_0)\n"
             "\t_gml_try_exception_0 = (func():\n"
-            '\t\tmessage = GMRuntime.gml_struct_get(err, "message")\n'
+            '\t\tmessage = GMRuntime.gml_selector_get(err, "message")\n'
             "\t\treturn GMRuntime.gml_undefined()\n"
             "\t).call()\n"
             "if GMRuntime.is_gml_exception(_gml_try_exception_0):\n"
@@ -1562,7 +1562,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
         self.assertIn("\t\t\treturn GMRuntime.gml_throw(inner)", output)
         self.assertIn("\treturn _gml_try_exception_1", output)
         self.assertIn("var outer = GMRuntime.gml_exception_struct(_gml_try_exception_0)", output)
-        self.assertIn('message = GMRuntime.gml_struct_get(outer, "message")', output)
+        self.assertIn('message = GMRuntime.gml_selector_get(outer, "message")', output)
 
     def test_rejects_control_flow_inside_finally_blocks(self):
         cases = (
@@ -1662,10 +1662,10 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             '\tGMRuntime.gml_variable_instance_set(_gml_with_target_0, "hp", '
             'GMRuntime.gml_add(GMRuntime.gml_variable_instance_get(_gml_with_target_0, "hp"), '
             'GMRuntime.gml_variable_instance_get(_gml_with_target_0, "damage")))\n'
-            '\tGMRuntime.gml_struct_set(self, "total", '
-            'GMRuntime.gml_add(GMRuntime.gml_struct_get(self, "total"), '
+            '\tGMRuntime.gml_selector_update(self, "total", '
+            'func(_gml_selector_value_1): return GMRuntime.gml_add(_gml_selector_value_1, '
             'GMRuntime.gml_variable_instance_get(_gml_with_target_0, "hp")))\n'
-            '\tGMRuntime.gml_struct_set(_gml_with_target_0, "flag", true)',
+            '\tGMRuntime.gml_selector_set(_gml_with_target_0, "flag", true)',
         )
 
     def test_with_preserves_enclosing_local_mutation(self):
@@ -1679,6 +1679,28 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             '\ttotal = GMRuntime.gml_add(total, GMRuntime.gml_variable_instance_get(_gml_with_target_0, "hp"))\n'
             "\tvar seen = total\n"
             '\tGMRuntime.gml_variable_instance_set(_gml_with_target_0, "hp", seen)',
+        )
+
+    def test_nested_with_preserves_self_other_and_outer_locals_for_selectors(self):
+        self.assertEqual(
+            transpile_gml_code(
+                "var total = 0; "
+                "with (o_parent) begin "
+                "with (o_enemy) begin "
+                "total += other.hp + self.hp; "
+                "other.hp = total; "
+                "self.hp = other.hp; "
+                "end end",
+                indent="",
+                asset_names={"o_parent", "o_enemy"},
+            ),
+            "var total = 0\n"
+            'for _gml_with_target_0 in GMRuntime.gml_with_targets(GMRuntime.gml_asset_get_index("o_parent"), self, other):\n'
+            '\tfor _gml_with_target_1 in GMRuntime.gml_with_targets(GMRuntime.gml_asset_get_index("o_enemy"), _gml_with_target_0, self):\n'
+            '\t\ttotal = GMRuntime.gml_add(total, GMRuntime.gml_add(GMRuntime.gml_selector_get(_gml_with_target_0, "hp"), '
+            'GMRuntime.gml_selector_get(_gml_with_target_1, "hp")))\n'
+            '\t\tGMRuntime.gml_selector_set(_gml_with_target_0, "hp", total)\n'
+            '\t\tGMRuntime.gml_selector_set(_gml_with_target_1, "hp", GMRuntime.gml_selector_get(_gml_with_target_0, "hp"))',
         )
 
     def test_delete_clears_only_named_struct_reference(self):
@@ -2075,6 +2097,35 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             transpile_gml_expression("instance_destroy()"),
             "GMRuntime.gml_instance_destroy(self)",
         )
+        self.assertEqual(
+            transpile_gml_code("with (o_enemy) hp = 0;", indent="", asset_names=asset_names),
+            'for _gml_with_target_0 in GMRuntime.gml_with_targets(GMRuntime.gml_asset_get_index("o_enemy"), self, other):\n'
+            '\tGMRuntime.gml_variable_instance_set(_gml_with_target_0, "hp", 0)',
+        )
+
+    def test_cross_instance_dot_access_uses_selector_helpers(self):
+        asset_names = {"o_enemy", "o_parent"}
+
+        self.assertEqual(
+            transpile_gml_expression("o_enemy.hp", asset_names=asset_names),
+            'GMRuntime.gml_selector_get(GMRuntime.gml_asset_get_index("o_enemy"), "hp")',
+        )
+        self.assertEqual(
+            transpile_gml_expression("(o_parent).hp", asset_names=asset_names),
+            'GMRuntime.gml_selector_get(GMRuntime.gml_asset_get_index("o_parent"), "hp")',
+        )
+        self.assertEqual(
+            transpile_gml_expression("enemy_id.hp", local_names={"enemy_id"}),
+            'GMRuntime.gml_selector_get(enemy_id, "hp")',
+        )
+        self.assertEqual(
+            transpile_gml_code("o_enemy.hp = 0;", indent="", asset_names=asset_names),
+            'GMRuntime.gml_selector_set(GMRuntime.gml_asset_get_index("o_enemy"), "hp", 0)',
+        )
+        self.assertEqual(
+            transpile_gml_code("enemy_id.hp = 10;", indent=""),
+            'GMRuntime.gml_selector_set(enemy_id, "hp", 10)',
+        )
 
     def test_transpiles_array_assignments_through_runtime(self):
         self.assertEqual(
@@ -2102,7 +2153,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
     def test_transpiles_struct_member_assignments_through_runtime(self):
         self.assertEqual(
             transpile_gml_code("mystruct.a = 20;", indent=""),
-            'GMRuntime.gml_struct_set(mystruct, "a", 20)',
+            'GMRuntime.gml_selector_set(mystruct, "a", 20)',
         )
         self.assertEqual(
             transpile_gml_code('mystruct[$ "x"] = score + 1;', indent=""),
@@ -2110,24 +2161,23 @@ class TestGMLStatementTranspiler(unittest.TestCase):
         )
         self.assertEqual(
             transpile_gml_code("mystruct.a += 1;", indent=""),
-            'GMRuntime.gml_struct_set(mystruct, "a", '
-            'GMRuntime.gml_add(GMRuntime.gml_struct_get(mystruct, "a"), 1))',
+            'GMRuntime.gml_selector_update(mystruct, "a", '
+            'func(_gml_selector_value_0): return GMRuntime.gml_add(_gml_selector_value_0, 1))',
         )
         self.assertEqual(
             transpile_gml_code("mystruct.a ??= 1;", indent=""),
-            'if GMRuntime.gml_is_nullish(GMRuntime.gml_struct_get(mystruct, "a")):\n'
-            '\tGMRuntime.gml_struct_set(mystruct, "a", 1)',
+            'GMRuntime.gml_selector_set_if_nullish(mystruct, "a", func(): return 1)',
         )
         self.assertEqual(
             transpile_gml_code("mystruct.a++;", indent=""),
-            'GMRuntime.gml_struct_set(mystruct, "a", '
-            'GMRuntime.gml_add(GMRuntime.gml_struct_get(mystruct, "a"), 1))',
+            'GMRuntime.gml_selector_update(mystruct, "a", '
+            'func(_gml_selector_value_0): return GMRuntime.gml_add(_gml_selector_value_0, 1))',
         )
         self.assertEqual(
             transpile_gml_code("get_struct().a += 1;", indent=""),
-            'var _gml_struct_target_0 = get_struct()\n'
-            'GMRuntime.gml_struct_set(_gml_struct_target_0, "a", '
-            'GMRuntime.gml_add(GMRuntime.gml_struct_get(_gml_struct_target_0, "a"), 1))',
+            'var _gml_selector_target_0 = get_struct()\n'
+            'GMRuntime.gml_selector_update(_gml_selector_target_0, "a", '
+            'func(_gml_selector_value_1): return GMRuntime.gml_add(_gml_selector_value_1, 1))',
         )
 
     def test_array_assignment_aliases_preserve_reference_mutation(self):
@@ -2143,8 +2193,8 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             transpile_gml_code("mystruct = {a: 1}; alias = mystruct; alias.a = 2; value = mystruct.a;", indent=""),
             'mystruct = GMRuntime.gml_struct({"a": 1})\n'
             "alias = mystruct\n"
-            'GMRuntime.gml_struct_set(alias, "a", 2)\n'
-            'value = GMRuntime.gml_struct_get(mystruct, "a")',
+            'GMRuntime.gml_selector_set(alias, "a", 2)\n'
+            'value = GMRuntime.gml_selector_get(mystruct, "a")',
         )
 
     def test_struct_function_arguments_pass_reference_without_clone(self):
@@ -2152,7 +2202,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             transpile_gml_code("mystruct = {a: 1}; mutate_struct(mystruct); value = mystruct.a;", indent=""),
             'mystruct = GMRuntime.gml_struct({"a": 1})\n'
             "mutate_struct(mystruct)\n"
-            'value = GMRuntime.gml_struct_get(mystruct, "a")',
+            'value = GMRuntime.gml_selector_get(mystruct, "a")',
         )
 
     def test_function_argument_reassignment_does_not_mutate_caller_value(self):

--- a/tests/test_instance_registry_godot.py
+++ b/tests/test_instance_registry_godot.py
@@ -138,6 +138,32 @@ def _write_smoke_scene(project_dir: Path) -> None:
         \tif not _check(GMRuntime.gml_instance_furthest(0, 20, enemy_selector).index == handle_b.index, "furthest picked the wrong instance"):
         \t\treturn
 
+        \tGMRuntime.gml_selector_set(enemy_selector, "hp", 7, self, null)
+        \tif not _check(first.hp == 7 and second.hp == 7, "object selector write did not update every child instance"):
+        \t\treturn
+        \tif not _check(GMRuntime.gml_selector_get(enemy_selector, "hp", self, null) == 7, "object selector read did not return first matching value"):
+        \t\treturn
+        \tGMRuntime.gml_selector_set(parent_selector, "hp", 9, self, null)
+        \tif not _check(first.hp == 9 and second.hp == 9, "parent selector write did not update inherited child instances"):
+        \t\treturn
+        \tGMRuntime.gml_variable_instance_set(parent_selector, "hp", 13)
+        \tif not _check(first.hp == 13 and second.hp == 13, "variable_instance_set did not update parent selector matches"):
+        \t\treturn
+        \tif not _check(GMRuntime.gml_variable_instance_get(parent_selector, "hp") == 13, "variable_instance_get did not read parent selector match"):
+        \t\treturn
+        \tif not _check(GMRuntime.gml_variable_instance_exists(parent_selector, "hp"), "variable_instance_exists did not inspect parent selector matches"):
+        \t\treturn
+        \tif not _check(GMRuntime.gml_variable_instance_get_names(parent_selector).has("hp"), "variable_instance_get_names did not inspect parent selector matches"):
+        \t\treturn
+        \tif not _check(GMRuntime.gml_variable_instance_names_count(parent_selector) > 0, "variable_instance_names_count did not inspect parent selector matches"):
+        \t\treturn
+        \tGMRuntime.gml_selector_set(handle_b, "hp", 11, self, null)
+        \tif not _check(first.hp == 13 and second.hp == 11, "handle selector write affected the wrong instances"):
+        \t\treturn
+        \tGMRuntime.gml_selector_set(raw_a, "hp", 5, self, null)
+        \tif not _check(first.hp == 5 and second.hp == 11, "raw instance id selector write affected the wrong instances"):
+        \t\treturn
+
         \tGMRuntime.gml_instance_destroy(handle_a)
         \tif not _check(not GMRuntime.gml_instance_exists(raw_a), "destroyed raw instance id still exists"):
         \t\treturn
@@ -183,7 +209,11 @@ class TestInstanceRegistryGodotSmoke(unittest.TestCase):
             _write_object(
                 project_dir,
                 "o_parent",
-                generate_script_content([], object_runtime=ObjectRuntimeConfig(object_name="o_parent")),
+                generate_script_content(
+                    [],
+                    instance_variables=["hp"],
+                    object_runtime=ObjectRuntimeConfig(object_name="o_parent"),
+                ),
             )
             _write_object(
                 project_dir,


### PR DESCRIPTION
Closes #486.

## Summary
- add selector get/set/update/name helpers backed by gml_with_targets so object and parent selectors can address registered instances
- lower non-direct dot member reads and writes through selector helpers while preserving direct self/other/global struct-style behavior through runtime targets
- make with statement targets selector-aware and add nested with coverage for self/other plus caller locals
- extend the Godot instance smoke test for object selector, parent selector, raw id, handle, and variable_instance_* access

## Tests
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest tests.test_instance_registry_godot
- ./venv/bin/python -m unittest