### PR TITLE
Finish GML control-flow parity

### DIFF
--- a/src/conversion/gml_transpiler_parts/gml_manual_scope.py
+++ b/src/conversion/gml_transpiler_parts/gml_manual_scope.py
@@ -230,8 +230,8 @@ _MANUAL_SCOPE_ENTRIES: tuple[GMLManualScopeEntry, ...] = (
         "source_diagnostic",
         "GameMaker_Language/GML_Overview/Language_Features.htm",
         ("Foundation",),
-        ("tests/test_gml_transpiler.py",),
-        "Most syntax exists; finally, with, switch traces, delete, and event inheritance are tracked by #585.",
+        ("tests/test_gml_transpiler.py", "tests/test_objects.py"),
+        "Finally preserves abrupt control flow, switch continue targets outer loops, delete covers member/accessor targets, and event inheritance has generated callback coverage.",
     ),
     _entry(
         "language_preprocessor_macros",

--- a/src/conversion/gml_transpiler_parts/statement_parser.py
+++ b/src/conversion/gml_transpiler_parts/statement_parser.py
@@ -9,7 +9,11 @@ from .emitter import _emit_instance_keyword_argument
 from .enum_helpers import _evaluate_enum_value_tokens
 from .expression_parser import _parse_gml_expression
 from .expression_service import transpile_gml_condition, transpile_gml_expression
-from .identifiers import _sanitize_gdscript_identifier, _validate_gml_identifier, _reject_asset_identifier_name
+from .identifiers import (
+    _reject_asset_identifier_name,
+    _sanitize_gdscript_identifier,
+    _validate_gml_identifier,
+)
 from .model import (
     GMLExtensionFunction,
     GMLExtensionFunctionMapping,
@@ -17,7 +21,11 @@ from .model import (
     _ScopeContext,
     _Token,
 )
-from .statements import _transpile_statement
+from .statements import (
+    _ControlFlowCapture,
+    _control_flow_dispatch_lines,
+    _transpile_statement,
+)
 from .utils import (
     _indent_lines,
     _insert_lines_before_continue,
@@ -53,6 +61,7 @@ class _StatementParser:
         static_scope_prefix: str | None = None,
         extension_functions: dict[str, GMLExtensionFunction] | None = None,
         extension_function_mappings: dict[str, GMLExtensionFunctionMapping] | None = None,
+        control_flow_capture: _ControlFlowCapture | None = None,
     ) -> None:
         self.tokens = tokens
         self.position = 0
@@ -78,6 +87,7 @@ class _StatementParser:
             extension_function_mappings=extension_function_mappings,
         )
         self.inherited_event_call = inherited_event_call
+        self.control_flow_capture = control_flow_capture
         self.macro_values: MutableMapping[str, str] = (
             macro_values if macro_values is not None else {}
         )
@@ -142,6 +152,7 @@ class _StatementParser:
             inherited_event_call=self.inherited_event_call,
             macro_values=self.macro_values,
             generated_counter=self.generated_counter,
+            control_flow_capture=self.control_flow_capture,
         )
 
     def _parse_macro_statement(self) -> list[str]:
@@ -483,6 +494,8 @@ class _StatementParser:
         switch_value = self._next_generated_name("_gml_switch_value")
         switch_matched = self._next_generated_name("_gml_switch_matched")
         switch_has_case = self._next_generated_name("_gml_switch_has_case")
+        switch_control = self._next_generated_name("_gml_switch_control")
+        switch_capture = self._switch_control_capture(switch_control)
         expression = transpile_gml_expression(
             _tokens_to_source(expression_tokens),
             local_names=self.local_names,
@@ -491,7 +504,7 @@ class _StatementParser:
             scope_context=self.scope_context,
             macro_values=self.macro_values,
         )
-        sections = self._parse_switch_sections()
+        sections = self._parse_switch_sections(switch_capture)
         case_values = [
             section_value
             for section_kind, section_value, _ in sections
@@ -503,12 +516,15 @@ class _StatementParser:
         ]
         has_case_expression = " or ".join(case_conditions) if case_conditions else "false"
 
-        lines = [
+        lines: list[str] = []
+        if switch_capture is not None:
+            lines.append(f"var {switch_control} = GMRuntime.gml_undefined()")
+        lines.extend([
             f"var {switch_value} = {expression}",
             f"var {switch_matched} = false",
             f"var {switch_has_case} = {has_case_expression}",
             "while true:",
-        ]
+        ])
         for section_kind, section_value, section_lines in sections:
             if section_kind == "case":
                 lines.append(
@@ -522,9 +538,40 @@ class _StatementParser:
             lines.append(f"\tif {switch_matched}:")
             lines.extend(f"\t\t{line}" for line in (section_lines or ["pass"]))
         lines.append("\tbreak")
+        if switch_capture is not None:
+            lines.extend(
+                _control_flow_dispatch_lines(
+                    switch_control,
+                    switch_capture,
+                    self.control_flow_capture,
+                )
+            )
         return lines
 
-    def _parse_switch_sections(self) -> list[tuple[str, str | None, list[str]]]:
+    def _switch_control_capture(self, switch_control: str) -> _ControlFlowCapture | None:
+        parent_capture = self.control_flow_capture
+        capture_return = bool(parent_capture and parent_capture.capture_return)
+        capture_exit = bool(parent_capture and parent_capture.capture_exit)
+        capture_throw = bool(parent_capture and parent_capture.capture_throw)
+        capture_continue = self.continue_depth > 0 or bool(
+            parent_capture and parent_capture.capture_continue
+        )
+        if not (capture_return or capture_exit or capture_throw or capture_continue):
+            return None
+        return _ControlFlowCapture(
+            switch_control,
+            self.loop_depth + 1,
+            self.continue_depth,
+            capture_return=capture_return,
+            capture_exit=capture_exit,
+            capture_throw=capture_throw,
+            capture_continue=capture_continue,
+        )
+
+    def _parse_switch_sections(
+        self,
+        control_flow_capture: _ControlFlowCapture | None,
+    ) -> list[tuple[str, str | None, list[str]]]:
         self._skip_newlines()
         self._consume("{")
         sections: list[tuple[str, str | None, list[str]]] = []
@@ -544,19 +591,35 @@ class _StatementParser:
                     macro_values=self.macro_values,
                 )
                 body_tokens = self._read_switch_section_body_tokens()
-                sections.append(("case", label, self._parse_switch_section_body(body_tokens)))
+                sections.append(
+                    (
+                        "case",
+                        label,
+                        self._parse_switch_section_body(body_tokens, control_flow_capture),
+                    )
+                )
                 continue
             if self._match_identifier("default"):
                 self._consume(":")
                 body_tokens = self._read_switch_section_body_tokens()
-                sections.append(("default", None, self._parse_switch_section_body(body_tokens)))
+                sections.append(
+                    (
+                        "default",
+                        None,
+                        self._parse_switch_section_body(body_tokens, control_flow_capture),
+                    )
+                )
                 continue
             raise GMLTranspileError(f"Expected switch case or default, got: {self._peek().value}")
 
         self._consume("}")
         return sections
 
-    def _parse_switch_section_body(self, body_tokens: list[_Token]) -> list[str]:
+    def _parse_switch_section_body(
+        self,
+        body_tokens: list[_Token],
+        control_flow_capture: _ControlFlowCapture | None,
+    ) -> list[str]:
         parser = _StatementParser(
             body_tokens,
             local_names=self.local_names,
@@ -574,6 +637,7 @@ class _StatementParser:
             macro_priorities=self.macro_priorities,
             macro_configuration=self.macro_configuration,
             global_names=self.global_names,
+            control_flow_capture=control_flow_capture,
         )
         lines = parser.parse()
         self.local_names.update(parser.local_names)
@@ -587,8 +651,23 @@ class _StatementParser:
 
     def _parse_try_statement(self) -> list[str]:
         self._consume_identifier("try")
-        exception_name = self._next_generated_name("_gml_try_exception")
-        try_lines = self._parse_body()
+        control_name = self._next_generated_name("_gml_try_control")
+        try_capture = _ControlFlowCapture(
+            control_name,
+            self.loop_depth,
+            self.continue_depth,
+            capture_return=True,
+            capture_exit=True,
+            capture_throw=True,
+            capture_break=self.loop_depth > 0,
+            capture_continue=self.continue_depth > 0,
+        )
+        parent_capture = self.control_flow_capture
+        self.control_flow_capture = try_capture
+        try:
+            try_lines = self._parse_body()
+        finally:
+            self.control_flow_capture = parent_capture
 
         self._skip_newlines()
         catch_name: str | None = None
@@ -597,9 +676,11 @@ class _StatementParser:
             catch_name = self._parse_catch_variable_name()
             had_catch_local = catch_name in self.local_names
             self.local_names.add(catch_name)
+            self.control_flow_capture = try_capture
             try:
                 catch_lines = self._parse_body()
             finally:
+                self.control_flow_capture = parent_capture
                 if not had_catch_local:
                     self.local_names.discard(catch_name)
 
@@ -616,30 +697,27 @@ class _StatementParser:
             raise GMLTranspileError("try requires catch or finally")
 
         lines = [
-            f"var {exception_name} = (func():",
+            f"var {control_name} = GMRuntime.gml_undefined()",
+            "while true:",
             *_indent_lines(try_lines or ["pass"]),
-            "\treturn GMRuntime.gml_undefined()",
-            ").call()",
+            "\tbreak",
         ]
 
         if catch_lines is not None and catch_name is not None:
             gdscript_catch_name = _sanitize_gdscript_identifier(catch_name)
             lines.extend([
-                f"if GMRuntime.is_gml_exception({exception_name}):",
-                f"\tvar {gdscript_catch_name} = GMRuntime.gml_exception_struct({exception_name})",
-                f"\t{exception_name} = (func():",
+                f"if not GMRuntime.is_undefined({control_name}) and {control_name}[\"kind\"] == \"throw\":",
+                f"\tvar {gdscript_catch_name} = GMRuntime.gml_exception_struct({control_name}[\"value\"])",
+                f"\t{control_name} = GMRuntime.gml_undefined()",
+                "\twhile true:",
                 *[f"\t\t{line}" if line else "" for line in (catch_lines or ["pass"])],
-                "\t\treturn GMRuntime.gml_undefined()",
-                "\t).call()",
+                "\t\tbreak",
             ])
 
         if finally_lines is not None:
             lines.extend(finally_lines or ["pass"])
 
-        lines.extend([
-            f"if GMRuntime.is_gml_exception({exception_name}):",
-            f"\treturn {exception_name}",
-        ])
+        lines.extend(_control_flow_dispatch_lines(control_name, try_capture, parent_capture))
         return lines
 
     def _parse_catch_variable_name(self) -> str:

--- a/src/conversion/gml_transpiler_parts/statements.py
+++ b/src/conversion/gml_transpiler_parts/statements.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from typing import Callable, Iterable, Mapping, MutableMapping, MutableSet
 
 from .constants import (
@@ -62,6 +63,18 @@ from .utils import (
 _MOTION_SYNCHRONIZED_BUILTINS = frozenset({"direction", "hspeed", "speed", "vspeed"})
 
 
+@dataclass(frozen=True)
+class _ControlFlowCapture:
+    variable_name: str
+    loop_depth: int
+    continue_depth: int
+    capture_return: bool = False
+    capture_exit: bool = False
+    capture_throw: bool = False
+    capture_break: bool = False
+    capture_continue: bool = False
+
+
 def _transpile_statement(
     statement: str,
     local_names: MutableSet[str] | None = None,
@@ -76,6 +89,7 @@ def _transpile_statement(
     inherited_event_call: str | None = None,
     macro_values: Mapping[str, str] | None = None,
     generated_counter: list[int] | None = None,
+    control_flow_capture: _ControlFlowCapture | None = None,
 ) -> list[str]:
     if not statement:
         return []
@@ -90,6 +104,8 @@ def _transpile_statement(
         _reject_finally_control_flow(finally_depth)
         if return_depth <= 0:
             raise GMLTranspileError("return used outside a function or method")
+        if control_flow_capture is not None and control_flow_capture.capture_return:
+            return _captured_control_flow_lines(control_flow_capture, "return")
         return ["return"]
     if statement.startswith("return "):
         _reject_finally_control_flow(finally_depth)
@@ -113,19 +129,38 @@ def _transpile_statement(
             scope_context=scope_context,
             macro_values=macro_values,
         )
+        if control_flow_capture is not None and control_flow_capture.capture_return:
+            return [
+                *prelude_lines,
+                *_captured_control_flow_lines(control_flow_capture, "return", return_value),
+            ]
         return [*prelude_lines, f"return {return_value}"]
     if statement == "break":
         _reject_finally_control_flow(finally_depth)
         if loop_depth <= 0:
             raise GMLTranspileError("break used outside a loop")
+        if (
+            control_flow_capture is not None
+            and control_flow_capture.capture_break
+            and loop_depth == control_flow_capture.loop_depth
+        ):
+            return _captured_control_flow_lines(control_flow_capture, "break")
         return ["break"]
     if statement == "continue":
         _reject_finally_control_flow(finally_depth)
         if continue_depth <= 0:
             raise GMLTranspileError("continue used outside a loop")
+        if (
+            control_flow_capture is not None
+            and control_flow_capture.capture_continue
+            and continue_depth == control_flow_capture.continue_depth
+        ):
+            return _captured_control_flow_lines(control_flow_capture, "continue")
         return ["continue"]
     if statement == "exit":
         _reject_finally_control_flow(finally_depth)
+        if control_flow_capture is not None and control_flow_capture.capture_exit:
+            return _captured_control_flow_lines(control_flow_capture, "exit")
         return ["return"]
     event_inherited_lines = _transpile_event_inherited_statement(statement, inherited_event_call)
     if event_inherited_lines is not None:
@@ -151,6 +186,15 @@ def _transpile_statement(
             scope_context=scope_context,
             macro_values=macro_values,
         )
+        if control_flow_capture is not None and control_flow_capture.capture_throw:
+            return [
+                *prelude_lines,
+                *_captured_control_flow_lines(
+                    control_flow_capture,
+                    "throw",
+                    f"GMRuntime.gml_throw({thrown_value})",
+                ),
+            ]
         return [*prelude_lines, f"return GMRuntime.gml_throw({thrown_value})"]
 
     if statement.startswith("delete "):
@@ -179,6 +223,9 @@ def _transpile_statement(
         if global_target is not None:
             global_scope, member_name = global_target
             return [f"GMRuntime.gml_struct_set({global_scope}, {member_name}, GMRuntime.gml_undefined())"]
+        delete_lines = _delete_target_lines(target_expr, local_names, scope_context)
+        if delete_lines is not None:
+            return delete_lines
         if not isinstance(target_expr, _Name):
             raise GMLTranspileError("delete can only be used with variables")
         scoped_target = _scoped_instance_assignment_parts(
@@ -1045,6 +1092,117 @@ def _transpile_statement(
 def _reject_finally_control_flow(finally_depth: int) -> None:
     if finally_depth > 0:
         raise GMLTranspileError("break, continue, exit, and return are not allowed inside finally")
+
+
+def _delete_target_lines(
+    target_expr: _Expression,
+    local_names: Iterable[str],
+    scope_context: _ScopeContext,
+) -> list[str] | None:
+    if isinstance(target_expr, _Member):
+        target = _emit_expression(
+            target_expr.target,
+            local_names,
+            scope_context=scope_context,
+        )[0]
+        return [f"GMRuntime.gml_struct_remove({target}, {json.dumps(target_expr.member)})"]
+    if isinstance(target_expr, _StructAccess):
+        target = _emit_expression(
+            target_expr.target,
+            local_names,
+            scope_context=scope_context,
+        )[0]
+        key = _emit_expression(target_expr.key, local_names, scope_context=scope_context)[0]
+        return [f"GMRuntime.gml_struct_remove({target}, {key})"]
+    if isinstance(target_expr, _Index | _ArrayRefAccess):
+        target = _emit_expression(
+            target_expr.target,
+            local_names,
+            scope_context=scope_context,
+        )[0]
+        index = _emit_expression(target_expr.index, local_names, scope_context=scope_context)[0]
+        return [f"GMRuntime.gml_array_delete({target}, {index})"]
+    if isinstance(target_expr, _DSMapAccess):
+        target = _emit_expression(
+            target_expr.target,
+            local_names,
+            scope_context=scope_context,
+        )[0]
+        key = _emit_expression(target_expr.key, local_names, scope_context=scope_context)[0]
+        return [f"GMRuntime.gml_ds_map_delete({target}, {key})"]
+    if isinstance(target_expr, _DSListAccess):
+        target = _emit_expression(
+            target_expr.target,
+            local_names,
+            scope_context=scope_context,
+        )[0]
+        index = _emit_expression(target_expr.index, local_names, scope_context=scope_context)[0]
+        return [f"GMRuntime.gml_ds_list_delete({target}, {index})"]
+    if isinstance(target_expr, _DSGridAccess):
+        raise GMLTranspileError("delete does not support DS grid accessors")
+    return None
+
+
+def _captured_control_flow_lines(
+    capture: _ControlFlowCapture,
+    kind: str,
+    value: str = "GMRuntime.gml_undefined()",
+) -> list[str]:
+    return [
+        f'{capture.variable_name} = {{"kind": {json.dumps(kind)}, "value": {value}}}',
+        "break",
+    ]
+
+
+def _control_flow_dispatch_lines(
+    control_name: str,
+    source_capture: _ControlFlowCapture,
+    parent_capture: _ControlFlowCapture | None = None,
+) -> list[str]:
+    lines: list[str] = []
+    for kind in ("return", "exit", "break", "continue", "throw"):
+        if not _capture_handles_kind(source_capture, kind):
+            continue
+        lines.append(
+            f"if not GMRuntime.is_undefined({control_name}) and "
+            f'{control_name}["kind"] == {json.dumps(kind)}:'
+        )
+        if parent_capture is not None and _capture_handles_kind(parent_capture, kind):
+            lines.extend(
+                _indent_lines(
+                    _captured_control_flow_lines(
+                        parent_capture,
+                        kind,
+                        f'{control_name}["value"]',
+                    )
+                )
+            )
+            continue
+        if kind == "return":
+            lines.append(f'\treturn {control_name}["value"]')
+        elif kind == "exit":
+            lines.append("\treturn")
+        elif kind == "break":
+            lines.append("\tbreak")
+        elif kind == "continue":
+            lines.append("\tcontinue")
+        elif kind == "throw":
+            lines.append(f'\treturn {control_name}["value"]')
+    return lines
+
+
+def _capture_handles_kind(capture: _ControlFlowCapture, kind: str) -> bool:
+    if kind == "return":
+        return capture.capture_return
+    if kind == "exit":
+        return capture.capture_exit
+    if kind == "throw":
+        return capture.capture_throw
+    if kind == "break":
+        return capture.capture_break
+    if kind == "continue":
+        return capture.capture_continue
+    return False
 
 
 def _nullish_assignment_lines(

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -1776,36 +1776,27 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             transpile_gml_code("throw;", indent="")
 
     def test_transpiles_try_catch_blocks(self):
-        self.assertEqual(
-            transpile_gml_code(
-                'try { throw "bad"; } catch (err) { message = err.message; }',
-                indent="",
-            ),
-            "var _gml_try_exception_0 = (func():\n"
-            '\treturn GMRuntime.gml_throw("bad")\n'
-            "\treturn GMRuntime.gml_undefined()\n"
-            ").call()\n"
-            "if GMRuntime.is_gml_exception(_gml_try_exception_0):\n"
-            "\tvar err = GMRuntime.gml_exception_struct(_gml_try_exception_0)\n"
-            "\t_gml_try_exception_0 = (func():\n"
-            '\t\tmessage = GMRuntime.gml_selector_get(err, "message")\n'
-            "\t\treturn GMRuntime.gml_undefined()\n"
-            "\t).call()\n"
-            "if GMRuntime.is_gml_exception(_gml_try_exception_0):\n"
-            "\treturn _gml_try_exception_0",
+        output = transpile_gml_code(
+            'try { throw "bad"; } catch (err) { message = err.message; }',
+            indent="",
         )
 
+        self.assertIn("var _gml_try_control_0 = GMRuntime.gml_undefined()", output)
+        self.assertIn('_gml_try_control_0 = {"kind": "throw", "value": GMRuntime.gml_throw("bad")}', output)
+        self.assertIn('if not GMRuntime.is_undefined(_gml_try_control_0) and _gml_try_control_0["kind"] == "throw":', output)
+        self.assertIn('var err = GMRuntime.gml_exception_struct(_gml_try_control_0["value"])', output)
+        self.assertIn('message = GMRuntime.gml_selector_get(err, "message")', output)
+        self.assertIn('return _gml_try_control_0["value"]', output)
+
     def test_transpiles_try_finally_blocks(self):
-        self.assertEqual(
-            transpile_gml_code("try { score = 1; } finally { cleaned = true; }", indent=""),
-            "var _gml_try_exception_0 = (func():\n"
-            "\tscore = 1\n"
-            "\treturn GMRuntime.gml_undefined()\n"
-            ").call()\n"
-            "cleaned = true\n"
-            "if GMRuntime.is_gml_exception(_gml_try_exception_0):\n"
-            "\treturn _gml_try_exception_0",
-        )
+        output = transpile_gml_code("try { score = 1; } finally { cleaned = true; }", indent="")
+
+        self.assertIn("var _gml_try_control_0 = GMRuntime.gml_undefined()", output)
+        self.assertIn("while true:\n\tscore = 1\n\tbreak", output)
+        self.assertIn("cleaned = true", output)
+        self.assertIn('if not GMRuntime.is_undefined(_gml_try_control_0) and _gml_try_control_0["kind"] == "return":', output)
+        self.assertIn('return _gml_try_control_0["value"]', output)
+        self.assertIn('if not GMRuntime.is_undefined(_gml_try_control_0) and _gml_try_control_0["kind"] == "throw":', output)
 
     def test_transpiles_nested_try_catch_propagation(self):
         output = transpile_gml_code(
@@ -1814,14 +1805,39 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             indent="",
         )
 
-        self.assertIn("var _gml_try_exception_0 = (func():", output)
-        self.assertIn("\tvar _gml_try_exception_1 = (func():", output)
-        self.assertIn("\t\treturn GMRuntime.gml_throw(\"bad\")", output)
-        self.assertIn("\t\tvar inner = GMRuntime.gml_exception_struct(_gml_try_exception_1)", output)
-        self.assertIn("\t\t\treturn GMRuntime.gml_throw(inner)", output)
-        self.assertIn("\treturn _gml_try_exception_1", output)
-        self.assertIn("var outer = GMRuntime.gml_exception_struct(_gml_try_exception_0)", output)
+        self.assertIn("var _gml_try_control_0 = GMRuntime.gml_undefined()", output)
+        self.assertIn("\tvar _gml_try_control_1 = GMRuntime.gml_undefined()", output)
+        self.assertIn('\t\t_gml_try_control_1 = {"kind": "throw", "value": GMRuntime.gml_throw("bad")}', output)
+        self.assertIn('var inner = GMRuntime.gml_exception_struct(_gml_try_control_1["value"])', output)
+        self.assertIn('_gml_try_control_1 = {"kind": "throw", "value": GMRuntime.gml_throw(inner)}', output)
+        self.assertIn('_gml_try_control_0 = {"kind": "throw", "value": _gml_try_control_1["value"]}', output)
+        self.assertIn('var outer = GMRuntime.gml_exception_struct(_gml_try_control_0["value"])', output)
         self.assertIn('message = GMRuntime.gml_selector_get(outer, "message")', output)
+
+    def test_finally_preserves_abrupt_control_flow_from_try_body(self):
+        return_output = transpile_gml_code(
+            "function f() { try { return 1; } finally { cleaned = true; } }",
+            indent="",
+        )
+        self.assertIn('_gml_try_control_0 = {"kind": "return", "value": 1}', return_output)
+        self.assertIn("cleaned = true", return_output)
+        self.assertIn('return _gml_try_control_0["value"]', return_output)
+
+        break_output = transpile_gml_code(
+            "while ready { try { break; } finally { cleaned = true; } after = true; }",
+            indent="",
+        )
+        self.assertIn('_gml_try_control_0 = {"kind": "break", "value": GMRuntime.gml_undefined()}', break_output)
+        self.assertIn("cleaned = true", break_output)
+        self.assertIn('if not GMRuntime.is_undefined(_gml_try_control_0) and _gml_try_control_0["kind"] == "break":\n\t\tbreak', break_output)
+
+        continue_output = transpile_gml_code(
+            "while ready { try { continue; } finally { cleaned = true; } after = true; }",
+            indent="",
+        )
+        self.assertIn('_gml_try_control_0 = {"kind": "continue", "value": GMRuntime.gml_undefined()}', continue_output)
+        self.assertIn("cleaned = true", continue_output)
+        self.assertIn('if not GMRuntime.is_undefined(_gml_try_control_0) and _gml_try_control_0["kind"] == "continue":\n\t\tcontinue', continue_output)
 
     def test_rejects_control_flow_inside_finally_blocks(self):
         cases = (
@@ -1845,6 +1861,28 @@ class TestGMLStatementTranspiler(unittest.TestCase):
         self.assertEqual(
             transpile_gml_code("delete mystruct;", indent=""),
             "mystruct = GMRuntime.gml_undefined()",
+        )
+
+    def test_transpiles_delete_member_and_accessor_targets(self):
+        self.assertEqual(
+            transpile_gml_code("delete mystruct.child;", indent=""),
+            'GMRuntime.gml_struct_remove(mystruct, "child")',
+        )
+        self.assertEqual(
+            transpile_gml_code('delete mystruct[$ "child"];', indent=""),
+            'GMRuntime.gml_struct_remove(mystruct, "child")',
+        )
+        self.assertEqual(
+            transpile_gml_code("delete items[2];", indent=""),
+            "GMRuntime.gml_array_delete(items, 2)",
+        )
+        self.assertEqual(
+            transpile_gml_code('delete inventory[? "food"];', indent=""),
+            'GMRuntime.gml_ds_map_delete(inventory, "food")',
+        )
+        self.assertEqual(
+            transpile_gml_code("delete queue[| 0];", indent=""),
+            "GMRuntime.gml_ds_list_delete(queue, 0)",
         )
 
     def test_transpiles_with_blocks(self):
@@ -1975,7 +2013,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             transpile_gml_code("delete make_struct();", indent="")
 
         with self.assertRaises(GMLTranspileError):
-            transpile_gml_code("delete mystruct.child;", indent="")
+            transpile_gml_code("delete grid[# 0, 0];", indent="")
 
     def test_transpiles_while_blocks(self):
         self.assertEqual(
@@ -2181,24 +2219,25 @@ class TestGMLStatementTranspiler(unittest.TestCase):
         )
 
     def test_switch_break_exits_switch_not_outer_loop(self):
-        self.assertEqual(
-            transpile_gml_code(
-                "while running begin switch (state) { case 1: score = 1; break; } ticks += 1; end",
-                indent="",
-            ),
-            "while GMRuntime.gml_bool(running):\n"
-            "\tvar _gml_switch_value_0 = state\n"
-            "\tvar _gml_switch_matched_1 = false\n"
-            "\tvar _gml_switch_has_case_2 = GMRuntime.gml_eq(_gml_switch_value_0, 1)\n"
-            "\twhile true:\n"
-            "\t\tif not _gml_switch_matched_1 and GMRuntime.gml_eq(_gml_switch_value_0, 1):\n"
-            "\t\t\t_gml_switch_matched_1 = true\n"
-            "\t\tif _gml_switch_matched_1:\n"
-            "\t\t\tscore = 1\n"
-            "\t\t\tbreak\n"
-            "\t\tbreak\n"
-            "\tticks = GMRuntime.gml_add(ticks, 1)",
+        output = transpile_gml_code(
+            "while running begin switch (state) { case 1: score = 1; break; } ticks += 1; end",
+            indent="",
         )
+
+        self.assertIn("while GMRuntime.gml_bool(running):", output)
+        self.assertIn("\t\tscore = 1\n\t\t\tbreak", output)
+        self.assertIn("\tticks = GMRuntime.gml_add(ticks, 1)", output)
+
+    def test_switch_continue_targets_outer_loop(self):
+        output = transpile_gml_code(
+            "while running begin switch (state) { case 1: if skip begin continue; end score = 1; break; } ticks += 1; end",
+            indent="",
+        )
+
+        self.assertIn("var _gml_switch_control_3 = GMRuntime.gml_undefined()", output)
+        self.assertIn('_gml_switch_control_3 = {"kind": "continue", "value": GMRuntime.gml_undefined()}', output)
+        self.assertIn('if not GMRuntime.is_undefined(_gml_switch_control_3) and _gml_switch_control_3["kind"] == "continue":\n\t\tcontinue', output)
+        self.assertIn("\tticks = GMRuntime.gml_add(ticks, 1)", output)
 
     def test_for_loop_preserves_execution_order(self):
         self.assertEqual(


### PR DESCRIPTION
Closes #585.

## Summary
- replace try/catch/finally lambda wrapping with explicit abrupt-control capture so finally runs before return, exit, break, continue, and throw propagation
- capture switch continue through a generated control sentinel so continue targets the enclosing loop instead of the switch loop
- lower delete for struct members, struct accessors, arrays, DS maps, and DS lists while keeping invalid DS grid deletes diagnostic
- update manual scope notes for the closed control-flow slice

## Tests
- ./venv/bin/python -m unittest tests.test_gml_transpiler tests.test_objects tests.test_gml_runtime tests.test_gml_manual_scope
- ./venv/bin/python -m unittest
- ./venv/bin/pyright --warnings