### PR TITLE
Fix settings menu localization crash

### DIFF
--- a/src/gui/dialogs/release_notes_dialog.py
+++ b/src/gui/dialogs/release_notes_dialog.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 from PySide6.QtWidgets import QDialog, QVBoxLayout, QTextBrowser, QMessageBox, QWidget
 
 from src.gui.theme import THEME
-from src.localization import get_localized
+from src.localization import get_localized, get_localized_list
 
 
 class ReleaseNotesDialog:
@@ -17,7 +17,7 @@ class ReleaseNotesDialog:
         if notes:
             self._display(notes)
         else:
-            errors = get_localized("ReleaseNotes_Error_NoInternet")
+            errors = get_localized_list("ReleaseNotes_Error_NoInternet")
             QMessageBox.critical(self._parent, errors[0], errors[1])
 
     def _fetch(self) -> str | None:

--- a/src/gui/dialogs/settings_dialog.py
+++ b/src/gui/dialogs/settings_dialog.py
@@ -1,6 +1,4 @@
 import multiprocessing
-from typing import cast
-
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QGridLayout,
@@ -10,7 +8,7 @@ from PySide6.QtWidgets import (
 from src.gui.theme import THEME
 from src.gui.setting_value import SettingValue
 from src.conversion.converter import CONVERSION_CATEGORIES
-from src.localization import get_localized
+from src.localization import get_localized, get_localized_dict, get_localized_list
 
 
 class SettingsDialog(QDialog):
@@ -51,14 +49,18 @@ class SettingsDialog(QDialog):
         grid = QGridLayout(categories_widget)
         grid.setSpacing(20)
 
-        labels = cast(dict[str, str], get_localized("Settings_Labels"))
-        headings = cast(list[str], get_localized("Settings_Categories_Headings"))
+        labels = get_localized_dict("Settings_Labels")
+        headings = get_localized_list("Settings_Categories_Headings")
+        if not headings:
+            headings = [key.replace("_", " ").title() for key in CONVERSION_CATEGORIES.keys()]
+
         categories_items = list(CONVERSION_CATEGORIES.items())
 
         for col, (_cat_key, setting_keys) in enumerate(categories_items):
             col_layout = QVBoxLayout()
 
-            cat_heading = QLabel(headings[col])
+            heading_text = headings[col] if col < len(headings) else _cat_key.replace("_", " ").title()
+            cat_heading = QLabel(heading_text)
             cat_heading.setStyleSheet(
                 f"font-size: {THEME['font_size_large']}pt; font-weight: bold;"
             )

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -23,7 +23,7 @@ from src.gui.dialogs.release_notes_dialog import ReleaseNotesDialog
 from src.gui.dialogs.language_dialog import LanguageDialog
 from src.conversion.converter import CONVERSION_CATEGORIES
 from src.version import get_version
-from src.localization import get_localized
+from src.localization import get_localized, get_localized_list
 from src.update_checker import UpdateChecker
 from src.update_checker import UpdateInfo
 from src.gui.dialogs.update_dialog import UpdateDialog
@@ -202,14 +202,14 @@ class MainWindow(QMainWindow):
         except OSError:
             return
         if not files:
-            errors = get_localized("Console_Error_InvalidProject")
+            errors = get_localized_list("Console_Error_InvalidProject")
             QMessageBox.warning(
                 self,
                 errors[0].format(file_name=file_name),
                 errors[1].format(file_name=file_name, file_extension=file_extension),
             )
         elif len(files) > 1:
-            errors = get_localized("Console_Error_MultipleGenericFiles")
+            errors = get_localized_list("Console_Error_MultipleGenericFiles")
             QMessageBox.warning(
                 self,
                 errors[0].format(file_extension=file_extension),

--- a/src/localization.py
+++ b/src/localization.py
@@ -10,14 +10,13 @@ def get_base_path() -> str:
         return cast(str, getattr(sys, '_MEIPASS'))
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-def _load_language_value(path: str, key: str) -> str | None:
+def _load_language_value(path: str, key: str) -> object | None:
     with open(path, 'r', encoding='utf-8') as file:
         data = cast(dict[str, Any], json.load(file))
-    value = data.get(key)
-    return value if isinstance(value, str) else None
+    return data.get(key)
 
 
-def get_localized(key: str) -> str:
+def _get_localized_raw(key: str) -> object | None:
     base_path = get_base_path()
     lang_file = os.path.join(base_path, 'Current Language')
     with open(lang_file, 'r', encoding='utf-8') as file:
@@ -31,10 +30,32 @@ def get_localized(key: str) -> str:
     except (OSError, json.JSONDecodeError, TypeError, ValueError):
         pass
 
-    # If an exception is thrown, the script will attempt to load the key from eng.json
     try:
-        value = _load_language_value(os.path.join(base_path, 'Languages', 'eng.json'), key)
-        return value or ""
+        return _load_language_value(os.path.join(base_path, 'Languages', 'eng.json'), key)
     except (OSError, json.JSONDecodeError, TypeError, ValueError):
-        return ""
-    # Finally, if eng.json fails, the script will return a blank string
+        return None
+
+
+def get_localized(key: str) -> str:
+    value = _get_localized_raw(key)
+    return value if isinstance(value, str) else ""
+
+
+def get_localized_list(key: str) -> list[str]:
+    value = _get_localized_raw(key)
+    if isinstance(value, list):
+        value_list = cast(list[object], value)
+        return [item for item in value_list if isinstance(item, str)]
+    return []
+
+
+def get_localized_dict(key: str) -> dict[str, str]:
+    value = _get_localized_raw(key)
+    if isinstance(value, dict):
+        value_dict = cast(dict[object, object], value)
+        return {
+            str(item_key): str(item_value)
+            for item_key, item_value in value_dict.items()
+            if isinstance(item_key, str) and isinstance(item_value, str)
+        }
+    return {}

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.5.0"
+VERSION = "0.5.1"
 
 def get_version():
     return VERSION


### PR DESCRIPTION
## Summary
- add typed localization helpers for strings, lists, and dicts
- guard settings dialog headings/labels against missing or mismatched localization
- bump version to 0.5.1

## Testing
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest
