### PR TITLE
Add runtime manager autoload generation

### DIFF
--- a/src/conversion/gml_runtime.py
+++ b/src/conversion/gml_runtime.py
@@ -17,19 +17,37 @@ from src.conversion.gml_runtime_parts.writer import (
     GML_RUNTIME_RESOURCE_PATH,
     write_gml_runtime,
 )
+from src.conversion.runtime_managers import (
+    RUNTIME_MANAGER_DEFINITIONS,
+    RUNTIME_MANAGER_RELATIVE_DIR,
+    RuntimeManagerDefinition,
+    register_runtime_manager_autoloads,
+    render_runtime_manager_script,
+    runtime_manager_autoloads,
+    runtime_manager_definitions,
+    write_runtime_managers,
+)
 
 __all__ = [
     "GML_RUNTIME_RELATIVE_PATH",
     "GML_RUNTIME_RESOURCE_PATH",
     "GML_RUNTIME_SCRIPT",
+    "RUNTIME_MANAGER_DEFINITIONS",
+    "RUNTIME_MANAGER_RELATIVE_DIR",
     "RUNTIME_SEGMENTS",
+    "RuntimeManagerDefinition",
     "RuntimeAPIIndexEntry",
     "RuntimeProvidedSymbol",
     "RuntimeSegmentDefinition",
     "duplicate_runtime_symbols",
+    "register_runtime_manager_autoloads",
+    "render_runtime_manager_script",
     "runtime_api_index",
+    "runtime_manager_autoloads",
+    "runtime_manager_definitions",
     "runtime_segment_names",
     "runtime_symbol_index",
     "validate_runtime_segments",
+    "write_runtime_managers",
     "write_gml_runtime",
 ]

--- a/src/conversion/gml_runtime_parts/writer.py
+++ b/src/conversion/gml_runtime_parts/writer.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 import os
 
+from src.conversion.runtime_managers import (
+    register_runtime_manager_autoloads,
+    write_runtime_managers,
+)
+
 from .script import GML_RUNTIME_SCRIPT
 
 GML_RUNTIME_RELATIVE_PATH = os.path.join("gm2godot", "gml_runtime.gd")
@@ -13,4 +18,6 @@ def write_gml_runtime(godot_project_path: str) -> str:
     os.makedirs(os.path.dirname(runtime_path), exist_ok=True)
     with open(runtime_path, "w", encoding="utf-8") as f:
         f.write(GML_RUNTIME_SCRIPT)
+    write_runtime_managers(godot_project_path)
+    register_runtime_manager_autoloads(godot_project_path)
     return runtime_path

--- a/src/conversion/project_godot.py
+++ b/src/conversion/project_godot.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Iterable
 from typing import Any
 
 
@@ -11,6 +12,24 @@ class GodotProjectFile:
     def set_main_scene(self, scene_path: str) -> bool:
         """Set [application] run/main_scene while preserving unrelated settings."""
         return self.set_setting("application", "run/main_scene", scene_path)
+
+    def set_autoloads(self, autoloads: Iterable[tuple[str, str]]) -> bool:
+        """Set managed [autoload] entries in deterministic order."""
+        if not os.path.isfile(self.project_godot_path):
+            return False
+
+        with open(self.project_godot_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        autoload_lines = tuple(
+            (name, self._format_value(self._autoload_value(path)))
+            for name, path in autoloads
+        )
+        updated = self._set_autoloads(content, autoload_lines)
+        with open(self.project_godot_path, "w", encoding="utf-8") as f:
+            f.write(updated)
+
+        return True
 
     def set_setting(self, section: str, key: str, value: Any) -> bool:
         if not os.path.isfile(self.project_godot_path):
@@ -72,6 +91,47 @@ class GodotProjectFile:
         lines.insert(insert_at, setting_line + newline)
         return "".join(lines)
 
+    @classmethod
+    def _set_autoloads(
+        cls,
+        content: str,
+        autoloads: tuple[tuple[str, str], ...],
+    ) -> str:
+        managed_names = {name for name, _value in autoloads}
+        setting_lines = [
+            f"{name}={formatted_value}"
+            for name, formatted_value in autoloads
+        ]
+        lines = content.splitlines(keepends=True)
+        newline = cls._detect_newline(content)
+        section_header = "[autoload]"
+
+        section_start = None
+        section_end = len(lines)
+        for index, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped == section_header:
+                section_start = index
+                section_end = len(lines)
+                continue
+            if section_start is not None and cls._is_section_header(stripped):
+                section_end = index
+                break
+
+        if section_start is None:
+            return cls._append_section(content, section_header, "\n".join(setting_lines), newline)
+
+        preserved_body: list[str] = []
+        for line in lines[section_start + 1:section_end]:
+            stripped = line.lstrip()
+            if any(stripped.startswith(f"{name}=") for name in managed_names):
+                continue
+            preserved_body.append(line)
+
+        managed_body = [line + newline for line in setting_lines]
+        lines[section_start + 1:section_end] = managed_body + preserved_body
+        return "".join(lines)
+
     @staticmethod
     def _append_section(
         content: str, section_header: str, setting_line: str, newline: str
@@ -81,6 +141,10 @@ class GodotProjectFile:
 
         separator = "" if content.endswith(("\n", "\r")) else newline
         return f"{content}{separator}{newline}{section_header}{newline}{setting_line}{newline}"
+
+    @staticmethod
+    def _autoload_value(path: str) -> str:
+        return path if path.startswith("*") else "*" + path
 
     @staticmethod
     def _is_section_header(stripped_line: str) -> bool:

--- a/src/conversion/runtime_managers.md
+++ b/src/conversion/runtime_managers.md
@@ -1,0 +1,26 @@
+# GM2Godot Runtime Managers
+
+Converted projects keep `res://gm2godot/gml_runtime.gd` as the compatibility facade so generated scripts can continue to call `GMRuntime.gml_*` helpers. New generated projects also receive deterministic autoload managers under `res://gm2godot/managers/`.
+
+The generated autoloads are:
+
+- `GMRuntime`: root registry and compatibility lifecycle.
+- `GMAssets`: asset registry, texture groups, audio groups, and dynamic assets.
+- `GMRooms`: room order, current room, transitions, and layers.
+- `GMInstances`: live instances, handles, object indices, and creation order.
+- `GMEvents`: frame events, alarms, timelines, and sequences.
+- `GMDraw`: draw state, surfaces, shader cache, and texture-group state.
+- `GMInput`: keyboard, mouse, gamepad, and gesture state.
+- `GMAudio`: audio instances, groups, emitters, and listeners.
+- `GMAsync`: async_load, HTTP, buffer, and networking queues.
+- `GMPlatform`: service hooks, extension callback schemas, OS/debug, and GC state.
+
+`project.godot` registers the managers in that order in `[autoload]`. Godot loads autoload nodes before the main scene and evaluates them in project order, which gives the runtime a stable startup sequence for later event, room, draw, input, audio, async, and platform migrations.
+
+The `GMRuntime` autoload records each manager in `manager_registry_snapshot()` and exposes `manager_order()`. Each manager owns named state buckets so future runtime slices can move domain state out of the static compatibility facade without changing generated GML helper call sites.
+
+## Compatibility
+
+The manager layer is enabled by default when `write_gml_runtime()` runs and `project.godot` exists. Existing generated scripts remain compatible because they still preload and call `res://gm2godot/gml_runtime.gd`.
+
+Projects can remove or override the generated `GM*` autoloads while keeping the static compatibility facade for tests or incremental migrations. New runtime code should prefer manager `state_bucket()` ownership for persistent domain state and keep `GMRuntime.gml_*` helpers as stable call-site facades.

--- a/src/conversion/runtime_managers.py
+++ b/src/conversion/runtime_managers.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Iterable
+
+from src.conversion.project_godot import GodotProjectFile
+
+RUNTIME_MANAGER_RELATIVE_DIR = os.path.join("gm2godot", "managers")
+
+
+@dataclass(frozen=True)
+class RuntimeManagerDefinition:
+    name: str
+    script_name: str
+    order: int
+    domain: str
+    dependencies: tuple[str, ...] = ()
+    state_keys: tuple[str, ...] = ()
+
+    @property
+    def relative_path(self) -> str:
+        return os.path.join(RUNTIME_MANAGER_RELATIVE_DIR, self.script_name)
+
+    @property
+    def resource_path(self) -> str:
+        return "res://" + self.relative_path.replace(os.sep, "/")
+
+
+RUNTIME_MANAGER_DEFINITIONS: tuple[RuntimeManagerDefinition, ...] = (
+    RuntimeManagerDefinition(
+        "GMRuntime",
+        "gm_runtime_manager.gd",
+        0,
+        "runtime",
+        state_keys=("manager_registry", "compatibility_facade", "startup"),
+    ),
+    RuntimeManagerDefinition(
+        "GMAssets",
+        "gm_assets.gd",
+        10,
+        "assets",
+        dependencies=("GMRuntime",),
+        state_keys=("asset_registry", "texture_groups", "audio_groups", "dynamic_assets"),
+    ),
+    RuntimeManagerDefinition(
+        "GMRooms",
+        "gm_rooms.gd",
+        20,
+        "rooms",
+        dependencies=("GMRuntime", "GMAssets"),
+        state_keys=("room_order", "current_room", "transitions", "layers"),
+    ),
+    RuntimeManagerDefinition(
+        "GMInstances",
+        "gm_instances.gd",
+        30,
+        "instances",
+        dependencies=("GMRuntime", "GMAssets", "GMRooms"),
+        state_keys=("instances", "handles", "object_indices", "creation_order"),
+    ),
+    RuntimeManagerDefinition(
+        "GMEvents",
+        "gm_events.gd",
+        40,
+        "events",
+        dependencies=("GMRuntime", "GMRooms", "GMInstances"),
+        state_keys=("event_queue", "alarms", "timeline_dispatch", "sequence_dispatch"),
+    ),
+    RuntimeManagerDefinition(
+        "GMDraw",
+        "gm_draw.gd",
+        50,
+        "draw",
+        dependencies=("GMRuntime", "GMAssets", "GMRooms", "GMInstances"),
+        state_keys=("draw_state", "surfaces", "shader_cache", "texture_groups"),
+    ),
+    RuntimeManagerDefinition(
+        "GMInput",
+        "gm_input.gd",
+        60,
+        "input",
+        dependencies=("GMRuntime", "GMEvents"),
+        state_keys=("keyboard", "mouse", "gamepad", "gestures"),
+    ),
+    RuntimeManagerDefinition(
+        "GMAudio",
+        "gm_audio.gd",
+        70,
+        "audio",
+        dependencies=("GMRuntime", "GMAssets"),
+        state_keys=("audio_instances", "audio_groups", "emitters", "listeners"),
+    ),
+    RuntimeManagerDefinition(
+        "GMAsync",
+        "gm_async.gd",
+        80,
+        "async",
+        dependencies=("GMRuntime", "GMEvents"),
+        state_keys=("async_load", "event_log", "http", "buffers", "networking"),
+    ),
+    RuntimeManagerDefinition(
+        "GMPlatform",
+        "gm_platform.gd",
+        90,
+        "platform",
+        dependencies=("GMRuntime", "GMAsync"),
+        state_keys=("service_hooks", "extension_schemas", "os_debug", "gc"),
+    ),
+)
+
+
+def runtime_manager_definitions() -> tuple[RuntimeManagerDefinition, ...]:
+    return tuple(sorted(RUNTIME_MANAGER_DEFINITIONS, key=lambda definition: definition.order))
+
+
+def runtime_manager_autoloads() -> tuple[tuple[str, str], ...]:
+    return tuple(
+        (definition.name, definition.resource_path)
+        for definition in runtime_manager_definitions()
+    )
+
+
+def write_runtime_managers(godot_project_path: str) -> tuple[str, ...]:
+    output_paths: list[str] = []
+    for definition in runtime_manager_definitions():
+        output_path = os.path.join(godot_project_path, definition.relative_path)
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(render_runtime_manager_script(definition))
+        output_paths.append(output_path)
+    return tuple(output_paths)
+
+
+def register_runtime_manager_autoloads(godot_project_path: str) -> bool:
+    project_path = os.path.join(godot_project_path, "project.godot")
+    return GodotProjectFile(project_path).set_autoloads(runtime_manager_autoloads())
+
+
+def render_runtime_manager_script(definition: RuntimeManagerDefinition) -> str:
+    dependencies = _gdscript_string_array(definition.dependencies)
+    state_keys = _gdscript_string_array(definition.state_keys)
+    return "\n".join([
+        "extends Node",
+        "",
+        f'const MANAGER_NAME = "{definition.name}"',
+        f'const MANAGER_DOMAIN = "{definition.domain}"',
+        f"const INITIALIZATION_ORDER = {definition.order}",
+        f"const DEPENDENCIES = {dependencies}",
+        f"const STATE_KEYS = {state_keys}",
+        "",
+        "var initialized = false",
+        "var initialization_index = -1",
+        "var state = {}",
+        "var managers = {}",
+        "var initialization_order = []",
+        "",
+        "",
+        "func _ready():",
+        "\tinitialize_runtime_manager()",
+        "",
+        "",
+        "func initialize_runtime_manager():",
+        "\tif initialized:",
+        "\t\treturn state",
+        "\t_seed_state()",
+        "\tinitialized = true",
+        "\tif MANAGER_NAME == \"GMRuntime\":",
+        "\t\tregister_manager(self)",
+        "\telse:",
+        "\t\tvar runtime_root = _gm2godot_runtime_root()",
+        "\t\tif runtime_root != null and runtime_root.has_method(\"register_manager\"):",
+        "\t\t\truntime_root.register_manager(self)",
+        "\treturn state",
+        "",
+        "",
+        "func manager_name():",
+        "\treturn MANAGER_NAME",
+        "",
+        "",
+        "func manager_domain():",
+        "\treturn MANAGER_DOMAIN",
+        "",
+        "",
+        "func manager_dependencies():",
+        "\treturn DEPENDENCIES.duplicate()",
+        "",
+        "",
+        "func manager_state_keys():",
+        "\treturn STATE_KEYS.duplicate()",
+        "",
+        "",
+        "func set_initialization_index(index):",
+        "\tinitialization_index = int(index)",
+        "",
+        "",
+        "func manager_initialization_index():",
+        "\treturn initialization_index",
+        "",
+        "",
+        "func state_bucket(key = \"default\"):",
+        "\tvar bucket_key = str(key)",
+        "\tif not state.has(bucket_key) or typeof(state[bucket_key]) != TYPE_DICTIONARY:",
+        "\t\tstate[bucket_key] = {}",
+        "\treturn state[bucket_key]",
+        "",
+        "",
+        "func state_snapshot():",
+        "\treturn state.duplicate(true)",
+        "",
+        "",
+        "func reset_runtime_state():",
+        "\tstate.clear()",
+        "\t_seed_state()",
+        "",
+        "",
+        "func register_manager(manager):",
+        "\tif manager == null or not manager.has_method(\"manager_name\"):",
+        "\t\treturn null",
+        "\tvar name = str(manager.manager_name())",
+        "\tif not managers.has(name):",
+        "\t\tinitialization_order.append(name)",
+        "\t\tif manager.has_method(\"set_initialization_index\"):",
+        "\t\t\tmanager.set_initialization_index(initialization_order.size() - 1)",
+        "\tmanagers[name] = manager",
+        "\tstate_bucket(\"manager_registry\")[name] = {",
+        "\t\t\"domain\": manager.manager_domain() if manager.has_method(\"manager_domain\") else \"\",",
+        "\t\t\"dependencies\": manager.manager_dependencies() if manager.has_method(\"manager_dependencies\") else [],",
+        "\t\t\"state_keys\": manager.manager_state_keys() if manager.has_method(\"manager_state_keys\") else [],",
+        "\t\t\"initialization_index\": manager.manager_initialization_index() if manager.has_method(\"manager_initialization_index\") else -1,",
+        "\t}",
+        "\treturn manager",
+        "",
+        "",
+        "func manager(name):",
+        "\treturn managers.get(str(name), null)",
+        "",
+        "",
+        "func manager_order():",
+        "\treturn initialization_order.duplicate()",
+        "",
+        "",
+        "func manager_registry_snapshot():",
+        "\treturn state_bucket(\"manager_registry\").duplicate(true)",
+        "",
+        "",
+        "func _seed_state():",
+        "\tstate[\"manager_name\"] = MANAGER_NAME",
+        "\tstate[\"domain\"] = MANAGER_DOMAIN",
+        "\tstate[\"dependencies\"] = DEPENDENCIES.duplicate()",
+        "\tstate[\"state_keys\"] = STATE_KEYS.duplicate()",
+        "\tfor key in STATE_KEYS:",
+        "\t\tif not state.has(key):",
+        "\t\t\tstate[key] = {}",
+        "",
+        "",
+        "func _gm2godot_runtime_root():",
+        "\tvar tree = get_tree()",
+        "\tif tree == null or tree.root == null:",
+        "\t\treturn null",
+        "\treturn tree.root.get_node_or_null(\"GMRuntime\")",
+        "",
+    ])
+
+
+def _gdscript_string_array(values: Iterable[str]) -> str:
+    return "[" + ", ".join(f'"{value}"' for value in values) + "]"
+
+
+__all__ = [
+    "RUNTIME_MANAGER_DEFINITIONS",
+    "RUNTIME_MANAGER_RELATIVE_DIR",
+    "RuntimeManagerDefinition",
+    "register_runtime_manager_autoloads",
+    "render_runtime_manager_script",
+    "runtime_manager_autoloads",
+    "runtime_manager_definitions",
+    "write_runtime_managers",
+]

--- a/tests/test_project_godot.py
+++ b/tests/test_project_godot.py
@@ -116,6 +116,57 @@ class TestGodotProjectFile(unittest.TestCase):
 
         self.assertFalse(result)
 
+    def test_set_autoloads_adds_managed_entries_in_order(self) -> None:
+        _write_file(self.project_path, (
+            '[application]\n'
+            'config/name="Existing"\n'
+        ))
+
+        result = GodotProjectFile(self.project_path).set_autoloads((
+            ("GMRuntime", "res://gm2godot/managers/gm_runtime_manager.gd"),
+            ("GMAssets", "res://gm2godot/managers/gm_assets.gd"),
+        ))
+
+        content = self._read_project()
+        self.assertTrue(result)
+        self.assertIn("[autoload]", content)
+        self.assertLess(content.index("GMRuntime="), content.index("GMAssets="))
+        self.assertIn('GMRuntime="*res://gm2godot/managers/gm_runtime_manager.gd"', content)
+        self.assertIn('GMAssets="*res://gm2godot/managers/gm_assets.gd"', content)
+        self.assertIn('[application]', content)
+
+    def test_set_autoloads_reorders_managed_entries_and_preserves_unrelated(self) -> None:
+        _write_file(self.project_path, (
+            '[autoload]\n'
+            'Custom="*res://custom.gd"\n'
+            'GMAssets="*res://old_assets.gd"\n'
+            'GMRuntime="*res://old_runtime.gd"\n'
+            '\n'
+            '[application]\n'
+            'config/name="Existing"\n'
+        ))
+
+        result = GodotProjectFile(self.project_path).set_autoloads((
+            ("GMRuntime", "res://gm2godot/managers/gm_runtime_manager.gd"),
+            ("GMAssets", "res://gm2godot/managers/gm_assets.gd"),
+        ))
+
+        content = self._read_project()
+        self.assertTrue(result)
+        self.assertLess(content.index("GMRuntime="), content.index("GMAssets="))
+        self.assertLess(content.index("GMAssets="), content.index("Custom="))
+        self.assertIn('Custom="*res://custom.gd"', content)
+        self.assertNotIn("old_assets", content)
+        self.assertNotIn("old_runtime", content)
+        self.assertIn('[application]', content)
+
+    def test_set_autoloads_returns_false_when_project_missing(self) -> None:
+        result = GodotProjectFile(self.project_path).set_autoloads((
+            ("GMRuntime", "res://gm2godot/managers/gm_runtime_manager.gd"),
+        ))
+
+        self.assertFalse(result)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_runtime_managers.py
+++ b/tests/test_runtime_managers.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from src.conversion.gml_runtime import (
+    GML_RUNTIME_RELATIVE_PATH,
+    RUNTIME_MANAGER_RELATIVE_DIR,
+    register_runtime_manager_autoloads,
+    render_runtime_manager_script,
+    runtime_manager_autoloads,
+    runtime_manager_definitions,
+    write_gml_runtime,
+    write_runtime_managers,
+)
+
+
+def _write_file(path: str, content: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+class TestRuntimeManagers(unittest.TestCase):
+    def setUp(self) -> None:
+        self.godot_dir = tempfile.mkdtemp()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.godot_dir)
+
+    def test_runtime_manager_definitions_are_deterministic(self) -> None:
+        definitions = runtime_manager_definitions()
+        names = [definition.name for definition in definitions]
+        orders = [definition.order for definition in definitions]
+
+        self.assertEqual(
+            names,
+            [
+                "GMRuntime",
+                "GMAssets",
+                "GMRooms",
+                "GMInstances",
+                "GMEvents",
+                "GMDraw",
+                "GMInput",
+                "GMAudio",
+                "GMAsync",
+                "GMPlatform",
+            ],
+        )
+        self.assertEqual(orders, sorted(orders))
+        self.assertEqual(definitions[0].dependencies, ())
+        for definition in definitions[1:]:
+            self.assertIn("GMRuntime", definition.dependencies)
+            self.assertTrue(definition.state_keys)
+
+    def test_runtime_manager_autoloads_use_generated_resource_paths(self) -> None:
+        autoloads = runtime_manager_autoloads()
+
+        self.assertEqual(autoloads[0], ("GMRuntime", "res://gm2godot/managers/gm_runtime_manager.gd"))
+        self.assertEqual(autoloads[-1], ("GMPlatform", "res://gm2godot/managers/gm_platform.gd"))
+
+    def test_rendered_manager_script_exposes_registry_and_state_buckets(self) -> None:
+        definition = runtime_manager_definitions()[0]
+
+        script = render_runtime_manager_script(definition)
+
+        self.assertIn("extends Node", script)
+        self.assertIn('const MANAGER_NAME = "GMRuntime"', script)
+        self.assertIn("func register_manager(manager):", script)
+        self.assertIn("func manager_order():", script)
+        self.assertIn("func state_bucket(key = \"default\"):", script)
+
+    def test_write_runtime_managers_writes_each_manager_script(self) -> None:
+        output_paths = write_runtime_managers(self.godot_dir)
+
+        self.assertEqual(len(output_paths), len(runtime_manager_definitions()))
+        for definition in runtime_manager_definitions():
+            path = os.path.join(self.godot_dir, definition.relative_path)
+            self.assertTrue(os.path.isfile(path), definition.name)
+        self.assertTrue(os.path.isdir(os.path.join(self.godot_dir, RUNTIME_MANAGER_RELATIVE_DIR)))
+
+    def test_register_runtime_manager_autoloads_updates_project_godot(self) -> None:
+        _write_file(os.path.join(self.godot_dir, "project.godot"), "[application]\n")
+
+        self.assertTrue(register_runtime_manager_autoloads(self.godot_dir))
+
+        with open(os.path.join(self.godot_dir, "project.godot"), "r", encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn("[autoload]", content)
+        self.assertLess(content.index("GMRuntime="), content.index("GMPlatform="))
+        self.assertIn('GMAsync="*res://gm2godot/managers/gm_async.gd"', content)
+
+    def test_write_gml_runtime_writes_facade_managers_and_project_autoloads(self) -> None:
+        _write_file(os.path.join(self.godot_dir, "project.godot"), "[application]\n")
+
+        runtime_path = write_gml_runtime(self.godot_dir)
+
+        self.assertEqual(runtime_path, os.path.join(self.godot_dir, GML_RUNTIME_RELATIVE_PATH))
+        self.assertTrue(os.path.isfile(os.path.join(self.godot_dir, "gm2godot", "gml_runtime.gd")))
+        self.assertTrue(os.path.isfile(os.path.join(self.godot_dir, "gm2godot", "managers", "gm_runtime_manager.gd")))
+        with open(os.path.join(self.godot_dir, "project.godot"), "r", encoding="utf-8") as f:
+            content = f.read()
+        self.assertIn('GMRuntime="*res://gm2godot/managers/gm_runtime_manager.gd"', content)
+        self.assertIn('GMPlatform="*res://gm2godot/managers/gm_platform.gd"', content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_managers_godot.py
+++ b/tests/test_runtime_managers_godot.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from src.conversion.gml_runtime import write_gml_runtime
+
+
+def _find_godot_binary() -> str | None:
+    env_path = os.environ.get("GODOT_BIN")
+    if env_path and os.path.isfile(env_path):
+        return env_path
+
+    path_binary = shutil.which("godot")
+    if path_binary is not None:
+        return path_binary
+
+    mac_binary = "/Applications/Godot.app/Contents/MacOS/Godot"
+    if os.path.isfile(mac_binary):
+        return mac_binary
+    return None
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class TestRuntimeManagersGodotSmoke(unittest.TestCase):
+    def test_generated_runtime_managers_autoload_in_order(self) -> None:
+        godot_binary = _find_godot_binary()
+        if godot_binary is None:
+            self.skipTest("Godot binary not available")
+
+        smoke_script = textwrap.dedent(
+            """\
+            extends Node
+
+            func _check(condition, message):
+            \tif not condition:
+            \t\tpush_error(str(message))
+            \t\tget_tree().quit(1)
+            \t\treturn false
+            \treturn true
+
+            func _ready():
+            \tcall_deferred("_run")
+
+            func _run():
+            \tvar runtime_root = get_node("/root/GMRuntime")
+            \tif not _check(runtime_root != null, "GMRuntime autoload missing"):
+            \t\treturn
+            \tvar expected = [
+            \t\t"GMRuntime",
+            \t\t"GMAssets",
+            \t\t"GMRooms",
+            \t\t"GMInstances",
+            \t\t"GMEvents",
+            \t\t"GMDraw",
+            \t\t"GMInput",
+            \t\t"GMAudio",
+            \t\t"GMAsync",
+            \t\t"GMPlatform"
+            \t]
+            \tif not _check(runtime_root.manager_order() == expected, "manager order mismatch"):
+            \t\treturn
+            \tvar registry = runtime_root.manager_registry_snapshot()
+            \tif not _check(registry.has("GMAssets"), "GMAssets registry missing"):
+            \t\treturn
+            \tif not _check(registry["GMAssets"]["dependencies"].has("GMRuntime"), "GMAssets dependency missing"):
+            \t\treturn
+            \tvar assets = get_node("/root/GMAssets")
+            \tif not _check(assets.state_bucket("asset_registry") is Dictionary, "GMAssets state bucket missing"):
+            \t\treturn
+            \tif not _check(get_node("/root/GMPlatform").manager_initialization_index() == 9, "GMPlatform order mismatch"):
+            \t\treturn
+            \tprint("RUNTIME_MANAGERS_SMOKE_OK")
+            \tget_tree().quit(0)
+            """
+        )
+
+        smoke_scene = textwrap.dedent(
+            """\
+            [gd_scene load_steps=2 format=3]
+
+            [ext_resource type="Script" path="res://smoke.gd" id="smoke_script"]
+
+            [node name="Smoke" type="Node"]
+            script = ExtResource("smoke_script")
+            """
+        )
+
+        with tempfile.TemporaryDirectory() as godot_tmp:
+            project_dir = Path(godot_tmp)
+            _write_text(project_dir / "project.godot", "[application]\n")
+            write_gml_runtime(str(project_dir))
+            _write_text(project_dir / "smoke.gd", smoke_script)
+            _write_text(project_dir / "smoke.tscn", smoke_scene)
+
+            try:
+                result = subprocess.run(
+                    [godot_binary, "--headless", "--path", str(project_dir), "smoke.tscn"],
+                    check=False,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    timeout=30,
+                )
+            except subprocess.TimeoutExpired as exc:
+                output = exc.output.decode("utf-8", errors="replace") if isinstance(exc.output, bytes) else str(exc.output or "")
+                self.fail("Godot runtime-manager smoke timed out\n" + output)
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("RUNTIME_MANAGERS_SMOKE_OK", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #594.

## Summary
- add generated GMRuntime/GMAssets/GMRooms/GMInstances/GMEvents/GMDraw/GMInput/GMAudio/GMAsync/GMPlatform manager autoload scripts with deterministic initialization metadata and state buckets
- register the manager autoloads in project.godot when the runtime is generated while preserving the existing GMRuntime.gml_* compatibility facade
- add line-preserving project.godot autoload updates, runtime manager docs, and headless manager initialization validation

## Tests
- ./venv/bin/python -m unittest tests.test_project_godot tests.test_runtime_managers tests.test_gml_runtime tests.test_runtime_managers_godot
- ./venv/bin/python -m unittest -v tests.test_runtime_managers_godot
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest tests.test_project_godot tests.test_project_settings tests.test_runtime_managers tests.test_runtime_managers_godot tests.test_gml_runtime tests.test_gml_runtime_segments tests.test_objects tests.test_scripts tests.test_rooms tests.test_converter
- ./venv/bin/python -m unittest