### PR TITLE
Harden GML accessors and DS handle resolution

### DIFF
--- a/src/conversion/gml_runtime_parts/manifest.py
+++ b/src/conversion/gml_runtime_parts/manifest.py
@@ -187,19 +187,19 @@ RUNTIME_SEGMENTS: tuple[RuntimeSegmentDefinition, ...] = (
     ),
     _segment(
         "57_ds_lists_stacks_queues.gd",
-        "List, stack, queue, and priority data structure handles.",
+        "List, stack, queue, and priority data structure handles with destroyed-handle guards.",
         depends_on=("00_prelude.gd", "10_handles_and_instances.gd"),
         tests=("tests/test_ds_collections_godot.py",),
     ),
     _segment(
         "58_ds_maps.gd",
-        "Map data structure handles, accessors, JSON bridges, and persistence.",
+        "Map data structure handles, accessors, destroyed-handle guards, JSON bridges, and persistence.",
         depends_on=("00_prelude.gd", "10_handles_and_instances.gd", "57_ds_lists_stacks_queues.gd"),
         tests=("tests/test_ds_collections_godot.py",),
     ),
     _segment(
         "59_ds_grids.gd",
-        "Grid data structure handles, regions, math operations, and persistence.",
+        "Grid data structure handles, accessors, regions, math operations, and destroyed-handle guards.",
         depends_on=("00_prelude.gd", "10_handles_and_instances.gd"),
         tests=("tests/test_ds_collections_godot.py",),
     ),

--- a/src/conversion/gml_runtime_parts/segments/50_static_types_and_clone.gd
+++ b/src/conversion/gml_runtime_parts/segments/50_static_types_and_clone.gd
@@ -98,9 +98,7 @@ static func _gml_resolve_instance(instance_value):
 
 static func _gml_resolve_ds_map(map_value):
 	if is_handle(map_value) or is_numeric(map_value) or is_string(map_value):
-		var resolved_map = gml_handle_resolve_for_kind(GML_DS_MAP_HANDLE_KIND, map_value)
-		if resolved_map != null:
-			return resolved_map
+		return gml_handle_resolve_for_kind(GML_DS_MAP_HANDLE_KIND, map_value)
 	return map_value
 
 
@@ -283,4 +281,3 @@ static func gml_type_name(value):
 	if gml_type != GML_TYPE_UNKNOWN:
 		return gml_type
 	return "godot_type_" + str(typeof(value))
-

--- a/src/conversion/gml_runtime_parts/segments/57_ds_lists_stacks_queues.gd
+++ b/src/conversion/gml_runtime_parts/segments/57_ds_lists_stacks_queues.gd
@@ -2,30 +2,22 @@
 
 static func _gml_resolve_ds_list(id_value):
 	if is_handle(id_value) or is_numeric(id_value) or is_string(id_value):
-		var resolved = gml_handle_resolve_for_kind(GML_DS_LIST_HANDLE_KIND, id_value)
-		if resolved != null:
-			return resolved
+		return gml_handle_resolve_for_kind(GML_DS_LIST_HANDLE_KIND, id_value)
 	return id_value
 
 static func _gml_resolve_ds_stack(id_value):
 	if is_handle(id_value) or is_numeric(id_value) or is_string(id_value):
-		var resolved = gml_handle_resolve_for_kind(GML_DS_STACK_HANDLE_KIND, id_value)
-		if resolved != null:
-			return resolved
+		return gml_handle_resolve_for_kind(GML_DS_STACK_HANDLE_KIND, id_value)
 	return id_value
 
 static func _gml_resolve_ds_queue(id_value):
 	if is_handle(id_value) or is_numeric(id_value) or is_string(id_value):
-		var resolved = gml_handle_resolve_for_kind(GML_DS_QUEUE_HANDLE_KIND, id_value)
-		if resolved != null:
-			return resolved
+		return gml_handle_resolve_for_kind(GML_DS_QUEUE_HANDLE_KIND, id_value)
 	return id_value
 
 static func _gml_resolve_ds_priority(id_value):
 	if is_handle(id_value) or is_numeric(id_value) or is_string(id_value):
-		var resolved = gml_handle_resolve_for_kind(GML_DS_PRIORITY_HANDLE_KIND, id_value)
-		if resolved != null:
-			return resolved
+		return gml_handle_resolve_for_kind(GML_DS_PRIORITY_HANDLE_KIND, id_value)
 	return id_value
 
 
@@ -316,7 +308,8 @@ static func gml_ds_list_set(id_value, pos, value):
 			if idx >= arr.size():
 				arr.resize(idx + 1)
 			arr[idx] = value
-	return value
+			return value
+	return gml_undefined()
 
 static func gml_ds_list_delete(id_value, pos):
 	var ds = _gml_resolve_ds_list(id_value)

--- a/src/conversion/gml_runtime_parts/segments/58_ds_maps.gd
+++ b/src/conversion/gml_runtime_parts/segments/58_ds_maps.gd
@@ -40,7 +40,7 @@ static func gml_ds_map_set(id_value, key, value):
 	if ds is Dictionary:
 		ds[key] = value
 		return value
-	return gml_unsupported_type_error("GML ds_map set", ds)
+	return gml_undefined()
 
 static func gml_ds_map_replace(id_value, key, value):
 	var ds = _gml_resolve_ds_map(id_value)
@@ -68,7 +68,7 @@ static func gml_ds_map_find_value(id_value, key):
 		if resolved_map.has(key):
 			return resolved_map[key]
 		return gml_undefined()
-	return gml_unsupported_type_error("GML ds_map access", resolved_map)
+	return gml_undefined()
 
 static func gml_ds_map_find_first(id_value):
 	var ds = _gml_resolve_ds_map(id_value)

--- a/src/conversion/gml_runtime_parts/segments/59_ds_grids.gd
+++ b/src/conversion/gml_runtime_parts/segments/59_ds_grids.gd
@@ -241,9 +241,7 @@ static func gml_ds_grid_write(id_value):
 
 static func _gml_resolve_ds_grid(id_value):
 	if is_handle(id_value) or is_numeric(id_value) or is_string(id_value):
-		var resolved = gml_handle_resolve_for_kind(GML_DS_GRID_HANDLE_KIND, id_value)
-		if resolved != null:
-			return resolved
+		return gml_handle_resolve_for_kind(GML_DS_GRID_HANDLE_KIND, id_value)
 	return id_value
 
 static func _gml_ds_grid_create_unregistered(w, h):

--- a/src/conversion/gml_transpiler_parts/gml_manual_scope.py
+++ b/src/conversion/gml_transpiler_parts/gml_manual_scope.py
@@ -270,7 +270,7 @@ _MANUAL_SCOPE_ENTRIES: tuple[GMLManualScopeEntry, ...] = (
         "GameMaker_Language/GML_Reference/Variable_Functions/Array_Functions/Array_Functions.htm",
         ("Arrays", "Accessors"),
         ("tests/test_gml_runtime.py",),
-        "Array helpers exist; copy/reference and nested accessor conformance are tracked by #583.",
+        "Array helpers and nested accessor mutation caching exist; exact copy/reference behavior remains partial.",
     ),
     _entry(
         "reference_asset_management",
@@ -511,7 +511,7 @@ _MANUAL_SCOPE_ENTRIES: tuple[GMLManualScopeEntry, ...] = (
         "GameMaker_Language/GML_Reference/Data_Structures/Data_Structures.htm",
         ("Data Structures Sequential", "Data Structures Maps", "Data Structures Grids", "Accessors"),
         ("tests/test_ds_collections_godot.py",),
-        "Core DS operations exist; serialization, nested marking, sorting, handle reuse, and edge cases remain open.",
+        "Core DS operations exist; accessor reads/writes return undefined for missing or destroyed handles, while serialization, sorting, and handle reuse remain partial.",
     ),
     _entry(
         "reference_strings",

--- a/src/conversion/gml_transpiler_parts/tokens.py
+++ b/src/conversion/gml_transpiler_parts/tokens.py
@@ -59,6 +59,13 @@ def _tokenize(source: str) -> list[_Token]:
                 tokens.append(_Token("DIRECTIVE", "#macro", line=line, column=column, index=index))
                 index += len("#macro")
                 continue
+            previous_index = index - 1
+            while previous_index >= 0 and source[previous_index].isspace():
+                previous_index -= 1
+            if previous_index >= 0 and source[previous_index] == "[":
+                tokens.append(_Token("OP", char, line=line, column=column, index=index))
+                index += 1
+                continue
             try:
                 color_literal, color_end = _read_hash_color_literal(source, index)
             except GMLTranspileError as exc:

--- a/src/conversion/gml_transpiler_parts/utils.py
+++ b/src/conversion/gml_transpiler_parts/utils.py
@@ -12,6 +12,7 @@ from .model import (
     _Binary,
     _Call,
     _DEFAULT_SCOPE_CONTEXT,
+    _DSGridAccess,
     _DSMapAccess,
     _DSListAccess,
     _Expression,
@@ -134,6 +135,12 @@ def _expression_needs_assignment_cache(expr: _Expression) -> bool:
         return (
             _expression_needs_assignment_cache(expr.target)
             or _expression_needs_assignment_cache(expr.index)
+        )
+    if isinstance(expr, _DSGridAccess):
+        return (
+            _expression_needs_assignment_cache(expr.target)
+            or _expression_needs_assignment_cache(expr.x_index)
+            or _expression_needs_assignment_cache(expr.y_index)
         )
     if isinstance(expr, _Member):
         return _expression_needs_assignment_cache(expr.target)

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -2164,6 +2164,53 @@ class TestGMLRuntimeScript(unittest.TestCase):
         self.assertIn("ds[key] = value", GML_RUNTIME_SCRIPT)
         self.assertNotIn("resolved_map.get(", GML_RUNTIME_SCRIPT)
 
+    def test_runtime_ds_accessors_treat_destroyed_handles_consistently(self):
+        self.assertIn(
+            "static func _gml_resolve_ds_map(map_value):\n"
+            "\tif is_handle(map_value) or is_numeric(map_value) or is_string(map_value):\n"
+            "\t\treturn gml_handle_resolve_for_kind(GML_DS_MAP_HANDLE_KIND, map_value)",
+            GML_RUNTIME_SCRIPT,
+        )
+        self.assertIn(
+            "static func _gml_resolve_ds_list(id_value):\n"
+            "\tif is_handle(id_value) or is_numeric(id_value) or is_string(id_value):\n"
+            "\t\treturn gml_handle_resolve_for_kind(GML_DS_LIST_HANDLE_KIND, id_value)",
+            GML_RUNTIME_SCRIPT,
+        )
+        self.assertIn(
+            "static func _gml_resolve_ds_grid(id_value):\n"
+            "\tif is_handle(id_value) or is_numeric(id_value) or is_string(id_value):\n"
+            "\t\treturn gml_handle_resolve_for_kind(GML_DS_GRID_HANDLE_KIND, id_value)",
+            GML_RUNTIME_SCRIPT,
+        )
+        self.assertIn(
+            "static func gml_ds_map_set(id_value, key, value):\n"
+            "\tvar ds = _gml_resolve_ds_map(id_value)\n"
+            "\tif ds is Dictionary:\n"
+            "\t\tds[key] = value\n"
+            "\t\treturn value\n"
+            "\treturn gml_undefined()",
+            GML_RUNTIME_SCRIPT,
+        )
+        self.assertIn(
+            "static func gml_ds_map_find_value(id_value, key):\n"
+            "\tvar resolved_map = _gml_resolve_ds_map(id_value)\n"
+            "\tif resolved_map is Dictionary:\n"
+            "\t\tif resolved_map.has(key):\n"
+            "\t\t\treturn resolved_map[key]\n"
+            "\t\treturn gml_undefined()\n"
+            "\treturn gml_undefined()",
+            GML_RUNTIME_SCRIPT,
+        )
+        self.assertIn(
+            "static func gml_ds_list_set(id_value, pos, value):\n"
+            "\tvar ds = _gml_resolve_ds_list(id_value)\n"
+            "\tvar idx = _to_int64_value(pos)\n"
+            "\tif ds is Dictionary:",
+            GML_RUNTIME_SCRIPT,
+        )
+        self.assertIn("\t\t\treturn value\n\treturn gml_undefined()", GML_RUNTIME_SCRIPT)
+
     def test_runtime_preserves_undefined_value_model(self):
         self.assertIn("class GMLUndefined:", GML_RUNTIME_SCRIPT)
         self.assertIn("static var _gml_undefined = GMLUndefined.new()", GML_RUNTIME_SCRIPT)

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -1401,6 +1401,33 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
             'GMRuntime.gml_ds_map_set(inventory, "food", amount)',
         )
 
+    def test_transpiles_ds_grid_mutation_targets_once(self):
+        self.assertEqual(
+            transpile_gml_code("grid[# next_x(), next_y()] += value;", indent=""),
+            "var _gml_grid_x_0 = next_x()\n"
+            "var _gml_grid_y_1 = next_y()\n"
+            "GMRuntime.gml_ds_grid_set(grid, _gml_grid_x_0, _gml_grid_y_1, "
+            "GMRuntime.gml_add(GMRuntime.gml_ds_grid_get(grid, _gml_grid_x_0, _gml_grid_y_1), value))",
+        )
+        self.assertEqual(
+            transpile_gml_code("grid[# next_x(), next_y()]++;", indent=""),
+            "var _gml_grid_x_0 = next_x()\n"
+            "var _gml_grid_y_1 = next_y()\n"
+            "GMRuntime.gml_ds_grid_set(grid, _gml_grid_x_0, _gml_grid_y_1, "
+            "GMRuntime.gml_add(GMRuntime.gml_ds_grid_get(grid, _gml_grid_x_0, _gml_grid_y_1), 1))",
+        )
+
+    def test_nested_mixed_accessor_mutation_caches_grid_cell_container(self):
+        self.assertEqual(
+            transpile_gml_code("result = grid[# next_x(), next_y()][? next_key()] += value;", indent=""),
+            "var _gml_map_target_0 = GMRuntime.gml_ds_grid_get(grid, next_x(), next_y())\n"
+            "var _gml_map_key_1 = next_key()\n"
+            "var _gml_assignment_value_2 = GMRuntime.gml_add("
+            "GMRuntime.gml_ds_map_find_value(_gml_map_target_0, _gml_map_key_1), value)\n"
+            "GMRuntime.gml_ds_map_set(_gml_map_target_0, _gml_map_key_1, _gml_assignment_value_2)\n"
+            "result = _gml_assignment_value_2",
+        )
+
     def test_any_values_pass_through_calls_without_lossy_conversion(self):
         self.assertEqual(
             transpile_gml_expression('callback([1, "x"], {value: undefined})'),


### PR DESCRIPTION
Closes #583.

## Summary
- tokenize [# ...] DS grid accessors without misclassifying them as hash color literals
- cache DS grid accessors when they are nested inside other mutation targets, preserving side-effect order
- normalize missing/destroyed DS map/list/grid accessor reads and writes to return undefined consistently
- update runtime/manual notes for accessor caching and destroyed-handle behavior

## Tests
- ./venv/bin/python -m unittest tests.test_gml_transpiler tests.test_gml_runtime tests.test_gml_manual_scope
- ./venv/bin/python -m unittest tests.test_ds_collections_godot
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest