### PR TITLE
Convert sequence timeline particle metadata

### DIFF
--- a/src/conversion/asset_registry.py
+++ b/src/conversion/asset_registry.py
@@ -11,6 +11,7 @@ from src.conversion.project_manifest import (
     ProjectTextureGroup,
     load_gamemaker_project_manifest,
 )
+from src.conversion.gml_transpiler import GMLTranspileError, transpile_gml_code
 from src.conversion.type_defs import (
     ConversionRunning,
     JsonDict,
@@ -130,6 +131,7 @@ class AssetRegistryConverter(BaseConverter):
         "animcurves": "animation_curve",
         "shaders": "shader",
         "tilesets": "tileset",
+        "particlesystems": "particle_system",
         "timelines": "timeline",
         "sequences": "sequence",
         "included_files": "included_file",
@@ -145,6 +147,7 @@ class AssetRegistryConverter(BaseConverter):
         "animcurves": "Animation Curve",
         "shaders": "Shader",
         "tilesets": "Tile Set",
+        "particlesystems": "Particle System",
         "timelines": "Timeline",
         "sequences": "Sequence",
         "included_files": "Included File",
@@ -239,6 +242,7 @@ class AssetRegistryConverter(BaseConverter):
                 )
             )
         self._write_group_compatibility_report(entries, texture_groups, audio_groups)
+        self._write_timeline_action_scripts(entries)
         write_path_registry(self.gm_project_path, self.godot_project_path, entries)
         write_animation_curve_registry(self.gm_project_path, self.godot_project_path, entries)
 
@@ -445,6 +449,12 @@ class AssetRegistryConverter(BaseConverter):
 
         if resource.kind == "sequences":
             return self._sequence_metadata(resource.raw_data)
+
+        if resource.kind == "timelines":
+            return self._timeline_metadata(resource)
+
+        if resource.kind == "particlesystems":
+            return self._particle_system_metadata(resource.raw_data)
 
         if resource.kind in {"sprites", "fonts", "tilesets"}:
             texture_group = self._reference_name(resource.raw_data.get("textureGroupId"))
@@ -655,7 +665,303 @@ class AssetRegistryConverter(BaseConverter):
             "playback_speed": self._metadata_float(playback_speed, 1.0),
             "loopmode": self._metadata_int(loopmode, 0),
             "tracks": tracks if isinstance(tracks, list) else [],
+            "moments": self._sequence_event_metadata(raw_data, ("moments", "momentEvents")),
+            "broadcasts": self._sequence_event_metadata(raw_data, ("broadcastMessages", "broadcasts")),
         }
+
+    def _timeline_metadata(self, resource: _ProjectResource) -> JsonDict:
+        moments = self._timeline_moment_metadata(resource)
+        frames = [
+            self._metadata_int(moment.get("frame"), 0)
+            for moment in moments
+            if isinstance(moment.get("frame"), int | float)
+        ]
+        return {
+            "moments": moments,
+            "moment_count": len(moments),
+            "max_moment": max(frames, default=-1),
+        }
+
+    def _timeline_moment_metadata(self, resource: _ProjectResource) -> list[JsonDict]:
+        raw_moments = resource.raw_data.get("momentList")
+        if not isinstance(raw_moments, list):
+            raw_moments = resource.raw_data.get("moments")
+        if not isinstance(raw_moments, list):
+            raw_moments = []
+
+        moments: list[JsonDict] = []
+        for index, raw_moment in enumerate(cast(list[object], raw_moments)):
+            if not isinstance(raw_moment, dict):
+                continue
+            moment = cast(JsonDict, raw_moment)
+            frame = self._metadata_int(
+                moment.get("moment", moment.get("frame", moment.get("time", index))),
+                index,
+            )
+            actions = self._timeline_action_metadata(resource, moment, frame)
+            moments.append({
+                "frame": frame,
+                "actions": actions,
+                "source_path": resource.source_path,
+            })
+
+        if not moments:
+            discovered_actions = self._timeline_discovered_source_actions(resource)
+            for frame, actions in discovered_actions:
+                moments.append({
+                    "frame": frame,
+                    "actions": actions,
+                    "source_path": resource.source_path,
+                })
+        return sorted(moments, key=lambda item: self._metadata_int(item.get("frame"), 0))
+
+    def _timeline_action_metadata(
+        self,
+        resource: _ProjectResource,
+        moment: JsonDict,
+        frame: int,
+    ) -> list[JsonDict]:
+        actions: list[JsonDict] = []
+        for raw_action in self._raw_action_items(moment):
+            action = self._timeline_action_from_raw(raw_action)
+            if action is not None:
+                actions.append(action)
+
+        source_filename = self._timeline_source_filename(resource, moment, frame)
+        if source_filename:
+            source_path = self._resource_relative_path(resource, source_filename)
+            actions.append({
+                "kind": "gml",
+                "source_path": source_path,
+                "script_path": self._timeline_action_script_resource_path(resource.name, frame),
+            })
+        return actions
+
+    def _timeline_discovered_source_actions(self, resource: _ProjectResource) -> list[tuple[int, list[JsonDict]]]:
+        discovered: list[tuple[int, list[JsonDict]]] = []
+        try:
+            filenames = sorted(os.listdir(os.path.dirname(resource.yy_path)))
+        except OSError:
+            return discovered
+
+        for filename in filenames:
+            if not filename.lower().endswith(".gml"):
+                continue
+            frame = self._timeline_frame_from_filename(filename)
+            if frame is None:
+                continue
+            discovered.append((
+                frame,
+                [{
+                    "kind": "gml",
+                    "source_path": self._resource_relative_path(resource, filename),
+                    "script_path": self._timeline_action_script_resource_path(resource.name, frame),
+                }],
+            ))
+        return discovered
+
+    def _timeline_source_filename(
+        self,
+        resource: _ProjectResource,
+        moment: JsonDict,
+        frame: int,
+    ) -> str:
+        for key in ("gmlFile", "eventFile", "filename", "source", "sourceFile"):
+            value = moment.get(key)
+            if isinstance(value, str) and value:
+                return value
+        for candidate in (
+            f"Moment_{frame}.gml",
+            f"moment_{frame}.gml",
+            f"Timeline_{frame}.gml",
+            f"{frame}.gml",
+        ):
+            if os.path.isfile(os.path.join(os.path.dirname(resource.yy_path), candidate)):
+                return candidate
+        return ""
+
+    def _raw_action_items(self, moment: JsonDict) -> list[object]:
+        raw_actions = moment.get("actions")
+        if not isinstance(raw_actions, list):
+            raw_actions = moment.get("actionList")
+        if isinstance(raw_actions, list):
+            return list(cast(list[object], raw_actions))
+        scripts = moment.get("scripts")
+        if isinstance(scripts, list):
+            return [{"script": script} for script in cast(list[object], scripts)]
+        callable_name = moment.get("callable")
+        if isinstance(callable_name, str) and callable_name:
+            return [{"callable": callable_name}]
+        return []
+
+    def _timeline_action_from_raw(self, raw_action: object) -> JsonDict | None:
+        if isinstance(raw_action, str) and raw_action:
+            return {"kind": "script", "script": raw_action}
+        if not isinstance(raw_action, dict):
+            return None
+        action = cast(JsonDict, raw_action)
+        callable_name = action.get("callable")
+        if isinstance(callable_name, str) and callable_name:
+            return {"kind": "callable", "callable": callable_name}
+        script = action.get("script") or action.get("scriptName") or action.get("name")
+        if isinstance(script, str) and script:
+            return {"kind": "script", "script": script}
+        return {"kind": "metadata", "raw": action}
+
+    def _sequence_event_metadata(self, raw_data: JsonDict, keys: tuple[str, ...]) -> list[JsonDict]:
+        events: list[JsonDict] = []
+        for key in keys:
+            raw_events = raw_data.get(key)
+            if not isinstance(raw_events, list):
+                continue
+            for index, raw_event in enumerate(cast(list[object], raw_events)):
+                if not isinstance(raw_event, dict):
+                    continue
+                event = cast(JsonDict, raw_event)
+                frame = self._metadata_float(
+                    event.get("frame", event.get("moment", event.get("time", index))),
+                    float(index),
+                )
+                normalized: JsonDict = {"frame": frame}
+                for name in ("name", "message", "event", "callable", "script"):
+                    value = event.get(name)
+                    if isinstance(value, str) and value:
+                        normalized[name] = value
+                normalized["raw"] = event
+                events.append(normalized)
+        return sorted(events, key=lambda item: self._metadata_float(item.get("frame"), 0.0))
+
+    def _particle_system_metadata(self, raw_data: JsonDict) -> JsonDict:
+        return {
+            "types": self._json_list(raw_data, ("particleTypes", "types")),
+            "emitters": self._json_list(raw_data, ("emitters",)),
+            "attractors": self._json_list(raw_data, ("attractors",)),
+            "destroyers": self._json_list(raw_data, ("destroyers",)),
+            "deflectors": self._json_list(raw_data, ("deflectors",)),
+            "changers": self._json_list(raw_data, ("changers",)),
+            "raw": raw_data,
+        }
+
+    def _write_timeline_action_scripts(self, entries: tuple[AssetRegistryEntry, ...]) -> None:
+        asset_names = {entry.name for entry in entries}
+        for entry in entries:
+            if entry.asset_type != "timeline":
+                continue
+            metadata = entry.metadata or {}
+            raw_moments = metadata.get("moments")
+            if not isinstance(raw_moments, list):
+                continue
+            for raw_moment in cast(list[object], raw_moments):
+                if not isinstance(raw_moment, dict):
+                    continue
+                moment = cast(JsonDict, raw_moment)
+                frame = self._metadata_int(moment.get("frame"), 0)
+                raw_actions = moment.get("actions")
+                if not isinstance(raw_actions, list):
+                    continue
+                for raw_action in cast(list[object], raw_actions):
+                    if not isinstance(raw_action, dict):
+                        continue
+                    action = cast(JsonDict, raw_action)
+                    source_path = action.get("source_path")
+                    script_path = action.get("script_path")
+                    if isinstance(source_path, str) and isinstance(script_path, str):
+                        self._write_timeline_action_script(entry.name, frame, source_path, script_path, asset_names)
+
+    def _write_timeline_action_script(
+        self,
+        timeline_name: str,
+        frame: int,
+        source_path: str,
+        script_path: str,
+        asset_names: set[str],
+    ) -> None:
+        if not script_path.startswith("res://"):
+            return
+        gm_source_path = os.path.join(self.gm_project_path, *source_path.split("/"))
+        try:
+            with open(gm_source_path, "r", encoding="utf-8") as source_file:
+                source = source_file.read()
+        except OSError:
+            self._safe_log(
+                "Warning: Could not read GameMaker timeline moment code for "
+                f"{timeline_name} frame {frame}: {gm_source_path}"
+            )
+            return
+
+        try:
+            body = transpile_gml_code(
+                source,
+                asset_names=asset_names,
+                source_path=gm_source_path,
+                event=f"timeline moment {frame}",
+                preserve_source_comments=True,
+                self_expression="_gm_instance",
+                other_expression="GMRuntime.gml_instance_noone()",
+                instance_target="_gm_instance",
+            )
+        except GMLTranspileError as exc:
+            message = (
+                "Warning: Could not transpile GameMaker timeline moment code for "
+                f"{timeline_name} frame {frame}: {gm_source_path}: {exc}"
+            )
+            if self.diagnostics is not None:
+                self.diagnostics.add_transpile_failure(
+                    message,
+                    source_path=gm_source_path,
+                    line=exc.line,
+                    column=exc.column,
+                    resource=timeline_name,
+                    resource_type="timeline",
+                    event=f"moment {frame}",
+                    workaround="Split or rewrite unsupported GML in this timeline moment.",
+                )
+            self._safe_log(message)
+            return
+
+        if not body.strip():
+            body = "\tpass"
+        output_path = os.path.join(self.godot_project_path, *script_path[len("res://"):].split("/"))
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as script_file:
+            script_file.write(
+                "\n".join([
+                    "extends RefCounted",
+                    "",
+                    'const GMRuntime = preload("res://gm2godot/gml_runtime.gd")',
+                    "",
+                    "static func execute(_gm_instance):",
+                    body.rstrip(),
+                    "",
+                ])
+            )
+
+    def _resource_relative_path(self, resource: _ProjectResource, filename: str) -> str:
+        return os.path.join(
+            os.path.dirname(resource.source_path),
+            filename,
+        ).replace(os.sep, "/")
+
+    @staticmethod
+    def _timeline_action_script_resource_path(timeline_name: str, frame: int) -> str:
+        safe_name = "".join(char if char.isalnum() or char == "_" else "_" for char in timeline_name)
+        return f"res://gm2godot/timelines/{safe_name}_{frame}.gd"
+
+    @staticmethod
+    def _timeline_frame_from_filename(filename: str) -> int | None:
+        stem = os.path.splitext(filename)[0]
+        digits = "".join(char for char in stem if char.isdigit())
+        if not digits:
+            return None
+        return int(digits)
+
+    @staticmethod
+    def _json_list(raw_data: JsonDict, keys: tuple[str, ...]) -> list[object]:
+        for key in keys:
+            value = raw_data.get(key)
+            if isinstance(value, list):
+                return list(cast(list[object], value))
+        return []
 
     def _room_order_indices(self, resources: Iterable[_ProjectResource]) -> dict[str, int]:
         rooms = {resource.name for resource in resources if resource.kind == "rooms"}

--- a/src/conversion/converter.py
+++ b/src/conversion/converter.py
@@ -147,6 +147,7 @@ class Converter:
                 update_log_callback=self.update_log_callback,
                 compact_logging=self.compact_logging,
                 max_workers=self.max_workers,
+                diagnostics=self.diagnostics,
             ).convert_all(), "Console_Convertor_Rooms"),
             ("asset_registry", lambda: AssetRegistryConverter(
                 gm_path, godot_path, self.log_callback,

--- a/src/conversion/gml_runtime_parts/segments/15_asset_registry.gd
+++ b/src/conversion/gml_runtime_parts/segments/15_asset_registry.gd
@@ -19,6 +19,10 @@ const GML_ASSET_TYPE_ALIASES = {
 	"shaders": "shader",
 	"tileset": "tileset",
 	"tilesets": "tileset",
+	"particle_system": "particle_system",
+	"particle_systems": "particle_system",
+	"particlesystem": "particle_system",
+	"particlesystems": "particle_system",
 	"timeline": "timeline",
 	"timelines": "timeline",
 	"sequence": "sequence",
@@ -36,6 +40,7 @@ const GML_ASSET_TYPE_NAMES = {
 	"path": "Path",
 	"shader": "Shader",
 	"tileset": "Tile Set",
+	"particle_system": "Particle System",
 	"timeline": "Timeline",
 	"sequence": "Sequence",
 	"included_file": "Included File"

--- a/src/conversion/gml_runtime_parts/segments/61_sequences_timelines.gd
+++ b/src/conversion/gml_runtime_parts/segments/61_sequences_timelines.gd
@@ -244,8 +244,10 @@ static func gml_layer_sequence_step(sequence_element_id, frames = 1.0):
 	if bool(instance.get("paused", false)) or bool(instance.get("finished", false)):
 		return true
 	var delta = _to_real(frames) * _to_real(instance.get("speedScale", 1.0)) * float(instance.get("headDirection", 1))
+	var previous_position = _to_real(instance.get("headPosition", 0.0))
 	var next_position = _to_real(instance.get("headPosition", 0.0)) + delta
 	instance["headPosition"] = _gml_sequence_clamp_head_position(instance, next_position)
+	_gml_sequence_dispatch_between(instance, previous_position, _to_real(instance["headPosition"]), delta)
 	return true
 
 
@@ -263,7 +265,7 @@ static func _gml_timeline_moments(timeline):
 		return null
 	var asset_id = int(entry["id"])
 	if not _gml_timeline_moments_by_asset_id.has(asset_id):
-		_gml_timeline_moments_by_asset_id[asset_id] = {}
+		_gml_timeline_moments_by_asset_id[asset_id] = _gml_timeline_seed_moments(entry)
 	return _gml_timeline_moments_by_asset_id[asset_id]
 
 
@@ -302,14 +304,18 @@ static func _gml_timeline_dispatch_between(instance, timeline, previous_position
 	var moments = _gml_timeline_moments(timeline)
 	if moments == null:
 		return
-	var from_position = min(previous_position, position)
-	var to_position = max(previous_position, position)
-	for moment in moments.keys():
+	var ordered_moments = moments.keys()
+	ordered_moments.sort()
+	if speed_value < 0.0:
+		ordered_moments.reverse()
+	for moment in ordered_moments:
 		var moment_value = float(moment)
-		if moment_value <= from_position or moment_value > to_position:
+		if speed_value >= 0.0 and (moment_value <= previous_position or moment_value > position):
 			continue
-		for script in moments[moment]:
-			gml_script_execute(script, [instance])
+		if speed_value < 0.0 and (moment_value >= previous_position or moment_value < position):
+			continue
+		for action in moments[moment]:
+			_gml_sequence_timeline_dispatch_action(instance, action)
 
 
 static func _gml_object_timeline_get(instance, member_name, fallback):
@@ -357,6 +363,8 @@ static func _gml_sequence_object_from_entry(entry):
 		"playbackSpeed": playback_speed,
 		"loopmode": loopmode,
 		"tracks": metadata.get("tracks", []) if typeof(metadata) == TYPE_DICTIONARY else [],
+		"moments": metadata.get("moments", []) if typeof(metadata) == TYPE_DICTIONARY else [],
+		"broadcasts": metadata.get("broadcasts", []) if typeof(metadata) == TYPE_DICTIONARY else [],
 		"metadata": metadata,
 	}
 
@@ -367,12 +375,14 @@ static func _gml_sequence_instance_record(node, sequence_object):
 		"sequence_id": int(sequence_object.get("id", -1)),
 		"elementID": gml_handle_invalid(GML_LAYER_ELEMENT_HANDLE_KIND),
 		"node": node,
+		"owner": _gml_sequence_owner_for_node(node),
 		"headPosition": 0.0,
 		"headDirection": 1,
 		"speedScale": 1.0,
 		"paused": false,
 		"finished": false,
 		"activeTracks": [],
+		"eventLog": [],
 	}
 
 
@@ -403,3 +413,101 @@ static func _gml_sequence_clamp_head_position(instance, position):
 
 static func _gml_sequence_has_tracks(sequence_object):
 	return typeof(sequence_object) == TYPE_DICTIONARY and sequence_object.has("tracks") and not sequence_object["tracks"].is_empty()
+
+
+static func _gml_timeline_seed_moments(entry):
+	var seeded = {}
+	var metadata = entry.get("metadata", {}) if entry.has("metadata") else {}
+	if typeof(metadata) != TYPE_DICTIONARY:
+		return seeded
+	var authored_moments = metadata.get("moments", [])
+	if typeof(authored_moments) != TYPE_ARRAY:
+		return seeded
+	for moment in authored_moments:
+		if typeof(moment) != TYPE_DICTIONARY:
+			continue
+		var frame = int(_to_real(moment.get("frame", 0)))
+		if not seeded.has(frame):
+			seeded[frame] = []
+		var actions = moment.get("actions", [])
+		if typeof(actions) == TYPE_ARRAY:
+			for action in actions:
+				seeded[frame].append(action)
+	return seeded
+
+
+static func _gml_sequence_dispatch_between(instance, previous_position, position, speed_value):
+	var sequence_object = instance.get("sequence", {})
+	if typeof(sequence_object) != TYPE_DICTIONARY:
+		return
+	var actions = []
+	for key in ["moments", "broadcasts"]:
+		var events = sequence_object.get(key, [])
+		if typeof(events) != TYPE_ARRAY:
+			continue
+		for event in events:
+			if typeof(event) != TYPE_DICTIONARY:
+				continue
+			var frame = _to_real(event.get("frame", 0.0))
+			if speed_value >= 0.0 and (frame <= previous_position or frame > position):
+				continue
+			if speed_value < 0.0 and (frame >= previous_position or frame < position):
+				continue
+			var event_action = {}
+			for event_key in event.keys():
+				event_action[event_key] = event[event_key]
+			event_action["kind"] = key.trim_suffix("s")
+			event_action["owner"] = instance.get("owner", null)
+			event_action["node"] = instance.get("node", null)
+			actions.append(event_action)
+	actions.sort_custom(_gml_sequence_event_sort)
+	for action in actions:
+		instance["eventLog"].append(action)
+		_gml_sequence_timeline_dispatch_action(instance.get("owner", null), action)
+
+
+static func _gml_sequence_event_sort(left, right):
+	var left_frame = _to_real(left.get("frame", 0.0)) if typeof(left) == TYPE_DICTIONARY else 0.0
+	var right_frame = _to_real(right.get("frame", 0.0)) if typeof(right) == TYPE_DICTIONARY else 0.0
+	if left_frame == right_frame:
+		return str(left.get("kind", "")) < str(right.get("kind", ""))
+	return left_frame < right_frame
+
+
+static func _gml_sequence_timeline_dispatch_action(instance, action):
+	if action is Callable:
+		gml_script_execute(action, [instance])
+		return
+	if typeof(action) != TYPE_DICTIONARY:
+		gml_script_execute(action, [instance])
+		return
+	var owner = action.get("owner", instance)
+	var callable_name = action.get("callable", "")
+	if is_string(callable_name) and owner is Object and owner.has_method(str(callable_name)):
+		owner.call(str(callable_name), instance, action)
+		return
+	var script_path = action.get("script_path", "")
+	if is_string(script_path) and str(script_path) != "":
+		_gml_sequence_timeline_execute_script_path(str(script_path), instance)
+		return
+	var script = action.get("script", null)
+	if script != null:
+		gml_script_execute(script, [instance])
+
+
+static func _gml_sequence_timeline_execute_script_path(script_path, instance):
+	var script_resource = load(script_path)
+	if script_resource != null and script_resource.has_method("execute"):
+		script_resource.execute(instance)
+
+
+static func _gml_sequence_owner_for_node(node):
+	if node is Node and node.is_inside_tree() and node.get_tree().current_scene is Node:
+		return node.get_tree().current_scene
+	if node is Node:
+		var parent = node.get_parent()
+		while parent is Node:
+			if parent.get_parent() == null:
+				return parent
+			parent = parent.get_parent()
+	return node

--- a/src/conversion/room_layers.py
+++ b/src/conversion/room_layers.py
@@ -239,6 +239,16 @@ def _serialize_layer(
             )
         )
 
+    if resource_type == "GMREffectLayer":
+        context.warn(
+            "Warning: GameMaker effect/filter layer {layer_name} in room {room_name} "
+            "is preserved as metadata; native shader/filter behavior requires project-specific "
+            "Godot material support.".format(
+                room_name=context.room.name,
+                layer_name=original_name,
+            )
+        )
+
     lines.extend(_layer_node_lines(layer, node_name, parent_path, original_name, resource_type))
 
     child_parent_path = node_name if parent_path == "." else f"{parent_path}/{node_name}"
@@ -641,6 +651,8 @@ def _asset_node_lines(
         asset_type = _asset_resource_type(asset)
         if asset_type == "GMRSpriteGraphic":
             lines.extend(_sprite_asset_lines(asset, node_name, parent_path, layer_name, context))
+        elif asset_type == "GMRParticleSystem":
+            lines.extend(_particle_system_asset_lines(asset, node_name, parent_path))
         else:
             context.warn(
                 "Warning: Unsupported GameMaker room asset type {asset_type} in room {room_name}, "
@@ -709,6 +721,31 @@ def _sprite_asset_lines(
         lines.append("metadata/gamemaker_placeholder = true")
         lines.append("metadata/gamemaker_unresolved_sprite_scene = true")
     lines.append("")
+    return lines
+
+
+def _particle_system_asset_lines(
+    asset: JsonDict,
+    node_name: str,
+    parent_path: str,
+) -> list[str]:
+    particle_system_id = _dict_value(asset.get("particlesystemId"))
+    particle_system_name = particle_system_id.get("name")
+    if not isinstance(particle_system_name, str) or not particle_system_name:
+        particle_system_name = _asset_name(asset)
+    lines = [f'[node name={godot_string(node_name)} type="Node2D" parent={godot_string(parent_path)}]']
+    lines.extend(_asset_transform_lines(asset))
+    lines.extend([
+        'metadata/gamemaker_layer_element_type = "particle_system"',
+        "metadata/gamemaker_particle_system_layer_element = true",
+        f"metadata/gamemaker_asset_name = {godot_value(_asset_name(asset))}",
+        f"metadata/gamemaker_asset_node_name = {godot_value(node_name)}",
+        f"metadata/gamemaker_asset_type = {godot_value(_asset_resource_type(asset))}",
+        f"metadata/gamemaker_particle_system_name = {godot_value(particle_system_name)}",
+        f"metadata/gamemaker_particle_system_id = {godot_value(particle_system_id)}",
+        f"metadata/gamemaker_asset_raw = {godot_value(asset)}",
+        "",
+    ])
     return lines
 
 

--- a/src/conversion/rooms.py
+++ b/src/conversion/rooms.py
@@ -7,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TypedDict, cast
 
 from src.conversion.base_converter import BaseConverter
+from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.gml_transpiler import GMLTranspileError, transpile_gml_code
 from src.conversion.project_godot import GodotProjectFile
 from src.conversion.resource_index import GameMakerResourceIndex, IndexedRoom
@@ -89,6 +90,15 @@ def _iter_room_instances(layers: object) -> list[JsonDict]:
     return instances
 
 
+def _iter_room_effect_layers(layers: object) -> list[JsonDict]:
+    effect_layers: list[JsonDict] = []
+    for layer in _dict_items(layers):
+        if _layer_resource_type(layer) == "GMREffectLayer":
+            effect_layers.append(layer)
+        effect_layers.extend(_iter_room_effect_layers(layer.get("layers") or layer.get("children")))
+    return effect_layers
+
+
 class RoomProcessResult(TypedDict):
     success: bool
     name: str
@@ -107,11 +117,12 @@ class RoomConverter(BaseConverter):
                   update_log_callback: LogCallback | None = None,
                   compact_logging: bool = False,
                   max_workers: int | None = None,
-                  resource_index: GameMakerResourceIndex | None = None) -> None:
+                  resource_index: GameMakerResourceIndex | None = None,
+                  diagnostics: DiagnosticCollector | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback,
                          progress_callback, conversion_running,
                          update_log_callback, compact_logging,
-                         max_workers=max_workers)
+                         max_workers=max_workers, diagnostics=diagnostics)
         self.godot_rooms_path = os.path.join(self.godot_project_path, "rooms")
         self.resource_index = resource_index
 
@@ -142,6 +153,7 @@ class RoomConverter(BaseConverter):
             self.gm_project_path,
             warn_callback=self._safe_log,
         )
+        self._record_effect_layer_diagnostics(room)
         serialized_layers = serialize_room_layers(
             room,
             gm_project_path=self.gm_project_path,
@@ -365,6 +377,29 @@ class RoomConverter(BaseConverter):
             ])
 
         return "\n".join(lines).rstrip() + "\n"
+
+    def _record_effect_layer_diagnostics(self, room: IndexedRoom) -> None:
+        if self.diagnostics is None:
+            return
+        for layer in _iter_room_effect_layers(room.layers):
+            layer_name = layer.get("%Name") or layer.get("name")
+            effect_type = layer.get("effectType")
+            self.diagnostics.add(
+                "warning",
+                "GM2GD-RESOURCE-UNSUPPORTED",
+                "GameMaker effect/filter layer {layer_name} in room {room_name} "
+                "is preserved as metadata; native shader/filter behavior requires "
+                "project-specific Godot material support.".format(
+                    layer_name=layer_name if isinstance(layer_name, str) and layer_name else "Layer",
+                    room_name=room.name,
+                ),
+                source_path=room.yy_path,
+                resource=room.name,
+                resource_type="room",
+                event=str(effect_type) if isinstance(effect_type, str) and effect_type else None,
+                issue_number=592,
+                workaround="Replace the effect with a Godot material/shader or add a project-specific compatibility mapping.",
+            )
 
     def _unique_instance_creation_method_name(
         self,

--- a/tests/test_asset_registry.py
+++ b/tests/test_asset_registry.py
@@ -118,6 +118,7 @@ class TestAssetRegistryConverter(unittest.TestCase):
                 ("animcurves", "ac_fade"),
                 ("sequences", "seq_intro"),
                 ("timelines", "tl_intro"),
+                ("particlesystems", "ps_spark"),
             ],
         )
         self._write_resource(
@@ -151,9 +152,38 @@ class TestAssetRegistryConverter(unittest.TestCase):
             "seq_intro",
             "GMSequence",
             "folders/Sequences.yy",
-            {"length": 120, "playbackSpeed": 30, "playback": 1, "tracks": [{"name": "Title"}]},
+            {
+                "length": 120,
+                "playbackSpeed": 30,
+                "playback": 1,
+                "tracks": [{"name": "Title"}],
+                "moments": [{"frame": 2, "callable": "_on_sequence_moment"}],
+                "broadcastMessages": [{"frame": 4, "message": "beat"}],
+            },
         )
-        self._write_resource("timelines", "tl_intro", "GMTimeline", "folders/Timelines.yy")
+        self._write_resource(
+            "timelines",
+            "tl_intro",
+            "GMTimeline",
+            "folders/Timelines.yy",
+            {
+                "momentList": [
+                    {"moment": 2, "eventFile": "Moment_2.gml"},
+                    {"moment": 4, "actions": [{"script": "scr_spawn"}]},
+                ]
+            },
+        )
+        _write_file(os.path.join(self.gm_dir, "timelines", "tl_intro", "Moment_2.gml"), "x = 42;\n")
+        self._write_resource(
+            "particlesystems",
+            "ps_spark",
+            "GMParticleSystem",
+            "folders/Particles.yy",
+            {
+                "particleTypes": [{"name": "pt_spark", "lifeMin": 10, "lifeMax": 20}],
+                "emitters": [{"name": "pe_spark", "streamNumber": 4}],
+            },
+        )
         _write_file(os.path.join(self.gm_dir, "datafiles", "config", "game.json"), "{}")
 
         entries = self._converter(organize_sounds_by_audio_group=True).build_entries()
@@ -202,7 +232,23 @@ class TestAssetRegistryConverter(unittest.TestCase):
         self.assertEqual(sequence_metadata["playback_speed"], 30.0)
         self.assertEqual(sequence_metadata["loopmode"], 1)
         self.assertEqual(sequence_metadata["tracks"], [{"name": "Title"}])
+        self.assertEqual(sequence_metadata["moments"][0]["callable"], "_on_sequence_moment")
+        self.assertEqual(sequence_metadata["broadcasts"][0]["message"], "beat")
         self.assertEqual(by_name["tl_intro"].asset_type, "timeline")
+        timeline_metadata = by_name["tl_intro"].metadata
+        self.assertIsNotNone(timeline_metadata)
+        assert timeline_metadata is not None
+        self.assertEqual(timeline_metadata["moment_count"], 2)
+        self.assertEqual(timeline_metadata["max_moment"], 4)
+        first_timeline_action = timeline_metadata["moments"][0]["actions"][0]
+        self.assertEqual(first_timeline_action["source_path"], "timelines/tl_intro/Moment_2.gml")
+        self.assertEqual(first_timeline_action["script_path"], "res://gm2godot/timelines/tl_intro_2.gd")
+        self.assertEqual(by_name["ps_spark"].asset_type, "particle_system")
+        particle_metadata = by_name["ps_spark"].metadata
+        self.assertIsNotNone(particle_metadata)
+        assert particle_metadata is not None
+        self.assertEqual(particle_metadata["types"][0]["name"], "pt_spark")
+        self.assertEqual(particle_metadata["emitters"][0]["name"], "pe_spark")
         self.assertEqual(by_name["config/game.json"].asset_type, "included_file")
         self.assertEqual(by_name["config/game.json"].godot_path, "res://included_files/config/game.json")
 
@@ -231,6 +277,7 @@ class TestAssetRegistryConverter(unittest.TestCase):
                 ("sprites", "s_player"),
                 ("paths", "path_patrol"),
                 ("animcurves", "ac_fade"),
+                ("timelines", "tl_intro"),
             ],
         )
         self._write_resource("sprites", "s_player", "GMSprite", "folders/Sprites.yy")
@@ -248,6 +295,14 @@ class TestAssetRegistryConverter(unittest.TestCase):
             "folders/Animation Curves.yy",
             {"channels": [{"name": "alpha", "points": [{"x": 0, "y": 1}]}]},
         )
+        self._write_resource(
+            "timelines",
+            "tl_intro",
+            "GMTimeline",
+            "folders/Timelines.yy",
+            {"momentList": [{"moment": 3, "eventFile": "Moment_3.gml"}]},
+        )
+        _write_file(os.path.join(self.gm_dir, "timelines", "tl_intro", "Moment_3.gml"), "x = 42;\n")
 
         registry_path = self._converter().convert_all()
 
@@ -264,15 +319,21 @@ class TestAssetRegistryConverter(unittest.TestCase):
         path_registry_path = os.path.join(self.godot_dir, PATH_REGISTRY_RELATIVE_PATH)
         path_scene_path = os.path.join(self.godot_dir, "paths", "path_patrol", "path_patrol.tscn")
         animation_curve_registry_path = os.path.join(self.godot_dir, ANIMATION_CURVE_REGISTRY_RELATIVE_PATH)
+        timeline_script_path = os.path.join(self.godot_dir, "gm2godot", "timelines", "tl_intro_3.gd")
         self.assertTrue(os.path.isfile(path_registry_path))
         self.assertTrue(os.path.isfile(path_scene_path))
         self.assertTrue(os.path.isfile(animation_curve_registry_path))
+        self.assertTrue(os.path.isfile(timeline_script_path))
         with open(path_scene_path, "r", encoding="utf-8") as f:
             path_scene = f.read()
         with open(animation_curve_registry_path, "r", encoding="utf-8") as f:
             curve_registry = f.read()
+        with open(timeline_script_path, "r", encoding="utf-8") as f:
+            timeline_script = f.read()
         self.assertIn('[node name="path_patrol" type="Path2D"]', path_scene)
         self.assertIn('"name": "ac_fade"', curve_registry)
+        self.assertIn("static func execute(_gm_instance):", timeline_script)
+        self.assertIn('GMRuntime.gml_variable_instance_set(_gm_instance, "x", 42)', timeline_script)
 
     def test_generates_actionable_texture_and_audio_group_registries(self) -> None:
         _write_json(

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -13,6 +13,7 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from src.conversion.rooms import ROOM_RUNTIME_SCRIPT_RELATIVE_PATH, RoomConverter
+from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.room_layers import (
     GAMEMAKER_EMPTY_TILE_SENTINEL,
     GAMEMAKER_TILE_FLIP_BIT,
@@ -723,6 +724,41 @@ class TestRoomConverter(unittest.TestCase):
         self.assertIn('metadata/gamemaker_layer_type = "GMREffectLayer"', content)
         self.assertIn('metadata/gamemaker_layer_effect_type = "_filter_whitenoise"', content)
         self.assertIn('metadata/gamemaker_layer_effect_properties = [{"name": "g_WhiteNoiseIntensity"', content)
+        self.assertTrue(any(
+            "effect/filter layer FX" in log and "preserved as metadata" in log
+            for log in self.logs
+        ))
+
+    def test_effect_layer_records_source_linked_diagnostic(self):
+        self._write_yyp(["r_effect_diag"])
+        room_path = self._write_room("r_effect_diag", layers=[
+            {
+                "%Name": "FX",
+                "resourceType": "GMREffectLayer",
+                "effectType": "_filter_whitenoise",
+            }
+        ])
+        diagnostics = DiagnosticCollector()
+        converter = RoomConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=lambda msg: self.logs.append(str(msg)),
+            progress_callback=lambda value: self.progress.append(value),
+            conversion_running=lambda: True,
+            max_workers=1,
+            diagnostics=diagnostics,
+        )
+
+        converter.convert_all()
+        recorded = diagnostics.diagnostics()
+
+        self.assertTrue(any(
+            diagnostic.code == "GM2GD-RESOURCE-UNSUPPORTED"
+            and diagnostic.source_path == room_path
+            and diagnostic.resource == "r_effect_diag"
+            and diagnostic.event == "_filter_whitenoise"
+            for diagnostic in recorded
+        ))
 
     def test_unsupported_layer_type_warns_and_emits_placeholder(self):
         self._write_yyp(["r_unknown"])
@@ -932,9 +968,10 @@ class TestRoomConverter(unittest.TestCase):
         self.assertIn('[node name="seq_intro" type="Node2D" parent="MixedAssets"]', content)
         self.assertIn('metadata/gamemaker_layer_element_type = "sequence"', content)
         self.assertIn('metadata/gamemaker_layer_element_type = "particle_system"', content)
+        self.assertIn("metadata/gamemaker_particle_system_layer_element = true", content)
         self.assertIn('metadata/gamemaker_layer_element_type = "tile"', content)
         self.assertIn('metadata/gamemaker_layer_element_type = "undefined"', content)
-        self.assertEqual(content.count("metadata/gamemaker_unsupported_asset = true"), 4)
+        self.assertEqual(content.count("metadata/gamemaker_unsupported_asset = true"), 3)
         self.assertTrue(any(
             "GMRSequenceGraphic" in log and "layer element type sequence" in log
             for log in self.logs

--- a/tests/test_sequences_timelines_godot.py
+++ b/tests/test_sequences_timelines_godot.py
@@ -43,7 +43,14 @@ def _write_registry(project_dir: Path) -> None:
             source_path="sequences/seq_intro/seq_intro.yy",
             godot_path="",
             legacy_id="sequences/seq_intro/seq_intro.yy",
-            metadata={"length": 12.0, "playback_speed": 1.0, "loopmode": 0, "tracks": []},
+            metadata={
+                "length": 12.0,
+                "playback_speed": 1.0,
+                "loopmode": 0,
+                "tracks": [],
+                "moments": [{"frame": 1.0, "callable": "_sequence_callback"}],
+                "broadcasts": [{"frame": 2.0, "message": "beat", "callable": "_sequence_callback"}],
+            },
         ),
         AssetRegistryEntry(
             id=400,
@@ -54,6 +61,11 @@ def _write_registry(project_dir: Path) -> None:
             source_path="timelines/tl_intro/tl_intro.yy",
             godot_path="",
             legacy_id="timelines/tl_intro/tl_intro.yy",
+            metadata={
+                "moments": [
+                    {"frame": 1, "actions": [{"kind": "callable", "callable": "_timeline_seed_callback"}]}
+                ]
+            },
         ),
     )
     _write_text(project_dir / "gm2godot" / "gml_asset_registry.gd", render_asset_registry_script(entries))
@@ -84,6 +96,16 @@ def _write_smoke_scene(project_dir: Path) -> None:
         \tif instance != self:
         \t\tGMRuntime.gml_global_scope()["timeline_wrong_self"] = true
 
+        func _timeline_seed_callback(instance, action):
+        \tGMRuntime.gml_global_scope()["timeline_seed_hits"] = GMRuntime.gml_global_scope().get("timeline_seed_hits", 0) + 1
+        \tif instance != self:
+        \t\tGMRuntime.gml_global_scope()["timeline_seed_wrong_self"] = true
+
+        func _sequence_callback(instance, action):
+        \tGMRuntime.gml_global_scope()["sequence_events"] = GMRuntime.gml_global_scope().get("sequence_events", 0) + 1
+        \tif action.get("message", "") == "beat":
+        \t\tGMRuntime.gml_global_scope()["sequence_broadcast"] = action["message"]
+
         func _ready():
         \tvar layer = Node2D.new()
         \tlayer.name = "Sequences"
@@ -108,6 +130,11 @@ def _write_smoke_scene(project_dir: Path) -> None:
         \t\treturn
         \tvar instance = GMRuntime.gml_layer_sequence_get_instance(element)
         \tif not _check(instance["sequence"]["name"] == "seq_intro" and instance["elementID"].index == element.index, "sequence instance mismatch"):
+        \t\treturn
+        \tGMRuntime.gml_layer_sequence_step(element, 2)
+        \tif not _check(GMRuntime.gml_global_scope().get("sequence_events", 0) == 2, "sequence authored events did not fire"):
+        \t\treturn
+        \tif not _check(GMRuntime.gml_global_scope().get("sequence_broadcast", "") == "beat", "sequence broadcast did not dispatch"):
         \t\treturn
         \tGMRuntime.gml_layer_sequence_headpos(element, 6)
         \tif not _check(GMRuntime.gml_layer_sequence_get_headpos(element) == 6, "sequence headpos mismatch"):
@@ -136,8 +163,10 @@ def _write_smoke_scene(project_dir: Path) -> None:
         \t\treturn
         \tif not _check(GMRuntime.gml_timeline_get_name(timeline_asset) == "tl_intro", "timeline_get_name failed"):
         \t\treturn
+        \tif not _check(GMRuntime.gml_timeline_size(timeline_asset) == 1 and GMRuntime.gml_timeline_max_moment(timeline_asset) == 1, "authored timeline metadata failed"):
+        \t\treturn
         \tGMRuntime.gml_timeline_moment_add_script(timeline_asset, 2, Callable(self, "_timeline_callback"))
-        \tif not _check(GMRuntime.gml_timeline_size(timeline_asset) == 1 and GMRuntime.gml_timeline_max_moment(timeline_asset) == 2, "timeline moment metadata failed"):
+        \tif not _check(GMRuntime.gml_timeline_size(timeline_asset) == 2 and GMRuntime.gml_timeline_max_moment(timeline_asset) == 2, "timeline moment metadata failed"):
         \t\treturn
         \ttimeline_index = timeline_asset
         \ttimeline_position = 0
@@ -145,12 +174,16 @@ def _write_smoke_scene(project_dir: Path) -> None:
         \ttimeline_running = true
         \tGMRuntime.gml_timeline_step(self)
         \tGMRuntime.gml_timeline_step(self)
+        \tif not _check(GMRuntime.gml_global_scope().get("timeline_seed_hits", 0) == 1, "authored timeline callback did not fire"):
+        \t\treturn
+        \tif not _check(not GMRuntime.gml_global_scope().get("timeline_seed_wrong_self", false), "authored timeline callback self mismatch"):
+        \t\treturn
         \tif not _check(GMRuntime.gml_global_scope().get("timeline_hits", 0) == 1, "timeline callback did not fire"):
         \t\treturn
         \tif not _check(not GMRuntime.gml_global_scope().get("timeline_wrong_self", false), "timeline callback self mismatch"):
         \t\treturn
         \tGMRuntime.gml_timeline_moment_clear(timeline_asset, 2)
-        \tif not _check(GMRuntime.gml_timeline_size(timeline_asset) == 0, "timeline clear moment failed"):
+        \tif not _check(GMRuntime.gml_timeline_size(timeline_asset) == 1, "timeline clear moment failed"):
         \t\treturn
 
         \tGMRuntime.gml_layer_sequence_destroy(element)


### PR DESCRIPTION
Closes #592.

## Summary
- preserve authored sequence tracks, moments, and broadcast metadata and dispatch sequence events deterministically from runtime playback
- parse timeline moment metadata, generate executable GDScript wrappers for supported moment .gml files, and seed the runtime timeline scheduler from authored moments
- add particle-system assets to the registry with type/emitter/affector metadata and emit explicit particle-system room layer nodes
- record source-linked diagnostics for GameMaker effect/filter room layers while preserving their parameters as metadata

## Tests
- ./venv/bin/python -m unittest tests.test_asset_registry tests.test_sequences_timelines_godot tests.test_rooms tests.test_gml_runtime_segments tests.test_gml_runtime tests.test_converter
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest