### PR TITLE
Add structured conversion diagnostics reports

### DIFF
--- a/src/conversion/base_converter.py
+++ b/src/conversion/base_converter.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from typing import Any, cast
 
 from src.localization import get_localized
+from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.type_defs import ConversionRunning, JsonDict, LogCallback, ProgressCallback, StrPath
 
 
@@ -18,7 +19,8 @@ class BaseConverter(ABC):
                  log_callback: LogCallback = print, progress_callback: ProgressCallback | None = None,
                  conversion_running: ConversionRunning | None = None,
                  update_log_callback: LogCallback | None = None, compact_logging: bool = False,
-                 max_workers: int | None = None) -> None:
+                 max_workers: int | None = None,
+                 diagnostics: DiagnosticCollector | None = None) -> None:
         self.gm_project_path = os.fspath(gm_project_path)
         self.godot_project_path = os.fspath(godot_project_path)
         self.log_callback: LogCallback = log_callback
@@ -27,16 +29,21 @@ class BaseConverter(ABC):
         self.update_log_callback: LogCallback = update_log_callback or log_callback
         self.compact_logging = compact_logging
         self.max_workers = max_workers or os.cpu_count() or 1
+        self.diagnostics = diagnostics
         self._lock = threading.Lock()
 
     def _safe_log(self, message: str) -> None:
         """Thread-safe wrapper for log_callback. Use in multi-threaded converters."""
         with self._lock:
+            if self.diagnostics is not None:
+                self.diagnostics.add_from_log_message(message)
             self.log_callback(message)
 
     def _safe_update_log(self, message: str) -> None:
         """Thread-safe wrapper for update_log_callback. Use in multi-threaded converters."""
         with self._lock:
+            if self.diagnostics is not None:
+                self.diagnostics.add_from_log_message(message)
             self.update_log_callback(message)
 
     def _safe_progress(self, value: int | float) -> None:

--- a/src/conversion/converter.py
+++ b/src/conversion/converter.py
@@ -14,6 +14,7 @@ from src.conversion.rooms import RoomConverter
 from src.conversion.shaders import ShaderConverter
 from src.conversion.included_files import IncludedFilesConverter
 from src.conversion.project_settings import ProjectSettingsConverter
+from src.conversion.diagnostics import DiagnosticCollector, write_conversion_diagnostic_reports
 from src.conversion.type_defs import BoolSetting, LogCallback, ProgressCallback
 
 from src.localization import get_localized
@@ -42,12 +43,19 @@ class Converter:
         self.progress_callback: ProgressCallback = progress_callback
         self.status_callback: LogCallback = status_callback
         self.conversion_running = conversion_running
-        self.update_log_callback: LogCallback = update_log_callback or log_callback
+        self._raw_log_callback: LogCallback = log_callback
+        self._raw_update_log_callback: LogCallback = update_log_callback or log_callback
+        self.update_log_callback: LogCallback = self._raw_update_log_callback
         self.compact_logging = compact_logging
         self.max_workers = max_workers
+        self.diagnostics = DiagnosticCollector()
 
     def convert(self, gm_path: str, gm_platform: str, godot_path: str,
                 settings: Mapping[str, BoolSetting]) -> None:
+        self.diagnostics = DiagnosticCollector()
+        self.log_callback = self.diagnostics.wrap_log_callback(self._raw_log_callback)
+        self.update_log_callback = self.diagnostics.wrap_log_callback(self._raw_update_log_callback)
+
         group_sounds_by_audio_group = False
         if "sound_group_folders" in settings:
             group_sounds_by_audio_group = settings["sound_group_folders"].get()
@@ -120,6 +128,7 @@ class Converter:
                 update_log_callback=self.update_log_callback,
                 compact_logging=self.compact_logging,
                 max_workers=self.max_workers,
+                diagnostics=self.diagnostics,
             ).convert_all(), "Console_Convertor_Scripts"),
             ("objects", lambda: ObjectConverter(
                 gm_path, godot_path, self.log_callback,
@@ -127,6 +136,7 @@ class Converter:
                 update_log_callback=self.update_log_callback,
                 compact_logging=self.compact_logging,
                 max_workers=self.max_workers,
+                diagnostics=self.diagnostics,
             ).convert_all(), "Console_Convertor_Objects"),
             ("rooms", lambda: RoomConverter(
                 gm_path, godot_path, self.log_callback,
@@ -145,11 +155,14 @@ class Converter:
             ).convert_all(), "Console_Convertor_AssetRegistry"),
         ]
 
-        for setting_key, converter_fn, log_key in converters:
-            setting = settings.get(setting_key)
-            if setting is not None and setting.get() and self.conversion_running.is_set():
-                log_message = get_localized(log_key)
-                self.log_callback(log_message)
-                self.status_callback(log_message)
-                converter_fn()
-                self.progress_callback(0)
+        try:
+            for setting_key, converter_fn, log_key in converters:
+                setting = settings.get(setting_key)
+                if setting is not None and setting.get() and self.conversion_running.is_set():
+                    log_message = get_localized(log_key)
+                    self.log_callback(log_message)
+                    self.status_callback(log_message)
+                    converter_fn()
+                    self.progress_callback(0)
+        finally:
+            write_conversion_diagnostic_reports(godot_path, self.diagnostics)

--- a/src/conversion/diagnostics.py
+++ b/src/conversion/diagnostics.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Callable, Literal, TypeAlias
+
+from src.conversion.type_defs import StrPath
+
+DiagnosticSeverity: TypeAlias = Literal["info", "warning", "error"]
+
+DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH = os.path.join(
+    "gm2godot", "conversion_diagnostics.json"
+)
+DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH = os.path.join(
+    "gm2godot", "conversion_diagnostics.md"
+)
+
+
+@dataclass(frozen=True)
+class ConversionDiagnostic:
+    severity: DiagnosticSeverity
+    code: str
+    message: str
+    source_path: str | None = None
+    line: int | None = None
+    column: int | None = None
+    resource: str | None = None
+    resource_type: str | None = None
+    event: str | None = None
+    api: str | None = None
+    manifest_entry: str | None = None
+    issue_number: int | None = None
+    workaround: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "severity": self.severity,
+            "code": self.code,
+            "message": self.message,
+            "source_path": self.source_path,
+            "line": self.line,
+            "column": self.column,
+            "resource": self.resource,
+            "resource_type": self.resource_type,
+            "event": self.event,
+            "api": self.api,
+            "manifest_entry": self.manifest_entry,
+            "issue_number": self.issue_number,
+            "workaround": self.workaround,
+        }
+
+
+class DiagnosticCollector:
+    def __init__(self) -> None:
+        self._diagnostics: list[ConversionDiagnostic] = []
+        self._recorded_messages: set[str] = set()
+
+    def add(
+        self,
+        severity: DiagnosticSeverity,
+        code: str,
+        message: str,
+        *,
+        source_path: str | None = None,
+        line: int | None = None,
+        column: int | None = None,
+        resource: str | None = None,
+        resource_type: str | None = None,
+        event: str | None = None,
+        api: str | None = None,
+        manifest_entry: str | None = None,
+        issue_number: int | None = None,
+        workaround: str | None = None,
+    ) -> ConversionDiagnostic:
+        diagnostic = ConversionDiagnostic(
+            severity=severity,
+            code=code,
+            message=message,
+            source_path=source_path,
+            line=line,
+            column=column,
+            resource=resource,
+            resource_type=resource_type,
+            event=event,
+            api=api,
+            manifest_entry=manifest_entry,
+            issue_number=issue_number,
+            workaround=workaround,
+        )
+        self._diagnostics.append(diagnostic)
+        self._recorded_messages.add(message)
+        return diagnostic
+
+    def add_from_log_message(
+        self, message: str, *, code: str = "GM2GD-WARNING"
+    ) -> ConversionDiagnostic | None:
+        if message in self._recorded_messages:
+            return None
+        stripped = message.strip()
+        severity = _severity_from_log_message(stripped)
+        if severity is None:
+            return None
+        return self.add(severity, code, stripped)
+
+    def add_transpile_failure(
+        self,
+        message: str,
+        *,
+        source_path: str | None = None,
+        resource: str | None = None,
+        resource_type: str | None = None,
+        event: str | None = None,
+        workaround: str | None = None,
+    ) -> ConversionDiagnostic:
+        api_name = _extract_gml_api_name(message)
+        issue_number = _extract_issue_number(message)
+        return self.add(
+            "warning",
+            "GM2GD-GML-TRANSPILE",
+            message,
+            source_path=source_path,
+            resource=resource,
+            resource_type=resource_type,
+            event=event,
+            api=api_name,
+            manifest_entry=api_name,
+            issue_number=issue_number,
+            workaround=workaround,
+        )
+
+    def wrap_log_callback(
+        self, log_callback: Callable[[str], None]
+    ) -> Callable[[str], None]:
+        def _wrapped(message: str) -> None:
+            self.add_from_log_message(message)
+            log_callback(message)
+
+        return _wrapped
+
+    def diagnostics(self) -> tuple[ConversionDiagnostic, ...]:
+        return tuple(self._diagnostics)
+
+    def summary(self) -> dict[str, int]:
+        counts = {"info": 0, "warning": 0, "error": 0}
+        for diagnostic in self._diagnostics:
+            counts[diagnostic.severity] += 1
+        counts["total"] = len(self._diagnostics)
+        return counts
+
+    def to_json_dict(self) -> dict[str, object]:
+        return {
+            "summary": self.summary(),
+            "diagnostics": [
+                diagnostic.to_dict()
+                for diagnostic in self._sorted_diagnostics()
+            ],
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_json_dict(), indent=2, sort_keys=True) + "\n"
+
+    def to_markdown(self) -> str:
+        lines = [
+            "# GM2Godot Conversion Diagnostics",
+            "",
+            "| Severity | Code | Source | Resource | Event/API | Message |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+        diagnostics = self._sorted_diagnostics()
+        if not diagnostics:
+            lines.append("| info | GM2GD-OK |  |  |  | No diagnostics recorded. |")
+            return "\n".join(lines) + "\n"
+
+        for diagnostic in diagnostics:
+            source = diagnostic.source_path or ""
+            resource_parts = [
+                value
+                for value in (diagnostic.resource_type, diagnostic.resource)
+                if value
+            ]
+            event_api = diagnostic.event or diagnostic.api or ""
+            message = _escape_markdown_table(diagnostic.message)
+            lines.append(
+                "| {severity} | {code} | {source} | {resource} | {event_api} | {message} |".format(
+                    severity=diagnostic.severity,
+                    code=diagnostic.code,
+                    source=_escape_markdown_table(source),
+                    resource=_escape_markdown_table("/".join(resource_parts)),
+                    event_api=_escape_markdown_table(event_api),
+                    message=message,
+                )
+            )
+        return "\n".join(lines) + "\n"
+
+    def write_reports(self, godot_project_path: StrPath) -> tuple[str, str]:
+        json_path = os.path.join(
+            os.fspath(godot_project_path), DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH
+        )
+        markdown_path = os.path.join(
+            os.fspath(godot_project_path), DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH
+        )
+        os.makedirs(os.path.dirname(json_path), exist_ok=True)
+        with open(json_path, "w", encoding="utf-8") as json_file:
+            json_file.write(self.to_json())
+        with open(markdown_path, "w", encoding="utf-8") as markdown_file:
+            markdown_file.write(self.to_markdown())
+        return json_path, markdown_path
+
+    def _sorted_diagnostics(self) -> tuple[ConversionDiagnostic, ...]:
+        return tuple(
+            sorted(
+                self._diagnostics,
+                key=lambda item: (
+                    item.severity,
+                    item.code,
+                    item.source_path or "",
+                    item.resource_type or "",
+                    item.resource or "",
+                    item.event or "",
+                    item.message,
+                ),
+            )
+        )
+
+
+def write_conversion_diagnostic_reports(
+    godot_project_path: StrPath, diagnostics: DiagnosticCollector
+) -> tuple[str, str]:
+    return diagnostics.write_reports(godot_project_path)
+
+
+def _escape_markdown_table(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ")
+
+
+def _severity_from_log_message(message: str) -> DiagnosticSeverity | None:
+    normalized = message.lower()
+    if normalized.startswith("warning:"):
+        return "warning"
+    if normalized.startswith("error:"):
+        return "error"
+    return None
+
+
+def _extract_gml_api_name(message: str) -> str | None:
+    match = re.search(r"GML API '([^']+)'", message)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def _extract_issue_number(message: str) -> int | None:
+    match = re.search(r"tracked by #(\d+)", message)
+    if match is None:
+        return None
+    try:
+        return int(match.group(1))
+    except ValueError:
+        return None

--- a/src/conversion/objects.py
+++ b/src/conversion/objects.py
@@ -7,6 +7,7 @@ from typing import TypedDict, cast
 
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
+from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.events.base import EventMapping
 from src.conversion.event_mapping import map_event
 from src.conversion.gml_runtime import write_gml_runtime
@@ -36,9 +37,11 @@ class ObjectConverter(BaseConverter):
                  log_callback: LogCallback = print, progress_callback: ProgressCallback | None = None,
                  conversion_running: ConversionRunning | None = None,
                  update_log_callback: LogCallback | None = None, compact_logging: bool = False,
-                 max_workers: int | None = None) -> None:
+                 max_workers: int | None = None,
+                 diagnostics: DiagnosticCollector | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback, progress_callback, conversion_running,
-                         update_log_callback, compact_logging, max_workers=max_workers)
+                         update_log_callback, compact_logging, max_workers=max_workers,
+                         diagnostics=diagnostics)
         self.godot_objects_path = os.path.join(self.godot_project_path, 'objects')
 
     def _get_valid_object_names(self) -> dict[str, str] | None:
@@ -292,10 +295,20 @@ class ObjectConverter(BaseConverter):
                     static_scope_prefix=f"{object_name}.{mapping.godot_func}",
                 )
             except GMLTranspileError as exc:
-                self._safe_log(
+                message = (
                     "Warning: Could not transpile GameMaker event code for "
                     f"{object_name}/{mapping.gml_filename}: {exc}"
                 )
+                if self.diagnostics is not None:
+                    self.diagnostics.add_transpile_failure(
+                        message,
+                        source_path=source_path,
+                        resource=object_name,
+                        resource_type="object",
+                        event=mapping.godot_func,
+                        workaround="Split or rewrite unsupported GML for this event, or add the missing runtime/API support tracked by the linked issue.",
+                    )
+                self._safe_log(message)
 
         return code_bodies, instance_variables
 

--- a/src/conversion/scripts.py
+++ b/src/conversion/scripts.py
@@ -10,6 +10,7 @@ from typing import Iterable
 from src.localization import get_localized
 from src.conversion.asset_registry import AssetRegistryConverter, AssetRegistryEntry
 from src.conversion.base_converter import BaseConverter
+from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.gml_runtime import write_gml_runtime
 from src.conversion.gml_transpiler import (
     EXTENSION_FUNCTION_MAPPING_FILENAME,
@@ -92,6 +93,7 @@ class ScriptConverter(BaseConverter):
         update_log_callback: LogCallback | None = None,
         compact_logging: bool = False,
         max_workers: int | None = None,
+        diagnostics: DiagnosticCollector | None = None,
     ) -> None:
         super().__init__(
             gm_project_path,
@@ -102,6 +104,7 @@ class ScriptConverter(BaseConverter):
             update_log_callback,
             compact_logging,
             max_workers=max_workers,
+            diagnostics=diagnostics,
         )
         self.godot_scripts_path = os.path.join(self.godot_project_path, "scripts")
 
@@ -332,12 +335,29 @@ class ScriptConverter(BaseConverter):
                 extension_function_mappings=extension_function_mappings,
             )
         except (OSError, GMLTranspileError) as exc:
-            self._safe_log(
-                get_localized("Console_Convertor_Scripts_ParseError").format(
-                    script_name=entry.name,
-                    error=str(exc),
-                )
+            message = get_localized("Console_Convertor_Scripts_ParseError").format(
+                script_name=entry.name,
+                error=str(exc),
             )
+            if self.diagnostics is not None:
+                if isinstance(exc, GMLTranspileError):
+                    self.diagnostics.add_transpile_failure(
+                        message,
+                        source_path=source_path,
+                        resource=entry.name,
+                        resource_type="script",
+                        workaround="Split or rewrite unsupported GML for this script, or add the missing runtime/API support tracked by the linked issue.",
+                    )
+                else:
+                    self.diagnostics.add(
+                        "warning",
+                        "GM2GD-SCRIPT-READ",
+                        message,
+                        source_path=source_path,
+                        resource=entry.name,
+                        resource_type="script",
+                    )
+            self._safe_log(message)
             return None
 
         os.makedirs(os.path.dirname(output_path), exist_ok=True)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -6,12 +6,14 @@ import threading
 import tempfile
 import shutil
 import unittest
+import json
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from src.conversion.converter import CONVERSION_CATEGORIES, Converter
+from src.conversion.diagnostics import DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH
 
 
 class TestConversionCategories(unittest.TestCase):
@@ -93,6 +95,41 @@ class TestConverterSkipsDisabled(unittest.TestCase):
         # With every setting False, no converter log/status messages should appear
         self.assertEqual(self.logs, [])
         self.assertEqual(self.statuses, [])
+        self.assertTrue(os.path.isfile(
+            os.path.join(self.godot_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
+        ))
+
+    def test_conversion_writes_warning_diagnostics_report(self):
+        with open(os.path.join(self.gm_dir, "Test.yyp"), "w", encoding="utf-8") as f:
+            f.write('{"resources": [}')
+
+        conversion_running = threading.Event()
+        conversion_running.set()
+
+        converter = Converter(
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            status_callback=lambda msg: self.statuses.append(msg),
+            conversion_running=conversion_running,
+        )
+        all_keys = (
+            CONVERSION_CATEGORIES["assets"]
+            + CONVERSION_CATEGORIES["project"]
+            + CONVERSION_CATEGORIES["wip"]
+        )
+        settings = {key: _FakeBooleanVar(False) for key in all_keys}
+        settings["asset_registry"] = _FakeBooleanVar(True)
+
+        converter.convert(self.gm_dir, "windows", self.godot_dir, settings)
+
+        self.assertTrue(any("Warning: Could not parse GameMaker project .yyp" in log for log in self.logs))
+        report_path = os.path.join(self.godot_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
+        with open(report_path, "r", encoding="utf-8") as report_file:
+            report = json.load(report_file)
+
+        self.assertEqual(report["summary"]["warning"], 1)
+        self.assertEqual(report["diagnostics"][0]["code"], "GM2GD-WARNING")
+        self.assertIn("Could not parse GameMaker project .yyp", report["diagnostics"][0]["message"])
 
 
 class TestConverterRespectsRunningFlag(unittest.TestCase):

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.diagnostics import (
+    DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH,
+    DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
+    DiagnosticCollector,
+)
+
+
+class TestDiagnosticCollector(unittest.TestCase):
+    def test_warning_log_wrapper_preserves_log_and_records_diagnostic(self):
+        logs: list[str] = []
+        diagnostics = DiagnosticCollector()
+        wrapped_log = diagnostics.wrap_log_callback(lambda message: logs.append(message))
+
+        wrapped_log("Warning: Unsupported room layer emitted as placeholder.")
+        wrapped_log("Converted sprite spr_player.")
+
+        self.assertEqual(logs, [
+            "Warning: Unsupported room layer emitted as placeholder.",
+            "Converted sprite spr_player.",
+        ])
+        recorded = diagnostics.diagnostics()
+        self.assertEqual(len(recorded), 1)
+        self.assertEqual(recorded[0].severity, "warning")
+        self.assertEqual(recorded[0].code, "GM2GD-WARNING")
+
+    def test_transpile_failure_extracts_api_and_issue_metadata(self):
+        diagnostics = DiagnosticCollector()
+
+        diagnostic = diagnostics.add_transpile_failure(
+            "Warning: Could not transpile GameMaker event code for obj/Create_0.gml: "
+            "GML API 'show_message_async' from Asynchronous Functions is unsupported; "
+            "tracked by #507. Dialog callbacks are not wired.",
+            source_path="/tmp/project/objects/obj/Create_0.gml",
+            resource="obj",
+            resource_type="object",
+            event="_ready",
+        )
+
+        self.assertEqual(diagnostic.api, "show_message_async")
+        self.assertEqual(diagnostic.manifest_entry, "show_message_async")
+        self.assertEqual(diagnostic.issue_number, 507)
+        self.assertEqual(diagnostic.source_path, "/tmp/project/objects/obj/Create_0.gml")
+        self.assertEqual(diagnostic.resource_type, "object")
+        self.assertEqual(diagnostic.event, "_ready")
+
+    def test_reports_are_written_as_deterministic_json_and_markdown(self):
+        tmp_dir = tempfile.mkdtemp()
+        try:
+            diagnostics = DiagnosticCollector()
+            diagnostics.add(
+                "warning",
+                "GM2GD-RESOURCE-UNSUPPORTED",
+                "Unsupported GameMaker room asset type GMREffectLayer.",
+                source_path="/tmp/project/rooms/r_main/r_main.yy",
+                resource="r_main",
+                resource_type="room",
+                issue_number=590,
+            )
+
+            json_path, markdown_path = diagnostics.write_reports(tmp_dir)
+
+            self.assertEqual(
+                json_path,
+                os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH),
+            )
+            self.assertEqual(
+                markdown_path,
+                os.path.join(tmp_dir, DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH),
+            )
+            with open(json_path, "r", encoding="utf-8") as json_file:
+                data = json.load(json_file)
+            with open(markdown_path, "r", encoding="utf-8") as markdown_file:
+                markdown = markdown_file.read()
+
+            self.assertEqual(data["summary"]["warning"], 1)
+            self.assertEqual(data["diagnostics"][0]["code"], "GM2GD-RESOURCE-UNSUPPORTED")
+            self.assertIn("GM2Godot Conversion Diagnostics", markdown)
+            self.assertIn("GM2GD-RESOURCE-UNSUPPORTED", markdown)
+        finally:
+            shutil.rmtree(tmp_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -11,6 +11,7 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from src.conversion.objects import ObjectConverter
+from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.type_defs import JsonDict
 
 
@@ -628,6 +629,32 @@ class TestScriptGeneration(unittest.TestCase):
             content,
         )
         self.assertIn("\tprint(label)", content)
+
+    def test_transpile_failure_records_structured_diagnostic(self):
+        self._setup_object("o_test", event_list=[{"eventType": 0, "eventNum": 0}])
+        source_path = os.path.join(self.gm_dir, "objects", "o_test", "Create_0.gml")
+        with open(source_path, "w", encoding="utf-8") as f:
+            f.write('show_message_async("Hello");')
+
+        diagnostics = DiagnosticCollector()
+        converter = ObjectConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+            diagnostics=diagnostics,
+        )
+        converter.convert_all()
+
+        recorded = diagnostics.diagnostics()
+        self.assertEqual(len(recorded), 1)
+        self.assertEqual(recorded[0].code, "GM2GD-GML-TRANSPILE")
+        self.assertEqual(recorded[0].api, "show_message_async")
+        self.assertEqual(recorded[0].issue_number, 507)
+        self.assertEqual(recorded[0].resource, "o_test")
+        self.assertEqual(recorded[0].resource_type, "object")
+        self.assertEqual(recorded[0].event, "_ready")
 
     def test_child_event_inherited_preserves_parent_exit_boundary(self):
         """exit in an inherited parent event should not abort the child event."""


### PR DESCRIPTION
Closes #576.

## Summary
- add typed conversion diagnostics with severity, stable code, source/resource/event/API context, manifest issue pointers, and workaround fields
- mirror warning/error log messages into diagnostics while preserving existing GUI/log callbacks
- emit deterministic JSON and Markdown diagnostic reports for every top-level conversion
- record structured object and script transpile failures, including unsupported GML API and issue metadata when available

## Tests
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest