### PR TITLE
Centralize GML value comparison semantics

### DIFF
--- a/src/conversion/gml_runtime_parts/manifest.py
+++ b/src/conversion/gml_runtime_parts/manifest.py
@@ -205,7 +205,7 @@ RUNTIME_SEGMENTS: tuple[RuntimeSegmentDefinition, ...] = (
     ),
     _segment(
         "50_static_types_and_clone.gd",
-        "Deep clone helpers and static type metadata.",
+        "Deep clone helpers, equality and ordering value semantics, and static type metadata.",
         depends_on=("00_prelude.gd", "20_methods_and_exceptions.gd", "40_arrays_structs_variables.gd"),
         tests=("tests/test_gml_runtime.py",),
     ),
@@ -253,7 +253,7 @@ RUNTIME_SEGMENTS: tuple[RuntimeSegmentDefinition, ...] = (
     ),
     _segment(
         "70_handle_string_helpers.gd",
-        "Handle parsing, string formatting, hashing, and value serialization helpers.",
+        "Handle parsing, Unicode codepoint string helpers, hashing, and value serialization helpers.",
         depends_on=("00_prelude.gd", "10_handles_and_instances.gd", "60_conversion_helpers.gd"),
         tests=("tests/test_gml_runtime.py",),
     ),

--- a/src/conversion/gml_runtime_parts/segments/50_static_types_and_clone.gd
+++ b/src/conversion/gml_runtime_parts/segments/50_static_types_and_clone.gd
@@ -148,6 +148,46 @@ static func gml_ne(left, right):
 	return not gml_eq(left, right)
 
 
+static func gml_lt(left, right):
+	if is_nan_value(left) or is_nan_value(right):
+		return false
+	if _is_arithmetic_real_operand(left) and _is_arithmetic_real_operand(right):
+		return _to_real(left) < _to_real(right)
+	if is_string(left) and is_string(right):
+		return str(left) < str(right)
+	return gml_unsupported_binary_type_error("GML less-than comparison", left, right)
+
+
+static func gml_lte(left, right):
+	if is_nan_value(left) or is_nan_value(right):
+		return false
+	if _is_arithmetic_real_operand(left) and _is_arithmetic_real_operand(right):
+		return _to_real(left) <= _to_real(right)
+	if is_string(left) and is_string(right):
+		return str(left) <= str(right)
+	return gml_unsupported_binary_type_error("GML less-than-or-equal comparison", left, right)
+
+
+static func gml_gt(left, right):
+	if is_nan_value(left) or is_nan_value(right):
+		return false
+	if _is_arithmetic_real_operand(left) and _is_arithmetic_real_operand(right):
+		return _to_real(left) > _to_real(right)
+	if is_string(left) and is_string(right):
+		return str(left) > str(right)
+	return gml_unsupported_binary_type_error("GML greater-than comparison", left, right)
+
+
+static func gml_gte(left, right):
+	if is_nan_value(left) or is_nan_value(right):
+		return false
+	if _is_arithmetic_real_operand(left) and _is_arithmetic_real_operand(right):
+		return _to_real(left) >= _to_real(right)
+	if is_string(left) and is_string(right):
+		return str(left) >= str(right)
+	return gml_unsupported_binary_type_error("GML greater-than-or-equal comparison", left, right)
+
+
 static func _is_gml_reference_value(value):
 	if is_undefined(value) or is_int64(value) or is_ptr(value) or is_handle(value):
 		return false
@@ -243,5 +283,4 @@ static func gml_type_name(value):
 	if gml_type != GML_TYPE_UNKNOWN:
 		return gml_type
 	return "godot_type_" + str(typeof(value))
-
 

--- a/src/conversion/gml_transpiler_parts/constants.py
+++ b/src/conversion/gml_transpiler_parts/constants.py
@@ -254,6 +254,13 @@ _BITWISE_RUNTIME_FUNCTIONS = {
     ">>": "gml_shift_right",
 }
 
+_COMPARISON_RUNTIME_FUNCTIONS = {
+    "<": "gml_lt",
+    "<=": "gml_lte",
+    ">": "gml_gt",
+    ">=": "gml_gte",
+}
+
 _DS_COLLECTIONS_FUNCTIONS = {
     "ds_list_create": "gml_ds_list_create",
     "ds_list_destroy": "gml_ds_list_destroy",

--- a/src/conversion/gml_transpiler_parts/emitter.py
+++ b/src/conversion/gml_transpiler_parts/emitter.py
@@ -13,6 +13,7 @@ from .constants import (
     _BUILTIN_ARRAY_VARIABLES,
     _BUILTIN_GLOBAL_VARIABLES,
     _BUILTIN_INSTANCE_VARIABLES,
+    _COMPARISON_RUNTIME_FUNCTIONS,
     _DIRECT_MEMBER_TARGETS,
     _GML_BUILTIN_CONSTANT_IDENTIFIERS,
     _GML_LITERAL_IDENTIFIERS,
@@ -883,6 +884,11 @@ def _emit_binary(
         left = _emit_expression(expr.left, local_names, scope_context=scope_context)[0]
         right = _emit_expression(expr.right, local_names, scope_context=scope_context)[0]
         return f"GMRuntime.gml_div({left}, {right})", _POSTFIX_PRECEDENCE
+
+    if expr.operator in _COMPARISON_RUNTIME_FUNCTIONS:
+        left = _emit_expression(expr.left, local_names, scope_context=scope_context)[0]
+        right = _emit_expression(expr.right, local_names, scope_context=scope_context)[0]
+        return f"GMRuntime.{_COMPARISON_RUNTIME_FUNCTIONS[expr.operator]}({left}, {right})", _POSTFIX_PRECEDENCE
 
     if expr.operator in _ARITHMETIC_RUNTIME_FUNCTIONS:
         left = _emit_expression(expr.left, local_names, scope_context=scope_context)[0]

--- a/src/conversion/gml_transpiler_parts/gml_manual_scope.py
+++ b/src/conversion/gml_transpiler_parts/gml_manual_scope.py
@@ -140,7 +140,7 @@ _MANUAL_SCOPE_ENTRIES: tuple[GMLManualScopeEntry, ...] = (
         _OVERVIEW_DOCS,
         ("Foundation", "Maths and Numbers", "Strings"),
         ("tests/test_gml_runtime.py",),
-        "Truthiness, equality, NaN, infinity, undefined, and string conversion need a full audit.",
+        "Runtime helpers centralize truthiness, equality, ordering, NaN, infinity, undefined, and string conversion semantics; exact string and handle edge cases remain partial.",
     ),
     _entry(
         "overview_conditionals",
@@ -153,7 +153,7 @@ _MANUAL_SCOPE_ENTRIES: tuple[GMLManualScopeEntry, ...] = (
         _OVERVIEW_DOCS,
         ("Foundation",),
         ("tests/test_gml_transpiler.py",),
-        "Syntax exists; exact truthiness and coercion are tracked by #581.",
+        "Conditional expression output routes through runtime truthiness helpers; uncovered expression contexts remain partial.",
     ),
     _entry(
         "overview_cross_instance_addressing",
@@ -524,7 +524,7 @@ _MANUAL_SCOPE_ENTRIES: tuple[GMLManualScopeEntry, ...] = (
         "GameMaker_Language/GML_Reference/Strings/Strings.htm",
         ("Strings",),
         ("tests/test_gml_runtime.py",),
-        "String subset exists; Unicode, byte length, formatting, and conversion edge cases are tracked by #581.",
+        "String helpers use Godot Unicode codepoint operations; byte length, formatting, locale case mapping, and template interpolation remain partial.",
     ),
     _entry(
         "reference_maths_numbers",

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -62,13 +62,21 @@ RUNTIME_VALUE_PARITY_CASES: tuple[RuntimeValueParityCase, ...] = (
         "undefined != infinity",
         "GMRuntime.gml_ne(GMRuntime.gml_undefined(), INF)",
     ),
+    RuntimeValueParityCase("score > 0", "GMRuntime.gml_gt(score, 0)"),
+    RuntimeValueParityCase("score >= 0", "GMRuntime.gml_gte(score, 0)"),
+    RuntimeValueParityCase("score < 10", "GMRuntime.gml_lt(score, 10)"),
+    RuntimeValueParityCase("score <= 10", "GMRuntime.gml_lte(score, 10)"),
+    RuntimeValueParityCase('"alpha" < "beta"', 'GMRuntime.gml_lt("alpha", "beta")'),
+    RuntimeValueParityCase("NaN < 1", "GMRuntime.gml_lt(NAN, 1)"),
     RuntimeValueParityCase("bool(pointer_null)", "GMRuntime.gml_bool(GMRuntime.gml_pointer_null())"),
     RuntimeValueParityCase("bool(0.5)", "GMRuntime.gml_bool(0.5)"),
     RuntimeValueParityCase("bool(0.50001)", "GMRuntime.gml_bool(0.50001)"),
     RuntimeValueParityCase("is_bool(true)", "GMRuntime.is_bool(true)"),
     RuntimeValueParityCase('string("abc")', 'GMRuntime.gml_string("abc")'),
+    RuntimeValueParityCase('string("Grüße")', 'GMRuntime.gml_string("Grüße")'),
     RuntimeValueParityCase('typeof("abc")', 'GMRuntime.gml_typeof("abc")'),
     RuntimeValueParityCase('is_string("abc")', 'GMRuntime.is_string("abc")'),
+    RuntimeValueParityCase('string_ord_at("é", 1)', 'GMRuntime.gml_string_ord_at("é", 1)'),
     RuntimeValueParityCase("real(score)", "GMRuntime.gml_real(score)"),
     RuntimeValueParityCase("int64(score)", "GMRuntime.gml_int64(score)"),
     RuntimeValueParityCase('int64("42")', 'GMRuntime.gml_int64("42")'),
@@ -978,6 +986,10 @@ class TestGMLRuntimeScript(unittest.TestCase):
             "is_infinity",
             "gml_eq",
             "gml_ne",
+            "gml_lt",
+            "gml_lte",
+            "gml_gt",
+            "gml_gte",
             "gml_div",
             "gml_int_div",
             "gml_real",
@@ -2587,6 +2599,16 @@ class TestGMLRuntimeScript(unittest.TestCase):
         self.assertIn("static func is_nan_value(value):\n\treturn is_number(value) and is_nan(float(value))", GML_RUNTIME_SCRIPT)
         self.assertIn("static func is_infinity(value):\n\treturn is_number(value) and is_inf(float(value))", GML_RUNTIME_SCRIPT)
 
+    def test_runtime_comparison_helpers_centralize_ordering_semantics(self):
+        self.assertIn("static func gml_lt(left, right):", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_lte(left, right):", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_gt(left, right):", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_gte(left, right):", GML_RUNTIME_SCRIPT)
+        self.assertIn("if is_nan_value(left) or is_nan_value(right):\n\t\treturn false", GML_RUNTIME_SCRIPT)
+        self.assertIn("if _is_arithmetic_real_operand(left) and _is_arithmetic_real_operand(right):", GML_RUNTIME_SCRIPT)
+        self.assertIn("if is_string(left) and is_string(right):", GML_RUNTIME_SCRIPT)
+        self.assertIn('return gml_unsupported_binary_type_error("GML less-than comparison", left, right)', GML_RUNTIME_SCRIPT)
+
     def test_runtime_bitwise_helpers_return_int64_values(self):
         self.assertIn("static func gml_bit_or(left, right):", GML_RUNTIME_SCRIPT)
         self.assertIn("return GMLInt64.new(_to_int64_value(left) | _to_int64_value(right))", GML_RUNTIME_SCRIPT)
@@ -2614,6 +2636,7 @@ class TestGMLRuntimeScript(unittest.TestCase):
         self.assertIn('return gml_unsupported_binary_type_error("GML divide", left, right)', GML_RUNTIME_SCRIPT)
         self.assertIn('return gml_unsupported_binary_type_error("GML integer divide", left, right)', GML_RUNTIME_SCRIPT)
         self.assertIn('return gml_unsupported_binary_type_error("GML modulo", left, right)', GML_RUNTIME_SCRIPT)
+        self.assertIn('return gml_unsupported_binary_type_error("GML less-than comparison", left, right)', GML_RUNTIME_SCRIPT)
         self.assertIn('return gml_unsupported_binary_type_error("GML pointer arithmetic", left, right)', GML_RUNTIME_SCRIPT)
         self.assertIn("static func gml_unsupported_binary_type_error(api_name, left, right):", GML_RUNTIME_SCRIPT)
         self.assertIn("return gml_error(", GML_RUNTIME_SCRIPT)

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -1925,7 +1925,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
     def test_transpiles_while_blocks(self):
         self.assertEqual(
             transpile_gml_code("while score > 0 begin score -= 1; end", indent=""),
-            "while score > 0:\n\tscore = GMRuntime.gml_sub(score, 1)",
+            "while GMRuntime.gml_gt(score, 0):\n\tscore = GMRuntime.gml_sub(score, 1)",
         )
         self.assertEqual(
             transpile_gml_code("while (count) count--;", indent=""),
@@ -2003,14 +2003,14 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             transpile_gml_code("do begin score += 1; end until score >= 3;", indent=""),
             "while true:\n"
             "\tscore = GMRuntime.gml_add(score, 1)\n"
-            "\tif score >= 3:\n"
+            "\tif GMRuntime.gml_gte(score, 3):\n"
             "\t\tbreak",
         )
         self.assertEqual(
             transpile_gml_code("do score += 1 until score >= 3;", indent=""),
             "while true:\n"
             "\tscore = GMRuntime.gml_add(score, 1)\n"
-            "\tif score >= 3:\n"
+            "\tif GMRuntime.gml_gte(score, 3):\n"
             "\t\tbreak",
         )
 
@@ -2031,11 +2031,11 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             ),
             "while true:\n"
             "\tif GMRuntime.gml_bool(should_skip):\n"
-            "\t\tif score >= 3:\n"
+            "\t\tif GMRuntime.gml_gte(score, 3):\n"
             "\t\t\tbreak\n"
             "\t\tcontinue\n"
             "\tscore = GMRuntime.gml_add(score, 1)\n"
-            "\tif score >= 3:\n"
+            "\tif GMRuntime.gml_gte(score, 3):\n"
             "\t\tbreak",
         )
 
@@ -2043,7 +2043,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
         self.assertEqual(
             transpile_gml_code("for (i = 0; i < 3; i++) begin score += i; end", indent=""),
             "i = 0\n"
-            "while i < 3:\n"
+            "while GMRuntime.gml_lt(i, 3):\n"
             "\tscore = GMRuntime.gml_add(score, i)\n"
             "\ti = GMRuntime.gml_add(i, 1)",
         )
@@ -2162,7 +2162,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             transpile_gml_code("for (var i = 0, total = 0; i < 3; i++) total += i;", indent=""),
             "var i = 0\n"
             "var total = 0\n"
-            "while i < 3:\n"
+            "while GMRuntime.gml_lt(i, 3):\n"
             "\ttotal = GMRuntime.gml_add(total, i)\n"
             "\ti = GMRuntime.gml_add(i, 1)",
         )
@@ -2174,7 +2174,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
                 indent="",
             ),
             "i = 0\n"
-            "while i < 3:\n"
+            "while GMRuntime.gml_lt(i, 3):\n"
             "\tif GMRuntime.gml_bool(skip):\n"
             "\t\ti = GMRuntime.gml_add(i, 1)\n"
             "\t\tcontinue\n"
@@ -2975,7 +2975,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
     def test_transpiles_if_blocks(self):
         self.assertEqual(
             transpile_gml_code("if score > 0 { score -= 1; } else { score = 0; }", indent=""),
-            "if score > 0:\n\tscore = GMRuntime.gml_sub(score, 1)\nelse:\n\tscore = 0",
+            "if GMRuntime.gml_gt(score, 0):\n\tscore = GMRuntime.gml_sub(score, 1)\nelse:\n\tscore = 0",
         )
 
     def test_transpiles_if_blocks_with_single_equals_conditions(self):


### PR DESCRIPTION
Closes #581.

## Summary
- route emitted relational operators through GMRuntime comparison helpers instead of raw GDScript operators
- add runtime ordering helpers for numeric, string, NaN, and unsupported mixed-type comparison behavior
- add parity coverage for comparison lowering, Unicode string conversion/codepoint cases, and value semantics helper exports
- update runtime manifest/manual scope notes for value and string approximation boundaries

## Tests
- ./venv/bin/python -m unittest tests.test_gml_transpiler tests.test_gml_runtime tests.test_gml_manual_scope
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest