### PR TITLE
Import typed project manifest metadata

### DIFF
--- a/src/conversion/converter.py
+++ b/src/conversion/converter.py
@@ -65,6 +65,7 @@ class Converter:
             self.progress_callback, self.conversion_running.is_set,
             gm_platform=gm_platform,
             max_workers=self.max_workers,
+            diagnostics=self.diagnostics,
         )
 
         converters: list[tuple[str, ConverterFn, str]] = [

--- a/src/conversion/project_manifest.py
+++ b/src/conversion/project_manifest.py
@@ -1,0 +1,792 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, Literal, Mapping, cast
+
+from src.conversion.type_defs import JsonDict, JsonList
+
+
+ProjectManifestSeverity = Literal["warning", "error"]
+
+_RESOURCE_TYPE_KIND = {
+    "GMAnimationCurve": "animcurves",
+    "GMAudioGroup": "audiogroups",
+    "GMExtension": "extensions",
+    "GMFont": "fonts",
+    "GMIncludedFile": "datafiles",
+    "GMNotes": "notes",
+    "GMObject": "objects",
+    "GMParticleSystem": "particlesystems",
+    "GMPath": "paths",
+    "GMRoom": "rooms",
+    "GMScript": "scripts",
+    "GMSequence": "sequences",
+    "GMShader": "shaders",
+    "GMSound": "sounds",
+    "GMSprite": "sprites",
+    "GMTileSet": "tilesets",
+    "GMTimeline": "timelines",
+}
+
+_KNOWN_PROJECT_FIELDS = frozenset({
+    "$GMProject",
+    "%Name",
+    "AudioGroups",
+    "ConfigValues",
+    "Configs",
+    "Folders",
+    "IncludedFiles",
+    "MetaData",
+    "RoomOrderNodes",
+    "TextureGroups",
+    "configs",
+    "copyToTargets",
+    "isDnDProject",
+    "mvc",
+    "name",
+    "parentProject",
+    "projectId",
+    "resources",
+    "resourceType",
+    "resourceVersion",
+    "tutorialPath",
+})
+
+
+def _empty_json_dict() -> JsonDict:
+    return cast(JsonDict, {})
+
+
+@dataclass(frozen=True)
+class ProjectSourceLocation:
+    path: str
+    line: int
+    field_path: str = ""
+
+
+@dataclass(frozen=True)
+class ProjectManifestDiagnostic:
+    severity: ProjectManifestSeverity
+    code: str
+    message: str
+    source: ProjectSourceLocation | None = None
+
+
+@dataclass(frozen=True)
+class ProjectResourceReference:
+    uuid: str
+    name: str
+    path: str
+    kind: str
+    resource_type: str
+    order: int
+    tags: tuple[str, ...] = ()
+    source: ProjectSourceLocation | None = None
+
+
+@dataclass(frozen=True)
+class ProjectConfigOverride:
+    configuration: str
+    field_path: str
+    value: object
+    source: ProjectSourceLocation | None = None
+
+
+@dataclass(frozen=True)
+class ProjectConfiguration:
+    name: str
+    parent: str = ""
+    overrides: tuple[ProjectConfigOverride, ...] = ()
+    source: ProjectSourceLocation | None = None
+    raw_data: JsonDict = field(default_factory=_empty_json_dict)
+
+
+@dataclass(frozen=True)
+class ProjectOption:
+    platform: str
+    key: str
+    value: object
+    source: ProjectSourceLocation | None = None
+
+
+@dataclass(frozen=True)
+class ProjectTextureGroup:
+    name: str
+    parent: str = ""
+    is_dynamic: bool = False
+    dynamic_path: str = ""
+    targets: tuple[str, ...] = ()
+    source: ProjectSourceLocation | None = None
+    raw_data: JsonDict = field(default_factory=_empty_json_dict)
+
+
+@dataclass(frozen=True)
+class ProjectAudioGroup:
+    name: str
+    targets: tuple[str, ...] = ()
+    source: ProjectSourceLocation | None = None
+    raw_data: JsonDict = field(default_factory=_empty_json_dict)
+
+
+@dataclass(frozen=True)
+class ProjectIncludedFile:
+    name: str
+    path: str
+    targets: tuple[str, ...] = ()
+    source: ProjectSourceLocation | None = None
+    raw_data: JsonDict = field(default_factory=_empty_json_dict)
+
+
+@dataclass(frozen=True)
+class GameMakerProjectManifest:
+    project_name: str
+    yyp_path: str | None
+    resource_type: str = ""
+    resource_version: str = ""
+    resources: tuple[ProjectResourceReference, ...] = ()
+    configurations: tuple[ProjectConfiguration, ...] = ()
+    options: tuple[ProjectOption, ...] = ()
+    texture_groups: tuple[ProjectTextureGroup, ...] = ()
+    audio_groups: tuple[ProjectAudioGroup, ...] = ()
+    included_files: tuple[ProjectIncludedFile, ...] = ()
+    diagnostics: tuple[ProjectManifestDiagnostic, ...] = ()
+    raw_data: JsonDict = field(default_factory=_empty_json_dict)
+
+    def get_option(self, key: str, platform: str | None = None) -> ProjectOption | None:
+        folded_key = key.casefold()
+        folded_platform = platform.casefold() if platform is not None else None
+        for option in reversed(self.options):
+            if option.key.casefold() != folded_key:
+                continue
+            if folded_platform is None or option.platform.casefold() == folded_platform:
+                return option
+        return None
+
+    def options_for_platform(self, platform: str) -> dict[str, ProjectOption]:
+        selected: dict[str, ProjectOption] = {}
+        for option in self.options:
+            if option.platform.casefold() in ("main", platform.casefold()):
+                selected[option.key] = option
+        return selected
+
+    def audio_group_names(self) -> list[str]:
+        return [group.name for group in self.audio_groups if group.name]
+
+    def find_resources(
+        self,
+        *,
+        uuid: str | None = None,
+        name: str | None = None,
+        path: str | None = None,
+        kind: str | None = None,
+        resource_type: str | None = None,
+    ) -> tuple[ProjectResourceReference, ...]:
+        normalized_path = _normalize_project_path(path) if path else None
+        matches: list[ProjectResourceReference] = []
+        for resource in self.resources:
+            if uuid is not None and resource.uuid != uuid:
+                continue
+            if name is not None and resource.name.casefold() != name.casefold():
+                continue
+            if normalized_path is not None and _normalize_project_path(resource.path) != normalized_path:
+                continue
+            if kind is not None and resource.kind.casefold() != kind.casefold():
+                continue
+            if resource_type is not None and resource.resource_type.casefold() != resource_type.casefold():
+                continue
+            matches.append(resource)
+        return tuple(matches)
+
+
+def load_gamemaker_project_manifest(
+    gm_project_path: str,
+    *,
+    target_platform: str | None = None,
+) -> GameMakerProjectManifest:
+    yyp_path = _find_yyp_path(gm_project_path)
+    diagnostics: list[ProjectManifestDiagnostic] = []
+    if yyp_path is None:
+        diagnostics.append(
+            ProjectManifestDiagnostic(
+                severity="warning",
+                code="GM2GD-PROJECT-YYP-MISSING",
+                message="No GameMaker project .yyp found; project manifest metadata is unavailable.",
+            )
+        )
+        return GameMakerProjectManifest(project_name="", yyp_path=None, diagnostics=tuple(diagnostics))
+
+    raw_data, raw_source = _read_lenient_json_file(yyp_path)
+    if raw_data is None:
+        diagnostics.append(
+            ProjectManifestDiagnostic(
+                severity="warning",
+                code="GM2GD-PROJECT-YYP-MALFORMED",
+                message=f"Could not parse GameMaker project .yyp: {yyp_path}",
+                source=ProjectSourceLocation(yyp_path, 1),
+            )
+        )
+        return GameMakerProjectManifest(project_name="", yyp_path=yyp_path, diagnostics=tuple(diagnostics))
+
+    resources = _parse_resources(raw_data, yyp_path, raw_source)
+    configurations = _parse_configurations(raw_data, yyp_path, raw_source)
+    options = _parse_project_options(gm_project_path)
+    texture_groups = _parse_texture_groups(raw_data, yyp_path, raw_source)
+    audio_groups = _parse_audio_groups(raw_data, yyp_path, raw_source)
+    included_files = _parse_included_files(raw_data, yyp_path, raw_source)
+    diagnostics.extend(_unknown_project_field_diagnostics(raw_data, yyp_path, raw_source))
+    diagnostics.extend(_resource_conflict_diagnostics(resources))
+    if target_platform is not None:
+        diagnostics.extend(_missing_target_option_diagnostics(options, target_platform))
+
+    return GameMakerProjectManifest(
+        project_name=_string_value(raw_data.get("%Name")) or _string_value(raw_data.get("name")),
+        yyp_path=yyp_path,
+        resource_type=_string_value(raw_data.get("resourceType")),
+        resource_version=_string_value(raw_data.get("resourceVersion")),
+        resources=resources,
+        configurations=configurations,
+        options=options,
+        texture_groups=texture_groups,
+        audio_groups=audio_groups,
+        included_files=included_files,
+        diagnostics=tuple(diagnostics),
+        raw_data=raw_data,
+    )
+
+
+def unsupported_project_option_diagnostics(
+    manifest: GameMakerProjectManifest,
+    *,
+    target_platform: str,
+    supported_keys: Iterable[str],
+) -> tuple[ProjectManifestDiagnostic, ...]:
+    supported = {key.casefold() for key in supported_keys}
+    diagnostics: list[ProjectManifestDiagnostic] = []
+    for option in manifest.options_for_platform(target_platform).values():
+        if not option.key.startswith("option_") or option.key.casefold() in supported:
+            continue
+        diagnostics.append(
+            ProjectManifestDiagnostic(
+                severity="warning",
+                code="GM2GD-PROJECT-OPTION-UNSUPPORTED",
+                message=(
+                    "Unsupported GameMaker project option "
+                    f"{option.key!r} for target {option.platform!r}; no Godot project setting is emitted."
+                ),
+                source=option.source,
+            )
+        )
+    return tuple(diagnostics)
+
+
+def _find_yyp_path(gm_project_path: str) -> str | None:
+    try:
+        yyp_files = sorted(name for name in os.listdir(gm_project_path) if name.endswith(".yyp"))
+    except OSError:
+        return None
+    if not yyp_files:
+        return None
+    return os.path.join(gm_project_path, yyp_files[0])
+
+
+def _read_lenient_json_file(path: str) -> tuple[JsonDict | None, str]:
+    try:
+        with open(path, "r", encoding="utf-8") as file:
+            source = file.read()
+        data = json.loads(re.sub(r",\s*([}\]])", r"\1", source))
+        return (cast(JsonDict, data), source) if isinstance(data, dict) else (None, source)
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return None, ""
+
+
+def _parse_resources(
+    yyp_data: JsonDict,
+    yyp_path: str,
+    raw_source: str,
+) -> tuple[ProjectResourceReference, ...]:
+    resources: list[ProjectResourceReference] = []
+    raw_resources = yyp_data.get("resources")
+    if not isinstance(raw_resources, list):
+        return ()
+    for order, raw_entry in enumerate(cast(JsonList, raw_resources)):
+        if not isinstance(raw_entry, dict):
+            continue
+        entry = cast(JsonDict, raw_entry)
+        reference = _resource_reference_from_entry(entry, order, yyp_path, raw_source)
+        if reference is not None:
+            resources.append(reference)
+    return tuple(resources)
+
+
+def _resource_reference_from_entry(
+    entry: JsonDict,
+    order: int,
+    yyp_path: str,
+    raw_source: str,
+) -> ProjectResourceReference | None:
+    data = entry
+    uuid = _string_value(entry.get("id")) or _string_value(entry.get("Key"))
+    value = entry.get("Value")
+    if isinstance(value, dict):
+        data = cast(JsonDict, value)
+        uuid = uuid or _string_value(data.get("id"))
+    nested_id = data.get("id")
+    if isinstance(nested_id, dict):
+        nested = cast(JsonDict, nested_id)
+        uuid = (
+            _string_value(nested.get("id"))
+            or _string_value(nested.get("uuid"))
+            or uuid
+        )
+        name = _string_value(nested.get("name"))
+        path = _string_value(nested.get("path"))
+    else:
+        name = _string_value(data.get("name")) or _string_value(data.get("%Name"))
+        path = (
+            _string_value(data.get("path"))
+            or _string_value(data.get("resourcePath"))
+            or _string_value(data.get("resource_path"))
+        )
+    if not path:
+        return None
+
+    resource_type = _string_value(data.get("resourceType")) or _resource_type_from_path(path)
+    kind = _kind_from_path(path) or _RESOURCE_TYPE_KIND.get(resource_type, "")
+    name = name or _name_from_path(path)
+    if not name or not kind:
+        return None
+
+    order_value = _int_value(data.get("order"), order)
+    return ProjectResourceReference(
+        uuid=uuid,
+        name=name,
+        path=_normalize_project_path(path),
+        kind=kind,
+        resource_type=resource_type,
+        order=order_value,
+        tags=_string_tuple(data.get("tags")),
+        source=ProjectSourceLocation(yyp_path, _line_for(raw_source, path), f"resources[{order}]"),
+    )
+
+
+def _parse_configurations(
+    yyp_data: JsonDict,
+    yyp_path: str,
+    raw_source: str,
+) -> tuple[ProjectConfiguration, ...]:
+    configs: dict[str, ProjectConfiguration] = {}
+    roots = yyp_data.get("configs")
+    if roots is None:
+        roots = yyp_data.get("Configs")
+    for node in _iter_config_nodes(roots):
+        name = _string_value(node.get("name")) or _string_value(node.get("%Name"))
+        if not name:
+            continue
+        parent = _config_parent_name(node)
+        overrides = _config_overrides_from_node(name, node, yyp_path, raw_source)
+        configs[name] = ProjectConfiguration(
+            name=name,
+            parent=parent,
+            overrides=overrides,
+            source=ProjectSourceLocation(yyp_path, _line_for(raw_source, name), f"configs.{name}"),
+            raw_data=node,
+        )
+
+    config_values = yyp_data.get("ConfigValues")
+    if isinstance(config_values, dict):
+        for name, raw_overrides in cast(JsonDict, config_values).items():
+            config_name = str(name)
+            overrides = _config_overrides_from_value(
+                config_name,
+                raw_overrides,
+                yyp_path,
+                raw_source,
+                "ConfigValues",
+            )
+            existing = configs.get(config_name)
+            if existing is None:
+                configs[config_name] = ProjectConfiguration(
+                    name=config_name,
+                    overrides=overrides,
+                    source=ProjectSourceLocation(yyp_path, _line_for(raw_source, config_name), f"ConfigValues.{config_name}"),
+                )
+            else:
+                configs[config_name] = ProjectConfiguration(
+                    name=existing.name,
+                    parent=existing.parent,
+                    overrides=existing.overrides + overrides,
+                    source=existing.source,
+                    raw_data=existing.raw_data,
+                )
+    return tuple(configs[name] for name in sorted(configs))
+
+
+def _iter_config_nodes(raw_configs: object) -> Iterable[JsonDict]:
+    if isinstance(raw_configs, dict):
+        config = cast(JsonDict, raw_configs)
+        if _string_value(config.get("name")) or _string_value(config.get("%Name")):
+            yield config
+        for key in ("children", "configs", "Configs"):
+            for child in _iter_config_nodes(config.get(key)):
+                yield child
+    elif isinstance(raw_configs, list):
+        for item in cast(JsonList, raw_configs):
+            if isinstance(item, dict):
+                yield from _iter_config_nodes(cast(JsonDict, item))
+
+
+def _config_parent_name(node: JsonDict) -> str:
+    raw_parent = node.get("parent") or node.get("parentConfig")
+    if isinstance(raw_parent, str):
+        return raw_parent
+    if isinstance(raw_parent, dict):
+        parent = cast(JsonDict, raw_parent)
+        return _string_value(parent.get("name")) or _string_value(parent.get("%Name"))
+    return ""
+
+
+def _config_overrides_from_node(
+    configuration: str,
+    node: JsonDict,
+    yyp_path: str,
+    raw_source: str,
+) -> tuple[ProjectConfigOverride, ...]:
+    overrides: list[ProjectConfigOverride] = []
+    for key in ("options", "values", "overrides", "macros", "resources", "textureGroups", "audioGroups", "includedFiles"):
+        if key in node:
+            overrides.extend(
+                _config_overrides_from_value(
+                    configuration,
+                    node[key],
+                    yyp_path,
+                    raw_source,
+                    key,
+                )
+            )
+    return tuple(overrides)
+
+
+def _config_overrides_from_value(
+    configuration: str,
+    value: object,
+    yyp_path: str,
+    raw_source: str,
+    field_path: str,
+) -> tuple[ProjectConfigOverride, ...]:
+    if isinstance(value, dict):
+        overrides: list[ProjectConfigOverride] = []
+        for key, nested_value in cast(JsonDict, value).items():
+            overrides.extend(
+                _config_overrides_from_value(
+                    configuration,
+                    nested_value,
+                    yyp_path,
+                    raw_source,
+                    f"{field_path}.{key}",
+                )
+            )
+        return tuple(overrides)
+    return (
+        ProjectConfigOverride(
+            configuration=configuration,
+            field_path=field_path,
+            value=value,
+            source=ProjectSourceLocation(yyp_path, _line_for(raw_source, field_path.split(".")[-1]), field_path),
+        ),
+    )
+
+
+def _parse_project_options(gm_project_path: str) -> tuple[ProjectOption, ...]:
+    options_root = os.path.join(gm_project_path, "options")
+    if not os.path.isdir(options_root):
+        return ()
+    options: list[ProjectOption] = []
+    for root, _dirs, files in os.walk(options_root):
+        for filename in sorted(files):
+            if not filename.endswith(".yy"):
+                continue
+            path = os.path.join(root, filename)
+            data, source = _read_lenient_json_file(path)
+            if data is None:
+                continue
+            platform = _option_platform_from_path(options_root, path)
+            for key, value in data.items():
+                if key.startswith("option_"):
+                    options.append(
+                        ProjectOption(
+                            platform=platform,
+                            key=key,
+                            value=value,
+                            source=ProjectSourceLocation(path, _line_for(source, key), key),
+                        )
+                    )
+    return tuple(options)
+
+
+def _option_platform_from_path(options_root: str, path: str) -> str:
+    relative = os.path.relpath(path, options_root)
+    parts = relative.split(os.sep)
+    if len(parts) > 1 and parts[0]:
+        return parts[0]
+    filename = os.path.splitext(os.path.basename(path))[0]
+    if filename.startswith("options_"):
+        return filename[len("options_"):]
+    return "main"
+
+
+def _parse_texture_groups(
+    yyp_data: JsonDict,
+    yyp_path: str,
+    raw_source: str,
+) -> tuple[ProjectTextureGroup, ...]:
+    raw_groups = yyp_data.get("TextureGroups") or yyp_data.get("textureGroups")
+    groups: list[ProjectTextureGroup] = []
+    for index, item in enumerate(_iter_dict_items(raw_groups)):
+        name = _entry_name(item)
+        if not name:
+            continue
+        groups.append(
+            ProjectTextureGroup(
+                name=name,
+                parent=_entry_reference_name(item.get("parent") or item.get("parentGroup")),
+                is_dynamic=bool(item.get("isDynamic") or item.get("dynamic") or item.get("dynamicTextureGroup")),
+                dynamic_path=_string_value(item.get("dynamicPath") or item.get("path")),
+                targets=_targets_from_mapping(item),
+                source=ProjectSourceLocation(yyp_path, _line_for(raw_source, name), f"TextureGroups[{index}]"),
+                raw_data=item,
+            )
+        )
+    return tuple(groups)
+
+
+def _parse_audio_groups(
+    yyp_data: JsonDict,
+    yyp_path: str,
+    raw_source: str,
+) -> tuple[ProjectAudioGroup, ...]:
+    groups: list[ProjectAudioGroup] = []
+    for index, item in enumerate(_iter_dict_items(yyp_data.get("AudioGroups"))):
+        name = _entry_name(item)
+        if not name:
+            continue
+        groups.append(
+            ProjectAudioGroup(
+                name=name,
+                targets=_targets_from_mapping(item),
+                source=ProjectSourceLocation(yyp_path, _line_for(raw_source, name), f"AudioGroups[{index}]"),
+                raw_data=item,
+            )
+        )
+    return tuple(groups)
+
+
+def _parse_included_files(
+    yyp_data: JsonDict,
+    yyp_path: str,
+    raw_source: str,
+) -> tuple[ProjectIncludedFile, ...]:
+    files: list[ProjectIncludedFile] = []
+    raw_files = yyp_data.get("IncludedFiles") or yyp_data.get("includedFiles")
+    for index, item in enumerate(_iter_dict_items(raw_files)):
+        path = _string_value(item.get("path") or item.get("filePath") or item.get("filename"))
+        name = _entry_name(item) or os.path.basename(path)
+        if not name and not path:
+            continue
+        files.append(
+            ProjectIncludedFile(
+                name=name,
+                path=_normalize_project_path(path),
+                targets=_targets_from_mapping(item),
+                source=ProjectSourceLocation(yyp_path, _line_for(raw_source, name or path), f"IncludedFiles[{index}]"),
+                raw_data=item,
+            )
+        )
+    return tuple(files)
+
+
+def _unknown_project_field_diagnostics(
+    yyp_data: JsonDict,
+    yyp_path: str,
+    raw_source: str,
+) -> tuple[ProjectManifestDiagnostic, ...]:
+    diagnostics: list[ProjectManifestDiagnostic] = []
+    for key in sorted(yyp_data):
+        if key in _KNOWN_PROJECT_FIELDS or key.startswith("$"):
+            continue
+        diagnostics.append(
+            ProjectManifestDiagnostic(
+                severity="warning",
+                code="GM2GD-PROJECT-UNKNOWN-FIELD",
+                message=f"Unknown GameMaker project manifest field {key!r}; preserving raw value only.",
+                source=ProjectSourceLocation(yyp_path, _line_for(raw_source, key), key),
+            )
+        )
+    return tuple(diagnostics)
+
+
+def _resource_conflict_diagnostics(
+    resources: tuple[ProjectResourceReference, ...],
+) -> tuple[ProjectManifestDiagnostic, ...]:
+    diagnostics: list[ProjectManifestDiagnostic] = []
+    diagnostics.extend(_duplicate_resource_diagnostics(resources, "uuid", lambda resource: resource.uuid))
+    diagnostics.extend(
+        _duplicate_resource_diagnostics(
+            resources,
+            "name",
+            lambda resource: f"{resource.kind}:{resource.name.casefold()}",
+        )
+    )
+    diagnostics.extend(
+        _duplicate_resource_diagnostics(
+            resources,
+            "path",
+            lambda resource: _normalize_project_path(resource.path).casefold(),
+        )
+    )
+    return tuple(diagnostics)
+
+
+def _duplicate_resource_diagnostics(
+    resources: tuple[ProjectResourceReference, ...],
+    label: str,
+    key_fn: Callable[[ProjectResourceReference], str],
+) -> tuple[ProjectManifestDiagnostic, ...]:
+    seen: dict[str, ProjectResourceReference] = {}
+    diagnostics: list[ProjectManifestDiagnostic] = []
+    for resource in resources:
+        key = key_fn(resource)
+        if not key:
+            continue
+        previous = seen.get(key)
+        if previous is None:
+            seen[key] = resource
+            continue
+        diagnostics.append(
+            ProjectManifestDiagnostic(
+                severity="warning",
+                code="GM2GD-PROJECT-RESOURCE-CONFLICT",
+                message=(
+                    f"Duplicate GameMaker resource {label} {key!r} for "
+                    f"{previous.kind}/{previous.name} and {resource.kind}/{resource.name}."
+                ),
+                source=resource.source,
+            )
+        )
+    return tuple(diagnostics)
+
+
+def _missing_target_option_diagnostics(
+    options: tuple[ProjectOption, ...],
+    target_platform: str,
+) -> tuple[ProjectManifestDiagnostic, ...]:
+    if any(option.platform.casefold() == target_platform.casefold() for option in options):
+        return ()
+    return (
+        ProjectManifestDiagnostic(
+            severity="warning",
+            code="GM2GD-PROJECT-TARGET-OPTIONS-MISSING",
+            message=f"No GameMaker options file found for target platform {target_platform!r}.",
+        ),
+    )
+
+
+def _iter_dict_items(value: object) -> Iterable[JsonDict]:
+    if isinstance(value, list):
+        for item in cast(JsonList, value):
+            if isinstance(item, dict):
+                yield cast(JsonDict, item)
+    elif isinstance(value, dict):
+        for item in cast(JsonDict, value).values():
+            if isinstance(item, dict):
+                yield cast(JsonDict, item)
+
+
+def _entry_name(data: JsonDict) -> str:
+    return _string_value(data.get("%Name")) or _string_value(data.get("name"))
+
+
+def _entry_reference_name(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        return _entry_name(cast(JsonDict, value))
+    return ""
+
+
+def _targets_from_mapping(data: Mapping[str, object]) -> tuple[str, ...]:
+    raw_targets = data.get("targets") or data.get("copyToTargets") or data.get("platforms")
+    if isinstance(raw_targets, list):
+        targets: list[str] = []
+        for target in cast(JsonList, raw_targets):
+            target_text = str(target)
+            if target_text:
+                targets.append(target_text)
+        return tuple(targets)
+    if isinstance(raw_targets, dict):
+        targets: list[str] = []
+        for key, value in cast(Mapping[str, object], raw_targets).items():
+            if bool(value):
+                targets.append(str(key))
+        return tuple(sorted(targets))
+    targets = []
+    for key, value in data.items():
+        if key.startswith("copyTo") and bool(value):
+            targets.append(key[len("copyTo"):].casefold())
+    return tuple(sorted(targets))
+
+
+def _resource_type_from_path(path: str) -> str:
+    kind = _kind_from_path(path)
+    for resource_type, mapped_kind in _RESOURCE_TYPE_KIND.items():
+        if mapped_kind == kind:
+            return resource_type
+    return ""
+
+
+def _kind_from_path(path: str) -> str:
+    normalized = _normalize_project_path(path)
+    if "/" not in normalized:
+        return ""
+    return normalized.split("/", 1)[0]
+
+
+def _name_from_path(path: str) -> str:
+    filename = os.path.basename(_normalize_project_path(path))
+    return os.path.splitext(filename)[0]
+
+
+def _string_value(value: object) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _int_value(value: object, default: int) -> int:
+    if isinstance(value, bool):
+        return default
+    if not isinstance(value, (int, float, str)):
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(str(item) for item in cast(JsonList, value) if str(item))
+
+
+def _normalize_project_path(path: str | None) -> str:
+    return (path or "").replace("\\", "/").strip()
+
+
+def _line_for(source: str, needle: str) -> int:
+    if not needle:
+        return 1
+    index = source.find(needle)
+    if index == -1:
+        return 1
+    return source.count("\n", 0, index) + 1

--- a/src/conversion/project_settings.py
+++ b/src/conversion/project_settings.py
@@ -7,6 +7,12 @@ from typing import Optional, List
 # Import localization manager
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
+from src.conversion.diagnostics import DiagnosticCollector
+from src.conversion.project_manifest import (
+    GameMakerProjectManifest,
+    load_gamemaker_project_manifest,
+    unsupported_project_option_diagnostics,
+)
 from src.conversion.type_defs import ConversionRunning, LogCallback, ProgressCallback
 
 class ProjectSettingsConverter(BaseConverter):
@@ -15,11 +21,17 @@ class ProjectSettingsConverter(BaseConverter):
                  progress_callback: ProgressCallback | None = None,
                  conversion_running: ConversionRunning | None = None,
                  gm_platform: str = 'windows',
-                 max_workers: int | None = None) -> None:
+                 max_workers: int | None = None,
+                 diagnostics: DiagnosticCollector | None = None,
+                 project_manifest: GameMakerProjectManifest | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path,
                          log_callback, progress_callback, conversion_running,
-                         max_workers=max_workers)
+                         max_workers=max_workers, diagnostics=diagnostics)
         self.gm_platform = gm_platform
+        self.project_manifest = project_manifest or load_gamemaker_project_manifest(
+            self.gm_project_path,
+            target_platform=gm_platform,
+        )
         self.options_platform_path = os.path.join(self.gm_project_path, 'options', self.gm_platform, f'options_{self.gm_platform}.yy')
         self.options_windows_path = os.path.join(self.gm_project_path, 'options', 'windows', f'options_windows.yy')
         self.options_main_path = os.path.join(self.gm_project_path, 'options', 'main', 'options_main.yy')
@@ -76,34 +88,25 @@ class ProjectSettingsConverter(BaseConverter):
         return None
 
     def get_gm_project_name(self) -> Optional[str]:
-        yyp_files = [f for f in os.listdir(self.gm_project_path) if f.endswith('.yyp')]
-        if not yyp_files:
+        if self.project_manifest.yyp_path is None:
             self.log_callback(get_localized("Console_Convertor_Settings_Error_yypNotFound"))
             return None
-
-        yyp_file = os.path.join(self.gm_project_path, yyp_files[0])
-        try:
-            with open(yyp_file, 'r', encoding='utf-8') as file:
-                content = file.read()
-                match = re.search(r'"%Name":\s*"([^"]*)"', content)
-                return match.group(1) if match else None
-        except Exception as e:
-            self.log_callback(get_localized("Console_Convertor_Settings_Error_yypNameNotRead").format(error=str(e)))
+        if not self.project_manifest.project_name:
+            self.log_callback(get_localized("Console_Convertor_Settings_Error_yypNameNotRead").format(error="missing %Name/name"))
             return None
+        return self.project_manifest.project_name
 
     def get_gm_option(self, option_name: str, file_path: str) -> Optional[str]:
+        option = self.project_manifest.get_option(
+            option_name,
+            self._platform_from_options_path(file_path),
+        )
+        if option is not None:
+            return self._option_value_as_string(option.value)
         if not os.path.exists(file_path):
             self.log_callback(get_localized("Console_Convertor_Settings_Error_yypNotFound"))
             return None
-
-        try:
-            with open(file_path, 'r', encoding='utf-8') as file:
-                content = file.read()
-                match = re.search(f'"{option_name}":\\s*([^,\n]+)', content)
-                return match.group(1).strip('"') if match else None
-        except Exception as e:
-            self.log_callback(get_localized("Console_Convertor_Settings_Error_yypGeneric").format(option_name=option_name, file_path=os.path.basename(file_path), error=str(e)))
-            return None
+        return None
 
     def update_project_name(self) -> None:
         project_godot_path = os.path.join(self.godot_project_path, 'project.godot')
@@ -142,23 +145,18 @@ class ProjectSettingsConverter(BaseConverter):
 
             content = re.sub(r'config/icon="res://.*"', 'config/icon="res://icon.png"', content)
 
-            settings_to_update = [
-                (f"option_windows_description_info", "config/description"),
-                (f"option_{self.gm_platform}_version", "config/version"),
-                (f"option_windows_use_splash", "boot_splash/show_image"),
-                (f"option_game_speed", "run/max_fps"),
-                (f"option_{self.gm_platform}_vsync", "window/vsync/vsync_mode"),
-                (f"option_{self.gm_platform}_sync", "window/vsync/vsync_mode"),
-                (f"option_{self.gm_platform}_resize_window", "window/size/resizable"),
-                (f"option_windows_borderless", "window/size/borderless"),
-                (f"option_{self.gm_platform}_interpolate_pixels", "textures/canvas_textures/default_texture_filter"),
-                (f"option_{self.gm_platform}_start_fullscreen", "window/size/mode")
-            ]
-
-            for gm_option, godot_setting in settings_to_update:
-                value = self.get_gm_option(gm_option, self.options_windows_path if 'windows' in gm_option else self.options_platform_path if self.gm_platform in gm_option else self.options_main_path)
-                if value:
+            for gm_option, platform, godot_setting, value_kind in self._project_setting_mappings():
+                option = self.project_manifest.get_option(gm_option, platform)
+                if option is not None:
+                    value = self._godot_project_setting_value(option.value, value_kind)
                     content = self.update_godot_setting(content, godot_setting, value)
+
+            for diagnostic in unsupported_project_option_diagnostics(
+                self.project_manifest,
+                target_platform=self.gm_platform,
+                supported_keys=self._supported_project_option_keys(),
+            ):
+                self._safe_log(f"Warning: {diagnostic.message}")
 
             with open(project_godot_path, 'w', encoding='utf-8') as file:
                 file.write(content)
@@ -168,16 +166,12 @@ class ProjectSettingsConverter(BaseConverter):
         except Exception as e:
             self.log_callback(get_localized("Console_Convertor_Settings_Error_NotUpdated").format(error=str(e)))
 
-    def update_godot_setting(self, content: str, setting: str, value: str, section: str = "application") -> str:
+    def update_godot_setting(self, content: str, setting: str, value: object, section: str = "application") -> str:
         if section not in content:
             content += f"\n[{section}]\n"
         
         setting_pattern = f"{setting}\\s*=.*"
-        
-        if value.lower() in ['true', 'false']:
-            new_setting = f'{setting}={value.lower()}'
-        else:
-            new_setting = f'{setting}="{value}"'
+        new_setting = f'{setting}={self._format_godot_value(value)}'
         
         if re.search(setting_pattern, content):
             content = re.sub(setting_pattern, new_setting, content)
@@ -192,35 +186,104 @@ class ProjectSettingsConverter(BaseConverter):
         return content
 
     def read_audio_groups(self) -> List[str]:
-        yyp_files = [f for f in os.listdir(self.gm_project_path) if f.endswith('.yyp')]
-        if not yyp_files:
+        if self.project_manifest.yyp_path is None:
             self.log_callback(get_localized("Console_Convertor_Settings_Error_yypNotFound"))
             return []
-
-        yyp_file = os.path.join(self.gm_project_path, yyp_files[0])
-        try:
-            with open(yyp_file, 'r', encoding='utf-8') as file:
-                yyp_content = file.read()
-                
-                audio_groups_match = re.search(r'"AudioGroups":\s*\[(.*?)\]', yyp_content, re.DOTALL)
-                if not audio_groups_match:
-                    self.log_callback(get_localized("Console_Convertor_AudioBus_Error_SectionNotFound_GM"))
-                    return []
-
-                audio_groups_content = audio_groups_match.group(1)
-                audio_group_names = re.findall(r'"%Name":\s*"([^"]*)"', audio_groups_content)
-                
-                if not audio_group_names:
-                    self.log_callback(get_localized("Console_Convertor_AudioBus_Error_NameNotFound_GM"))
-
-                    return []
-
-                self.log_callback(get_localized("Console_Convertor_AudioBus_Group_Found").format(audio_group_names=', '.join(audio_group_names)))
-                return audio_group_names
-
-        except Exception as e:
-            self.log_callback(get_localized("Console_Convertor_AudioBus_Error_Group_Generic").format(error=str(e)))
+        audio_group_names = self.project_manifest.audio_group_names()
+        if not audio_group_names:
+            self.log_callback(get_localized("Console_Convertor_AudioBus_Error_SectionNotFound_GM"))
             return []
+        self.log_callback(get_localized("Console_Convertor_AudioBus_Group_Found").format(audio_group_names=', '.join(audio_group_names)))
+        return audio_group_names
+
+    def _project_setting_mappings(self) -> list[tuple[str, str, str, str]]:
+        return [
+            ("option_windows_description_info", "windows", "config/description", "string"),
+            (f"option_{self.gm_platform}_version", self.gm_platform, "config/version", "string"),
+            ("option_windows_use_splash", "windows", "boot_splash/show_image", "bool"),
+            ("option_game_speed", "main", "run/max_fps", "int"),
+            (f"option_{self.gm_platform}_vsync", self.gm_platform, "window/vsync/vsync_mode", "vsync"),
+            (f"option_{self.gm_platform}_sync", self.gm_platform, "window/vsync/vsync_mode", "vsync"),
+            (f"option_{self.gm_platform}_resize_window", self.gm_platform, "window/size/resizable", "bool"),
+            ("option_windows_borderless", "windows", "window/size/borderless", "bool"),
+            (
+                f"option_{self.gm_platform}_interpolate_pixels",
+                self.gm_platform,
+                "textures/canvas_textures/default_texture_filter",
+                "texture_filter",
+            ),
+            (f"option_{self.gm_platform}_start_fullscreen", self.gm_platform, "window/size/mode", "fullscreen"),
+        ]
+
+    def _supported_project_option_keys(self) -> set[str]:
+        return {key for key, _platform, _setting, _kind in self._project_setting_mappings()}
+
+    def _platform_from_options_path(self, file_path: str) -> str:
+        options_root = os.path.join(self.gm_project_path, "options")
+        try:
+            relative = os.path.relpath(file_path, options_root)
+        except ValueError:
+            relative = os.path.basename(file_path)
+        parts = relative.split(os.sep)
+        if len(parts) > 1 and parts[0]:
+            return parts[0]
+        filename = os.path.splitext(os.path.basename(file_path))[0]
+        if filename.startswith("options_"):
+            return filename[len("options_"):]
+        return "main"
+
+    @staticmethod
+    def _option_value_as_string(value: object) -> str:
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        return str(value)
+
+    def _godot_project_setting_value(self, value: object, value_kind: str) -> object:
+        if value_kind == "bool":
+            return self._bool_option(value)
+        if value_kind == "int":
+            return self._int_option(value)
+        if value_kind == "vsync":
+            return 1 if self._bool_option(value) else 0
+        if value_kind == "texture_filter":
+            return 1 if self._bool_option(value) else 0
+        if value_kind == "fullscreen":
+            return 3 if self._bool_option(value) else 0
+        return value
+
+    @staticmethod
+    def _bool_option(value: object) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return value != 0
+        return str(value).casefold() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _int_option(value: object) -> int:
+        if isinstance(value, bool):
+            return 1 if value else 0
+        if not isinstance(value, (int, float, str)):
+            return 0
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _format_godot_value(value: object) -> str:
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return str(value)
+        value_text = str(value)
+        lowered = value_text.casefold()
+        if lowered in {"true", "false"}:
+            return lowered
+        if re.fullmatch(r"-?\d+(?:\.\d+)?", value_text):
+            return value_text
+        escaped = value_text.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
 
     def generate_audio_bus_layout(self) -> None:
         audio_groups = self.read_audio_groups()

--- a/src/conversion/resource_index.py
+++ b/src/conversion/resource_index.py
@@ -4,6 +4,11 @@ from dataclasses import dataclass, field, replace
 from typing import Any, ClassVar, cast
 
 from src.conversion.base_converter import BaseConverter
+from src.conversion.project_manifest import (
+    GameMakerProjectManifest,
+    ProjectResourceReference,
+    load_gamemaker_project_manifest,
+)
 from src.conversion.type_defs import (
     ConversionRunning,
     JsonDict,
@@ -31,6 +36,10 @@ class IndexedResource:
     yyp_path: str
     godot_path: str
     subfolder: str = ""
+    uuid: str = ""
+    resource_type: str = ""
+    order: int = 0
+    tags: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -93,6 +102,7 @@ class GameMakerResourceIndex(BaseConverter):
                          max_workers=max_workers)
         self.yyp_path: str | None = None
         self.yyp_data: JsonDict | None = None
+        self.project_manifest: GameMakerProjectManifest | None = None
         self.resources: dict[str, dict[str, IndexedResource]] = self._empty_resources()
         self.rooms: dict[str, IndexedRoom] = {}
         self.extension_functions: dict[str, IndexedExtensionFunction] = {}
@@ -110,11 +120,12 @@ class GameMakerResourceIndex(BaseConverter):
         self.extension_functions = {}
         self.room_order = []
         self.used_room_order_fallback = False
-        self.yyp_path = self.find_yyp_path()
-        self.yyp_data = self._read_yy_file(self.yyp_path) if self.yyp_path else None
+        self.project_manifest = load_gamemaker_project_manifest(self.gm_project_path)
+        self.yyp_path = self.project_manifest.yyp_path
+        self.yyp_data = self.project_manifest.raw_data if self.project_manifest.raw_data else None
 
         if self.yyp_data is not None:
-            self._index_yyp_resources(self.yyp_data)
+            self._index_yyp_resources()
             self._parse_indexed_rooms()
             self._apply_yyp_room_order(self.yyp_data)
             self._resolve_room_inheritance()
@@ -180,6 +191,49 @@ class GameMakerResourceIndex(BaseConverter):
         resource = self.get_resource(kind, name)
         return resource.godot_path if resource else None
 
+    def find_project_resources(
+        self,
+        *,
+        uuid: str | None = None,
+        name: str | None = None,
+        path: str | None = None,
+        kind: str | None = None,
+        resource_type: str | None = None,
+    ) -> tuple[ProjectResourceReference, ...]:
+        """Return manifest resource references matched by UUID, name, path, kind, or type."""
+        if self.project_manifest is None:
+            return ()
+        return self.project_manifest.find_resources(
+            uuid=uuid,
+            name=name,
+            path=path,
+            kind=kind,
+            resource_type=resource_type,
+        )
+
+    def resolve_indexed_resource(
+        self,
+        *,
+        uuid: str | None = None,
+        name: str | None = None,
+        path: str | None = None,
+        kind: str | None = None,
+        resource_type: str | None = None,
+    ) -> IndexedResource | None:
+        """Return the first indexed resource matched by manifest metadata."""
+        matches = self.find_project_resources(
+            uuid=uuid,
+            name=name,
+            path=path,
+            kind=kind,
+            resource_type=resource_type,
+        )
+        for reference in matches:
+            resource = self.get_resource(reference.kind, reference.name)
+            if resource is not None:
+                return resource
+        return None
+
     def get_extension_function(self, name: str) -> IndexedExtensionFunction | None:
         """Return extension function metadata by GML function name, if discovered."""
         return self.extension_functions.get(name)
@@ -195,13 +249,14 @@ class GameMakerResourceIndex(BaseConverter):
     def _empty_resources(self) -> dict[str, dict[str, IndexedResource]]:
         return {kind: {} for kind in self.RESOURCE_EXTENSIONS}
 
-    def _index_yyp_resources(self, yyp_data: JsonDict) -> None:
-        for resource_entry in yyp_data.get("resources", []):
-            res_id = resource_entry.get("id", {})
-            yyp_path = res_id.get("path", "")
-            kind = self._kind_from_yyp_path(yyp_path)
+    def _index_yyp_resources(self) -> None:
+        if self.project_manifest is None:
+            return
+        for resource_ref in self.project_manifest.resources:
+            yyp_path = resource_ref.path
+            kind = resource_ref.kind
             if kind == "extensions":
-                name = res_id.get("name") or self._name_from_yyp_path(yyp_path)
+                name = resource_ref.name or self._name_from_yyp_path(yyp_path)
                 if name:
                     yy_path = os.path.normpath(os.path.join(self.gm_project_path, yyp_path))
                     self._index_extension_resource(name, yy_path, yyp_path)
@@ -209,7 +264,7 @@ class GameMakerResourceIndex(BaseConverter):
             if kind not in self.RESOURCE_EXTENSIONS:
                 continue
 
-            name = res_id.get("name") or self._name_from_yyp_path(yyp_path)
+            name = resource_ref.name or self._name_from_yyp_path(yyp_path)
             if not name:
                 continue
 
@@ -220,7 +275,7 @@ class GameMakerResourceIndex(BaseConverter):
                 )
                 continue
 
-            self.resources[kind][name] = self._make_resource(kind, name, yy_path, yyp_path)
+            self.resources[kind][name] = self._make_resource(kind, name, yy_path, yyp_path, resource_ref)
 
     def _index_disk_resources(self) -> None:
         for kind in self.RESOURCE_EXTENSIONS:
@@ -565,7 +620,12 @@ class GameMakerResourceIndex(BaseConverter):
         self.room_order = ordered
 
     def _make_resource(
-        self, kind: str, name: str, yy_path: str, yyp_path: str
+        self,
+        kind: str,
+        name: str,
+        yy_path: str,
+        yyp_path: str,
+        resource_ref: ProjectResourceReference | None = None,
     ) -> IndexedResource:
         subfolder = self._get_subfolder_from_yy(yy_path)
         return IndexedResource(
@@ -575,6 +635,10 @@ class GameMakerResourceIndex(BaseConverter):
             yyp_path=yyp_path,
             godot_path=self.godot_res_path(kind, name, subfolder),
             subfolder=subfolder,
+            uuid=resource_ref.uuid if resource_ref is not None else "",
+            resource_type=resource_ref.resource_type if resource_ref is not None else "",
+            order=resource_ref.order if resource_ref is not None else 0,
+            tags=resource_ref.tags if resource_ref is not None else (),
         )
 
     @classmethod

--- a/tests/test_project_manifest.py
+++ b/tests/test_project_manifest.py
@@ -1,0 +1,126 @@
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.project_manifest import load_gamemaker_project_manifest
+
+
+def _write_file(path: str, content: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as file:
+        file.write(content)
+
+
+class TestGameMakerProjectManifest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gm_dir = tempfile.mkdtemp()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.gm_dir)
+
+    def test_parses_manifest_graph_options_configs_and_groups(self) -> None:
+        _write_file(
+            os.path.join(self.gm_dir, "Manifest.yyp"),
+            """\
+{
+  "$GMProject": "",
+  "%Name": "ManifestFixture",
+  "resourceType": "GMProject",
+  "resourceVersion": "1.7",
+  "resources": [
+    {"id": {"id": "uuid-sprite", "name": "s_player", "path": "sprites/s_player/s_player.yy"}, "resourceType": "GMSprite", "order": 2, "tags": ["hero", "combat"]},
+    {"Key": "uuid-room", "Value": {"id": "uuid-room", "name": "r_main", "resourcePath": "rooms/r_main/r_main.yy", "resourceType": "GMRoom", "order": 1}}
+  ],
+  "Configs": [
+    {"name": "Default", "options": {"option_game_speed": 60}, "children": [
+      {"name": "Mobile", "parent": "Default", "overrides": {"AudioGroups": {"music": "audiogroup_mobile"}}}
+    ]}
+  ],
+  "ConfigValues": {"Mobile": {"options": {"option_android_version": "2.0.0"}}},
+  "TextureGroups": [
+    {"%Name": "texturegroup_world", "parentGroup": {"name": "Default"}, "isDynamic": true, "dynamicPath": "tg/world", "copyToWindows": true}
+  ],
+  "AudioGroups": [
+    {"%Name": "audiogroup_default"},
+    {"%Name": "audiogroup_music", "targets": ["windows", "android"]}
+  ],
+  "IncludedFiles": [
+    {"name": "license.txt", "path": "datafiles/license.txt", "copyToWindows": true}
+  ],
+  "FutureManifestThing": {"keep": true}
+}
+""",
+        )
+        _write_file(
+            os.path.join(self.gm_dir, "options", "main", "options_main.yy"),
+            '{"option_game_speed":144,}',
+        )
+        _write_file(
+            os.path.join(self.gm_dir, "options", "windows", "options_windows.yy"),
+            '{"option_windows_version":"1.2.3","option_windows_resize_window":true,}',
+        )
+
+        manifest = load_gamemaker_project_manifest(self.gm_dir, target_platform="windows")
+
+        self.assertEqual(manifest.project_name, "ManifestFixture")
+        self.assertEqual(manifest.resource_version, "1.7")
+        sprite = manifest.find_resources(uuid="uuid-sprite")[0]
+        self.assertEqual(sprite.name, "s_player")
+        self.assertEqual(sprite.kind, "sprites")
+        self.assertEqual(sprite.resource_type, "GMSprite")
+        self.assertEqual(sprite.tags, ("hero", "combat"))
+        assert sprite.source is not None
+        self.assertEqual(sprite.source.path, os.path.join(self.gm_dir, "Manifest.yyp"))
+        self.assertGreater(sprite.source.line, 0)
+        self.assertEqual(manifest.find_resources(path="rooms\\r_main\\r_main.yy")[0].uuid, "uuid-room")
+        self.assertEqual(manifest.find_resources(resource_type="GMRoom")[0].name, "r_main")
+        game_speed = manifest.get_option("option_game_speed", "main")
+        windows_version = manifest.get_option("option_windows_version", "windows")
+        assert game_speed is not None
+        assert windows_version is not None
+        self.assertEqual(game_speed.value, 144)
+        self.assertEqual(windows_version.value, "1.2.3")
+        self.assertEqual(manifest.audio_group_names(), ["audiogroup_default", "audiogroup_music"])
+        self.assertEqual(manifest.texture_groups[0].name, "texturegroup_world")
+        self.assertTrue(manifest.texture_groups[0].is_dynamic)
+        self.assertEqual(manifest.texture_groups[0].targets, ("windows",))
+        self.assertEqual(manifest.included_files[0].path, "datafiles/license.txt")
+        mobile = next(config for config in manifest.configurations if config.name == "Mobile")
+        self.assertEqual(mobile.parent, "Default")
+        self.assertTrue(any("AudioGroups" in override.field_path for override in mobile.overrides))
+        self.assertTrue(any("option_android_version" in override.field_path for override in mobile.overrides))
+        self.assertTrue(
+            any(diagnostic.code == "GM2GD-PROJECT-UNKNOWN-FIELD" for diagnostic in manifest.diagnostics)
+        )
+
+    def test_reports_duplicate_resource_conflicts_without_rejecting_manifest(self) -> None:
+        _write_file(
+            os.path.join(self.gm_dir, "Conflicts.yyp"),
+            """\
+{
+  "%Name": "Conflicts",
+  "resourceType": "GMProject",
+  "resources": [
+    {"id": {"id": "duplicate-id", "name": "s_player", "path": "sprites/s_player/s_player.yy"}, "resourceType": "GMSprite"},
+    {"id": {"id": "duplicate-id", "name": "s_player", "path": "sprites/s_player_hd/s_player_hd.yy"}, "resourceType": "GMSprite"}
+  ]
+}
+""",
+        )
+
+        manifest = load_gamemaker_project_manifest(self.gm_dir)
+
+        self.assertEqual(len(manifest.resources), 2)
+        self.assertTrue(
+            any(diagnostic.code == "GM2GD-PROJECT-RESOURCE-CONFLICT" for diagnostic in manifest.diagnostics)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_settings.py
+++ b/tests/test_project_settings.py
@@ -151,6 +151,69 @@ class TestReadAudioGroups(unittest.TestCase):
         self.assertEqual(groups, [])
 
 
+class TestUpdateProjectSettingsFromManifest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs: list[str] = []
+
+        with open(os.path.join(self.gm_dir, "Game.yyp"), "w", encoding="utf-8") as f:
+            f.write('{ "%Name": "Manifest Settings", "resourceType": "GMProject" }')
+        os.makedirs(os.path.join(self.gm_dir, "options", "main"), exist_ok=True)
+        os.makedirs(os.path.join(self.gm_dir, "options", "windows"), exist_ok=True)
+        with open(os.path.join(self.gm_dir, "options", "main", "options_main.yy"), "w", encoding="utf-8") as f:
+            f.write('{"option_game_speed":144,}')
+        with open(os.path.join(self.gm_dir, "options", "windows", "options_windows.yy"), "w", encoding="utf-8") as f:
+            f.write(
+                "{"
+                '"option_windows_description_info":"Arcade run",'
+                '"option_windows_version":"1.2.3",'
+                '"option_windows_use_splash":false,'
+                '"option_windows_vsync":false,'
+                '"option_windows_resize_window":true,'
+                '"option_windows_borderless":false,'
+                '"option_windows_interpolate_pixels":true,'
+                '"option_windows_start_fullscreen":true,'
+                '"option_windows_custom_future":true,'
+                "}"
+            )
+        self.project_godot = os.path.join(self.godot_dir, "project.godot")
+        with open(self.project_godot, "w", encoding="utf-8") as f:
+            f.write(SAMPLE_PROJECT_GODOT)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def _make_converter(self) -> ProjectSettingsConverter:
+        return ProjectSettingsConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+            gm_platform="windows",
+        )
+
+    def test_updates_project_godot_from_typed_options_and_reports_gaps(self) -> None:
+        converter = self._make_converter()
+        converter.update_project_settings()
+
+        with open(self.project_godot, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        self.assertIn('config/description="Arcade run"', content)
+        self.assertIn('config/version="1.2.3"', content)
+        self.assertIn("boot_splash/show_image=false", content)
+        self.assertIn("run/max_fps=144", content)
+        self.assertIn("window/vsync/vsync_mode=0", content)
+        self.assertIn("window/size/resizable=true", content)
+        self.assertIn("window/size/borderless=false", content)
+        self.assertIn("textures/canvas_textures/default_texture_filter=1", content)
+        self.assertIn("window/size/mode=3", content)
+        self.assertTrue(any("option_windows_custom_future" in log for log in self.logs))
+
+
 class TestConvertIconFallback(unittest.TestCase):
     """Test that convert_icon falls back to other platforms when the selected platform has no icons."""
 

--- a/tests/test_resource_index.py
+++ b/tests/test_resource_index.py
@@ -219,6 +219,37 @@ class TestGameMakerResourceIndex(unittest.TestCase):
             os.path.join("tilesets", "ts_ground", "ts_ground.yy")
         ))
 
+    def test_preserves_manifest_resource_metadata_and_resolves_by_graph_fields(self) -> None:
+        _write_file(
+            os.path.join(self.gm_dir, "Graph.yyp"),
+            "{\n"
+            '  "resources":[\n'
+            '    {"id":{"id":"uuid-sprite","name":"s_player","path":"sprites/s_player/s_player.yy"},'
+            '"resourceType":"GMSprite","tags":["hero"],"order":7}\n'
+            "  ],\n"
+            '  "RoomOrderNodes":[],\n'
+            '  "resourceType":"GMProject"\n'
+            "}\n",
+        )
+        self._write_resource("sprites", "s_player", "folders/Sprites/Actors.yy", "GMSprite")
+
+        index = self._build_index()
+        sprite = index.get_resource("sprites", "s_player")
+        resolved_by_uuid = index.resolve_indexed_resource(uuid="uuid-sprite")
+        resolved_by_path = index.resolve_indexed_resource(path="sprites\\s_player\\s_player.yy")
+        refs_by_type = index.find_project_resources(resource_type="GMSprite")
+
+        assert sprite is not None
+        assert resolved_by_uuid is not None
+        assert resolved_by_path is not None
+        self.assertEqual(sprite.uuid, "uuid-sprite")
+        self.assertEqual(sprite.resource_type, "GMSprite")
+        self.assertEqual(sprite.tags, ("hero",))
+        self.assertEqual(sprite.order, 7)
+        self.assertEqual(resolved_by_uuid.name, "s_player")
+        self.assertEqual(resolved_by_path.name, "s_player")
+        self.assertEqual([resource.name for resource in refs_by_type], ["s_player"])
+
     def test_indexes_extension_functions_from_yyp_metadata(self) -> None:
         self._write_yyp([("extensions", "AdSDK")])
         self._write_extension("AdSDK")


### PR DESCRIPTION
Closes #587.

## Summary
- add a typed GameMaker project manifest parser for resources, configs, config overrides, options, texture groups, audio groups, included files, source locations, unknown-field diagnostics, and duplicate resource conflicts
- thread manifest metadata into the resource index with UUID/name/path/type resolution and preserved resource tags/order/type data
- make project settings and audio bus generation consume typed options/audio groups instead of regex-only project reads
- emit unsupported project option diagnostics through the conversion diagnostic collector

## Tests
- ./venv/bin/python -m unittest tests.test_project_manifest tests.test_resource_index tests.test_project_settings tests.test_converter
- ./venv/bin/python -m unittest
- ./venv/bin/pyright --warnings