### PR TITLE
Add platform-service compatibility hooks

### DIFF
--- a/src/conversion/gml_runtime_parts/script.py
+++ b/src/conversion/gml_runtime_parts/script.py
@@ -33,6 +33,7 @@ _RUNTIME_SEGMENT_NAMES = (
     "70_handle_string_helpers.gd",
     "71_flex_panels.gd",
     "72_os_debug_gc.gd",
+    "73_platform_services.gd",
     "80_static_hash_clone_error.gd",
 )
 _RUNTIME_SEGMENT_DIR = Path(__file__).with_name("segments")

--- a/src/conversion/gml_runtime_parts/segments/00_prelude.gd
+++ b/src/conversion/gml_runtime_parts/segments/00_prelude.gd
@@ -202,6 +202,12 @@ static func gml_builtin_global(name):
 		return int(Engine.get_frames_per_second())
 	if key == "fps_real":
 		return Engine.get_frames_per_second()
+	if key == "browser_height":
+		return gml_browser_height()
+	if key == "browser_width":
+		return gml_browser_width()
+	if key == "webgl_enabled":
+		return gml_webgl_enabled()
 	if key == "os_browser":
 		return gml_os_browser()
 	if key == "os_device":

--- a/src/conversion/gml_runtime_parts/segments/73_platform_services.gd
+++ b/src/conversion/gml_runtime_parts/segments/73_platform_services.gd
@@ -1,0 +1,159 @@
+static var _gml_platform_service_hooks = {}
+
+
+static func gml_platform_service_register(service_name, hook):
+	var key = str(service_name)
+	if is_undefined(hook) or hook == null:
+		_gml_platform_service_hooks.erase(key)
+	else:
+		_gml_platform_service_hooks[key] = hook
+	return null
+
+
+static func gml_platform_service_is_available(service_name):
+	return _gml_platform_service_hooks.has(str(service_name))
+
+
+static func gml_platform_service_has_api(service_name, api_name):
+	var hook = _gml_platform_service_hooks.get(str(service_name), null)
+	if hook == null:
+		return false
+	var method_name = str(api_name)
+	if typeof(hook) == TYPE_DICTIONARY:
+		return typeof(hook.get(method_name, null)) == TYPE_CALLABLE
+	return hook is Object and hook.has_method(method_name)
+
+
+static func gml_platform_service_call(service_name, api_name, args = []):
+	var hook = _gml_platform_service_hooks.get(str(service_name), null)
+	if hook == null:
+		return gml_platform_service_unsupported(api_name, service_name)
+	var method_name = str(api_name)
+	if typeof(hook) == TYPE_DICTIONARY:
+		var callback = hook.get(method_name, null)
+		if typeof(callback) == TYPE_CALLABLE:
+			return callback.callv(args)
+	if hook is Object and hook.has_method(method_name):
+		return hook.callv(method_name, args)
+	return gml_platform_service_unsupported(api_name, service_name)
+
+
+static func gml_platform_service_unsupported(api_name, service_name, detail = ""):
+	var message = (
+		"GML platform-service API "
+		+ str(api_name)
+		+ " requires an optional "
+		+ str(service_name)
+		+ " addon/plugin or closed platform SDK integration."
+	)
+	if str(detail) != "":
+		message += " " + str(detail)
+	return gml_error(message)
+
+
+static func _gml_platform_service_try_call(service_name, api_name, args, fallback):
+	if gml_platform_service_has_api(service_name, api_name):
+		return gml_platform_service_call(service_name, api_name, args)
+	return fallback
+
+
+static func _gml_platform_service_required_call(service_name, api_name, args):
+	return gml_platform_service_call(service_name, api_name, args)
+
+
+static func gml_steam_is_initialized():
+	return gml_bool(_gml_platform_service_try_call("steam", "steam_is_initialized", [], false))
+
+
+static func gml_browser_width():
+	return _gml_platform_service_try_call("web", "browser_width", [], DisplayServer.window_get_size().x)
+
+
+static func gml_browser_height():
+	return _gml_platform_service_try_call("web", "browser_height", [], DisplayServer.window_get_size().y)
+
+
+static func gml_browser_input_capture(enable):
+	return _gml_platform_service_try_call("web", "browser_input_capture", [enable], null)
+
+
+static func gml_webgl_enabled():
+	return gml_bool(_gml_platform_service_try_call("web", "webgl_enabled", [], true))
+
+
+static func gml_url_get_domain(url = ""):
+	if gml_platform_service_has_api("web", "url_get_domain"):
+		return gml_platform_service_call("web", "url_get_domain", [])
+	var text = str(url)
+	if text == "":
+		return ""
+	var scheme_index = text.find("://")
+	if scheme_index >= 0:
+		text = text.substr(scheme_index + 3)
+	var slash_index = text.find("/")
+	if slash_index >= 0:
+		text = text.substr(0, slash_index)
+	var at_index = text.rfind("@")
+	if at_index >= 0:
+		text = text.substr(at_index + 1)
+	var colon_index = text.find(":")
+	if colon_index >= 0:
+		text = text.substr(0, colon_index)
+	return text
+
+
+static func gml_url_open(url):
+	if gml_platform_service_has_api("web", "url_open"):
+		return gml_platform_service_call("web", "url_open", [url])
+	var error = OS.shell_open(str(url))
+	if error != OK:
+		push_warning("GM2Godot url_open failed for " + str(url) + " with error " + str(error))
+	return null
+
+
+static func gml_url_open_ext(url, target):
+	if gml_platform_service_has_api("web", "url_open_ext"):
+		return gml_platform_service_call("web", "url_open_ext", [url, target])
+	return gml_url_open(url)
+
+
+static func gml_url_open_full(url, target, options):
+	if gml_platform_service_has_api("web", "url_open_full"):
+		return gml_platform_service_call("web", "url_open_full", [url, target, options])
+	return gml_url_open(url)
+
+
+static func gml_xboxlive_user_is_signed_in():
+	return gml_bool(_gml_platform_service_try_call("xboxlive", "xboxlive_user_is_signed_in", [], false))
+
+
+static func gml_xboxlive_user_is_signing_in():
+	return gml_bool(_gml_platform_service_try_call("xboxlive", "xboxlive_user_is_signing_in", [], false))
+
+
+static func gml_xboxlive_gamertag_for_user():
+	return _gml_platform_service_try_call("xboxlive", "xboxlive_gamertag_for_user", [], "")
+
+
+static func gml_xboxlive_show_account_picker():
+	return _gml_platform_service_required_call("xboxlive", "xboxlive_show_account_picker", [])
+
+
+static func gml_wallpaper_set_config(settings_array):
+	return _gml_platform_service_required_call("wallpaper", "wallpaper_set_config", [settings_array])
+
+
+static func gml_wallpaper_set_subscriptions(subscriptions):
+	return _gml_platform_service_required_call("wallpaper", "wallpaper_set_subscriptions", [subscriptions])
+
+
+static func gml_cloud_synchronise():
+	return _gml_platform_service_required_call("cloud", "cloud_synchronise", [])
+
+
+static func gml_cloud_string_save(data, description):
+	return _gml_platform_service_required_call("cloud", "cloud_string_save", [data, description])
+
+
+static func gml_cloud_file_save(path, description):
+	return _gml_platform_service_required_call("cloud", "cloud_file_save", [path, description])

--- a/src/conversion/gml_transpiler_parts/constants.py
+++ b/src/conversion/gml_transpiler_parts/constants.py
@@ -501,6 +501,8 @@ _BUILTIN_VARIABLE_REGISTRY = {
     "bbox_left": _BuiltinVariableMetadata("instance", "0", False, False, "collision_bounds"),
     "bbox_right": _BuiltinVariableMetadata("instance", "0", False, False, "collision_bounds"),
     "bbox_top": _BuiltinVariableMetadata("instance", "0", False, False, "collision_bounds"),
+    "browser_height": _BuiltinVariableMetadata("global", "0", False, False, "platform"),
+    "browser_width": _BuiltinVariableMetadata("global", "0", False, False, "platform"),
     "current_time": _BuiltinVariableMetadata("global", "0", False, False, "time"),
     "debug_mode": _BuiltinVariableMetadata("global", "false", False, False, "debug"),
     "depth": _BuiltinVariableMetadata("instance", "0", True, False, "rendering"),
@@ -568,6 +570,7 @@ _BUILTIN_VARIABLE_REGISTRY = {
     "visible": _BuiltinVariableMetadata("instance", "true", True, False, "rendering"),
     "vspeed": _BuiltinVariableMetadata("instance", "0", True, False, "motion"),
     "temp_directory": _BuiltinVariableMetadata("global", "", False, False, "files"),
+    "webgl_enabled": _BuiltinVariableMetadata("global", "true", False, False, "platform"),
     "working_directory": _BuiltinVariableMetadata("global", "", False, False, "files"),
     "x": _BuiltinVariableMetadata("instance", "0", True, False, "transform"),
     "xprevious": _BuiltinVariableMetadata("instance", "0", True, False, "motion"),
@@ -1163,6 +1166,24 @@ _OS_DEBUG_GC_RUNTIME_FUNCTIONS = {
     "weak_ref_create": "gml_weak_ref_create",
     "weak_ref_alive": "gml_weak_ref_alive",
     "weak_ref_any_alive": "gml_weak_ref_any_alive",
+}
+
+_PLATFORM_SERVICE_RUNTIME_FUNCTIONS = {
+    "steam_is_initialized": "gml_steam_is_initialized",
+    "browser_input_capture": "gml_browser_input_capture",
+    "url_open": "gml_url_open",
+    "url_open_ext": "gml_url_open_ext",
+    "url_open_full": "gml_url_open_full",
+    "url_get_domain": "gml_url_get_domain",
+    "xboxlive_user_is_signed_in": "gml_xboxlive_user_is_signed_in",
+    "xboxlive_user_is_signing_in": "gml_xboxlive_user_is_signing_in",
+    "xboxlive_gamertag_for_user": "gml_xboxlive_gamertag_for_user",
+    "xboxlive_show_account_picker": "gml_xboxlive_show_account_picker",
+    "wallpaper_set_config": "gml_wallpaper_set_config",
+    "wallpaper_set_subscriptions": "gml_wallpaper_set_subscriptions",
+    "cloud_synchronise": "gml_cloud_synchronise",
+    "cloud_string_save": "gml_cloud_string_save",
+    "cloud_file_save": "gml_cloud_file_save",
 }
 
 _DRAW_RUNTIME_FUNCTIONS = {

--- a/src/conversion/gml_transpiler_parts/gml_api_manifest.py
+++ b/src/conversion/gml_transpiler_parts/gml_api_manifest.py
@@ -385,6 +385,211 @@ def _os_debug_gc_entries() -> tuple[GMLAPIEntry, ...]:
     return implemented_entries + partial_entries + planned_entries + unsupported_entries
 
 
+_PLATFORM_SERVICE_OWNER_MODULE = "src.conversion.gml_runtime_parts.segments.73_platform_services"
+_PLATFORM_STEAM_DOCS_PATH = "GameMaker_Language/GML_Reference/Steam/Steam.htm"
+_PLATFORM_IAP_DOCS_PATH = "GameMaker_Language/GML_Reference/In_App_Purchases/In_App_Purchases.htm"
+_PLATFORM_WEB_DOCS_PATH = "GameMaker_Language/GML_Reference/Web_And_HTML5/Web_And_HTML5.htm"
+_PLATFORM_XBOX_DOCS_PATH = "GameMaker_Language/GML_Reference/UWP_And_XBox_Live/UWP_And_XBox_Live.htm"
+_PLATFORM_WALLPAPER_DOCS_PATH = "GameMaker_Language/GML_Reference/Live_Wallpapers/Live_Wallpapers.htm"
+_PLATFORM_ASYNC_DOCS_PATH = "GameMaker_Language/GML_Reference/Asynchronous_Functions/Asynchronous_Functions.htm"
+_PLATFORM_RUNTIME_HOOK_APIS: tuple[tuple[str, str, GMLAPISupportFlag, str], ...] = (
+    ("steam_is_initialized", _PLATFORM_STEAM_DOCS_PATH, "yes", "Returns false without a registered Steam hook; registered Steam addons can override the value."),
+    ("url_open", _PLATFORM_WEB_DOCS_PATH, "no", "Uses OS.shell_open outside web exports and allows a web hook to provide target-specific window behavior."),
+    ("url_open_ext", _PLATFORM_WEB_DOCS_PATH, "no", "Uses OS.shell_open outside web exports and allows a web hook to honor the HTML5 target parameter."),
+    ("url_open_full", _PLATFORM_WEB_DOCS_PATH, "no", "Uses OS.shell_open outside web exports and allows a web hook to honor the HTML5 target/options parameters."),
+    ("url_get_domain", _PLATFORM_WEB_DOCS_PATH, "yes", "Returns an empty string without a web hook; hook implementations can report the hosting domain."),
+    ("browser_height", _PLATFORM_WEB_DOCS_PATH, "yes", "Falls back to the Godot window height when no browser/web hook is registered."),
+    ("browser_width", _PLATFORM_WEB_DOCS_PATH, "yes", "Falls back to the Godot window width when no browser/web hook is registered."),
+    ("browser_input_capture", _PLATFORM_WEB_DOCS_PATH, "yes", "No-ops unless a web hook implements browser input capture policy."),
+    ("webgl_enabled", _PLATFORM_WEB_DOCS_PATH, "yes", "Matches GameMaker's non-browser true fallback unless a web hook reports otherwise."),
+    ("xboxlive_user_is_signed_in", _PLATFORM_XBOX_DOCS_PATH, "yes", "Returns false without a registered Xbox Live hook; platform addons can provide real account state."),
+    ("xboxlive_user_is_signing_in", _PLATFORM_XBOX_DOCS_PATH, "yes", "Returns false without a registered Xbox Live hook; platform addons can provide real sign-in state."),
+    ("xboxlive_gamertag_for_user", _PLATFORM_XBOX_DOCS_PATH, "yes", "Returns an empty string without a registered Xbox Live hook."),
+    ("xboxlive_show_account_picker", _PLATFORM_XBOX_DOCS_PATH, "no", "Routes through a required Xbox Live hook and reports an explicit diagnostic when unavailable."),
+    ("wallpaper_set_config", _PLATFORM_WALLPAPER_DOCS_PATH, "no", "Routes through a required live wallpaper hook and reports an explicit diagnostic when unavailable."),
+    ("wallpaper_set_subscriptions", _PLATFORM_WALLPAPER_DOCS_PATH, "no", "Routes through a required live wallpaper hook and reports an explicit diagnostic when unavailable."),
+    ("cloud_synchronise", _PLATFORM_ASYNC_DOCS_PATH, "no", "Routes through a required cloud-save hook because the built-in Android cloud API is obsolete."),
+    ("cloud_string_save", _PLATFORM_ASYNC_DOCS_PATH, "no", "Routes through a required cloud-save hook because the built-in Android cloud API is obsolete."),
+    ("cloud_file_save", _PLATFORM_ASYNC_DOCS_PATH, "no", "Routes through a required cloud-save hook because the built-in Android cloud API is obsolete."),
+)
+_PLATFORM_UNSUPPORTED_GROUPS = (
+    (
+        (
+            "steam_activate_overlay",
+            "steam_get_persona_name",
+            "steam_set_achievement",
+            "steam_get_achievement",
+            "steam_user_owns_dlc",
+            "steam_download_scores",
+            "steam_upload_score",
+            "steam_ugc_create_item",
+            "steam_ugc_publish",
+        ),
+        _PLATFORM_STEAM_DOCS_PATH,
+        "Steam APIs now live in the Steam extension and need an optional Godot Steam addon hook; GM2Godot rejects unhooked calls with this diagnostic.",
+    ),
+    (
+        (
+            "iap_data",
+            "iap_activate",
+            "iap_status",
+            "iap_enumerate_products",
+            "iap_restore_all",
+            "iap_acquire",
+            "iap_consume",
+            "iap_product_details",
+            "iap_purchase_details",
+            "mac_refresh_receipt_validation",
+        ),
+        _PLATFORM_IAP_DOCS_PATH,
+        "Store purchase APIs are deprecated or extension-backed and require a platform store addon/plugin integration.",
+    ),
+    (
+        (
+            "clickable_exists",
+            "clickable_add",
+            "clickable_add_ext",
+            "clickable_change",
+            "clickable_change_ext",
+            "clickable_set_style",
+            "clickable_delete",
+            "analytics_event",
+            "analytics_event_ext",
+            "http_get_request_crossorigin",
+            "http_set_request_crossorigin",
+        ),
+        _PLATFORM_WEB_DOCS_PATH,
+        "HTML5 DOM/CORS helpers require a web export policy and JavaScript bridge hook instead of a portable Godot runtime call.",
+    ),
+    (
+        (
+            "uwp_suspend",
+            "uwp_is_suspending",
+            "uwp_is_constrained",
+            "uwp_was_terminated",
+            "uwp_was_closed_by_user",
+            "uwp_show_help",
+            "uwp_license_trial_version",
+            "uwp_license_trial_user",
+            "uwp_license_trial_time_remaining",
+            "uwp_check_privilege",
+            "xboxlive_get_user_count",
+            "xboxlive_get_user",
+            "xboxlive_get_activating_user",
+            "xboxlive_user_is_guest",
+            "xboxlive_user_is_active",
+            "xboxlive_user_is_remote",
+            "xboxlive_user_id_for_user",
+            "xboxlive_sponsor_for_user",
+            "xboxlive_set_rich_presence",
+            "xboxlive_gamedisplayname_for_user",
+            "xboxlive_user_for_pad",
+            "xboxlive_pad_for_user",
+            "xboxlive_pad_count_for_user",
+            "xboxlive_agegroup_for_user",
+            "xboxlive_gamerscore_for_user",
+            "xboxlive_show_profile_card_for_user",
+            "xboxlive_reputation_for_user",
+            "xboxlive_sprite_add_from_gamerpicture",
+            "xboxlive_generate_player_session_id",
+            "xboxlive_set_savedata_user",
+            "xboxlive_get_savedata_user",
+            "xboxlive_get_file_error",
+            "xboxlive_stats_setup",
+            "xboxlive_stats_add_user",
+            "xboxlive_stats_remove_user",
+            "xboxlive_stats_flush_user",
+            "xboxlive_stats_set_stat_real",
+            "xboxlive_stats_set_stat_int",
+            "xboxlive_stats_set_stat_string",
+            "xboxlive_stats_delete_stat",
+            "xboxlive_stats_get_stat_names",
+            "xboxlive_stats_get_stat",
+            "xboxlive_stats_get_leaderboard",
+            "xboxlive_stats_get_social_leaderboard",
+            "xboxlive_achievement_show_achievements",
+            "xboxlive_achievement_load_friends",
+            "xboxlive_achievement_load_leaderboard",
+            "xboxlive_achievements_set_progress",
+            "xboxlive_get_stats_for_user",
+            "xboxlive_read_player_leaderboard",
+            "xboxlive_fire_event",
+            "xboxlive_matchmaking_start",
+            "xboxlive_matchmaking_stop",
+            "xboxlive_matchmaking_create",
+            "xboxlive_matchmaking_find",
+            "xboxlive_matchmaking_session_get_users",
+            "xboxlive_matchmaking_join_session",
+            "xboxlive_matchmaking_session_leave",
+            "xboxlive_matchmaking_send_invites",
+            "xboxlive_matchmaking_set_joinable_session",
+            "xboxlive_matchmaking_join_invite",
+        ),
+        _PLATFORM_XBOX_DOCS_PATH,
+        "UWP/Xbox Live APIs require a closed platform SDK/export runner or a registered platform addon hook.",
+    ),
+)
+_PLATFORM_EVENT_APIS = (
+    ("async_steam_event", _PLATFORM_STEAM_DOCS_PATH, "src.conversion.events.mappings.other_async_steam", "Async Steam event mapping is generated; payload production depends on a Steam addon hook."),
+    ("async_cloud_save_event", _PLATFORM_ASYNC_DOCS_PATH, "src.conversion.events.mappings.other_async_platform", "Async Cloud Save event mapping is generated; payload production depends on a cloud-save addon hook."),
+    ("async_social_event", _PLATFORM_XBOX_DOCS_PATH, "src.conversion.events.mappings.other_async_platform", "Async Social/platform event mapping is generated; payload production depends on the platform addon."),
+    ("async_push_notification_event", _PLATFORM_ASYNC_DOCS_PATH, "src.conversion.events.mappings.other_async_platform", "Async Push Notification event mapping is generated; notification delivery depends on a mobile notification extension."),
+    ("wallpaper_config_event", _PLATFORM_WALLPAPER_DOCS_PATH, "src.conversion.events.mappings.other_wallpaper", "Wallpaper Config event mapping is generated; payload production depends on the live wallpaper companion hook."),
+    ("wallpaper_subscription_data_event", _PLATFORM_WALLPAPER_DOCS_PATH, "src.conversion.events.mappings.other_wallpaper", "Wallpaper Subscription Data event mapping is generated; payload production depends on the live wallpaper companion hook."),
+    ("push_notifications_extension", _PLATFORM_ASYNC_DOCS_PATH, "src.conversion.gml_transpiler_parts.gml_api_manifest", "Current GameMaker push notification behavior is extension-backed; converted projects need an explicit mobile notification addon."),
+)
+
+
+def _platform_service_entries() -> tuple[GMLAPIEntry, ...]:
+    partial_entries = tuple(
+        _entry(
+            name,
+            "Platform Services",
+            "partial",
+            _PLATFORM_SERVICE_OWNER_MODULE,
+            "n/a",
+            "yes",
+            "partial",
+            smoke_coverage,
+            docs_path,
+            notes,
+        )
+        for name, docs_path, smoke_coverage, notes in _PLATFORM_RUNTIME_HOOK_APIS
+    )
+    unsupported_entries = tuple(
+        _entry(
+            name,
+            "Platform Services",
+            "unsupported",
+            "src.conversion.gml_transpiler_parts.gml_api_manifest",
+            "n/a",
+            "no",
+            "no",
+            "no",
+            docs_path,
+            notes,
+        )
+        for names, docs_path, notes in _PLATFORM_UNSUPPORTED_GROUPS
+        for name in names
+    )
+    event_entries = tuple(
+        _entry(
+            name,
+            "Platform Services",
+            "partial" if name != "push_notifications_extension" else "planned",
+            owner_module,
+            "n/a",
+            "n/a",
+            "n/a",
+            "yes" if name != "push_notifications_extension" else "no",
+            docs_path,
+            notes,
+        )
+        for name, docs_path, owner_module, notes in _PLATFORM_EVENT_APIS
+    )
+    return partial_entries + unsupported_entries + event_entries
+
+
 _GML_API_ENTRIES: tuple[GMLAPIEntry, ...] = (
     _entry(
         "gml_api_compatibility_report",
@@ -5588,42 +5793,7 @@ _GML_API_ENTRIES: tuple[GMLAPIEntry, ...] = (
     ),
     *_flexpanel_entries(),
     *_os_debug_gc_entries(),
-    _entry(
-        "steam_is_initialized",
-        "Platform Services",
-        "unsupported",
-        "src.conversion.events.mappings.other_async_steam",
-        "n/a",
-        "no",
-        "no",
-        "partial",
-        "GameMaker_Language/GML_Reference/Steam/Steam.htm",
-        "Needs optional Steam addon/SDK integration; pure transpilation cannot provide it.",
-    ),
-    _entry(
-        "iap_activate",
-        "Platform Services",
-        "unsupported",
-        "src.conversion.events.mappings.other_async_platform",
-        "n/a",
-        "no",
-        "no",
-        "partial",
-        "GameMaker_Language/GML_Reference/In_App_Purchases/In_App_Purchases.htm",
-        "Requires platform store SDK integration outside the core transpiler.",
-    ),
-    _entry(
-        "browser_input_capture",
-        "Platform Services",
-        "planned",
-        "src.conversion.gml_runtime_parts",
-        "n/a",
-        "no",
-        "no",
-        "no",
-        "GameMaker_Language/GML_Reference/Web_And_HTML5/Web_And_HTML5.htm",
-        "Requires HTML5/export-target policy.",
-    ),
+    *_platform_service_entries(),
     _entry(
         "external_define",
         "Extensions",

--- a/src/conversion/gml_transpiler_parts/gml_function_dispatch.py
+++ b/src/conversion/gml_transpiler_parts/gml_function_dispatch.py
@@ -24,6 +24,7 @@ from .constants import (
     _MP_GRID_RUNTIME_FUNCTIONS,
     _NETWORK_RUNTIME_FUNCTIONS,
     _OS_DEBUG_GC_RUNTIME_FUNCTIONS,
+    _PLATFORM_SERVICE_RUNTIME_FUNCTIONS,
     _PATH_RUNTIME_FUNCTIONS,
     _PHYSICS_RUNTIME_FUNCTIONS,
     _ROOM_RUNTIME_FUNCTIONS,
@@ -687,6 +688,24 @@ _OS_DEBUG_GC_ARITY: dict[str, tuple[int, int | None]] = {
     "weak_ref_any_alive": (1, 3),
 }
 
+_PLATFORM_SERVICE_ARITY: dict[str, tuple[int, int | None]] = {
+    "steam_is_initialized": (0, 0),
+    "browser_input_capture": (1, 1),
+    "url_open": (1, 1),
+    "url_open_ext": (2, 2),
+    "url_open_full": (3, 3),
+    "url_get_domain": (0, 0),
+    "xboxlive_user_is_signed_in": (0, 0),
+    "xboxlive_user_is_signing_in": (0, 0),
+    "xboxlive_gamertag_for_user": (0, 0),
+    "xboxlive_show_account_picker": (0, 0),
+    "wallpaper_set_config": (1, 1),
+    "wallpaper_set_subscriptions": (1, 1),
+    "cloud_synchronise": (0, 0),
+    "cloud_string_save": (2, 2),
+    "cloud_file_save": (2, 2),
+}
+
 _DRAW_ARITY: dict[str, tuple[int, int | None]] = {
     "draw_self": (0, 0),
     "draw_sprite": (4, 4),
@@ -959,6 +978,10 @@ def _build_function_descriptors() -> dict[str, GMLFunctionDescriptor]:
 
     for name, target in _OS_DEBUG_GC_RUNTIME_FUNCTIONS.items():
         min_args, max_args = _OS_DEBUG_GC_ARITY[name]
+        descriptors[name] = _descriptor(name, min_args, max_args, "runtime", target)
+
+    for name, target in _PLATFORM_SERVICE_RUNTIME_FUNCTIONS.items():
+        min_args, max_args = _PLATFORM_SERVICE_ARITY[name]
         descriptors[name] = _descriptor(name, min_args, max_args, "runtime", target)
 
     for name, target in _DS_COLLECTIONS_FUNCTIONS.items():

--- a/tests/test_gml_api_manifest.py
+++ b/tests/test_gml_api_manifest.py
@@ -307,6 +307,21 @@ class TestGMLAPIManifest(unittest.TestCase):
         assert gml_pragma is not None
         self.assertEqual(gml_pragma.status, "unsupported")
         self.assertEqual(gml_pragma.issue_number, 515)
+        steam_is_initialized = get_gml_api_entry("steam_is_initialized")
+        self.assertIsNotNone(steam_is_initialized)
+        assert steam_is_initialized is not None
+        self.assertEqual(steam_is_initialized.status, "partial")
+        self.assertEqual(steam_is_initialized.issue_number, 516)
+        browser_input_capture = get_gml_api_entry("browser_input_capture")
+        self.assertIsNotNone(browser_input_capture)
+        assert browser_input_capture is not None
+        self.assertEqual(browser_input_capture.status, "partial")
+        self.assertEqual(browser_input_capture.issue_number, 516)
+        iap_activate = get_gml_api_entry("iap_activate")
+        self.assertIsNotNone(iap_activate)
+        assert iap_activate is not None
+        self.assertEqual(iap_activate.status, "unsupported")
+        self.assertEqual(iap_activate.issue_number, 516)
         self.assertTrue(is_known_gml_api("draw_sprite"))
         self.assertTrue(is_known_gml_api("working_directory"))
         self.assertFalse(is_known_gml_api("project_local_function"))
@@ -430,6 +445,13 @@ class TestGMLAPIManifest(unittest.TestCase):
             "gc_get_stats",
             "weak_ref_create",
             "weak_ref_any_alive",
+            "steam_is_initialized",
+            "browser_input_capture",
+            "url_open",
+            "url_get_domain",
+            "xboxlive_user_is_signed_in",
+            "wallpaper_set_config",
+            "cloud_synchronise",
             "keyboard_check",
             "method",
             "show_debug_message",
@@ -559,6 +581,38 @@ class TestGMLAPIManifest(unittest.TestCase):
                 self.assertIn(name, entries)
                 self.assertEqual(entries[name].issue_number, 515)
 
+    def test_platform_services_manifest_represents_hooked_and_closed_platform_surfaces(self):
+        entries = {
+            entry.name: entry
+            for entry in iter_gml_api_entries()
+            if entry.category == "Platform Services"
+        }
+
+        for name in (
+            "steam_is_initialized",
+            "url_open_full",
+            "browser_width",
+            "webgl_enabled",
+            "iap_activate",
+            "clickable_add",
+            "xboxlive_matchmaking_create",
+            "wallpaper_set_config",
+            "cloud_synchronise",
+            "async_push_notification_event",
+            "async_cloud_save_event",
+            "async_social_event",
+            "wallpaper_subscription_data_event",
+            "push_notifications_extension",
+        ):
+            with self.subTest(name=name):
+                self.assertIn(name, entries)
+                self.assertEqual(entries[name].issue_number, 516)
+
+        self.assertEqual(entries["steam_is_initialized"].status, "partial")
+        self.assertEqual(entries["browser_width"].runtime_support, "partial")
+        self.assertEqual(entries["iap_activate"].status, "unsupported")
+        self.assertEqual(entries["xboxlive_matchmaking_create"].status, "unsupported")
+
     def test_function_descriptor_arity_validation_is_deterministic(self):
         descriptor = get_gml_function_descriptor("struct_set")
 
@@ -589,6 +643,12 @@ class TestGMLAPIManifest(unittest.TestCase):
             transpile_gml_expression("physics_joint_distance_create()")
         with self.assertRaisesRegex(GMLTranspileError, "external_call.*unsupported"):
             transpile_gml_expression("external_call('native_ext', 'fn')")
+        with self.assertRaisesRegex(GMLTranspileError, "iap_activate.*unsupported.*#516.*store"):
+            transpile_gml_expression("iap_activate()")
+        with self.assertRaisesRegex(GMLTranspileError, "clickable_add.*unsupported.*#516.*HTML5"):
+            transpile_gml_expression("clickable_add(0, 0, 100, 40, 'https://example.com')")
+        with self.assertRaisesRegex(GMLTranspileError, "xboxlive_matchmaking_create.*unsupported.*#516.*Xbox"):
+            transpile_gml_expression("xboxlive_matchmaking_create()")
 
     def test_transpiler_rejects_wrong_arity_for_known_helpers(self):
         with self.assertRaisesRegex(GMLTranspileError, "real.*expects 1.*got 0"):

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -2373,6 +2373,19 @@ class TestGMLRuntimeScript(unittest.TestCase):
         self.assertIn('if key == "os_type":', GML_RUNTIME_SCRIPT)
         self.assertIn('if key == "fps_real":', GML_RUNTIME_SCRIPT)
 
+    def test_runtime_contains_platform_service_compatibility_helpers(self):
+        self.assertIn("static func gml_platform_service_register", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_platform_service_call", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_platform_service_unsupported", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_steam_is_initialized", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_browser_input_capture", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_url_open", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_xboxlive_user_is_signed_in", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_wallpaper_set_config", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_cloud_synchronise", GML_RUNTIME_SCRIPT)
+        self.assertIn('if key == "browser_width":', GML_RUNTIME_SCRIPT)
+        self.assertIn('if key == "webgl_enabled":', GML_RUNTIME_SCRIPT)
+
     def test_write_gml_runtime_writes_support_script(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             runtime_path = write_gml_runtime(tmpdir)

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -3402,6 +3402,43 @@ class TestGMLStatementTranspiler(unittest.TestCase):
         with self.assertRaisesRegex(GMLTranspileError, "weak_ref_any_alive.*expects 1 to 3.*got 4"):
             transpile_gml_code("weak_ref_any_alive(items, 0, 1, true);", indent="")
 
+    def test_platform_service_helpers_lower_to_runtime_and_builtins(self):
+        self.assertEqual(
+            transpile_gml_expression("steam_is_initialized()"),
+            "GMRuntime.gml_steam_is_initialized()",
+        )
+        self.assertEqual(
+            transpile_gml_expression("browser_width + browser_height"),
+            'GMRuntime.gml_add(GMRuntime.gml_builtin_global("browser_width"), GMRuntime.gml_builtin_global("browser_height"))',
+        )
+        self.assertEqual(
+            transpile_gml_expression("webgl_enabled"),
+            'GMRuntime.gml_builtin_global("webgl_enabled")',
+        )
+        self.assertEqual(
+            transpile_gml_code(
+                'browser_input_capture(true);'
+                'domain = url_get_domain();'
+                'url_open_ext("https://example.com", "_blank");'
+                'signed_in = xboxlive_user_is_signed_in();'
+                'wallpaper_set_subscriptions(subscriptions);'
+                'cloud_id = cloud_synchronise();',
+                indent="",
+            ),
+            "GMRuntime.gml_browser_input_capture(true)\n"
+            "domain = GMRuntime.gml_url_get_domain()\n"
+            'GMRuntime.gml_url_open_ext("https://example.com", "_blank")\n'
+            "signed_in = GMRuntime.gml_xboxlive_user_is_signed_in()\n"
+            "GMRuntime.gml_wallpaper_set_subscriptions(subscriptions)\n"
+            "cloud_id = GMRuntime.gml_cloud_synchronise()",
+        )
+
+    def test_platform_service_helper_arity_errors_are_deterministic(self):
+        with self.assertRaisesRegex(GMLTranspileError, "url_open.*expects 1.*got 0"):
+            transpile_gml_code("url_open();", indent="")
+        with self.assertRaisesRegex(GMLTranspileError, "browser_input_capture.*expects 1.*got 0"):
+            transpile_gml_code("browser_input_capture();", indent="")
+
     def test_math_helper_arity_errors_are_deterministic(self):
         with self.assertRaisesRegex(GMLTranspileError, "clamp.*expects 3.*got 2"):
             transpile_gml_code("clamp(1, 2);", indent="")

--- a/tests/test_platform_services_godot.py
+++ b/tests/test_platform_services_godot.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from src.conversion.gml_runtime import write_gml_runtime
+
+
+def _find_godot_binary() -> str | None:
+    env_path = os.environ.get("GODOT_BIN")
+    if env_path and os.path.isfile(env_path):
+        return env_path
+
+    path_binary = shutil.which("godot")
+    if path_binary is not None:
+        return path_binary
+
+    mac_binary = "/Applications/Godot.app/Contents/MacOS/Godot"
+    if os.path.isfile(mac_binary):
+        return mac_binary
+    return None
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class TestPlatformServicesGodotSmoke(unittest.TestCase):
+    def test_platform_service_hooks_and_safe_fallbacks(self) -> None:
+        godot_binary = _find_godot_binary()
+        if godot_binary is None:
+            self.skipTest("Godot binary not available")
+
+        smoke_script = textwrap.dedent(
+            """\
+            extends Node
+
+            const GMRuntime = preload("res://gm2godot/gml_runtime.gd")
+
+            func _check(condition, message):
+            \tif not condition:
+            \t\tpush_error(str(message))
+            \t\tget_tree().quit(1)
+            \t\treturn false
+            \treturn true
+
+            func _ready():
+            \tcall_deferred("_run")
+
+            func _run():
+            \tif not _check(GMRuntime.gml_steam_is_initialized() == false, "steam fallback failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_xboxlive_user_is_signed_in() == false, "xbox sign-in fallback failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_xboxlive_user_is_signing_in() == false, "xbox signing-in fallback failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_xboxlive_gamertag_for_user() == "", "xbox gamertag fallback failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_browser_width() >= 0, "browser width fallback failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_browser_height() >= 0, "browser height fallback failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_webgl_enabled() == true, "webgl fallback failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_browser_input_capture(true) == null, "browser capture fallback failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_url_get_domain() == "", "empty domain fallback failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_url_get_domain("https://user@example.com:443/a") == "example.com", "domain parse failed"):
+            \t\treturn
+
+            \tGMRuntime.gml_platform_service_register("steam", {
+            \t\t"steam_is_initialized": func(): return true,
+            \t})
+            \tif not _check(GMRuntime.gml_steam_is_initialized(), "steam hook failed"):
+            \t\treturn
+
+            \tGMRuntime.gml_platform_service_register("web", {
+            \t\t"browser_input_capture": func(enable): return "capture:" + str(enable),
+            \t\t"browser_width": func(): return 640,
+            \t\t"browser_height": func(): return 360,
+            \t\t"url_get_domain": func(): return "hook.example",
+            \t\t"webgl_enabled": func(): return false,
+            \t})
+            \tif not _check(GMRuntime.gml_browser_input_capture(false) == "capture:false", "web capture hook failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_browser_width() == 640, "browser width hook failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_browser_height() == 360, "browser height hook failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_url_get_domain() == "hook.example", "domain hook failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_webgl_enabled() == false, "webgl hook failed"):
+            \t\treturn
+
+            \tGMRuntime.gml_platform_service_register("xboxlive", {
+            \t\t"xboxlive_user_is_signed_in": func(): return true,
+            \t\t"xboxlive_gamertag_for_user": func(): return "PlayerOne",
+            \t})
+            \tif not _check(GMRuntime.gml_xboxlive_user_is_signed_in(), "xbox sign-in hook failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_xboxlive_gamertag_for_user() == "PlayerOne", "xbox gamertag hook failed"):
+            \t\treturn
+
+            \tGMRuntime.gml_platform_service_register("steam", null)
+            \tGMRuntime.gml_platform_service_register("web", null)
+            \tGMRuntime.gml_platform_service_register("xboxlive", null)
+            \tprint("PLATFORM_SERVICES_SMOKE_OK")
+            \tget_tree().quit(0)
+            """
+        )
+
+        smoke_scene = textwrap.dedent(
+            """\
+            [gd_scene load_steps=2 format=3]
+
+            [ext_resource type="Script" path="res://smoke.gd" id="smoke_script"]
+
+            [node name="Smoke" type="Node"]
+            script = ExtResource("smoke_script")
+            """
+        )
+
+        with tempfile.TemporaryDirectory() as godot_tmp:
+            project_dir = Path(godot_tmp)
+            _write_text(project_dir / "project.godot", "[application]\n")
+            write_gml_runtime(str(project_dir))
+            _write_text(project_dir / "smoke.gd", smoke_script)
+            _write_text(project_dir / "smoke.tscn", smoke_scene)
+
+            try:
+                result = subprocess.run(
+                    [godot_binary, "--headless", "--path", str(project_dir), "smoke.tscn"],
+                    check=False,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    timeout=30,
+                )
+            except subprocess.TimeoutExpired as exc:
+                output = exc.output.decode("utf-8", errors="replace") if isinstance(exc.output, bytes) else str(exc.output or "")
+                self.fail("Godot platform-services smoke timed out\n" + output)
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("PLATFORM_SERVICES_SMOKE_OK", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #516.

## Summary
- add GMRuntime platform-service hook registration and safe fallbacks for Steam, Web/HTML5, Xbox account metadata, live wallpaper, and cloud-save bridges
- expose browser/web globals plus URL and platform helper lowering through the descriptor registry
- expand the Platform Services manifest with Steam, IAP, Web/HTML5, Xbox/UWP, Live Wallpaper, push, cloud-save, and social async classifications
- add Python coverage and a headless Godot smoke test for hook registration and fallback behavior

## Tests
- ./venv/bin/python -m unittest tests.test_gml_api_manifest tests.test_gml_transpiler tests.test_gml_runtime
- ./venv/bin/python -m unittest tests.test_platform_services_godot
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest
- git diff --check