### PR TITLE
Expand room layer element runtime support

### DIFF
--- a/src/conversion/gml_runtime_parts/segments/11_layers.gd
+++ b/src/conversion/gml_runtime_parts/segments/11_layers.gd
@@ -47,6 +47,34 @@ static func gml_layer_get_depth(layer):
 	return _gml_layer_handle_depth(handle)
 
 
+static func gml_layer_get_x(layer):
+	var node = _gml_layer_resolve_node(layer)
+	if node == null:
+		return 0
+	return _gml_layer_node_axis(node, "x")
+
+
+static func gml_layer_get_y(layer):
+	var node = _gml_layer_resolve_node(layer)
+	if node == null:
+		return 0
+	return _gml_layer_node_axis(node, "y")
+
+
+static func gml_layer_get_hspeed(layer):
+	var node = _gml_layer_resolve_node(layer)
+	if node == null:
+		return 0
+	return _gml_layer_node_speed(node, "h")
+
+
+static func gml_layer_get_vspeed(layer):
+	var node = _gml_layer_resolve_node(layer)
+	if node == null:
+		return 0
+	return _gml_layer_node_speed(node, "v")
+
+
 static func gml_layer_depth(layer, depth):
 	var handle = _gml_layer_resolve_handle(layer)
 	if not gml_handle_is_valid(handle):
@@ -57,6 +85,62 @@ static func gml_layer_depth(layer, depth):
 	var resolved_depth = int(_to_real(depth))
 	node.z_index = -resolved_depth
 	node.set_meta("gamemaker_layer_depth", resolved_depth)
+	return true
+
+
+static func gml_layer_x(layer, x):
+	var node = _gml_layer_resolve_node(layer)
+	if node == null:
+		return false
+	var value = _to_real(x)
+	_gml_layer_set_node_axis(node, "x", value)
+	return true
+
+
+static func gml_layer_y(layer, y):
+	var node = _gml_layer_resolve_node(layer)
+	if node == null:
+		return false
+	var value = _to_real(y)
+	_gml_layer_set_node_axis(node, "y", value)
+	return true
+
+
+static func gml_layer_hspeed(layer, speed):
+	var node = _gml_layer_resolve_node(layer)
+	if node == null:
+		return false
+	node.set_meta("gamemaker_layer_hspeed", _to_real(speed))
+	return true
+
+
+static func gml_layer_vspeed(layer, speed):
+	var node = _gml_layer_resolve_node(layer)
+	if node == null:
+		return false
+	node.set_meta("gamemaker_layer_vspeed", _to_real(speed))
+	return true
+
+
+static func gml_layer_set_visible(layer, visible):
+	var node = _gml_layer_resolve_node(layer)
+	if node == null:
+		return false
+	var resolved_visible = gml_bool(visible)
+	if node is CanvasItem:
+		node.visible = resolved_visible
+	node.set_meta("gamemaker_layer_visible", resolved_visible)
+	return true
+
+
+static func gml_layer_get_visible(layer):
+	var node = _gml_layer_resolve_node(layer)
+	if node == null:
+		return false
+	if node.has_meta("gamemaker_layer_visible"):
+		return bool(node.get_meta("gamemaker_layer_visible"))
+	if node is CanvasItem:
+		return bool(node.visible)
 	return true
 
 
@@ -74,6 +158,10 @@ static func gml_layer_create(depth, layer_name = ""):
 	node.set_meta("gamemaker_layer_type", "runtime")
 	node.set_meta("gamemaker_layer_depth", resolved_depth)
 	node.set_meta("gamemaker_layer_visible", true)
+	node.set_meta("gamemaker_layer_x", 0)
+	node.set_meta("gamemaker_layer_y", 0)
+	node.set_meta("gamemaker_layer_hspeed", 0)
+	node.set_meta("gamemaker_layer_vspeed", 0)
 	node.set_meta("gamemaker_placeholder", true)
 	parent.add_child(node)
 	return _gml_layer_register_node(node)
@@ -143,10 +231,31 @@ static func gml_layer_get_all_elements(layer):
 	return elements
 
 
+static func gml_layer_element_move(element, layer):
+	var element_node = _gml_layer_element_resolve_node(element)
+	var layer_node = _gml_layer_resolve_node(layer)
+	if element_node == null or layer_node == null:
+		return false
+	if element_node == layer_node:
+		return false
+	if not (element_node is Node) or not (layer_node is Node):
+		return false
+	if element_node.get_parent() == layer_node:
+		return true
+	if element_node.get_parent() != null:
+		element_node.reparent(layer_node, true)
+	else:
+		layer_node.add_child(element_node)
+	_gml_layer_element_register(element_node)
+	return true
+
+
 static func gml_layer_get_element_type(element):
 	var node = _gml_layer_element_resolve_node(element)
 	if node == null:
 		return "undefined"
+	if node.has_meta("gamemaker_layer_element_type"):
+		return str(node.get_meta("gamemaker_layer_element_type"))
 	if (
 		node.has_meta("gamemaker_instance_name")
 		or node.has_meta("_gm2godot_instance_id")
@@ -164,9 +273,7 @@ static func gml_layer_get_element_type(element):
 		return "sequence"
 	if node.has_meta("gamemaker_asset_name"):
 		var asset_type = str(node.get_meta("gamemaker_asset_type", ""))
-		if asset_type.findn("sprite") >= 0:
-			return "sprite"
-		return "asset"
+		return _gml_layer_element_type_for_asset_type(asset_type)
 	return "undefined"
 
 
@@ -275,6 +382,49 @@ static func _gml_layer_handle_depth(handle):
 	if node is CanvasItem:
 		return -int(node.z_index)
 	return 0
+
+
+static func _gml_layer_node_axis(node, axis):
+	var key = "gamemaker_layer_" + str(axis)
+	if node.has_meta(key):
+		return _to_real(node.get_meta(key))
+	if node is Node2D:
+		return node.position.x if str(axis) == "x" else node.position.y
+	return 0
+
+
+static func _gml_layer_set_node_axis(node, axis, value):
+	var key = "gamemaker_layer_" + str(axis)
+	if node is Node2D:
+		if str(axis) == "x":
+			node.position.x = value
+		else:
+			node.position.y = value
+	node.set_meta(key, value)
+
+
+static func _gml_layer_node_speed(node, axis):
+	var key = "gamemaker_layer_hspeed" if str(axis) == "h" else "gamemaker_layer_vspeed"
+	if node.has_meta(key):
+		return _to_real(node.get_meta(key))
+	return 0
+
+
+static func _gml_layer_element_type_for_asset_type(asset_type):
+	var normalized = str(asset_type).to_lower()
+	if normalized.find("sprite") >= 0:
+		return "sprite"
+	if normalized.find("sequence") >= 0:
+		return "sequence"
+	if normalized.find("particle") >= 0:
+		return "particle_system"
+	if normalized.find("oldtile") >= 0 or normalized.find("old_tile") >= 0:
+		return "old_tilemap"
+	if normalized.find("tilemap") >= 0 or normalized.find("tile_map") >= 0:
+		return "tilemap"
+	if normalized.ends_with("tile") or normalized.find("tilegraphic") >= 0:
+		return "tile"
+	return "undefined"
 
 
 static func _gml_layer_handle_name(handle):

--- a/src/conversion/gml_transpiler_parts/constants.py
+++ b/src/conversion/gml_transpiler_parts/constants.py
@@ -1227,12 +1227,23 @@ _LAYER_RUNTIME_FUNCTIONS = {
     "layer_get_name": "gml_layer_get_name",
     "layer_get_all": "gml_layer_get_all",
     "layer_get_depth": "gml_layer_get_depth",
+    "layer_get_x": "gml_layer_get_x",
+    "layer_get_y": "gml_layer_get_y",
+    "layer_get_hspeed": "gml_layer_get_hspeed",
+    "layer_get_vspeed": "gml_layer_get_vspeed",
     "layer_depth": "gml_layer_depth",
+    "layer_x": "gml_layer_x",
+    "layer_y": "gml_layer_y",
+    "layer_hspeed": "gml_layer_hspeed",
+    "layer_vspeed": "gml_layer_vspeed",
     "layer_create": "gml_layer_create",
     "layer_destroy": "gml_layer_destroy",
     "layer_add_instance": "gml_layer_add_instance",
     "layer_get_all_elements": "gml_layer_get_all_elements",
+    "layer_element_move": "gml_layer_element_move",
     "layer_get_element_type": "gml_layer_get_element_type",
+    "layer_set_visible": "gml_layer_set_visible",
+    "layer_get_visible": "gml_layer_get_visible",
 }
 
 _SEQUENCE_TIMELINE_RUNTIME_FUNCTIONS = {

--- a/src/conversion/gml_transpiler_parts/gml_api_manifest.py
+++ b/src/conversion/gml_transpiler_parts/gml_api_manifest.py
@@ -140,12 +140,23 @@ _LAYER_IMPLEMENTED_APIS = frozenset(
         "layer_get_name",
         "layer_get_all",
         "layer_get_depth",
+        "layer_get_x",
+        "layer_get_y",
+        "layer_get_hspeed",
+        "layer_get_vspeed",
         "layer_depth",
+        "layer_x",
+        "layer_y",
+        "layer_hspeed",
+        "layer_vspeed",
         "layer_create",
         "layer_destroy",
         "layer_add_instance",
         "layer_get_all_elements",
+        "layer_element_move",
         "layer_get_element_type",
+        "layer_set_visible",
+        "layer_get_visible",
     }
 )
 _LAYER_UNSUPPORTED_ELEMENT_APIS = (

--- a/src/conversion/gml_transpiler_parts/gml_function_dispatch.py
+++ b/src/conversion/gml_transpiler_parts/gml_function_dispatch.py
@@ -629,12 +629,23 @@ _LAYER_ARITY: dict[str, tuple[int, int | None]] = {
     "layer_get_name": (1, 1),
     "layer_get_all": (0, 0),
     "layer_get_depth": (1, 1),
+    "layer_get_x": (1, 1),
+    "layer_get_y": (1, 1),
+    "layer_get_hspeed": (1, 1),
+    "layer_get_vspeed": (1, 1),
     "layer_depth": (2, 2),
+    "layer_x": (2, 2),
+    "layer_y": (2, 2),
+    "layer_hspeed": (2, 2),
+    "layer_vspeed": (2, 2),
     "layer_create": (1, 2),
     "layer_destroy": (1, 1),
     "layer_add_instance": (2, 2),
     "layer_get_all_elements": (1, 1),
+    "layer_element_move": (2, 2),
     "layer_get_element_type": (1, 1),
+    "layer_set_visible": (2, 2),
+    "layer_get_visible": (1, 1),
 }
 
 _SEQUENCE_TIMELINE_ARITY: dict[str, tuple[int, int | None]] = {

--- a/src/conversion/room_layers.py
+++ b/src/conversion/room_layers.py
@@ -280,12 +280,20 @@ def _layer_node_lines(
     lines = [
         f'[node name={godot_string(node_name)} type="Node2D" parent={godot_string(parent_path)}]',
         f"visible = {godot_value(visible)}",
+        "position = Vector2({x}, {y})".format(
+            x=_format_number(layer.get("x", 0)),
+            y=_format_number(layer.get("y", 0)),
+        ),
         f"z_index = {z_index}",
         f"metadata/gamemaker_layer_name = {godot_value(original_name)}",
         f"metadata/gamemaker_layer_node_name = {godot_value(node_name)}",
         f"metadata/gamemaker_layer_type = {godot_value(resource_type)}",
         f"metadata/gamemaker_layer_depth = {godot_value(depth)}",
         f"metadata/gamemaker_layer_visible = {godot_value(visible)}",
+        f"metadata/gamemaker_layer_x = {godot_value(layer.get('x', 0))}",
+        f"metadata/gamemaker_layer_y = {godot_value(layer.get('y', 0))}",
+        f"metadata/gamemaker_layer_hspeed = {godot_value(layer.get('hspeed', 0))}",
+        f"metadata/gamemaker_layer_vspeed = {godot_value(layer.get('vspeed', 0))}",
         f"metadata/gamemaker_layer_grid_x = {godot_value(layer.get('gridX'))}",
         f"metadata/gamemaker_layer_grid_y = {godot_value(layer.get('gridY'))}",
         f"metadata/gamemaker_layer_properties = {godot_value(layer.get('properties', []))}",
@@ -485,15 +493,13 @@ def _tile_map_layer_lines(
     lines = [
         f'[node name="TileMap" type="TileMapLayer" parent={godot_string(parent_path)}]',
         f"visible = {godot_value(bool(layer.get('visible', True)))}",
-        "position = Vector2({x}, {y})".format(
-            x=_format_number(layer.get("x", 0)),
-            y=_format_number(layer.get("y", 0)),
-        ),
+        "position = Vector2(0, 0)",
         f'tile_set = ExtResource("{ext_resource_id}")',
     ]
     if tile_map_data:
         lines.append(f"tile_map_data = {tile_map_data}")
     lines.extend([
+        'metadata/gamemaker_layer_element_type = "tilemap"',
         "metadata/gamemaker_tile_layer = true",
         f"metadata/gamemaker_tileset = {godot_value(tileset_name)}",
         f"metadata/gamemaker_tile_width = {godot_value(width)}",
@@ -624,11 +630,13 @@ def _asset_node_lines(
         else:
             context.warn(
                 "Warning: Unsupported GameMaker room asset type {asset_type} in room {room_name}, "
-                "layer {layer_name}, asset {asset_name}; emitted Node2D placeholder.".format(
+                "layer {layer_name}, asset {asset_name}; emitted Node2D placeholder with "
+                "layer element type {element_type}.".format(
                     asset_type=asset_type,
                     room_name=context.room.name,
                     layer_name=layer_name,
                     asset_name=asset_name,
+                    element_type=_layer_element_type_for_asset_type(asset_type),
                 )
             )
             lines.extend(_unsupported_asset_lines(asset, node_name, parent_path, asset_type))
@@ -668,6 +676,7 @@ def _sprite_asset_lines(
 
     lines.extend(_asset_transform_lines(asset))
     lines.extend([
+        'metadata/gamemaker_layer_element_type = "sprite"',
         f"metadata/gamemaker_asset_name = {godot_value(_asset_name(asset))}",
         f"metadata/gamemaker_asset_node_name = {godot_value(node_name)}",
         f"metadata/gamemaker_asset_type = {godot_value(_asset_resource_type(asset))}",
@@ -695,6 +704,7 @@ def _unsupported_asset_lines(
     lines = [f'[node name={godot_string(node_name)} type="Node2D" parent={godot_string(parent_path)}]']
     lines.extend(_asset_transform_lines(asset))
     lines.extend([
+        f"metadata/gamemaker_layer_element_type = {godot_value(_layer_element_type_for_asset_type(asset_type))}",
         f"metadata/gamemaker_asset_name = {godot_value(_asset_name(asset))}",
         f"metadata/gamemaker_asset_node_name = {godot_value(node_name)}",
         f"metadata/gamemaker_asset_type = {godot_value(asset_type)}",
@@ -835,10 +845,7 @@ def _background_color_lines(
     lines = [
         f'[node name="BackgroundVisual" type="ColorRect" parent={godot_string(parent_path)}]',
         f"visible = {godot_value(bool(layer.get('visible', True)))}",
-        "position = Vector2({x}, {y})".format(
-            x=_format_number(layer.get("x", 0)),
-            y=_format_number(layer.get("y", 0)),
-        ),
+        "position = Vector2(0, 0)",
         "size = Vector2({width}, {height})".format(
             width=_format_number(width),
             height=_format_number(height),
@@ -866,10 +873,7 @@ def _background_sprite_lines(
             resource_id=ext_resource_id,
         ),
         f"visible = {godot_value(bool(layer.get('visible', True)))}",
-        "position = Vector2({x}, {y})".format(
-            x=_format_number(layer.get("x", 0)),
-            y=_format_number(layer.get("y", 0)),
-        ),
+        "position = Vector2(0, 0)",
         "modulate = {color}".format(color=_godot_color(layer.get("colour", 4294967295))),
     ]
     lines.extend(_background_metadata_lines(layer, "sprite"))
@@ -881,6 +885,7 @@ def _background_sprite_lines(
 def _background_metadata_lines(layer: JsonDict, visual_type: str) -> list[str]:
     colour = layer.get("colour")
     lines = [
+        'metadata/gamemaker_layer_element_type = "background"',
         "metadata/gamemaker_background_visual = true",
         f"metadata/gamemaker_background_visual_type = {godot_value(visual_type)}",
         f"metadata/gamemaker_background_sprite = {godot_value(_background_sprite_name(layer))}",
@@ -1075,6 +1080,7 @@ def _instance_scene_lines(
             scale_y=_format_number(instance.get("scaleY", 1)),
         ),
         f"metadata/gamemaker_instance_name = {godot_value(instance_name)}",
+        'metadata/gamemaker_layer_element_type = "instance"',
         f"metadata/gamemaker_instance_node_name = {godot_value(node_name)}",
         f"metadata/gamemaker_instance_object_name = {godot_value(object_name)}",
         f"metadata/gamemaker_instance_creation_order_index = {godot_value(order_index)}",
@@ -1157,6 +1163,23 @@ def _asset_resource_type(asset: JsonDict) -> str:
         if key.startswith("$GMR"):
             return key[1:]
     return "UnknownAsset"
+
+
+def _layer_element_type_for_asset_type(asset_type: str) -> str:
+    normalized = asset_type.lower()
+    if "sprite" in normalized:
+        return "sprite"
+    if "sequence" in normalized:
+        return "sequence"
+    if "particle" in normalized:
+        return "particle_system"
+    if "oldtile" in normalized or "old_tile" in normalized:
+        return "old_tilemap"
+    if "tilemap" in normalized or "tile_map" in normalized:
+        return "tilemap"
+    if normalized.endswith("tile") or "tilegraphic" in normalized:
+        return "tile"
+    return "undefined"
 
 
 def _layer_name(layer: JsonDict) -> str:

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -3326,12 +3326,23 @@ class TestGMLStatementTranspiler(unittest.TestCase):
                 "name = layer_get_name(layer_id);"
                 "layers = layer_get_all();"
                 "depth = layer_get_depth(layer_id);"
+                "lx = layer_get_x(layer_id);"
+                "ly = layer_get_y(layer_id);"
+                "hs = layer_get_hspeed(layer_id);"
+                "vs = layer_get_vspeed(layer_id);"
                 "layer_depth(layer_id, 50);"
+                "layer_x(layer_id, 8);"
+                "layer_y(layer_id, 16);"
+                "layer_hspeed(layer_id, 2);"
+                "layer_vspeed(layer_id, -1);"
                 "front = layer_get_id_at_depth(50);"
                 'fx = layer_create(25, "Effects");'
                 "layer_add_instance(fx, id);"
                 "elements = layer_get_all_elements(layer_id);"
+                "layer_element_move(elements[0], fx);"
                 "kind = layer_get_element_type(elements[0]);"
+                "layer_set_visible(fx, false);"
+                "visible = layer_get_visible(fx);"
                 "layer_destroy(fx);",
                 indent="",
             ),
@@ -3340,12 +3351,23 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             "name = GMRuntime.gml_layer_get_name(layer_id)\n"
             "layers = GMRuntime.gml_layer_get_all()\n"
             "depth = GMRuntime.gml_layer_get_depth(layer_id)\n"
+            "lx = GMRuntime.gml_layer_get_x(layer_id)\n"
+            "ly = GMRuntime.gml_layer_get_y(layer_id)\n"
+            "hs = GMRuntime.gml_layer_get_hspeed(layer_id)\n"
+            "vs = GMRuntime.gml_layer_get_vspeed(layer_id)\n"
             "GMRuntime.gml_layer_depth(layer_id, 50)\n"
+            "GMRuntime.gml_layer_x(layer_id, 8)\n"
+            "GMRuntime.gml_layer_y(layer_id, 16)\n"
+            "GMRuntime.gml_layer_hspeed(layer_id, 2)\n"
+            "GMRuntime.gml_layer_vspeed(layer_id, -1)\n"
             "front = GMRuntime.gml_layer_get_id_at_depth(50)\n"
             'fx = GMRuntime.gml_layer_create(25, "Effects")\n'
             "GMRuntime.gml_layer_add_instance(fx, id)\n"
             "elements = GMRuntime.gml_layer_get_all_elements(layer_id)\n"
+            "GMRuntime.gml_layer_element_move(GMRuntime.gml_array_get(elements, 0), fx)\n"
             "kind = GMRuntime.gml_layer_get_element_type(GMRuntime.gml_array_get(elements, 0))\n"
+            "GMRuntime.gml_layer_set_visible(fx, false)\n"
+            "visible = GMRuntime.gml_layer_get_visible(fx)\n"
             "GMRuntime.gml_layer_destroy(fx)",
         )
 

--- a/tests/test_layers_runtime_godot.py
+++ b/tests/test_layers_runtime_godot.py
@@ -90,6 +90,11 @@ def _write_smoke_scene(project_dir: Path) -> None:
         \tnode.set_meta("gamemaker_layer_node_name", name)
         \tnode.set_meta("gamemaker_layer_depth", depth)
         \tnode.set_meta("gamemaker_layer_type", "GMRInstanceLayer")
+        \tnode.set_meta("gamemaker_layer_x", 0)
+        \tnode.set_meta("gamemaker_layer_y", 0)
+        \tnode.set_meta("gamemaker_layer_hspeed", 0)
+        \tnode.set_meta("gamemaker_layer_vspeed", 0)
+        \tnode.set_meta("gamemaker_layer_visible", true)
         \tadd_child(node)
         \treturn node
 
@@ -111,6 +116,19 @@ def _write_smoke_scene(project_dir: Path) -> None:
         \t\treturn
         \tif not _check(instances.z_index == -50 and GMRuntime.gml_layer_get_depth(layer_id) == 50, "layer_depth did not update z"):
         \t\treturn
+        \tif not _check(GMRuntime.gml_layer_x(layer_id, 8) and GMRuntime.gml_layer_y(layer_id, 16), "layer position setters failed"):
+        \t\treturn
+        \tif not _check(instances.position == Vector2(8, 16) and GMRuntime.gml_layer_get_x(layer_id) == 8 and GMRuntime.gml_layer_get_y(layer_id) == 16, "layer position getters mismatch"):
+        \t\treturn
+        \tif not _check(GMRuntime.gml_layer_hspeed(layer_id, 2) and GMRuntime.gml_layer_vspeed(layer_id, -1), "layer speed setters failed"):
+        \t\treturn
+        \tif not _check(GMRuntime.gml_layer_get_hspeed(layer_id) == 2 and GMRuntime.gml_layer_get_vspeed(layer_id) == -1, "layer speed getters mismatch"):
+        \t\treturn
+        \tif not _check(GMRuntime.gml_layer_set_visible(layer_id, false) and not GMRuntime.gml_layer_get_visible(layer_id), "layer visibility setters failed"):
+        \t\treturn
+        \tif not _check(not instances.visible, "layer_set_visible did not update CanvasItem visibility"):
+        \t\treturn
+        \tGMRuntime.gml_layer_set_visible(layer_id, true)
         \tif not _check(GMRuntime.gml_layer_get_id_at_depth(50).index == layer_id.index, "layer_get_id_at_depth mismatch"):
         \t\treturn
 
@@ -149,6 +167,10 @@ def _write_smoke_scene(project_dir: Path) -> None:
         \t\tGMRuntime.gml_layer_get_element_type(elements[1]),
         \t]
         \tif not _check(element_types.has("instance") and element_types.has("sprite"), "layer element type mismatch: " + str(element_types)):
+        \t\treturn
+        \tif not _check(GMRuntime.gml_layer_element_move(elements[1], fx), "layer_element_move returned false"):
+        \t\treturn
+        \tif not _check(sprite_element.get_parent() == fx_node, "layer_element_move did not reparent element"):
         \t\treturn
 
         \tvar particles = GMRuntime.gml_part_system_create_layer(fx, false)

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -426,9 +426,14 @@ class TestRoomConverter(unittest.TestCase):
 
         self.assertIn('[node name="Instances" type="Node2D" parent="."]', content)
         self.assertIn('visible = true', content)
+        self.assertIn('position = Vector2(0, 0)', content)
         self.assertIn('z_index = -100', content)
         self.assertIn('metadata/gamemaker_layer_type = "GMRInstanceLayer"', content)
         self.assertIn('metadata/gamemaker_layer_depth = 100', content)
+        self.assertIn('metadata/gamemaker_layer_x = 0', content)
+        self.assertIn('metadata/gamemaker_layer_y = 0', content)
+        self.assertIn('metadata/gamemaker_layer_hspeed = 0', content)
+        self.assertIn('metadata/gamemaker_layer_vspeed = 0', content)
         self.assertIn('metadata/gamemaker_layer_grid_x = 32', content)
         self.assertIn('metadata/gamemaker_layer_grid_y = 16', content)
         self.assertIn('metadata/gamemaker_layer_properties = {"alpha": 1}', content)
@@ -462,6 +467,7 @@ class TestRoomConverter(unittest.TestCase):
         self.assertIn('[node name="BackgroundVisual" type="ColorRect" parent="Backgrounds"]', content)
         self.assertIn('size = Vector2(320, 180)', content)
         self.assertIn('color = Color(1, 1, 1, 1)', content)
+        self.assertIn('metadata/gamemaker_layer_element_type = "background"', content)
         self.assertIn('metadata/gamemaker_background_visual = true', content)
         self.assertIn('metadata/gamemaker_background_visual_type = "color"', content)
 
@@ -492,6 +498,7 @@ class TestRoomConverter(unittest.TestCase):
             content,
         )
         self.assertIn('position = Vector2(16, 32)', content)
+        self.assertIn('metadata/gamemaker_layer_element_type = "background"', content)
         self.assertIn('modulate = Color(1, 1, 1, 1)', content)
         self.assertIn('metadata/gamemaker_background_visual_type = "sprite"', content)
 
@@ -518,6 +525,8 @@ class TestRoomConverter(unittest.TestCase):
         self.assertIn('metadata/gamemaker_background_vtiled = false', content)
         self.assertIn('metadata/gamemaker_background_hspeed = 2', content)
         self.assertIn('metadata/gamemaker_background_vspeed = 0', content)
+        self.assertIn('metadata/gamemaker_layer_hspeed = 2', content)
+        self.assertIn('metadata/gamemaker_layer_vspeed = 0', content)
         self.assertIn('metadata/gamemaker_background_stretch = true', content)
         self.assertIn('metadata/gamemaker_background_animation_fps = 12', content)
         self.assertTrue(any(
@@ -537,10 +546,14 @@ class TestRoomConverter(unittest.TestCase):
         self._make_converter().convert_all()
         content = self._read_scene("r_depths")
 
-        self.assertIn('[node name="Depth200" type="Node2D" parent="."]\nvisible = true\nz_index = -200', content)
-        self.assertIn('[node name="Depth100" type="Node2D" parent="."]\nvisible = true\nz_index = -100', content)
-        self.assertIn('[node name="Depth0" type="Node2D" parent="."]\nvisible = true\nz_index = 0', content)
-        self.assertIn('[node name="DepthMinus100" type="Node2D" parent="."]\nvisible = true\nz_index = 100', content)
+        self.assertIn('[node name="Depth200" type="Node2D" parent="."]', content)
+        self.assertIn("z_index = -200", content)
+        self.assertIn('[node name="Depth100" type="Node2D" parent="."]', content)
+        self.assertIn("z_index = -100", content)
+        self.assertIn('[node name="Depth0" type="Node2D" parent="."]', content)
+        self.assertIn("z_index = 0", content)
+        self.assertIn('[node name="DepthMinus100" type="Node2D" parent="."]', content)
+        self.assertIn("z_index = 100", content)
 
     def test_generates_nested_layer_placeholders_depth_first(self):
         self._write_yyp(["r_nested"])
@@ -625,6 +638,7 @@ class TestRoomConverter(unittest.TestCase):
         self.assertIn('position = Vector2(8, 16)', content)
         self.assertIn('tile_set = ExtResource("1")', content)
         self.assertIn('tile_map_data = PackedByteArray(0, 0', content)
+        self.assertIn('metadata/gamemaker_layer_element_type = "tilemap"', content)
         self.assertIn('metadata/gamemaker_tile_decoded_cell_count = 6', content)
         self.assertIn('metadata/gamemaker_tile_non_empty_cell_count = 3', content)
         self.assertIn('metadata/gamemaker_tile_empty_values = [0, -2147483648]', content)
@@ -755,6 +769,7 @@ class TestRoomConverter(unittest.TestCase):
         self.assertIn('rotation_degrees = 90', content)
         self.assertIn('scale = Vector2(2, 0.5)', content)
         self.assertIn('metadata/gamemaker_instance_name = "inst_player"', content)
+        self.assertIn('metadata/gamemaker_layer_element_type = "instance"', content)
         self.assertIn('metadata/gamemaker_instance_object_name = "o_player"', content)
         self.assertIn('metadata/gamemaker_instance_x = 100', content)
         self.assertIn('metadata/gamemaker_instance_y = 200', content)
@@ -851,9 +866,43 @@ class TestRoomConverter(unittest.TestCase):
         self.assertIn('rotation_degrees = 15', content)
         self.assertIn('scale = Vector2(2, 3)', content)
         self.assertIn('modulate = Color(1, 1, 1, 1)', content)
+        self.assertIn('metadata/gamemaker_layer_element_type = "sprite"', content)
         self.assertIn('metadata/gamemaker_asset_sprite_name = "s_decor"', content)
         self.assertIn('metadata/gamemaker_asset_head_position = 4', content)
         self.assertIn('metadata/gamemaker_asset_animation_speed = 0.5', content)
+
+    def test_asset_layer_classifies_unsupported_element_types_with_diagnostics(self):
+        self._write_yyp(["r_elements"])
+        self._write_room("r_elements", layers=[
+            {
+                "%Name": "MixedAssets",
+                "resourceType": "GMRAssetLayer",
+                "assets": [
+                    {"%Name": "seq_intro", "resourceType": "GMRSequenceGraphic", "x": 1},
+                    {"%Name": "ps_fx", "resourceType": "GMRParticleSystem", "x": 2},
+                    {"%Name": "legacy_tile", "resourceType": "GMRTileGraphic", "x": 3},
+                    {"%Name": "label", "resourceType": "GMRTextGraphic", "x": 4},
+                ],
+            }
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_elements")
+
+        self.assertIn('[node name="seq_intro" type="Node2D" parent="MixedAssets"]', content)
+        self.assertIn('metadata/gamemaker_layer_element_type = "sequence"', content)
+        self.assertIn('metadata/gamemaker_layer_element_type = "particle_system"', content)
+        self.assertIn('metadata/gamemaker_layer_element_type = "tile"', content)
+        self.assertIn('metadata/gamemaker_layer_element_type = "undefined"', content)
+        self.assertEqual(content.count("metadata/gamemaker_unsupported_asset = true"), 4)
+        self.assertTrue(any(
+            "GMRSequenceGraphic" in log and "layer element type sequence" in log
+            for log in self.logs
+        ))
+        self.assertTrue(any(
+            "GMRTextGraphic" in log and "layer element type undefined" in log
+            for log in self.logs
+        ))
 
     def test_ignored_asset_is_skipped_with_warning(self):
         self._write_yyp(["r_assets"], extra_resources=[("sprites", "s_decor")])


### PR DESCRIPTION
Closes #590.

## Summary
- preserve generated layer offset, speed, visibility, and element type metadata
- classify supported and unsupported GameMaker layer element types with explicit diagnostics
- add runtime layer x/y/hspeed/vspeed/visibility and layer_element_move helpers
- route the new layer helpers through the GML transpiler and compatibility manifest

## Tests
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest tests.test_rooms tests.test_layers_runtime_godot tests.test_gml_transpiler
- ./venv/bin/python -m unittest