### PR TITLE
Complete method identity and static chain coverage

### DIFF
--- a/src/conversion/gml_runtime_parts/segments/20_methods_and_exceptions.gd
+++ b/src/conversion/gml_runtime_parts/segments/20_methods_and_exceptions.gd
@@ -219,6 +219,20 @@ static func gml_method_get_index(method):
 	return method
 
 
+static func _gml_method_same(left, right):
+	if not is_method(left) or not is_method(right):
+		return false
+	var left_self = gml_method_get_self(left)
+	var right_self = gml_method_get_self(right)
+	if not gml_eq(left_self, right_self):
+		return false
+	var left_index = gml_method_get_index(left)
+	var right_index = gml_method_get_index(right)
+	if typeof(left_index) == TYPE_CALLABLE or typeof(right_index) == TYPE_CALLABLE:
+		return typeof(left_index) == TYPE_CALLABLE and typeof(right_index) == TYPE_CALLABLE and left_index == right_index
+	return gml_eq(left_index, right_index)
+
+
 static func _gml_method_call_args(array_args, offset, num_args):
 	var source = [] if array_args == null else array_args
 	if typeof(source) != TYPE_ARRAY:

--- a/src/conversion/gml_runtime_parts/segments/50_static_types_and_clone.gd
+++ b/src/conversion/gml_runtime_parts/segments/50_static_types_and_clone.gd
@@ -133,6 +133,8 @@ static func gml_eq(left, right):
 		return is_ptr(left) and is_ptr(right) and left.value == right.value and left.invalid == right.invalid
 	if is_handle(left) or is_handle(right):
 		return _gml_handle_eq(left, right)
+	if is_method(left) or is_method(right):
+		return _gml_method_same(left, right)
 	if is_nan_value(left) or is_nan_value(right):
 		return false
 	if is_numeric(left) and is_numeric(right):

--- a/src/conversion/gml_transpiler_parts/gml_manual_scope.py
+++ b/src/conversion/gml_transpiler_parts/gml_manual_scope.py
@@ -192,7 +192,7 @@ _MANUAL_SCOPE_ENTRIES: tuple[GMLManualScopeEntry, ...] = (
         _OVERVIEW_DOCS,
         ("Script Functions",),
         ("tests/test_scripts.py", "tests/test_script_runtime_godot.py"),
-        "Script wrappers exist; function identity and legacy/current import variants need hardening.",
+        "Script wrappers preserve callable identity for registry/global lookups; unsupported multi-function current-script assets emit migration diagnostics.",
     ),
     _entry(
         "overview_methods",
@@ -205,7 +205,7 @@ _MANUAL_SCOPE_ENTRIES: tuple[GMLManualScopeEntry, ...] = (
         _OVERVIEW_DOCS,
         ("Script Functions", "Foundation"),
         ("tests/test_gml_transpiler.py",),
-        "Bound methods exist; method identity and method_get_* parity remain open.",
+        "Bound methods expose self/index helpers and compare identity by bound self plus method index.",
     ),
     _entry(
         "overview_statics_constructors",
@@ -218,7 +218,7 @@ _MANUAL_SCOPE_ENTRIES: tuple[GMLManualScopeEntry, ...] = (
         _OVERVIEW_DOCS,
         ("Arrays", "Accessors", "Foundation", "Script Functions"),
         ("tests/test_gml_transpiler.py", "tests/test_gml_runtime.py"),
-        "Core syntax exists; static chains, copy/reference parity, and accessor edge cases remain open.",
+        "Constructor static chains, inherited statics, closure-backed function literals, and accessor edge cases have focused runtime coverage.",
     ),
     _entry(
         "language_control_flow",

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -121,6 +121,14 @@ RUNTIME_VALUE_PARITY_CASES: tuple[RuntimeValueParityCase, ...] = (
     ),
     RuntimeValueParityCase("method_get_self(callback)", "GMRuntime.gml_method_get_self(callback)"),
     RuntimeValueParityCase("method_get_index(callback)", "GMRuntime.gml_method_get_index(callback)"),
+    RuntimeValueParityCase(
+        "method(player, callback) == method(player, callback)",
+        "GMRuntime.gml_eq(GMRuntime.gml_method(player, callback), GMRuntime.gml_method(player, callback))",
+    ),
+    RuntimeValueParityCase(
+        "method(player, callback) != method(enemy, callback)",
+        "GMRuntime.gml_ne(GMRuntime.gml_method(player, callback), GMRuntime.gml_method(enemy, callback))",
+    ),
     RuntimeValueParityCase("method_call(callback)", "GMRuntime.gml_method_call(callback)"),
     RuntimeValueParityCase(
         "method_call(callback, [1, 2, 3], 1, 2)",
@@ -423,6 +431,10 @@ RUNTIME_VALUE_PARITY_CASES: tuple[RuntimeValueParityCase, ...] = (
     RuntimeValueParityCase("script_exists(scr_add)", 'GMRuntime.gml_script_exists(GMRuntime.gml_asset_get_index("scr_add"))'),
     RuntimeValueParityCase("script_get_name(scr_add)", 'GMRuntime.gml_script_get_name(GMRuntime.gml_asset_get_index("scr_add"))'),
     RuntimeValueParityCase("global_function('scr_add')", "GMRuntime.gml_global_function('scr_add')"),
+    RuntimeValueParityCase(
+        "script_get_callable(scr_add) == global_function('scr_add')",
+        'GMRuntime.gml_eq(GMRuntime.gml_script_get_callable(GMRuntime.gml_asset_get_index("scr_add")), GMRuntime.gml_global_function(\'scr_add\'))',
+    ),
     RuntimeValueParityCase("argument0", "GMRuntime.gml_argument(0)"),
     RuntimeValueParityCase("argument15", "GMRuntime.gml_argument(15)"),
     RuntimeValueParityCase("5 div 2", "GMRuntime.gml_int_div(5, 2)"),
@@ -1874,6 +1886,20 @@ class TestGMLRuntimeScript(unittest.TestCase):
         self.assertIn("return method", GML_RUNTIME_SCRIPT)
         self.assertIn("if is_method(value):\n\t\treturn GML_TYPE_METHOD", GML_RUNTIME_SCRIPT)
 
+    def test_runtime_method_identity_uses_bound_self_and_index(self):
+        self.assertIn("static func _gml_method_same(left, right):", GML_RUNTIME_SCRIPT)
+        self.assertIn("if not is_method(left) or not is_method(right):\n\t\treturn false", GML_RUNTIME_SCRIPT)
+        self.assertIn("var left_self = gml_method_get_self(left)", GML_RUNTIME_SCRIPT)
+        self.assertIn("var right_self = gml_method_get_self(right)", GML_RUNTIME_SCRIPT)
+        self.assertIn("if not gml_eq(left_self, right_self):\n\t\treturn false", GML_RUNTIME_SCRIPT)
+        self.assertIn("var left_index = gml_method_get_index(left)", GML_RUNTIME_SCRIPT)
+        self.assertIn("var right_index = gml_method_get_index(right)", GML_RUNTIME_SCRIPT)
+        self.assertIn(
+            "return typeof(left_index) == TYPE_CALLABLE and typeof(right_index) == TYPE_CALLABLE and left_index == right_index",
+            GML_RUNTIME_SCRIPT,
+        )
+        self.assertIn("return gml_eq(left_index, right_index)", GML_RUNTIME_SCRIPT)
+
     def test_runtime_constructor_methods_allocate_new_structs(self):
         self.assertIn("static func gml_constructor(scope, func_or_method):", GML_RUNTIME_SCRIPT)
         self.assertIn("var constructor_method = gml_method(scope, func_or_method, true)", GML_RUNTIME_SCRIPT)
@@ -1920,6 +1946,7 @@ class TestGMLRuntimeScript(unittest.TestCase):
         self.assertIn("return not gml_eq(left, right)", GML_RUNTIME_SCRIPT)
 
     def test_runtime_reference_equality_uses_identity(self):
+        self.assertIn("if is_method(left) or is_method(right):\n\t\treturn _gml_method_same(left, right)", GML_RUNTIME_SCRIPT)
         self.assertIn("static func _is_gml_reference_value(value):", GML_RUNTIME_SCRIPT)
         self.assertIn("if _is_gml_reference_value(left) or _is_gml_reference_value(right):", GML_RUNTIME_SCRIPT)
         self.assertIn(

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -846,6 +846,14 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
             transpile_gml_expression("method_get_index(callback)"),
             "GMRuntime.gml_method_get_index(callback)",
         )
+        self.assertEqual(
+            transpile_gml_expression("method(player, callback) == method(player, callback)"),
+            "GMRuntime.gml_eq(GMRuntime.gml_method(player, callback), GMRuntime.gml_method(player, callback))",
+        )
+        self.assertEqual(
+            transpile_gml_expression("method(player, callback) != method(enemy, callback)"),
+            "GMRuntime.gml_ne(GMRuntime.gml_method(player, callback), GMRuntime.gml_method(enemy, callback))",
+        )
         self.assertEqual(transpile_gml_expression("method_call(callback)"), "GMRuntime.gml_method_call(callback)")
         self.assertEqual(
             transpile_gml_expression("method_call(callback, [1, 2, 3], 1, 2)"),
@@ -3733,6 +3741,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
                 "ok = script_exists(scr_add);"
                 "name = script_get_name(scr_add);"
                 "fn = global_function('scr_add');"
+                "same = script_get_callable(scr_add) == global_function('scr_add');"
                 "legacy = argument0 + argument1 + argument_count;",
                 indent="",
                 asset_names={"scr_add"},
@@ -3741,6 +3750,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             "ok = GMRuntime.gml_script_exists(GMRuntime.gml_asset_get_index(\"scr_add\"))\n"
             "name = GMRuntime.gml_script_get_name(GMRuntime.gml_asset_get_index(\"scr_add\"))\n"
             "fn = GMRuntime.gml_global_function('scr_add')\n"
+            "same = GMRuntime.gml_eq(GMRuntime.gml_script_get_callable(GMRuntime.gml_asset_get_index(\"scr_add\")), GMRuntime.gml_global_function('scr_add'))\n"
             "legacy = GMRuntime.gml_add(GMRuntime.gml_add(GMRuntime.gml_argument(0), GMRuntime.gml_argument(1)), GMRuntime.gml_builtin_global(\"argument_count\"))",
         )
 

--- a/tests/test_script_runtime_godot.py
+++ b/tests/test_script_runtime_godot.py
@@ -89,12 +89,24 @@ class TestScriptRuntimeGodotSmoke(unittest.TestCase):
 
             const GMRuntime = preload("res://gm2godot/gml_runtime.gd")
 
+            var _parent_constructor_method = null
+
             func _check(condition, message):
             \tif not condition:
             \t\tpush_error(str(message))
             \t\tget_tree().quit(1)
             \t\treturn false
             \treturn true
+
+            func _identity(value = 0):
+            \treturn value
+
+            func _parent_constructor(instance, value):
+            \tGMRuntime.gml_variable_instance_set(instance, "parent_value", value)
+
+            func _child_constructor(instance, value):
+            \tGMRuntime.gml_constructor_inherit(instance, _parent_constructor_method, [value])
+            \tGMRuntime.gml_variable_instance_set(instance, "child_value", value + 1)
 
             func _ready():
             \tcall_deferred("_run")
@@ -113,11 +125,43 @@ class TestScriptRuntimeGodotSmoke(unittest.TestCase):
             \t\treturn
 
             \tvar callable = GMRuntime.gml_global_function("scr_modern")
+            \tif not _check(GMRuntime.gml_eq(callable, GMRuntime.gml_script_get_callable(modern_id)), "script callable identity failed"):
+            \t\treturn
             \tvar callbacks = [callable]
             \tvar method_result = GMRuntime.gml_method_call(callbacks[0], [4, 6])
             \tif not _check(method_result == 10, "callable lookup did not remain method-callable: " + str(method_result)):
             \t\treturn
             \tif not _check(GMRuntime.gml_script_execute(modern_id, [5]) == 9, "optional default argument failed"):
+            \t\treturn
+
+            \tvar method_a = GMRuntime.gml_method(self, Callable(self, "_identity"))
+            \tvar method_b = GMRuntime.gml_method(self, Callable(self, "_identity"))
+            \tvar method_c = GMRuntime.gml_method(GMRuntime.gml_struct({}), Callable(self, "_identity"))
+            \tif not _check(GMRuntime.gml_eq(method_a, method_b), "bound method identity failed"):
+            \t\treturn
+            \tif not _check(not GMRuntime.gml_eq(method_a, method_c), "bound method self identity failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_method_get_self(method_a) == self, "method_get_self failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_method_get_index(method_a) == Callable(self, "_identity"), "method_get_index failed"):
+            \t\treturn
+
+            \t_parent_constructor_method = GMRuntime.gml_constructor(self, Callable(self, "_parent_constructor"))
+            \tvar child_constructor = GMRuntime.gml_constructor(self, Callable(self, "_child_constructor"))
+            \tvar parent_static = GMRuntime.gml_static_get(_parent_constructor_method)
+            \tvar child_static = GMRuntime.gml_static_get(child_constructor)
+            \tGMRuntime.gml_struct_set(parent_static, "kind", "parent")
+            \tGMRuntime.gml_struct_set(child_static, "kind", "child")
+            \tvar instance = GMRuntime.gml_new(child_constructor, [6])
+            \tif not _check(GMRuntime.gml_variable_instance_get(instance, "parent_value") == 6, "parent constructor did not run"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_variable_instance_get(instance, "child_value") == 7, "child constructor did not run"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_is_instanceof(instance, child_constructor), "child instanceof failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_is_instanceof(instance, _parent_constructor_method), "parent instanceof failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_struct_get(GMRuntime.gml_static_get(GMRuntime.gml_static_get(instance)), "kind") == "parent", "static chain parent lookup failed"):
             \t\treturn
 
             \tprint("SCRIPT_RUNTIME_SMOKE_OK")

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -7,6 +7,7 @@ import unittest
 from pathlib import Path
 from typing import cast
 
+from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.scripts import (
     SCRIPT_REGISTRY_RELATIVE_PATH,
     ScriptConverter,
@@ -163,6 +164,51 @@ class TestScriptConverter(unittest.TestCase):
 
         legacy_script = (self.godot_dir / "scripts" / "Game" / "scr_add.gd").read_text(encoding="utf-8")
         self.assertIn('AdBridge.show_rewarded("zone_1")', legacy_script)
+
+    def test_records_migration_diagnostic_for_unsupported_multi_function_script_assets(self) -> None:
+        self._write_project()
+        project_path = self.gm_dir / "ScriptTest.yyp"
+        project = json.loads(project_path.read_text(encoding="utf-8"))
+        resources = cast(list[object], project["resources"])
+        resources.append(_resource_entry("scripts", "scr_multi"))
+        _write_json(project_path, project)
+        _write_json(
+            self.gm_dir / "scripts" / "scr_multi" / "scr_multi.yy",
+            {
+                "%Name": "scr_multi",
+                "name": "scr_multi",
+                "parent": {"name": "Game", "path": "folders/Scripts/Game.yy"},
+                "resourceType": "GMScript",
+            },
+        )
+        _write_text(
+            self.gm_dir / "scripts" / "scr_multi" / "scr_multi.gml",
+            "function helper(a) { return a; } function scr_multi(a) { return helper(a); }",
+        )
+        diagnostics = DiagnosticCollector()
+
+        registry_path = ScriptConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=lambda message: self.logs.append(str(message)),
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            diagnostics=diagnostics,
+        ).convert_all()
+
+        self.assertEqual(registry_path, str(self.godot_dir / SCRIPT_REGISTRY_RELATIVE_PATH))
+        recorded = diagnostics.diagnostics()
+        self.assertEqual(len(recorded), 1)
+        diagnostic = recorded[0]
+        self.assertEqual(diagnostic.code, "GM2GD-GML-TRANSPILE")
+        self.assertEqual(diagnostic.resource, "scr_multi")
+        self.assertEqual(diagnostic.resource_type, "script")
+        self.assertIn("Unexpected token: function", diagnostic.message)
+        self.assertIn("Split or rewrite unsupported GML", diagnostic.workaround or "")
+        registry = (self.godot_dir / SCRIPT_REGISTRY_RELATIVE_PATH).read_text(encoding="utf-8")
+        self.assertIn('"name": "scr_add"', registry)
+        self.assertIn('"name": "scr_modern"', registry)
+        self.assertNotIn('"name": "scr_multi"', registry)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #584.

## Summary
- compare GML method values by bound self plus method index before generic reference equality
- add script runtime smoke coverage for script callable identity, method_get_* identity, constructor static inheritance, and static-chain lookup
- document the closure/script compatibility policy and lock unsupported multi-function script assets to migration diagnostics

## Tests
- ./venv/bin/python -m unittest tests.test_gml_runtime tests.test_gml_transpiler tests.test_scripts tests.test_gml_manual_scope tests.test_script_runtime_godot
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest