### PR TITLE
Convert path tileset tilemap and curve metadata

### DIFF
--- a/src/conversion/animation_curve_registry.py
+++ b/src/conversion/animation_curve_registry.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from typing import Iterable, Protocol, cast
+
+from src.conversion.type_defs import JsonDict
+
+ANIMATION_CURVE_REGISTRY_RELATIVE_PATH = os.path.join(
+    "gm2godot", "gml_animation_curve_registry.gd"
+)
+ANIMATION_CURVE_REGISTRY_RESOURCE_PATH = "res://gm2godot/gml_animation_curve_registry.gd"
+
+
+class _AnimationCurveAssetEntry(Protocol):
+    @property
+    def id(self) -> int: ...
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def kind(self) -> str: ...
+
+    @property
+    def source_path(self) -> str: ...
+
+
+@dataclass(frozen=True)
+class AnimationCurvePoint:
+    x: float
+    y: float
+    bezier_x0: float = 0.0
+    bezier_y0: float = 0.0
+    bezier_x1: float = 0.0
+    bezier_y1: float = 0.0
+
+    def to_godot_dict(self) -> JsonDict:
+        return {
+            "x": self.x,
+            "y": self.y,
+            "bezier_x0": self.bezier_x0,
+            "bezier_y0": self.bezier_y0,
+            "bezier_x1": self.bezier_x1,
+            "bezier_y1": self.bezier_y1,
+        }
+
+
+@dataclass(frozen=True)
+class AnimationCurveChannel:
+    name: str
+    function: str
+    iterations: int
+    points: tuple[AnimationCurvePoint, ...]
+
+    def to_godot_dict(self) -> JsonDict:
+        return {
+            "name": self.name,
+            "function": self.function,
+            "iterations": self.iterations,
+            "points": [point.to_godot_dict() for point in self.points],
+        }
+
+
+@dataclass(frozen=True)
+class AnimationCurveRegistryEntry:
+    id: int
+    name: str
+    channels: tuple[AnimationCurveChannel, ...]
+
+    def to_godot_dict(self) -> JsonDict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "channels": [channel.to_godot_dict() for channel in self.channels],
+        }
+
+
+def build_animation_curve_registry_entries(
+    gm_project_path: str,
+    asset_entries: Iterable[_AnimationCurveAssetEntry],
+) -> tuple[AnimationCurveRegistryEntry, ...]:
+    entries: list[AnimationCurveRegistryEntry] = []
+    for asset_entry in asset_entries:
+        if asset_entry.kind != "animcurves":
+            continue
+        yy_path = os.path.join(gm_project_path, asset_entry.source_path)
+        data = _read_json_lenient(yy_path)
+        if data is None:
+            continue
+        entries.append(_animation_curve_entry_from_yy(asset_entry, data))
+    return tuple(entries)
+
+
+def render_animation_curve_registry_script(
+    entries: Iterable[AnimationCurveRegistryEntry],
+) -> str:
+    entry_dicts = [entry.to_godot_dict() for entry in entries]
+    lines = [
+        "extends RefCounted\n\n",
+        "static func entries():\n",
+        "\treturn ",
+        json.dumps(entry_dicts, indent="\t"),
+        "\n",
+    ]
+    return "".join(lines)
+
+
+def write_animation_curve_registry(
+    gm_project_path: str,
+    godot_project_path: str,
+    asset_entries: Iterable[_AnimationCurveAssetEntry],
+) -> str:
+    entries = build_animation_curve_registry_entries(gm_project_path, asset_entries)
+    registry_path = os.path.join(godot_project_path, ANIMATION_CURVE_REGISTRY_RELATIVE_PATH)
+    os.makedirs(os.path.dirname(registry_path), exist_ok=True)
+    with open(registry_path, "w", encoding="utf-8") as f:
+        f.write(render_animation_curve_registry_script(entries))
+    return registry_path
+
+
+def _animation_curve_entry_from_yy(
+    asset_entry: _AnimationCurveAssetEntry,
+    data: JsonDict,
+) -> AnimationCurveRegistryEntry:
+    channels: list[AnimationCurveChannel] = []
+    raw_channels = data.get("channels")
+    if isinstance(raw_channels, list):
+        for raw_channel in cast(list[object], raw_channels):
+            if not isinstance(raw_channel, dict):
+                continue
+            channels.append(_animation_curve_channel_from_yy(cast(JsonDict, raw_channel)))
+    return AnimationCurveRegistryEntry(
+        id=asset_entry.id,
+        name=asset_entry.name,
+        channels=tuple(channels),
+    )
+
+
+def _animation_curve_channel_from_yy(channel: JsonDict) -> AnimationCurveChannel:
+    raw_points = channel.get("points")
+    points: list[AnimationCurvePoint] = []
+    if isinstance(raw_points, list):
+        for raw_point in cast(list[object], raw_points):
+            if not isinstance(raw_point, dict):
+                continue
+            point = cast(JsonDict, raw_point)
+            points.append(
+                AnimationCurvePoint(
+                    x=_number(point.get("x"), 0.0),
+                    y=_number(point.get("y"), 0.0),
+                    bezier_x0=_number(point.get("bezierX0"), 0.0),
+                    bezier_y0=_number(point.get("bezierY0"), 0.0),
+                    bezier_x1=_number(point.get("bezierX1"), 0.0),
+                    bezier_y1=_number(point.get("bezierY1"), 0.0),
+                )
+            )
+    return AnimationCurveChannel(
+        name=_string(channel.get("name")),
+        function=_string(channel.get("function")),
+        iterations=int(_number(channel.get("iterations"), 1.0)),
+        points=tuple(points),
+    )
+
+
+def _read_json_lenient(path: str) -> JsonDict | None:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            content = f.read()
+    except OSError:
+        return None
+    try:
+        data = json.loads(re.sub(r",\s*([}\]])", r"\1", content))
+    except json.JSONDecodeError:
+        return None
+    return cast(JsonDict, data) if isinstance(data, dict) else None
+
+
+def _number(value: object, default: float) -> float:
+    if isinstance(value, bool):
+        return float(int(value))
+    if isinstance(value, int | float):
+        return float(value)
+    return default
+
+
+def _string(value: object) -> str:
+    return value if isinstance(value, str) else ""

--- a/src/conversion/asset_registry.py
+++ b/src/conversion/asset_registry.py
@@ -19,6 +19,7 @@ from src.conversion.type_defs import (
     StrPath,
 )
 from src.conversion.path_registry import write_path_registry
+from src.conversion.animation_curve_registry import write_animation_curve_registry
 
 ASSET_REGISTRY_RELATIVE_PATH = os.path.join("gm2godot", "gml_asset_registry.gd")
 ASSET_REGISTRY_RESOURCE_PATH = "res://gm2godot/gml_asset_registry.gd"
@@ -126,6 +127,7 @@ class AssetRegistryConverter(BaseConverter):
         "scripts": "script",
         "fonts": "font",
         "paths": "path",
+        "animcurves": "animation_curve",
         "shaders": "shader",
         "tilesets": "tileset",
         "timelines": "timeline",
@@ -140,6 +142,7 @@ class AssetRegistryConverter(BaseConverter):
         "scripts": "Script",
         "fonts": "Font",
         "paths": "Path",
+        "animcurves": "Animation Curve",
         "shaders": "Shader",
         "tilesets": "Tile Set",
         "timelines": "Timeline",
@@ -151,6 +154,7 @@ class AssetRegistryConverter(BaseConverter):
         "objects": ".tscn",
         "rooms": ".tscn",
         "tilesets": ".tres",
+        "paths": ".tscn",
     }
     KIND_ORDER: ClassVar[dict[str, int]] = {
         kind: index for index, kind in enumerate(RESOURCE_TYPE_BY_KIND)
@@ -236,6 +240,7 @@ class AssetRegistryConverter(BaseConverter):
             )
         self._write_group_compatibility_report(entries, texture_groups, audio_groups)
         write_path_registry(self.gm_project_path, self.godot_project_path, entries)
+        write_animation_curve_registry(self.gm_project_path, self.godot_project_path, entries)
 
         self.log_callback(
             "Generated GameMaker asset registry: {path} ({count} assets)".format(

--- a/src/conversion/path_registry.py
+++ b/src/conversion/path_registry.py
@@ -24,6 +24,9 @@ class _PathAssetEntry(Protocol):
     @property
     def source_path(self) -> str: ...
 
+    @property
+    def godot_path(self) -> str: ...
+
 
 @dataclass(frozen=True)
 class PathPoint:
@@ -40,7 +43,9 @@ class PathRegistryEntry:
     id: int
     name: str
     closed: bool
+    kind: int
     precision: int
+    godot_path: str
     points: tuple[PathPoint, ...]
 
     def to_godot_dict(self) -> JsonDict:
@@ -48,7 +53,9 @@ class PathRegistryEntry:
             "id": self.id,
             "name": self.name,
             "closed": self.closed,
+            "kind": self.kind,
             "precision": self.precision,
+            "godot_path": self.godot_path,
             "points": [point.to_godot_dict() for point in self.points],
         }
 
@@ -87,6 +94,8 @@ def write_path_registry(
     asset_entries: Iterable[_PathAssetEntry],
 ) -> str:
     entries = build_path_registry_entries(gm_project_path, asset_entries)
+    for entry in entries:
+        _write_path_scene(godot_project_path, entry)
     registry_path = os.path.join(godot_project_path, PATH_REGISTRY_RELATIVE_PATH)
     os.makedirs(os.path.dirname(registry_path), exist_ok=True)
     with open(registry_path, "w", encoding="utf-8") as f:
@@ -113,9 +122,49 @@ def _path_entry_from_yy(asset_entry: _PathAssetEntry, data: JsonDict) -> PathReg
         id=asset_entry.id,
         name=asset_entry.name,
         closed=bool(data.get("closed", False)),
+        kind=int(_number(data.get("kind"), 0.0)),
         precision=int(_number(data.get("precision"), 4.0)),
+        godot_path=asset_entry.godot_path,
         points=tuple(points),
     )
+
+
+def render_path_scene(entry: PathRegistryEntry) -> str:
+    curve_points: list[str] = []
+    tilts: list[str] = []
+    for point in entry.points:
+        curve_points.extend(("0", "0", "0", "0", _format_number(point.x), _format_number(point.y)))
+        tilts.append("0")
+    curve_data = "PackedVector2Array({values})".format(values=", ".join(curve_points))
+    tilt_data = "PackedFloat32Array({values})".format(values=", ".join(tilts))
+    lines = [
+        "[gd_scene load_steps=2 format=3]",
+        "",
+        '[sub_resource type="Curve2D" id="Curve2D_1"]',
+        '_data = {"points": ' + curve_data + ', "tilts": ' + tilt_data + "}",
+        f"point_count = {len(entry.points)}",
+        "",
+        f"[node name={json.dumps(entry.name)} type=\"Path2D\"]",
+        'curve = SubResource("Curve2D_1")',
+        f"metadata/gamemaker_path_id = {entry.id}",
+        f"metadata/gamemaker_path_name = {json.dumps(entry.name)}",
+        f"metadata/gamemaker_path_closed = {json.dumps(entry.closed)}",
+        f"metadata/gamemaker_path_kind = {entry.kind}",
+        f"metadata/gamemaker_path_precision = {entry.precision}",
+        f"metadata/gamemaker_path_points = {json.dumps([point.to_godot_dict() for point in entry.points])}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _write_path_scene(godot_project_path: str, entry: PathRegistryEntry) -> None:
+    if not entry.godot_path.startswith("res://"):
+        return
+    relative_path = entry.godot_path[len("res://"):]
+    output_path = os.path.join(godot_project_path, *relative_path.split("/"))
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(render_path_scene(entry))
 
 
 def _read_json_lenient(path: str) -> JsonDict | None:
@@ -143,3 +192,8 @@ def _number(value: object, default: float) -> float:
         return float(value)
     return default
 
+
+def _format_number(value: float) -> str:
+    if value == int(value):
+        return str(int(value))
+    return ("{:.6f}".format(value)).rstrip("0").rstrip(".")

--- a/src/conversion/room_layers.py
+++ b/src/conversion/room_layers.py
@@ -366,12 +366,26 @@ def decode_tile_compressed_data(
     tile_data_format: int = 1,
 ) -> list[int]:
     """Expand GameMaker TileCompressedData format 1 into a row-major cell array."""
-    if tile_data_format != 1:
+    if tile_data_format not in (0, 1):
         raise ValueError(f"Unsupported GameMaker tile data format: {tile_data_format}")
     if serialise_width < 0 or serialise_height < 0:
         raise ValueError("GameMaker tile data dimensions must be non-negative")
 
     expected_length = serialise_width * serialise_height
+    if tile_data_format == 0:
+        decoded = [
+            _require_int(value, "TileCompressedData value")
+            for value in compressed_data
+        ]
+        if len(decoded) != expected_length:
+            raise ValueError(
+                "Malformed GameMaker tile data: decoded {actual} cells, expected {expected}".format(
+                    actual=len(decoded),
+                    expected=expected_length,
+                )
+            )
+        return decoded
+
     decoded: list[int] = []
     index = 0
     while index < len(compressed_data):

--- a/src/conversion/tilesets.py
+++ b/src/conversion/tilesets.py
@@ -23,6 +23,13 @@ class TilesetData(TypedDict):
     tileyoff: int
     tile_count: int
     out_columns: int
+    tileAnimationFrames: list[JsonDict]
+    tileAnimationSpeed: float
+    brushes: list[JsonDict]
+    autoTileSets: list[JsonDict]
+    tileSetCollisions: list[JsonDict]
+    out_tilehborder: int
+    out_tilevborder: int
 
 
 class TilesetSuccess(TypedDict):
@@ -106,6 +113,13 @@ class TileSetConverter(BaseConverter):
                 "tileyoff": int(data.get('tileyoff', 0)),
                 "tile_count": int(data.get('tile_count', 0)),
                 "out_columns": int(data.get('out_columns', 0)),
+                "tileAnimationFrames": _json_dict_list(data.get("tileAnimationFrames")),
+                "tileAnimationSpeed": _float(data.get("tileAnimationSpeed"), 15.0),
+                "brushes": _json_dict_list(data.get("brushes")),
+                "autoTileSets": _json_dict_list(data.get("autoTileSets")),
+                "tileSetCollisions": _json_dict_list(data.get("tileSetCollisions")),
+                "out_tilehborder": int(data.get("out_tilehborder", 0)),
+                "out_tilevborder": int(data.get("out_tilevborder", 0)),
             }
         except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
             return None
@@ -198,6 +212,21 @@ class TileSetConverter(BaseConverter):
         lines.append('[resource]')
         lines.append(f'tile_size = Vector2i({tile_w}, {tile_h})')
         lines.append('sources/0 = SubResource("TileSetAtlasSource_1")')
+        lines.append(f"metadata/gamemaker_tileset_tile_count = {tileset_data['tile_count']}")
+        lines.append(f"metadata/gamemaker_tileset_out_columns = {tileset_data['out_columns']}")
+        lines.append(f"metadata/gamemaker_tileset_animation_speed = {_format_number(tileset_data['tileAnimationSpeed'])}")
+        lines.append(
+            "metadata/gamemaker_tileset_animation_frames = "
+            + json.dumps(tileset_data["tileAnimationFrames"])
+        )
+        lines.append("metadata/gamemaker_tileset_brushes = " + json.dumps(tileset_data["brushes"]))
+        lines.append("metadata/gamemaker_tileset_auto_tile_sets = " + json.dumps(tileset_data["autoTileSets"]))
+        lines.append(
+            "metadata/gamemaker_tileset_collisions = "
+            + json.dumps(tileset_data["tileSetCollisions"])
+        )
+        lines.append(f"metadata/gamemaker_tileset_out_tilehborder = {tileset_data['out_tilehborder']}")
+        lines.append(f"metadata/gamemaker_tileset_out_tilevborder = {tileset_data['out_tilevborder']}")
         lines.append('')
 
         return '\n'.join(lines)
@@ -244,8 +273,29 @@ class TileSetConverter(BaseConverter):
         tres_path = os.path.join(output_dir, tileset_name + '.tres')
         with open(tres_path, 'w', encoding='utf-8') as f:
             f.write(tres_content)
+        self._warn_preserved_metadata(tileset_name, tileset_data)
 
         return {"success": True, "name": tileset_name, "tileset_data": tileset_data}
+
+    def _warn_preserved_metadata(self, tileset_name: str, tileset_data: TilesetData) -> None:
+        preserved_features: list[str] = []
+        if tileset_data["tileAnimationFrames"]:
+            preserved_features.append("animation frames")
+        if tileset_data["tileSetCollisions"]:
+            preserved_features.append("collision data")
+        if tileset_data["autoTileSets"]:
+            preserved_features.append("auto-tile metadata")
+        if tileset_data["brushes"]:
+            preserved_features.append("brush metadata")
+        if not preserved_features:
+            return
+        self._safe_log(
+            "Warning: GameMaker tileset {name} preserves {features} as Godot metadata; "
+            "native TileSet behavior may require follow-up runtime/editor support.".format(
+                name=tileset_name,
+                features=", ".join(preserved_features),
+            )
+        )
 
     def convert_tilesets(self) -> None:
         """Main tileset conversion method."""
@@ -316,3 +366,27 @@ class TileSetConverter(BaseConverter):
 
     def convert_all(self) -> None:
         self.convert_tilesets()
+
+
+def _json_dict_list(value: object) -> list[JsonDict]:
+    if not isinstance(value, list):
+        return []
+    items: list[JsonDict] = []
+    for item in cast(list[object], value):
+        if isinstance(item, dict):
+            items.append(cast(JsonDict, item))
+    return items
+
+
+def _float(value: object, default: float) -> float:
+    if isinstance(value, bool):
+        return float(int(value))
+    if isinstance(value, int | float):
+        return float(value)
+    return default
+
+
+def _format_number(value: float) -> str:
+    if value == int(value):
+        return str(int(value))
+    return ("{:.6f}".format(value)).rstrip("0").rstrip(".")

--- a/tests/test_animation_curve_registry.py
+++ b/tests/test_animation_curve_registry.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from dataclasses import dataclass
+
+from src.conversion.animation_curve_registry import (
+    build_animation_curve_registry_entries,
+    render_animation_curve_registry_script,
+    write_animation_curve_registry,
+)
+
+
+@dataclass(frozen=True)
+class _AssetEntry:
+    id: int
+    name: str
+    kind: str
+    source_path: str
+
+
+class TestAnimationCurveRegistry(unittest.TestCase):
+    def test_builds_animation_curve_registry_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            curve_dir = os.path.join(tmpdir, "animcurves", "ac_bounce")
+            os.makedirs(curve_dir)
+            with open(os.path.join(curve_dir, "ac_bounce.yy"), "w", encoding="utf-8") as f:
+                f.write(
+                    '{\n'
+                    '  "name": "ac_bounce",\n'
+                    '  "channels": [\n'
+                    '    {"name": "height", "function": "linear", "iterations": 1,\n'
+                    '     "points": [\n'
+                    '       {"x": 0.0, "y": 0.0, "bezierX0": 0.1, "bezierY0": 0.2,},\n'
+                    '       {"x": 1.0, "y": 1.0, "bezierX1": 0.8, "bezierY1": 0.9,},\n'
+                    '     ],},\n'
+                    '  ],\n'
+                    '}\n'
+                )
+
+            entries = build_animation_curve_registry_entries(
+                tmpdir,
+                (
+                    _AssetEntry(
+                        300,
+                        "ac_bounce",
+                        "animcurves",
+                        "animcurves/ac_bounce/ac_bounce.yy",
+                    ),
+                ),
+            )
+
+        self.assertEqual(len(entries), 1)
+        entry = entries[0]
+        self.assertEqual(entry.id, 300)
+        self.assertEqual(entry.name, "ac_bounce")
+        self.assertEqual(entry.channels[0].name, "height")
+        self.assertEqual(entry.channels[0].points[1].bezier_x1, 0.8)
+
+    def test_writes_animation_curve_registry_script(self) -> None:
+        with tempfile.TemporaryDirectory() as gm_dir, tempfile.TemporaryDirectory() as godot_dir:
+            curve_dir = os.path.join(gm_dir, "animcurves", "ac_fade")
+            os.makedirs(curve_dir)
+            with open(os.path.join(curve_dir, "ac_fade.yy"), "w", encoding="utf-8") as f:
+                f.write('{"name":"ac_fade","channels":[{"name":"alpha","points":[{"x":0,"y":1}]}]}\n')
+
+            registry_path = write_animation_curve_registry(
+                gm_dir,
+                godot_dir,
+                (
+                    _AssetEntry(
+                        301,
+                        "ac_fade",
+                        "animcurves",
+                        "animcurves/ac_fade/ac_fade.yy",
+                    ),
+                ),
+            )
+            with open(registry_path, "r", encoding="utf-8") as f:
+                content = f.read()
+
+        self.assertIn("extends RefCounted", content)
+        self.assertIn('"id": 301', content)
+        self.assertIn('"name": "ac_fade"', content)
+        self.assertIn('"channels"', content)
+        self.assertEqual(
+            render_animation_curve_registry_script(()),
+            "extends RefCounted\n\nstatic func entries():\n\treturn []\n",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_asset_registry.py
+++ b/tests/test_asset_registry.py
@@ -18,6 +18,8 @@ from src.conversion.asset_registry import (
     AssetRegistryConverter,
     GROUP_COMPATIBILITY_REPORT_RELATIVE_PATH,
 )
+from src.conversion.animation_curve_registry import ANIMATION_CURVE_REGISTRY_RELATIVE_PATH
+from src.conversion.path_registry import PATH_REGISTRY_RELATIVE_PATH
 
 
 def _write_json(path: str, data: dict[str, object]) -> None:
@@ -112,6 +114,8 @@ class TestAssetRegistryConverter(unittest.TestCase):
                 ("objects", "o_player"),
                 ("scripts", "scr_spawn"),
                 ("fonts", "fnt_ui"),
+                ("paths", "path_patrol"),
+                ("animcurves", "ac_fade"),
                 ("sequences", "seq_intro"),
                 ("timelines", "tl_intro"),
             ],
@@ -140,6 +144,8 @@ class TestAssetRegistryConverter(unittest.TestCase):
         self._write_resource("objects", "o_player", "GMObject", "folders/Objects/Actors.yy")
         self._write_resource("scripts", "scr_spawn", "GMScript", "folders/Scripts/Game.yy")
         self._write_resource("fonts", "fnt_ui", "GMFont", "folders/Fonts/UI.yy")
+        self._write_resource("paths", "path_patrol", "GMPath", "folders/Paths/Movement.yy")
+        self._write_resource("animcurves", "ac_fade", "GMAnimationCurve", "folders/Animation Curves.yy")
         self._write_resource(
             "sequences",
             "seq_intro",
@@ -182,6 +188,12 @@ class TestAssetRegistryConverter(unittest.TestCase):
         self.assertEqual(by_name["o_player"].godot_path, "res://objects/Actors/o_player/o_player.tscn")
         self.assertEqual(by_name["scr_spawn"].godot_path, "res://scripts/Game/scr_spawn.gd")
         self.assertEqual(by_name["fnt_ui"].godot_path, "res://fonts/UI/fnt_ui.tres")
+        self.assertEqual(by_name["path_patrol"].asset_type, "path")
+        self.assertEqual(
+            by_name["path_patrol"].godot_path,
+            "res://paths/Movement/path_patrol/path_patrol.tscn",
+        )
+        self.assertEqual(by_name["ac_fade"].asset_type, "animation_curve")
         self.assertEqual(by_name["seq_intro"].asset_type, "sequence")
         sequence_metadata = by_name["seq_intro"].metadata
         self.assertIsNotNone(sequence_metadata)
@@ -213,8 +225,29 @@ class TestAssetRegistryConverter(unittest.TestCase):
         self.assertEqual(first_ids, second_ids)
 
     def test_convert_all_writes_runtime_registry_script(self) -> None:
-        _write_yyp(self.gm_dir, [("sprites", "s_player")])
+        _write_yyp(
+            self.gm_dir,
+            [
+                ("sprites", "s_player"),
+                ("paths", "path_patrol"),
+                ("animcurves", "ac_fade"),
+            ],
+        )
         self._write_resource("sprites", "s_player", "GMSprite", "folders/Sprites.yy")
+        self._write_resource(
+            "paths",
+            "path_patrol",
+            "GMPath",
+            "folders/Paths.yy",
+            {"points": [{"x": 0, "y": 0}, {"x": 16, "y": 0}]},
+        )
+        self._write_resource(
+            "animcurves",
+            "ac_fade",
+            "GMAnimationCurve",
+            "folders/Animation Curves.yy",
+            {"channels": [{"name": "alpha", "points": [{"x": 0, "y": 1}]}]},
+        )
 
         registry_path = self._converter().convert_all()
 
@@ -227,6 +260,19 @@ class TestAssetRegistryConverter(unittest.TestCase):
         self.assertIn("static func gml_asset_registry_entries():", content)
         self.assertIn('"name": "s_player"', content)
         self.assertIn('"type": "sprite"', content)
+
+        path_registry_path = os.path.join(self.godot_dir, PATH_REGISTRY_RELATIVE_PATH)
+        path_scene_path = os.path.join(self.godot_dir, "paths", "path_patrol", "path_patrol.tscn")
+        animation_curve_registry_path = os.path.join(self.godot_dir, ANIMATION_CURVE_REGISTRY_RELATIVE_PATH)
+        self.assertTrue(os.path.isfile(path_registry_path))
+        self.assertTrue(os.path.isfile(path_scene_path))
+        self.assertTrue(os.path.isfile(animation_curve_registry_path))
+        with open(path_scene_path, "r", encoding="utf-8") as f:
+            path_scene = f.read()
+        with open(animation_curve_registry_path, "r", encoding="utf-8") as f:
+            curve_registry = f.read()
+        self.assertIn('[node name="path_patrol" type="Path2D"]', path_scene)
+        self.assertIn('"name": "ac_fade"', curve_registry)
 
     def test_generates_actionable_texture_and_audio_group_registries(self) -> None:
         _write_json(

--- a/tests/test_path_registry.py
+++ b/tests/test_path_registry.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 from src.conversion.path_registry import (
     build_path_registry_entries,
+    render_path_scene,
     render_path_registry_script,
     write_path_registry,
 )
@@ -18,6 +19,7 @@ class _AssetEntry:
     name: str
     kind: str
     source_path: str
+    godot_path: str = ""
 
 
 class TestPathRegistry(unittest.TestCase):
@@ -30,6 +32,7 @@ class TestPathRegistry(unittest.TestCase):
                     '{\n'
                     '  "name": "path_patrol",\n'
                     '  "closed": false,\n'
+                    '  "kind": 1,\n'
                     '  "precision": 4,\n'
                     '  "points": [\n'
                     '    {"x": 0, "y": 0, "speed": 100,},\n'
@@ -40,7 +43,15 @@ class TestPathRegistry(unittest.TestCase):
 
             entries = build_path_registry_entries(
                 tmpdir,
-                (_AssetEntry(100, "path_patrol", "paths", "paths/path_patrol/path_patrol.yy"),),
+                (
+                    _AssetEntry(
+                        100,
+                        "path_patrol",
+                        "paths",
+                        "paths/path_patrol/path_patrol.yy",
+                        "res://paths/path_patrol/path_patrol.tscn",
+                    ),
+                ),
             )
 
         self.assertEqual(len(entries), 1)
@@ -48,7 +59,13 @@ class TestPathRegistry(unittest.TestCase):
         self.assertEqual(entry.id, 100)
         self.assertEqual(entry.name, "path_patrol")
         self.assertFalse(entry.closed)
+        self.assertEqual(entry.kind, 1)
+        self.assertEqual(entry.godot_path, "res://paths/path_patrol/path_patrol.tscn")
         self.assertEqual([(point.x, point.y, point.speed) for point in entry.points], [(0.0, 0.0, 100.0), (32.0, 0.0, 80.0)])
+        scene = render_path_scene(entry)
+        self.assertIn('[node name="path_patrol" type="Path2D"]', scene)
+        self.assertIn('[sub_resource type="Curve2D" id="Curve2D_1"]', scene)
+        self.assertIn("metadata/gamemaker_path_kind = 1", scene)
 
     def test_renders_and_writes_path_registry_script(self) -> None:
         with tempfile.TemporaryDirectory() as gm_dir, tempfile.TemporaryDirectory() as godot_dir:
@@ -60,15 +77,28 @@ class TestPathRegistry(unittest.TestCase):
             path = write_path_registry(
                 gm_dir,
                 godot_dir,
-                (_AssetEntry(101, "path_patrol", "paths", "paths/path_patrol/path_patrol.yy"),),
+                (
+                    _AssetEntry(
+                        101,
+                        "path_patrol",
+                        "paths",
+                        "paths/path_patrol/path_patrol.yy",
+                        "res://paths/path_patrol/path_patrol.tscn",
+                    ),
+                ),
             )
             with open(path, "r", encoding="utf-8") as f:
                 content = f.read()
+            scene_exists = os.path.isfile(
+                os.path.join(godot_dir, "paths", "path_patrol", "path_patrol.tscn")
+            )
 
         self.assertIn("extends RefCounted", content)
         self.assertIn('"id": 101', content)
         self.assertIn('"name": "path_patrol"', content)
         self.assertIn('"closed": true', content)
+        self.assertIn('"godot_path": "res://paths/path_patrol/path_patrol.tscn"', content)
+        self.assertTrue(scene_exists)
         self.assertEqual(render_path_registry_script(()), "extends RefCounted\n\nstatic func entries():\n\treturn []\n")
 
 

--- a/tests/test_paths_motion_godot.py
+++ b/tests/test_paths_motion_godot.py
@@ -81,7 +81,7 @@ def _write_registries(project_dir: Path) -> int:
             asset_type="path",
             type_name="Path",
             source_path="paths/path_patrol/path_patrol.yy",
-            godot_path="",
+            godot_path="res://paths/path_patrol/path_patrol.tscn",
             legacy_id="paths/path_patrol/path_patrol.yy",
         ),
     )
@@ -90,7 +90,9 @@ def _write_registries(project_dir: Path) -> int:
             id=path_id,
             name="path_patrol",
             closed=False,
+            kind=0,
             precision=4,
+            godot_path="res://paths/path_patrol/path_patrol.tscn",
             points=(PathPoint(0, 0), PathPoint(20, 0)),
         ),
     )

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -596,6 +596,18 @@ class TestRoomConverter(unittest.TestCase):
         self.assertTrue(is_empty_gamemaker_tile(GAMEMAKER_EMPTY_TILE_SENTINEL))
         self.assertFalse(is_empty_gamemaker_tile(1))
 
+    def test_decodes_raw_gamemaker_tile_data_format_zero(self):
+        decoded = decode_tile_compressed_data(
+            2,
+            2,
+            [1, 0, GAMEMAKER_EMPTY_TILE_SENTINEL, 2],
+            tile_data_format=0,
+        )
+
+        self.assertEqual(decoded, [1, 0, GAMEMAKER_EMPTY_TILE_SENTINEL, 2])
+        with self.assertRaisesRegex(ValueError, "decoded 1 cells, expected 4"):
+            decode_tile_compressed_data(2, 2, [1], tile_data_format=0)
+
     def test_gamemaker_tile_flags_map_to_godot_alternative_bits(self):
         raw_tile = 3 | GAMEMAKER_TILE_MIRROR_BIT | GAMEMAKER_TILE_FLIP_BIT | GAMEMAKER_TILE_ROTATE_BIT
         tile = decode_gamemaker_tile(raw_tile)
@@ -642,6 +654,34 @@ class TestRoomConverter(unittest.TestCase):
         self.assertIn('metadata/gamemaker_tile_decoded_cell_count = 6', content)
         self.assertIn('metadata/gamemaker_tile_non_empty_cell_count = 3', content)
         self.assertIn('metadata/gamemaker_tile_empty_values = [0, -2147483648]', content)
+
+    def test_tile_layer_accepts_raw_tile_data_format_zero(self):
+        self._write_yyp(["r_raw_tiles"], extra_resources=[("tilesets", "ts_ground")])
+        self._write_tileset("ts_ground", tile_count=4, out_columns=2)
+        self._write_tileset_resource("ts_ground")
+        self._write_room("r_raw_tiles", layers=[
+            {
+                "%Name": "Tiles",
+                "resourceType": "GMRTileLayer",
+                "visible": True,
+                "tilesetId": {"name": "ts_ground", "path": "tilesets/ts_ground/ts_ground.yy"},
+                "tiles": {
+                    "SerialiseWidth": 2,
+                    "SerialiseHeight": 2,
+                    "TileDataFormat": 0,
+                    "TileCompressedData": [1, 0, GAMEMAKER_EMPTY_TILE_SENTINEL, 2],
+                },
+            }
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_raw_tiles")
+
+        self.assertIn('[node name="TileMap" type="TileMapLayer" parent="Tiles"]', content)
+        self.assertIn('metadata/gamemaker_tile_data_format = 0', content)
+        self.assertIn('metadata/gamemaker_tile_decoded_cell_count = 4', content)
+        self.assertIn('metadata/gamemaker_tile_non_empty_cell_count = 2', content)
+        self.assertFalse(any("Could not decode GameMaker tile data" in log for log in self.logs))
 
     def test_missing_tileset_warns_without_emitting_tilemaplayer(self):
         self._write_yyp(["r_tiles"])

--- a/tests/test_tilesets.py
+++ b/tests/test_tilesets.py
@@ -143,6 +143,39 @@ class TestTileSetConverterBasic(unittest.TestCase):
         self.assertIn('TileSetAtlasSource', content)
         self.assertIn('Vector2i(16, 16)', content)
         self.assertIn('0:0/0 = 0', content)
+        self.assertIn('metadata/gamemaker_tileset_tile_count = 4', content)
+        self.assertIn('metadata/gamemaker_tileset_animation_frames = []', content)
+
+    def test_warns_when_preserving_tileset_metadata(self):
+        yy_content = (
+            '{\n'
+            '  "$GMTileSet": "v1",\n'
+            '  "%Name": "ts_ground",\n'
+            '  "spriteId": {"name": "s_ground", "path": "sprites/s_ground/s_ground.yy",},\n'
+            '  "tileWidth": 16,\n'
+            '  "tileHeight": 16,\n'
+            '  "tile_count": 2,\n'
+            '  "out_columns": 2,\n'
+            '  "tileAnimationFrames": [{"frames": [0, 1], "duration": 2,}],\n'
+            '  "brushes": [{"name": "grass",}],\n'
+            '  "autoTileSets": [{"name": "terrain",}],\n'
+            '  "tileSetCollisions": [{"tileId": 1, "points": [[0, 0], [16, 0]],}],\n'
+            '  "parent": {"name": "Tilesets", "path": "folders/Tilesets.yy",},\n'
+            '  "resourceType": "GMTileSet",\n'
+            '  "resourceVersion": "2.0",\n'
+            '}'
+        )
+        with open(os.path.join(self.gm_dir, "tilesets", "ts_ground", "ts_ground.yy"), "w") as f:
+            f.write(yy_content)
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        self.assertTrue(any(
+            "preserves animation frames, collision data, auto-tile metadata, brush metadata"
+            in log
+            for log in self.logs
+        ))
 
     def test_copies_sprite_image(self):
         converter = self._make_converter()
@@ -262,6 +295,36 @@ class TestParseTilesetYY(unittest.TestCase):
         result = cast(TilesetData, result)
         self.assertEqual(result["sprite_name"], "s_tc")
         self.assertEqual(result["tileWidth"], 16)
+
+    def test_preserves_animation_collision_and_autotile_metadata(self):
+        content = (
+            '{\n'
+            '  "spriteId": {"name": "s_meta", "path": "sprites/s_meta/s_meta.yy",},\n'
+            '  "tileWidth": 16,\n'
+            '  "tileHeight": 16,\n'
+            '  "tile_count": 2,\n'
+            '  "out_columns": 2,\n'
+            '  "tileAnimationFrames": [{"frames": [0, 1], "duration": 2,}],\n'
+            '  "tileAnimationSpeed": 12.5,\n'
+            '  "brushes": [{"name": "grass",}],\n'
+            '  "autoTileSets": [{"name": "terrain",}],\n'
+            '  "tileSetCollisions": [{"tileId": 1, "points": [[0, 0], [16, 0]],}],\n'
+            '  "out_tilehborder": 1,\n'
+            '  "out_tilevborder": 2,\n'
+            '}'
+        )
+        self._write_tileset_yy("ts_meta", content)
+
+        result = self.converter._parse_tileset_yy("ts_meta")
+        self.assertIsNotNone(result)
+        result = cast(TilesetData, result)
+        self.assertEqual(result["tileAnimationSpeed"], 12.5)
+        self.assertEqual(result["out_tilehborder"], 1)
+        tres = self.converter._generate_tileset_tres("ts_meta", result)
+        self.assertIn('metadata/gamemaker_tileset_animation_speed = 12.5', tres)
+        self.assertIn('metadata/gamemaker_tileset_animation_frames = [{"frames": [0, 1], "duration": 2}]', tres)
+        self.assertIn('metadata/gamemaker_tileset_auto_tile_sets = [{"name": "terrain"}]', tres)
+        self.assertIn('metadata/gamemaker_tileset_collisions = [{"tileId": 1', tres)
 
 
 class TestTileSetConverterSubfolders(unittest.TestCase):


### PR DESCRIPTION
Closes #591.

## Summary
- generate Path2D scenes for GameMaker paths and extend the path registry with kind, precision, Godot path, and point metadata
- add an animation curve registry for GameMaker animcurves and wire it into asset-registry generation
- preserve tileset animation, brush, autotile, collision, border, and tile-count metadata in generated TileSet resources with diagnostics
- accept raw TileDataFormat 0 tilemap data alongside compressed format 1

## Tests
- ./venv/bin/python -m unittest tests.test_asset_registry tests.test_path_registry tests.test_animation_curve_registry tests.test_tilesets tests.test_rooms tests.test_paths_motion_godot
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest