### PR TITLE
Expand GML preprocessor policy

### DIFF
--- a/src/conversion/converter.py
+++ b/src/conversion/converter.py
@@ -129,6 +129,7 @@ class Converter:
                 compact_logging=self.compact_logging,
                 max_workers=self.max_workers,
                 diagnostics=self.diagnostics,
+                macro_configuration=gm_platform,
             ).convert_all(), "Console_Convertor_Scripts"),
             ("objects", lambda: ObjectConverter(
                 gm_path, godot_path, self.log_callback,
@@ -137,6 +138,7 @@ class Converter:
                 compact_logging=self.compact_logging,
                 max_workers=self.max_workers,
                 diagnostics=self.diagnostics,
+                macro_configuration=gm_platform,
             ).convert_all(), "Console_Convertor_Objects"),
             ("rooms", lambda: RoomConverter(
                 gm_path, godot_path, self.log_callback,

--- a/src/conversion/gml_transpiler_parts/api.py
+++ b/src/conversion/gml_transpiler_parts/api.py
@@ -25,6 +25,7 @@ def transpile_gml_code(
     instance_variables: MutableSet[str] | None = None,
     inherited_event_call: str | None = None,
     macro_configuration: str | None = None,
+    active_preprocessor_symbols: Iterable[str] | None = None,
     top_level_global_scope: bool = False,
     legacy_global_builtins: bool = False,
     asset_names: Iterable[str] | None = None,
@@ -45,6 +46,7 @@ def transpile_gml_code(
         instance_variables=instance_variables,
         inherited_event_call=inherited_event_call,
         macro_configuration=macro_configuration,
+        active_preprocessor_symbols=active_preprocessor_symbols,
         top_level_global_scope=top_level_global_scope,
         legacy_global_builtins=legacy_global_builtins,
         asset_names=asset_names,
@@ -66,6 +68,7 @@ def transpile_gml_code_with_source_map(
     instance_variables: MutableSet[str] | None = None,
     inherited_event_call: str | None = None,
     macro_configuration: str | None = None,
+    active_preprocessor_symbols: Iterable[str] | None = None,
     top_level_global_scope: bool = False,
     legacy_global_builtins: bool = False,
     asset_names: Iterable[str] | None = None,
@@ -79,7 +82,11 @@ def transpile_gml_code_with_source_map(
     generated_line_offset: int = 0,
 ) -> GMLTranspileResult:
     """Transpile supported GML statements and return trace metadata."""
-    preprocessed = preprocess_gml_source(source, macro_configuration=macro_configuration)
+    preprocessed = preprocess_gml_source(
+        source,
+        macro_configuration=macro_configuration,
+        active_symbols=active_preprocessor_symbols,
+    )
     parser = _StatementParser(
         _tokenize(preprocessed.source),
         local_names=local_names,

--- a/src/conversion/gml_transpiler_parts/gml_manual_scope.py
+++ b/src/conversion/gml_transpiler_parts/gml_manual_scope.py
@@ -243,8 +243,8 @@ _MANUAL_SCOPE_ENTRIES: tuple[GMLManualScopeEntry, ...] = (
         "source_diagnostic",
         "GameMaker_Language/GML_Overview/Preprocessor.htm",
         ("Preprocessor",),
-        ("tests/test_gml_transpiler.py",),
-        "Directive policy and full preprocessor expressions are tracked by #586.",
+        ("tests/test_gml_transpiler.py", "tests/test_scripts.py", "tests/test_objects.py"),
+        "Boolean/comparison preprocessor expressions, selected configuration symbols, and unsupported directive diagnostics have regression coverage.",
     ),
     _entry(
         "reference_variable_functions",

--- a/src/conversion/gml_transpiler_parts/preprocessor.py
+++ b/src/conversion/gml_transpiler_parts/preprocessor.py
@@ -3,16 +3,28 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Iterable, TypeAlias
 
 from .identifiers import _validate_gml_identifier
 from .model import GMLTranspileError
-from .utils import _join_macro_continuation_lines, _strip_comments
+from .utils import _join_macro_continuation_lines, _macro_configuration_matches, _strip_comments
 
 
 _DIRECTIVE_RE = re.compile(r"^\s*#([A-Za-z_][A-Za-z0-9_]*)\b(.*)$")
 _DEFINE_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)(?:\s+(.*))?$")
-_DEFINED_RE = re.compile(r"^defined\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)$", re.IGNORECASE)
+_MACRO_RE = re.compile(r"^(?:(?P<configuration>[A-Za-z_][A-Za-z0-9_]*):)?(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?:\s+(?P<value>.*))?$")
+_CONDITION_TOKEN_RE = re.compile(
+    r"\s*("
+    r"&&|\|\||\^\^|==|!=|<=|>=|[()!<>+-]"
+    r"|\$[0-9A-Fa-f_]+"
+    r"|0[xX][0-9A-Fa-f_]+"
+    r"|0[bB][01_]+"
+    r"|(?:\d[\d_]*(?:\.[\d_]*)?|\.[\d_]+)"
+    r"|[A-Za-z_][A-Za-z0-9_]*"
+    r"|\"(?:\\.|[^\"])*\"|'(?:\\.|[^'])*'"
+    r")",
+    re.IGNORECASE,
+)
 _EDITOR_ONLY_DIRECTIVES = frozenset({"#region", "#endregion"})
 _SUPPORTED_DIRECTIVES = frozenset({
     "#define",
@@ -25,6 +37,7 @@ _SUPPORTED_DIRECTIVES = frozenset({
     "#macro",
     *_EDITOR_ONLY_DIRECTIVES,
 })
+_PreprocessValue: TypeAlias = bool | float | str
 
 
 @dataclass(frozen=True)
@@ -60,6 +73,7 @@ def preprocess_gml_source(
 ) -> GMLPreprocessResult:
     """Apply compile-time directive handling before tokenization."""
     symbols = {symbol.casefold() for symbol in (active_symbols or ())}
+    symbol_values: dict[str, str] = {}
     if macro_configuration:
         symbols.add(macro_configuration.casefold())
 
@@ -81,6 +95,7 @@ def preprocess_gml_source(
                     directive,
                     directive_body,
                     symbols,
+                    symbol_values,
                     diagnostics,
                     line_number,
                     line,
@@ -110,6 +125,7 @@ def preprocess_gml_source(
                         directive,
                         directive_body,
                         symbols,
+                        symbol_values,
                         diagnostics,
                         line_number,
                         line,
@@ -151,6 +167,12 @@ def preprocess_gml_source(
             continue
 
         if directive == "#macro":
+            _preprocess_macro(
+                directive_body,
+                symbols,
+                symbol_values,
+                macro_configuration,
+            )
             output_lines.append(line)
             continue
 
@@ -159,7 +181,16 @@ def preprocess_gml_source(
             continue
 
         if directive == "#define":
-            output_lines.append(_preprocess_define(directive_body, symbols, diagnostics, line_number, line))
+            output_lines.append(
+                _preprocess_define(
+                    directive_body,
+                    symbols,
+                    symbol_values,
+                    diagnostics,
+                    line_number,
+                    line,
+                )
+            )
             continue
 
         directive_name = directive if directive in _SUPPORTED_DIRECTIVES else directive
@@ -190,6 +221,7 @@ def preprocess_gml_source(
 def _preprocess_define(
     directive_body: str,
     symbols: set[str],
+    symbol_values: dict[str, str],
     diagnostics: list[GMLPreprocessorDiagnostic],
     line_number: int,
     line: str,
@@ -207,14 +239,35 @@ def _preprocess_define(
         return ""
     symbols.add(name.casefold())
     if value:
+        symbol_values[name.casefold()] = value
         return f"#macro {name} {value}"
     return ""
+
+
+def _preprocess_macro(
+    directive_body: str,
+    symbols: set[str],
+    symbol_values: dict[str, str],
+    macro_configuration: str | None,
+) -> None:
+    match = _MACRO_RE.match(directive_body)
+    if match is None:
+        return
+    configuration = match.group("configuration")
+    if configuration is not None and not _macro_configuration_matches(configuration, macro_configuration):
+        return
+    name = match.group("name")
+    value = (match.group("value") or "").strip()
+    symbols.add(name.casefold())
+    if value:
+        symbol_values[name.casefold()] = value
 
 
 def _evaluate_conditional(
     directive: str,
     expression: str,
     symbols: set[str],
+    symbol_values: dict[str, str],
     diagnostics: list[GMLPreprocessorDiagnostic],
     line_number: int,
     line: str,
@@ -224,7 +277,7 @@ def _evaluate_conditional(
     if directive == "#ifndef":
         return not _symbol_defined(expression, symbols)
 
-    value = _evaluate_condition_expression(expression, symbols)
+    value = _evaluate_condition_expression(expression, symbols, symbol_values)
     if value is None:
         _add_diagnostic(
             diagnostics,
@@ -237,22 +290,240 @@ def _evaluate_conditional(
     return value
 
 
-def _evaluate_condition_expression(expression: str, symbols: set[str]) -> bool | None:
-    expression = expression.strip()
-    if not expression:
+def _evaluate_condition_expression(
+    expression: str,
+    symbols: set[str],
+    symbol_values: dict[str, str],
+) -> bool | None:
+    tokens = _condition_tokens(expression)
+    if not tokens:
         return None
-    if expression.startswith("!"):
-        value = _evaluate_condition_expression(expression[1:].strip(), symbols)
-        return None if value is None else not value
-    if expression.casefold() in {"true", "1"}:
-        return True
-    if expression.casefold() in {"false", "0"}:
+    parser = _ConditionParser(tokens, symbols, symbol_values)
+    value = parser.parse()
+    if value is None or not parser.at_end():
+        return None
+    return _condition_truthy(value)
+
+
+def _condition_tokens(expression: str) -> list[str]:
+    tokens: list[str] = []
+    index = 0
+    while index < len(expression):
+        match = _CONDITION_TOKEN_RE.match(expression, index)
+        if match is None:
+            if expression[index:].strip() == "":
+                break
+            return []
+        tokens.append(match.group(1))
+        index = match.end()
+    return tokens
+
+
+class _ConditionParser:
+    def __init__(
+        self,
+        tokens: list[str],
+        symbols: set[str],
+        symbol_values: dict[str, str],
+    ) -> None:
+        self.tokens = tokens
+        self.symbols = symbols
+        self.symbol_values = symbol_values
+        self.position = 0
+
+    def at_end(self) -> bool:
+        return self.position >= len(self.tokens)
+
+    def parse(self) -> _PreprocessValue | None:
+        return self._parse_or()
+
+    def _parse_or(self) -> _PreprocessValue | None:
+        left = self._parse_and()
+        if left is None:
+            return None
+        while self._check("||", "or", "^^", "xor"):
+            operator = self._advance()
+            right = self._parse_and()
+            if right is None:
+                return None
+            if operator.casefold() in ("^^", "xor"):
+                left = _condition_truthy(left) != _condition_truthy(right)
+            else:
+                left = _condition_truthy(left) or _condition_truthy(right)
+        return left
+
+    def _parse_and(self) -> _PreprocessValue | None:
+        left = self._parse_comparison()
+        if left is None:
+            return None
+        while self._match("&&", "and"):
+            right = self._parse_comparison()
+            if right is None:
+                return None
+            left = _condition_truthy(left) and _condition_truthy(right)
+        return left
+
+    def _parse_comparison(self) -> _PreprocessValue | None:
+        left = self._parse_unary()
+        if left is None:
+            return None
+        while self._check("==", "!=", "<", "<=", ">", ">="):
+            operator = self._advance()
+            right = self._parse_unary()
+            if right is None:
+                return None
+            compared = _compare_condition_values(left, right, operator)
+            if compared is None:
+                return None
+            left = compared
+        return left
+
+    def _parse_unary(self) -> _PreprocessValue | None:
+        if self._match("!", "not"):
+            value = self._parse_unary()
+            return None if value is None else not _condition_truthy(value)
+        if self._match("+"):
+            value = self._parse_unary()
+            return _condition_numeric_value(value) if value is not None else None
+        if self._match("-"):
+            value = self._parse_unary()
+            number = _condition_numeric_value(value) if value is not None else None
+            return None if number is None else -number
+        return self._parse_primary()
+
+    def _parse_primary(self) -> _PreprocessValue | None:
+        if self._match("("):
+            value = self._parse_or()
+            if value is None or not self._match(")"):
+                return None
+            return value
+        if self._match("defined"):
+            if not self._match("(") or self.at_end():
+                return None
+            name = self._advance()
+            if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name) or not self._match(")"):
+                return None
+            return _symbol_defined(name, self.symbols)
+        if self.at_end():
+            return None
+        token = self._advance()
+        return _condition_token_value(token, self.symbols, self.symbol_values)
+
+    def _match(self, *values: str) -> bool:
+        if self._check(*values):
+            self.position += 1
+            return True
         return False
-    defined_match = _DEFINED_RE.match(expression)
-    if defined_match is not None:
-        return _symbol_defined(defined_match.group(1), symbols)
-    if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", expression):
-        return _symbol_defined(expression, symbols)
+
+    def _check(self, *values: str) -> bool:
+        if self.at_end():
+            return False
+        current = self.tokens[self.position]
+        return any(current.casefold() == value.casefold() for value in values)
+
+    def _advance(self) -> str:
+        token = self.tokens[self.position]
+        self.position += 1
+        return token
+
+
+def _condition_token_value(
+    token: str,
+    symbols: set[str],
+    symbol_values: dict[str, str],
+) -> _PreprocessValue | None:
+    lowered = token.casefold()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    literal = _condition_literal_value(token)
+    if literal is not None:
+        return literal
+    if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", token):
+        value = symbol_values.get(lowered)
+        if value is not None:
+            parsed_value = _condition_literal_value(value)
+            return parsed_value
+        return _symbol_defined(token, symbols)
+    return None
+
+
+def _condition_literal_value(value: str) -> _PreprocessValue | None:
+    stripped = value.strip()
+    if stripped.casefold() == "true":
+        return True
+    if stripped.casefold() == "false":
+        return False
+    number = _condition_number_value(stripped)
+    if number is not None:
+        return number
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in ("'", '"'):
+        return stripped[1:-1]
+    return None
+
+
+def _condition_number_value(value: str) -> float | None:
+    cleaned = value.replace("_", "")
+    sign = 1.0
+    if cleaned.startswith(("+", "-")):
+        if cleaned[0] == "-":
+            sign = -1.0
+        cleaned = cleaned[1:]
+    if re.fullmatch(r"\$[0-9A-Fa-f]+", cleaned):
+        return sign * float(int(cleaned[1:], 16))
+    if re.fullmatch(r"0[xX][0-9A-Fa-f]+", cleaned):
+        return sign * float(int(cleaned[2:], 16))
+    if re.fullmatch(r"0[bB][01]+", cleaned):
+        return sign * float(int(cleaned[2:], 2))
+    if re.fullmatch(r"(?:\d+(?:\.\d*)?|\.\d+)", cleaned):
+        return sign * float(cleaned)
+    return None
+
+
+def _condition_numeric_value(value: _PreprocessValue) -> float | None:
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, float):
+        return value
+    return None
+
+
+def _condition_truthy(value: _PreprocessValue) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        return value > 0.0
+    return value != ""
+
+
+def _compare_condition_values(
+    left: _PreprocessValue,
+    right: _PreprocessValue,
+    operator: str,
+) -> bool | None:
+    if isinstance(left, bool):
+        left = 1.0 if left else 0.0
+    if isinstance(right, bool):
+        right = 1.0 if right else 0.0
+    if isinstance(left, float) and isinstance(right, float):
+        if operator == "==":
+            return left == right
+        if operator == "!=":
+            return left != right
+        if operator == "<":
+            return left < right
+        if operator == "<=":
+            return left <= right
+        if operator == ">":
+            return left > right
+        if operator == ">=":
+            return left >= right
+    if isinstance(left, str) and isinstance(right, str):
+        if operator == "==":
+            return left == right
+        if operator == "!=":
+            return left != right
     return None
 
 

--- a/src/conversion/objects.py
+++ b/src/conversion/objects.py
@@ -60,11 +60,13 @@ class ObjectConverter(BaseConverter):
                  conversion_running: ConversionRunning | None = None,
                  update_log_callback: LogCallback | None = None, compact_logging: bool = False,
                  max_workers: int | None = None,
-                 diagnostics: DiagnosticCollector | None = None) -> None:
+                 diagnostics: DiagnosticCollector | None = None,
+                 macro_configuration: str | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback, progress_callback, conversion_running,
                          update_log_callback, compact_logging, max_workers=max_workers,
                          diagnostics=diagnostics)
         self.godot_objects_path = os.path.join(self.godot_project_path, 'objects')
+        self.macro_configuration = macro_configuration
 
     def _get_valid_object_names(self) -> dict[str, str] | None:
         """Parse the .yyp project file and return a dict of object name -> subfolder.
@@ -320,6 +322,7 @@ class ObjectConverter(BaseConverter):
                     source,
                     instance_variables=instance_variables,
                     inherited_event_call=inherited_event_call,
+                    macro_configuration=self.macro_configuration,
                     asset_names=asset_names,
                     static_scope_prefix=f"{object_name}.{mapping.godot_func}",
                     source_path=source_path,

--- a/src/conversion/scripts.py
+++ b/src/conversion/scripts.py
@@ -99,6 +99,7 @@ class ScriptConverter(BaseConverter):
         compact_logging: bool = False,
         max_workers: int | None = None,
         diagnostics: DiagnosticCollector | None = None,
+        macro_configuration: str | None = None,
     ) -> None:
         super().__init__(
             gm_project_path,
@@ -112,6 +113,7 @@ class ScriptConverter(BaseConverter):
             diagnostics=diagnostics,
         )
         self.godot_scripts_path = os.path.join(self.godot_project_path, "scripts")
+        self.macro_configuration = macro_configuration
 
     def _asset_entries(self) -> tuple[AssetRegistryEntry, ...]:
         registry_converter = AssetRegistryConverter(
@@ -263,6 +265,7 @@ class ScriptConverter(BaseConverter):
             local_names=local_names,
             extension_functions=extension_functions,
             extension_function_mappings=extension_function_mappings,
+            macro_configuration=self.macro_configuration,
             source_path=source_path,
             event=f"script:{declaration.name}",
             preserve_source_comments=True,
@@ -330,6 +333,7 @@ class ScriptConverter(BaseConverter):
             static_scope_prefix=f"{entry.name}.script",
             extension_functions=extension_functions,
             extension_function_mappings=extension_function_mappings,
+            macro_configuration=self.macro_configuration,
             source_path=source_path,
             event=f"script:{entry.name}",
             preserve_source_comments=True,

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -1009,12 +1009,86 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
             "score = 4",
         )
 
+    def test_preprocessor_evaluates_boolean_and_comparison_expressions(self):
+        self.assertEqual(
+            transpile_gml_code(
+                "#define BUILD 2\n"
+                "#if (BUILD >= 2 && defined(Android)) || false\n"
+                "score = 7\n"
+                "#else\n"
+                "score = 0\n"
+                "#endif\n",
+                indent="",
+                macro_configuration="Android",
+            ),
+            "score = 7",
+        )
+        self.assertEqual(
+            transpile_gml_code(
+                "#macro CHANNEL 'beta'\n"
+                "#if CHANNEL == 'beta' && !defined(DISABLED)\n"
+                "score = 3\n"
+                "#else\n"
+                "score = 0\n"
+                "#endif\n",
+                indent="",
+            ),
+            "score = 3",
+        )
+        self.assertEqual(
+            transpile_gml_code(
+                "#define BUILD 1\n"
+                "#if BUILD > 1 || Windows\n"
+                "score = 1\n"
+                "#else\n"
+                "score = 2\n"
+                "#endif\n",
+                indent="",
+                macro_configuration="Android",
+            ),
+            "score = 2",
+        )
+        self.assertEqual(
+            transpile_gml_code(
+                "#define MASK $10\n"
+                "#define OFFSET -1\n"
+                "#if MASK == 0x10 && !OFFSET ^^ false\n"
+                "score = 5\n"
+                "#else\n"
+                "score = 0\n"
+                "#endif\n",
+                indent="",
+            ),
+            "score = 5",
+        )
+
     def test_preprocessor_reports_unsupported_directives_with_source_context(self):
         with self.assertRaisesRegex(
             GMLTranspileError,
             r"Unsupported preprocessor directive #import at line 1: #import \"native.gml\"",
         ):
             transpile_gml_code('#import "native.gml"\nscore = 1', indent="")
+        with self.assertRaisesRegex(
+            GMLTranspileError,
+            r"Unsupported preprocessor directive #include at line 1: #include \"shared.gml\"",
+        ):
+            transpile_gml_code('#include "shared.gml"\nscore = 1', indent="")
+        with self.assertRaisesRegex(
+            GMLTranspileError,
+            r"Unsupported preprocessor directive #gml_pragma at line 1: #gml_pragma global",
+        ):
+            transpile_gml_code("#gml_pragma global\nscore = 1", indent="")
+
+        with self.assertRaisesRegex(
+            GMLTranspileError,
+            r"Unsupported preprocessor condition 'BUILD &&' at line 2: #if BUILD &&",
+        ):
+            transpile_gml_code("#define BUILD 1\n#if BUILD &&\nscore = 1\n#endif", indent="")
+        with self.assertRaisesRegex(
+            GMLTranspileError,
+            r"Unsupported preprocessor condition 'BUILD == 2' at line 2: #if BUILD == 2",
+        ):
+            transpile_gml_code("#define BUILD 1 + 1\n#if BUILD == 2\nscore = 1\n#endif", indent="")
 
     def test_preprocessor_preserves_macro_lines_in_structured_result(self):
         result = preprocess_gml_source("#region R\n#macro VALUE 7\n#endregion\nscore = VALUE")

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -142,12 +142,13 @@ class TestObjectConverterBasic(unittest.TestCase):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_converter(self) -> ObjectConverter:
+    def _make_converter(self, macro_configuration: str | None = None) -> ObjectConverter:
         return ObjectConverter(
             self.gm_dir, self.godot_dir,
             log_callback=lambda msg: self.logs.append(msg),
             progress_callback=lambda v: None,
             conversion_running=lambda: True,
+            macro_configuration=macro_configuration,
         )
 
     def test_converts_object_to_godot_dir(self):
@@ -380,12 +381,13 @@ class TestObjectConverterSubfolders(unittest.TestCase):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_converter(self) -> ObjectConverter:
+    def _make_converter(self, macro_configuration: str | None = None) -> ObjectConverter:
         return ObjectConverter(
             self.gm_dir, self.godot_dir,
             log_callback=lambda msg: self.logs.append(msg),
             progress_callback=lambda v: None,
             conversion_running=lambda: True,
+            macro_configuration=macro_configuration,
         )
 
     def test_object_in_subfolder(self):
@@ -462,12 +464,13 @@ class TestScriptGeneration(unittest.TestCase):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_converter(self) -> ObjectConverter:
+    def _make_converter(self, macro_configuration: str | None = None) -> ObjectConverter:
         return ObjectConverter(
             self.gm_dir, self.godot_dir,
             log_callback=lambda msg: self.logs.append(msg),
             progress_callback=lambda v: None,
             conversion_running=lambda: True,
+            macro_configuration=macro_configuration,
         )
 
     def _setup_object(self, name: str, sprite_name: str | None = None,
@@ -552,6 +555,31 @@ class TestScriptGeneration(unittest.TestCase):
             "func _ready():\n\t_gm_register_instance()\n\t_gm_initialize_motion_runtime()\n\tsuper._ready()",
             content,
         )
+
+    def test_script_event_sources_use_selected_macro_configuration(self):
+        self._setup_object("o_test", event_list=[{"eventType": 0, "eventNum": 0}])
+        with open(
+            os.path.join(self.gm_dir, "objects", "o_test", "Create_0.gml"),
+            "w",
+            encoding="utf-8",
+        ) as f:
+            f.write(
+                "#if Android\n"
+                "score = 11;\n"
+                "#else\n"
+                "score = 22;\n"
+                "#endif\n"
+            )
+
+        converter = self._make_converter(macro_configuration="Android")
+        converter.convert_all()
+
+        gd_path = os.path.join(self.godot_dir, "objects", "o_test", "o_test.gd")
+        with open(gd_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        self.assertIn("\tscore = 11", content)
+        self.assertNotIn("\tscore = 22", content)
 
     def test_script_with_create_event(self):
         """eventType 0 should produce func _ready()."""

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -94,13 +94,14 @@ class TestScriptConverter(unittest.TestCase):
             "function scr_modern(a, b = 4) { return a + b; }",
         )
 
-    def _converter(self) -> ScriptConverter:
+    def _converter(self, macro_configuration: str | None = None) -> ScriptConverter:
         return ScriptConverter(
             self.gm_dir,
             self.godot_dir,
             log_callback=lambda message: self.logs.append(str(message)),
             progress_callback=lambda _value: None,
             conversion_running=lambda: True,
+            macro_configuration=macro_configuration,
         )
 
     def test_converts_scripts_and_generated_registry(self) -> None:
@@ -164,6 +165,23 @@ class TestScriptConverter(unittest.TestCase):
 
         legacy_script = (self.godot_dir / "scripts" / "Game" / "scr_add.gd").read_text(encoding="utf-8")
         self.assertIn('AdBridge.show_rewarded("zone_1")', legacy_script)
+
+    def test_applies_macro_configuration_to_script_sources(self) -> None:
+        self._write_project()
+        _write_text(
+            self.gm_dir / "scripts" / "scr_modern" / "scr_modern.gml",
+            "#if Android\n"
+            "function scr_modern() { return 11; }\n"
+            "#else\n"
+            "function scr_modern() { return 22; }\n"
+            "#endif\n",
+        )
+
+        self._converter(macro_configuration="Android").convert_all()
+
+        modern_script = (self.godot_dir / "scripts" / "Game" / "scr_modern.gd").read_text(encoding="utf-8")
+        self.assertIn("return 11", modern_script)
+        self.assertNotIn("return 22", modern_script)
 
     def test_records_migration_diagnostic_for_unsupported_multi_function_script_assets(self) -> None:
         self._write_project()


### PR DESCRIPTION
Closes #586.

## Summary
- evaluate boolean, grouped, comparison, defined(), numeric, string, and XOR preprocessor conditions from #define/#macro values
- thread selected macro configuration into script and object conversion, including top-level platform selection
- keep unsupported #import/#include/#gml_pragma and malformed or unevaluable conditions on stable source-line diagnostics
- update manual scope coverage for the preprocessor slice

## Tests
- ./venv/bin/python -m unittest tests.test_gml_transpiler tests.test_scripts tests.test_objects
- ./venv/bin/python -m unittest
- ./venv/bin/pyright --warnings