### PR TITLE
Execute room creation lifecycle code

### DIFF
--- a/src/conversion/gml_runtime_parts/segments/40_arrays_structs_variables.gd
+++ b/src/conversion/gml_runtime_parts/segments/40_arrays_structs_variables.gd
@@ -235,8 +235,13 @@ static func gml_struct_get(struct_value, member_name):
 			return struct_value[key]
 		return gml_undefined()
 	if typeof(struct_value) == TYPE_OBJECT:
+		if _gml_object_has_builtin_field(struct_value, key):
+			return _gml_object_builtin_field_get(struct_value, key)
 		if _object_has_property(struct_value, key):
 			return struct_value.get(key)
+		var dynamic_fields = _gml_object_dynamic_fields(struct_value)
+		if dynamic_fields.has(key):
+			return dynamic_fields[key]
 		return gml_undefined()
 	return gml_unsupported_type_error("GML struct access", struct_value)
 
@@ -365,7 +370,11 @@ static func gml_struct_exists(struct_value, member_name):
 	if typeof(struct_value) == TYPE_DICTIONARY:
 		return struct_value.has(key)
 	if typeof(struct_value) == TYPE_OBJECT:
-		return _object_has_property(struct_value, key)
+		return (
+			_gml_object_has_builtin_field(struct_value, key)
+			or _object_has_property(struct_value, key)
+			or _gml_object_dynamic_fields(struct_value).has(key)
+		)
 	return false
 
 
@@ -375,7 +384,12 @@ static func gml_struct_set(struct_value, member_name, value):
 		struct_value[key] = value
 		return value
 	if typeof(struct_value) == TYPE_OBJECT:
-		struct_value.set(key, value)
+		if _gml_object_has_builtin_field(struct_value, key):
+			_gml_object_builtin_field_set(struct_value, key, value)
+		elif _object_has_property(struct_value, key):
+			struct_value.set(key, value)
+		else:
+			_gml_object_dynamic_fields(struct_value, true)[key] = value
 		return value
 	return gml_unsupported_type_error("GML struct access", struct_value)
 
@@ -385,6 +399,11 @@ static func gml_struct_remove(struct_value, member_name):
 	if typeof(struct_value) == TYPE_DICTIONARY:
 		struct_value.erase(key)
 		return gml_undefined()
+	if typeof(struct_value) == TYPE_OBJECT:
+		var dynamic_fields = _gml_object_dynamic_fields(struct_value)
+		if dynamic_fields.has(key):
+			dynamic_fields.erase(key)
+			return gml_undefined()
 	return gml_unsupported_type_error("GML mutable struct access", struct_value)
 
 
@@ -395,6 +414,12 @@ static func gml_struct_get_names(struct_value):
 		var names = []
 		for property in struct_value.get_property_list():
 			names.append(property.get("name"))
+		for builtin_name in _gml_object_builtin_field_names(struct_value):
+			if not names.has(builtin_name):
+				names.append(builtin_name)
+		for dynamic_name in _gml_object_dynamic_fields(struct_value).keys():
+			if not names.has(dynamic_name):
+				names.append(dynamic_name)
 		return names
 	return []
 
@@ -403,8 +428,70 @@ static func gml_struct_names_count(struct_value):
 	if typeof(struct_value) == TYPE_DICTIONARY:
 		return struct_value.size()
 	if typeof(struct_value) == TYPE_OBJECT:
-		return struct_value.get_property_list().size()
+		return gml_struct_get_names(struct_value).size()
 	return -1
+
+
+static func _gml_object_dynamic_fields(object_value, create = false):
+	if typeof(object_value) != TYPE_OBJECT:
+		return {}
+	var meta_name = "_gm2godot_dynamic_fields"
+	if object_value.has_meta(meta_name):
+		var fields = object_value.get_meta(meta_name)
+		if typeof(fields) == TYPE_DICTIONARY:
+			return fields
+	if not bool(create):
+		return {}
+	var new_fields = {}
+	object_value.set_meta(meta_name, new_fields)
+	return new_fields
+
+
+static func _gml_object_builtin_field_names(object_value):
+	if object_value is Node2D:
+		return ["x", "y", "image_angle", "image_xscale", "image_yscale"]
+	return []
+
+
+static func _gml_object_has_builtin_field(object_value, member_name):
+	return _gml_object_builtin_field_names(object_value).has(str(member_name))
+
+
+static func _gml_object_builtin_field_get(object_value, member_name):
+	var key = str(member_name)
+	if object_value is Node2D:
+		if key == "x":
+			return object_value.position.x
+		if key == "y":
+			return object_value.position.y
+		if key == "image_angle":
+			return object_value.rotation_degrees
+		if key == "image_xscale":
+			return object_value.scale.x
+		if key == "image_yscale":
+			return object_value.scale.y
+	return gml_undefined()
+
+
+static func _gml_object_builtin_field_set(object_value, member_name, value):
+	var key = str(member_name)
+	if object_value is Node2D:
+		if key == "x":
+			object_value.position.x = _to_real(value)
+			return value
+		if key == "y":
+			object_value.position.y = _to_real(value)
+			return value
+		if key == "image_angle":
+			object_value.rotation_degrees = _to_real(value)
+			return value
+		if key == "image_xscale":
+			object_value.scale.x = _to_real(value)
+			return value
+		if key == "image_yscale":
+			object_value.scale.y = _to_real(value)
+			return value
+	return value
 
 
 static func gml_struct_foreach(struct_value, callback):

--- a/src/conversion/gml_runtime_parts/segments/55_room_game_flow.gd
+++ b/src/conversion/gml_runtime_parts/segments/55_room_game_flow.gd
@@ -21,9 +21,12 @@ static func gml_room_enter_scene(scene, force = false):
 	_gml_room_pending_entry = null
 	gml_layer_register_scene(scene)
 	_gml_room_update_current(entry, scene)
+	_gml_room_warn_persistent_room(scene)
+	_gml_room_run_instance_creation_code(scene)
 	if not _gml_room_game_started:
 		_gml_room_game_started = true
 		_gml_room_dispatch_lifecycle(scene, "_on_game_start")
+	_gml_room_run_room_creation_code(scene)
 	_gml_room_dispatch_lifecycle(scene, "_on_room_start")
 	return true
 
@@ -175,6 +178,55 @@ static func _gml_room_dispatch_lifecycle(root_node, method_name):
 			node.call(method_name)
 
 
+static func _gml_room_run_instance_creation_code(scene):
+	if scene == null or not scene.has_method("_gm2godot_run_instance_creation_code"):
+		return
+	for entry in _gml_room_instance_creation_code_entries(scene):
+		var node = entry["node"]
+		if _gml_room_node_was_restored_persistent(node):
+			_gml_room_warn_persistent_instance_creation_code(node)
+			continue
+		scene.call("_gm2godot_run_instance_creation_code", node)
+
+
+static func _gml_room_run_room_creation_code(scene):
+	if scene != null and scene.has_method("_gm2godot_room_creation_code"):
+		scene.call("_gm2godot_room_creation_code")
+
+
+static func _gml_room_instance_creation_code_entries(root_node):
+	var entries = []
+	var traversal_order = 0
+	for node in _gml_room_tree_nodes(root_node):
+		if node == root_node:
+			continue
+		if not node.has_meta("gamemaker_has_creation_code") or not bool(node.get_meta("gamemaker_has_creation_code")):
+			continue
+		if node.has_meta("gamemaker_creation_code_file_exists") and not bool(node.get_meta("gamemaker_creation_code_file_exists")):
+			continue
+		var order_index = 1073741824
+		if node.has_meta("gamemaker_instance_creation_order_index"):
+			var metadata_order = node.get_meta("gamemaker_instance_creation_order_index")
+			if metadata_order != null:
+				order_index = int(metadata_order)
+		entries.append({
+			"node": node,
+			"order_index": order_index,
+			"traversal_order": traversal_order,
+		})
+		traversal_order += 1
+	entries.sort_custom(_gml_room_creation_code_entry_less)
+	return entries
+
+
+static func _gml_room_creation_code_entry_less(left, right):
+	var left_order = int(left["order_index"])
+	var right_order = int(right["order_index"])
+	if left_order == right_order:
+		return int(left["traversal_order"]) < int(right["traversal_order"])
+	return left_order < right_order
+
+
 static func _gml_room_tree_nodes(root_node):
 	var nodes = []
 	if root_node == null:
@@ -208,6 +260,7 @@ static func _gml_room_restore_persistent_instances(scene):
 	for node in persistent_root.get_children():
 		node.reparent(scene, true)
 		node.set_meta("_gm2godot_room_preserving_persistent", false)
+		node.set_meta("_gm2godot_room_restored_persistent", true)
 
 
 static func _gml_room_node_is_persistent(node):
@@ -218,6 +271,37 @@ static func _gml_room_node_is_persistent(node):
 	if node is Object and _object_has_property(node, "persistent"):
 		return bool(node.get("persistent"))
 	return false
+
+
+static func _gml_room_node_was_restored_persistent(node):
+	return (
+		node != null
+		and node.has_meta("_gm2godot_room_restored_persistent")
+		and bool(node.get_meta("_gm2godot_room_restored_persistent"))
+	)
+
+
+static func _gml_room_warn_persistent_instance_creation_code(node):
+	if node == null:
+		return
+	if node.has_meta("_gm2godot_persistent_creation_code_warning_emitted") and bool(node.get_meta("_gm2godot_persistent_creation_code_warning_emitted")):
+		return
+	node.set_meta("_gm2godot_persistent_creation_code_warning_emitted", true)
+	var instance_name = str(node.name)
+	if node.has_meta("gamemaker_instance_name"):
+		instance_name = str(node.get_meta("gamemaker_instance_name"))
+	push_warning("GM2Godot preserves persistent instance " + instance_name + " across room transitions; its instance creation code is not rerun after restore.")
+
+
+static func _gml_room_warn_persistent_room(scene):
+	if scene == null:
+		return
+	if not scene.has_meta("gamemaker_room_persistent") or not bool(scene.get_meta("gamemaker_room_persistent")):
+		return
+	if scene.has_meta("_gm2godot_persistent_room_warning_emitted") and bool(scene.get_meta("_gm2godot_persistent_room_warning_emitted")):
+		return
+	scene.set_meta("_gm2godot_persistent_room_warning_emitted", true)
+	push_warning("GM2Godot does not preserve full persistent room state; room lifecycle code runs when the generated Godot scene enters.")
 
 
 static func _gml_room_persistent_root():

--- a/src/conversion/gml_transpiler_parts/api.py
+++ b/src/conversion/gml_transpiler_parts/api.py
@@ -8,6 +8,7 @@ from .extension_functions import (
     normalize_extension_function_mappings,
     normalize_extension_functions,
 )
+from .model import _ScopeContext
 from .preprocessor import preprocess_gml_source
 from .source_map import (
     GMLTranspileResult,
@@ -37,6 +38,9 @@ def transpile_gml_code(
     event: str | None = None,
     preserve_source_comments: bool = False,
     generated_line_offset: int = 0,
+    self_expression: str = "self",
+    other_expression: str = "other",
+    instance_target: str | None = None,
 ) -> str:
     """Transpile supported GML statements to GDScript."""
     return transpile_gml_code_with_source_map(
@@ -58,6 +62,9 @@ def transpile_gml_code(
         event=event,
         preserve_source_comments=preserve_source_comments,
         generated_line_offset=generated_line_offset,
+        self_expression=self_expression,
+        other_expression=other_expression,
+        instance_target=instance_target,
     ).code
 
 
@@ -80,6 +87,9 @@ def transpile_gml_code_with_source_map(
     event: str | None = None,
     preserve_source_comments: bool = False,
     generated_line_offset: int = 0,
+    self_expression: str = "self",
+    other_expression: str = "other",
+    instance_target: str | None = None,
 ) -> GMLTranspileResult:
     """Transpile supported GML statements and return trace metadata."""
     preprocessed = preprocess_gml_source(
@@ -98,6 +108,11 @@ def transpile_gml_code_with_source_map(
         global_names=_LEGACY_GLOBAL_BUILTINS if legacy_global_builtins else None,
         asset_names=asset_names,
         static_scope_prefix=static_scope_prefix,
+        scope_context=_ScopeContext(
+            self_expression=self_expression,
+            other_expression=other_expression,
+            instance_target=instance_target,
+        ),
         extension_functions=normalize_extension_functions(extension_functions),
         extension_function_mappings=normalize_extension_function_mappings(extension_function_mappings),
     )

--- a/src/conversion/room_creation_code.py
+++ b/src/conversion/room_creation_code.py
@@ -27,6 +27,7 @@ class RoomCreationCodeRoom(Protocol):
 ROOM_EXECUTION_ORDER = [
     "object_create",
     "instance_creation_code",
+    "game_start",
     "room_creation_code",
     "room_start",
 ]

--- a/src/conversion/rooms.py
+++ b/src/conversion/rooms.py
@@ -2,23 +2,27 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import TypedDict
+from typing import TypedDict, cast
 
 from src.conversion.base_converter import BaseConverter
+from src.conversion.gml_transpiler import GMLTranspileError, transpile_gml_code
 from src.conversion.project_godot import GodotProjectFile
 from src.conversion.resource_index import GameMakerResourceIndex, IndexedRoom
 from src.conversion.room_creation_code import (
     ROOM_EXECUTION_ORDER,
     instance_creation_order_names,
+    resolve_instance_creation_code,
     resolve_room_creation_code,
 )
 from src.conversion.room_layers import godot_string, serialize_room_layers
-from src.conversion.type_defs import ConversionRunning, LogCallback, ProgressCallback, StrPath
+from src.conversion.type_defs import ConversionRunning, JsonDict, LogCallback, ProgressCallback, StrPath
 
 ROOM_RUNTIME_SCRIPT_RELATIVE_PATH = os.path.join("gm2godot", "gml_room_node.gd")
 ROOM_RUNTIME_SCRIPT_RESOURCE_PATH = "res://gm2godot/gml_room_node.gd"
 ROOM_RUNTIME_EXT_RESOURCE_ID = "gm_room_runtime"
+ROOM_SCRIPT_BASE_RESOURCE_PATH = "res://gm2godot/gml_room_node.gd"
 
 
 def render_room_runtime_script() -> str:
@@ -28,6 +32,61 @@ def render_room_runtime_script() -> str:
         "func _ready():\n"
         "\tGMRuntime.gml_room_enter_scene(self)\n"
     )
+
+
+class InstanceCreationCodeMethod(TypedDict):
+    source_path: str
+    method_name: str
+    body: str
+
+
+def _room_script_resource_path(room: IndexedRoom) -> str:
+    if room.godot_path.endswith(".tscn"):
+        return room.godot_path[:-5] + ".gd"
+    return room.godot_path + ".gd"
+
+
+def _gdscript_identifier_suffix(value: str, fallback: str) -> str:
+    identifier = re.sub(r"[^0-9A-Za-z_]", "_", value).strip("_")
+    if not identifier:
+        identifier = fallback
+    if identifier[0].isdigit():
+        identifier = "_" + identifier
+    return identifier
+
+
+def _dict_items(value: object) -> list[JsonDict]:
+    if not isinstance(value, list):
+        return []
+    items: list[JsonDict] = []
+    for item in cast(list[object], value):
+        if isinstance(item, dict):
+            items.append(cast(JsonDict, item))
+    return items
+
+
+def _layer_resource_type(layer: JsonDict) -> str:
+    resource_type = layer.get("resourceType")
+    if isinstance(resource_type, str) and resource_type:
+        return resource_type
+    for key in layer:
+        if key.startswith("$GMR"):
+            return key[1:]
+    return "UnknownLayer"
+
+
+def _instance_name(instance: JsonDict) -> str:
+    name = instance.get("%Name") or instance.get("name")
+    return name if isinstance(name, str) and name else "Instance"
+
+
+def _iter_room_instances(layers: object) -> list[JsonDict]:
+    instances: list[JsonDict] = []
+    for layer in _dict_items(layers):
+        if _layer_resource_type(layer) == "GMRInstanceLayer":
+            instances.extend(_dict_items(layer.get("instances")))
+        instances.extend(_iter_room_instances(layer.get("layers") or layer.get("children")))
+    return instances
 
 
 class RoomProcessResult(TypedDict):
@@ -71,7 +130,10 @@ class RoomConverter(BaseConverter):
         ).build()
 
     def _generate_room_scene(
-        self, room: IndexedRoom, resource_index: GameMakerResourceIndex | None = None
+        self,
+        room: IndexedRoom,
+        resource_index: GameMakerResourceIndex | None = None,
+        room_script_resource_path: str | None = None,
     ) -> str:
         room_settings = room.room_settings
         physics_settings = room.physics_settings
@@ -87,13 +149,14 @@ class RoomConverter(BaseConverter):
             warn_callback=self._safe_log,
         )
 
+        script_resource_path = room_script_resource_path or ROOM_RUNTIME_SCRIPT_RESOURCE_PATH
         if serialized_layers.ext_resource_lines:
             lines = [
                 f"[gd_scene format=3 load_steps={len(serialized_layers.ext_resource_lines) + 2}]",
                 "",
                 (
                     '[ext_resource type="Script" path="{path}" id="{resource_id}"]'.format(
-                        path=ROOM_RUNTIME_SCRIPT_RESOURCE_PATH,
+                        path=script_resource_path,
                         resource_id=ROOM_RUNTIME_EXT_RESOURCE_ID,
                     )
                 ),
@@ -106,7 +169,7 @@ class RoomConverter(BaseConverter):
                 "",
                 (
                     '[ext_resource type="Script" path="{path}" id="{resource_id}"]'.format(
-                        path=ROOM_RUNTIME_SCRIPT_RESOURCE_PATH,
+                        path=script_resource_path,
                         resource_id=ROOM_RUNTIME_EXT_RESOURCE_ID,
                     )
                 ),
@@ -156,6 +219,176 @@ class RoomConverter(BaseConverter):
             )
         return os.path.join(self.godot_rooms_path, room.name, room.name + ".tscn")
 
+    def _room_script_output_path(self, room: IndexedRoom) -> str:
+        script_resource_path = _room_script_resource_path(room)
+        if script_resource_path.startswith("res://"):
+            relative_path = script_resource_path[len("res://"):]
+            return os.path.join(self.godot_project_path, *relative_path.split("/"))
+        return os.path.splitext(self._room_output_path(room))[0] + ".gd"
+
+    def _generate_room_script(
+        self,
+        room: IndexedRoom,
+        resource_index: GameMakerResourceIndex | None = None,
+    ) -> str | None:
+        asset_names = self._asset_names(resource_index)
+        room_creation_code = resolve_room_creation_code(room, self.gm_project_path)
+        room_creation_body: str | None = None
+        if room_creation_code.has_code and room_creation_code.exists:
+            room_creation_body = self._transpile_creation_code(
+                room_creation_code.source_path,
+                room.name,
+                "room creation code",
+                asset_names=asset_names,
+                top_level_global_scope=True,
+            )
+
+        instance_methods: list[InstanceCreationCodeMethod] = []
+        used_method_names: dict[str, int] = {}
+        for instance in _iter_room_instances(room.layers):
+            creation_code = resolve_instance_creation_code(room, instance)
+            if not creation_code.has_code or not creation_code.exists:
+                continue
+            instance_name = _instance_name(instance)
+            method_name = self._unique_instance_creation_method_name(
+                instance_name,
+                used_method_names,
+            )
+            body = self._transpile_creation_code(
+                creation_code.source_path,
+                room.name,
+                f"instance creation code for {instance_name}",
+                asset_names=asset_names,
+                self_expression="_gm_instance",
+                other_expression="GMRuntime.gml_instance_noone()",
+                instance_target="_gm_instance",
+            )
+            if body is None:
+                continue
+            instance_methods.append({
+                "source_path": creation_code.source_path,
+                "method_name": method_name,
+                "body": body,
+            })
+
+        if room_creation_body is None and not instance_methods:
+            return None
+        return self._render_room_script(room_creation_body, instance_methods)
+
+    def _transpile_creation_code(
+        self,
+        source_path: str,
+        room_name: str,
+        label: str,
+        *,
+        asset_names: set[str],
+        top_level_global_scope: bool = False,
+        self_expression: str = "self",
+        other_expression: str = "other",
+        instance_target: str | None = None,
+    ) -> str | None:
+        try:
+            with open(source_path, "r", encoding="utf-8") as f:
+                source = f.read()
+        except OSError:
+            self._safe_log(
+                "Warning: Could not read GameMaker {label} for room {room}: {path}".format(
+                    label=label,
+                    room=room_name,
+                    path=source_path,
+                )
+            )
+            return None
+
+        try:
+            return transpile_gml_code(
+                source,
+                asset_names=asset_names,
+                top_level_global_scope=top_level_global_scope,
+                source_path=source_path,
+                event=label,
+                preserve_source_comments=True,
+                self_expression=self_expression,
+                other_expression=other_expression,
+                instance_target=instance_target,
+            )
+        except GMLTranspileError as exc:
+            self._safe_log(
+                "Warning: Could not transpile GameMaker {label} for room {room}: {path}: {error}".format(
+                    label=label,
+                    room=room_name,
+                    path=source_path,
+                    error=exc,
+                )
+            )
+            return None
+
+    def _render_room_script(
+        self,
+        room_creation_body: str | None,
+        instance_methods: list[InstanceCreationCodeMethod],
+    ) -> str:
+        lines = [f'extends "{ROOM_SCRIPT_BASE_RESOURCE_PATH}"']
+        if instance_methods:
+            lines.extend([
+                "",
+                "func _gm2godot_run_instance_creation_code(_gm_instance):",
+                "\tif _gm_instance == null:",
+                "\t\treturn false",
+                "\tif not _gm_instance.has_meta(\"gamemaker_creation_code_source_path\"):",
+                "\t\treturn false",
+                "\tvar _gm_source_path = str(_gm_instance.get_meta(\"gamemaker_creation_code_source_path\"))",
+                "\tmatch _gm_source_path:",
+            ])
+            for method in instance_methods:
+                lines.extend([
+                    f"\t\t{json.dumps(method['source_path'])}:",
+                    f"\t\t\t{method['method_name']}(_gm_instance)",
+                    "\t\t\treturn true",
+                ])
+            lines.extend([
+                "\treturn false",
+            ])
+
+            for method in instance_methods:
+                lines.extend([
+                    "",
+                    f"func {method['method_name']}(_gm_instance):",
+                    method["body"],
+                ])
+
+        if room_creation_body is not None:
+            lines.extend([
+                "",
+                "func _gm2godot_room_creation_code():",
+                room_creation_body,
+            ])
+
+        return "\n".join(lines).rstrip() + "\n"
+
+    def _unique_instance_creation_method_name(
+        self,
+        instance_name: str,
+        used_method_names: dict[str, int],
+    ) -> str:
+        base = "_gm2godot_instance_creation_code_" + _gdscript_identifier_suffix(
+            instance_name,
+            "instance",
+        )
+        count = used_method_names.get(base, 0)
+        used_method_names[base] = count + 1
+        if count == 0:
+            return base
+        return f"{base}_{count + 1}"
+
+    def _asset_names(self, resource_index: GameMakerResourceIndex | None) -> set[str]:
+        if resource_index is None:
+            return set()
+        names = set(resource_index.rooms.keys())
+        for resources in resource_index.resources.values():
+            names.update(resources.keys())
+        return names
+
     def _process_room(
         self, room: IndexedRoom, resource_index: GameMakerResourceIndex | None = None
     ) -> RoomProcessResult | None:
@@ -163,9 +396,17 @@ class RoomConverter(BaseConverter):
             return None
 
         output_path = self._room_output_path(room)
+        room_script = self._generate_room_script(room, resource_index)
+        room_script_resource_path: str | None = None
+        if room_script is not None:
+            room_script_resource_path = _room_script_resource_path(room)
+            script_output_path = self._room_script_output_path(room)
+            os.makedirs(os.path.dirname(script_output_path), exist_ok=True)
+            with open(script_output_path, "w", encoding="utf-8") as f:
+                f.write(room_script)
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
         with open(output_path, "w", encoding="utf-8") as f:
-            f.write(self._generate_room_scene(room, resource_index))
+            f.write(self._generate_room_scene(room, resource_index, room_script_resource_path))
 
         width = room.room_settings.get("Width", 1024)
         height = room.room_settings.get("Height", 768)

--- a/tests/test_room_game_flow_godot.py
+++ b/tests/test_room_game_flow_godot.py
@@ -192,6 +192,132 @@ def _write_scripts(project_dir: Path) -> None:
 
 
 class TestRoomGameFlowGodotSmoke(unittest.TestCase):
+    def test_room_creation_code_lifecycle_trace_order(self) -> None:
+        godot_binary = _find_godot_binary()
+        if godot_binary is None:
+            self.skipTest("Godot binary not available")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir)
+            _write_text(
+                project_dir / "project.godot",
+                '[application]\nconfig/name="RoomLifecycleSmoke"\nrun/main_scene="res://rooms/r_one/r_one.tscn"\n',
+            )
+            write_gml_runtime(str(project_dir))
+            _write_text(project_dir / "gm2godot" / "gml_room_node.gd", render_room_runtime_script())
+            _write_registry(project_dir)
+            _write_text(
+                project_dir / "probe.gd",
+                textwrap.dedent(
+                    """\
+                    extends Node2D
+
+                    const GMRuntime = preload("res://gm2godot/gml_runtime.gd")
+
+                    func _ready():
+                    \tGMRuntime.gml_global_scope()["trace"] = []
+                    \tGMRuntime.gml_global_scope()["trace"].append("object_create")
+
+                    func _on_game_start():
+                    \tGMRuntime.gml_global_scope()["trace"].append("game_start")
+
+                    func _on_room_start():
+                    \tGMRuntime.gml_global_scope()["trace"].append("room_start")
+                    \tcall_deferred("_verify_trace")
+
+                    func _verify_trace():
+                    \tvar expected = ["object_create", "instance_creation_code", "game_start", "room_creation_code", "room_start"]
+                    \tvar trace = GMRuntime.gml_global_scope()["trace"]
+                    \tif trace != expected:
+                    \t\tpush_error("Lifecycle trace mismatch: " + str(trace))
+                    \t\tget_tree().quit(1)
+                    \t\treturn
+                    \tif GMRuntime.gml_variable_instance_get(self, "creation_ran") != true:
+                    \t\tpush_error("Instance creation code did not run against the instance scope")
+                    \t\tget_tree().quit(1)
+                    \t\treturn
+                    \tif int(position.x) != 42:
+                    \t\tpush_error("Instance creation code did not update scoped x")
+                    \t\tget_tree().quit(1)
+                    \t\treturn
+                    \tprint("ROOM_CREATION_LIFECYCLE_TRACE_OK")
+                    \tget_tree().quit(0)
+                    """
+                ),
+            )
+            _write_text(
+                project_dir / "rooms" / "r_one" / "r_one.gd",
+                textwrap.dedent(
+                    """\
+                    extends "res://gm2godot/gml_room_node.gd"
+
+                    func _gm2godot_run_instance_creation_code(_gm_instance):
+                    \tif _gm_instance == null:
+                    \t\treturn false
+                    \tif str(_gm_instance.get_meta("gamemaker_creation_code_source_path")) != "rooms/r_one/InstanceCreationCode_Probe.gml":
+                    \t\treturn false
+                    \tGMRuntime.gml_global_scope()["trace"].append("instance_creation_code")
+                    \tGMRuntime.gml_variable_instance_set(_gm_instance, "creation_ran", true)
+                    \tGMRuntime.gml_variable_instance_set(_gm_instance, "x", 42)
+                    \treturn true
+
+                    func _gm2godot_room_creation_code():
+                    \tGMRuntime.gml_global_scope()["trace"].append("room_creation_code")
+                    """
+                ),
+            )
+            _write_text(
+                project_dir / "rooms" / "r_one" / "r_one.tscn",
+                textwrap.dedent(
+                    """\
+                    [gd_scene load_steps=3 format=3]
+
+                    [ext_resource type="Script" path="res://rooms/r_one/r_one.gd" id="gm_room_runtime"]
+                    [ext_resource type="Script" path="res://probe.gd" id="probe"]
+
+                    [node name="r_one" type="Node2D"]
+                    script = ExtResource("gm_room_runtime")
+                    metadata/gamemaker_room_width = 320
+                    metadata/gamemaker_room_height = 180
+                    metadata/gamemaker_room_persistent = false
+
+                    [node name="Probe" type="Node2D" parent="."]
+                    script = ExtResource("probe")
+                    metadata/gamemaker_instance_name = "Probe"
+                    metadata/gamemaker_has_creation_code = true
+                    metadata/gamemaker_creation_code_file_exists = true
+                    metadata/gamemaker_creation_code_source_path = "rooms/r_one/InstanceCreationCode_Probe.gml"
+                    metadata/gamemaker_instance_creation_order_index = 0
+                    """
+                ),
+            )
+
+            godot_env = dict(os.environ)
+            godot_env["HOME"] = str(project_dir)
+            result = subprocess.run(
+                [
+                    godot_binary,
+                    "--headless",
+                    "--log-file",
+                    str(project_dir / "godot.log"),
+                    "--path",
+                    str(project_dir),
+                    "--scene",
+                    "res://rooms/r_one/r_one.tscn",
+                    "--quit-after",
+                    "10",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=20,
+                check=False,
+                env=godot_env,
+            )
+            output = result.stdout + result.stderr
+
+        self.assertEqual(result.returncode, 0, output)
+        self.assertIn("ROOM_CREATION_LIFECYCLE_TRACE_OK", output)
+
     def test_room_runtime_transitions_lifecycle_and_persistent_nodes(self) -> None:
         godot_binary = _find_godot_binary()
         if godot_binary is None:

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -308,6 +308,17 @@ class TestRoomConverter(unittest.TestCase):
         with open(tscn_path, "r", encoding="utf-8") as f:
             return f.read()
 
+    def _read_room_script(self, room_name: str, *subfolders: str) -> str:
+        script_path = os.path.join(
+            self.godot_dir,
+            "rooms",
+            *subfolders,
+            room_name,
+            room_name + ".gd",
+        )
+        with open(script_path, "r", encoding="utf-8") as f:
+            return f.read()
+
     def test_generates_minimal_room_scene_with_metadata(self):
         self._write_yyp(["r_test"])
         room_yy_path = self._write_room(
@@ -976,16 +987,21 @@ class TestRoomConverter(unittest.TestCase):
         self.assertIn('metadata/gamemaker_is_dnd = true', content)
         self.assertIn('metadata/gamemaker_creation_code_file_exists = true', content)
         self.assertIn(
-            'metadata/gamemaker_execution_order = ["object_create", "instance_creation_code", "room_creation_code", "room_start"]',
+            'metadata/gamemaker_execution_order = ["object_create", "instance_creation_code", "game_start", "room_creation_code", "room_start"]',
             content,
         )
         self.assertIn(
             'metadata/gamemaker_room_creation_code_execution_phase = "room_creation_code"',
             content,
         )
-        self.assertIn('metadata/gamemaker_room_creation_code_execution_phase_index = 2', content)
-        self.assertNotIn('func ', content)
-        self.assertNotIn('RoomCreationCode.gd', content)
+        self.assertIn('metadata/gamemaker_room_creation_code_execution_phase_index = 3', content)
+        self.assertIn(
+            '[ext_resource type="Script" path="res://rooms/r_code/r_code.gd" id="gm_room_runtime"]',
+            content,
+        )
+        script = self._read_room_script("r_code")
+        self.assertIn('extends "res://gm2godot/gml_room_node.gd"', script)
+        self.assertIn("func _gm2godot_room_creation_code():", script)
 
     def test_room_creation_code_missing_warns_and_marks_missing(self):
         self._write_yyp(["r_missing_code"])
@@ -1055,8 +1071,71 @@ class TestRoomConverter(unittest.TestCase):
             content,
         )
         self.assertIn('metadata/gamemaker_creation_code_execution_phase_index = 1', content)
-        self.assertNotIn('func ', content)
-        self.assertNotIn('InstanceCreationCode_inst_player.gd', content)
+        self.assertIn(
+            '[ext_resource type="Script" path="res://rooms/r_instance_code/r_instance_code.gd" id="gm_room_runtime"]',
+            content,
+        )
+        script = self._read_room_script("r_instance_code")
+        self.assertIn("func _gm2godot_run_instance_creation_code(_gm_instance):", script)
+        self.assertIn(
+            "func _gm2godot_instance_creation_code_inst_player(_gm_instance):",
+            script,
+        )
+        self.assertIn(json.dumps(instance_code_path), script)
+
+    def test_room_and_instance_creation_code_are_transpiled_with_correct_scope(self):
+        self._write_yyp(["r_exec"], extra_resources=[("objects", "o_player")])
+        self._write_object("o_player")
+        self._write_object_scene("o_player")
+        room_creation_path = os.path.join(
+            self.gm_dir,
+            "rooms",
+            "r_exec",
+            "RoomCreationCode.gml",
+        )
+        instance_code_path = os.path.join(
+            self.gm_dir,
+            "rooms",
+            "r_exec",
+            "InstanceCreationCode_inst_player.gml",
+        )
+        _write_file(room_creation_path, 'room_trace = "room creation";\n')
+        _write_file(instance_code_path, 'x = 42; custom_value = "instance creation";\n')
+        self._write_room(
+            "r_exec",
+            creation_code_file="RoomCreationCode.gml",
+            layers=[
+                {
+                    "%Name": "Instances",
+                    "resourceType": "GMRInstanceLayer",
+                    "instances": [
+                        {
+                            "name": "inst_player",
+                            "objectId": {"name": "o_player"},
+                            "hasCreationCode": True,
+                        }
+                    ],
+                }
+            ],
+        )
+
+        self._make_converter().convert_all()
+        script = self._read_room_script("r_exec")
+
+        self.assertIn("func _gm2godot_room_creation_code():", script)
+        self.assertIn(
+            'GMRuntime.gml_struct_set(GMRuntime.gml_global_scope(), "room_trace", "room creation")',
+            script,
+        )
+        self.assertIn("func _gm2godot_run_instance_creation_code(_gm_instance):", script)
+        self.assertIn(
+            'GMRuntime.gml_variable_instance_set(_gm_instance, "x", 42)',
+            script,
+        )
+        self.assertIn(
+            'GMRuntime.gml_variable_instance_set(_gm_instance, "custom_value", "instance creation")',
+            script,
+        )
 
     def test_instance_creation_code_missing_warns_and_marks_missing(self):
         self._write_yyp(["r_missing_instance_code"], extra_resources=[("objects", "o_player")])
@@ -1132,7 +1211,7 @@ class TestRoomConverter(unittest.TestCase):
         content = self._read_scene("r_lifecycle")
 
         self.assertIn(
-            'metadata/gamemaker_execution_order = ["object_create", "instance_creation_code", "room_creation_code", "room_start"]',
+            'metadata/gamemaker_execution_order = ["object_create", "instance_creation_code", "game_start", "room_creation_code", "room_start"]',
             content,
         )
         self.assertIn('metadata/gamemaker_instance_creation_order = ["inst_a", "inst_b"]', content)


### PR DESCRIPTION
Closes #589.

## Summary
- generate per-room scripts for executable room and instance creation code
- dispatch instance creation code, Game Start, room creation code, and Room Start in documented room-enter order
- keep instance creation code scoped to the target instance and add runtime dynamic fields for creation-time variables
- emit explicit runtime warnings for persistent room/state limitations

## Tests
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest tests.test_rooms tests.test_room_game_flow_godot tests.test_gml_transpiler
- ./venv/bin/python -m unittest