### PR TITLE
Add deterministic input event dispatch

### DIFF
--- a/src/conversion/event_mapping.py
+++ b/src/conversion/event_mapping.py
@@ -4,6 +4,7 @@ from src.conversion.events.registry import (
     INPUT_MERGED_MAPPING,
     is_input_event,
     map_event,
+    map_input_event,
 )
 
 
@@ -13,4 +14,5 @@ __all__ = [
     "INPUT_MERGED_MAPPING",
     "is_input_event",
     "map_event",
+    "map_input_event",
 ]

--- a/src/conversion/events/mappings/input.py
+++ b/src/conversion/events/mappings/input.py
@@ -1,4 +1,5 @@
 from src.conversion.events.base import EventMapping
+from src.conversion.type_defs import JsonDict
 
 
 # Input event types are merged into a single _input(event) function.
@@ -6,3 +7,41 @@ from src.conversion.events.base import EventMapping
 # now so they are recognized as supported input instead of unknown events.
 INPUT_EVENT_TYPES: set[int] = {5, 6, 9, 10, 13}
 INPUT_MERGED_MAPPING = EventMapping("_input", "event", 4, "")
+
+_INPUT_FUNCTION_PREFIXES: dict[int, str] = {
+    5: "keyboard",
+    6: "mouse",
+    9: "key_press",
+    10: "key_release",
+    13: "gesture",
+}
+
+_INPUT_GML_PREFIXES: dict[int, str] = {
+    5: "Keyboard",
+    6: "Mouse",
+    9: "KeyPress",
+    10: "KeyRelease",
+    13: "Gesture",
+}
+
+
+def map_input_event(event: JsonDict) -> EventMapping | None:
+    """Map an input event to its event-specific generated method.
+
+    The public ``map_event`` API still returns ``None`` for these events so
+    callers can treat them as merged input. Object conversion uses this helper
+    to load and transpile the original ``Keyboard_*.gml``, ``Mouse_*.gml``,
+    and gesture source files into methods that the GMInput router dispatches.
+    """
+    event_type = int(event.get("eventType", -1))
+    event_num = int(event.get("eventNum", 0))
+    function_prefix = _INPUT_FUNCTION_PREFIXES.get(event_type)
+    gml_prefix = _INPUT_GML_PREFIXES.get(event_type)
+    if function_prefix is None or gml_prefix is None:
+        return None
+    return EventMapping(
+        f"_gm_input_{function_prefix}_{event_num}",
+        "",
+        4,
+        f"{gml_prefix}_{event_num}.gml",
+    )

--- a/src/conversion/events/registry.py
+++ b/src/conversion/events/registry.py
@@ -85,3 +85,12 @@ def map_event(event: JsonDict) -> EventMapping | None:
         return handler(event, gml_filename)
 
     return EventMapping(f"_on_event_{event_type}_{event_num}", "", 20, gml_filename)
+
+
+def map_input_event(event: JsonDict) -> EventMapping | None:
+    """Map an input event to its source-backed generated handler."""
+    from src.conversion.events.mappings.input import map_input_event as _map_input_event
+
+    if not is_input_event(event):
+        return None
+    return _map_input_event(event)

--- a/src/conversion/gml_runtime_parts/segments/53_game_input.gd
+++ b/src/conversion/gml_runtime_parts/segments/53_game_input.gd
@@ -15,9 +15,19 @@ static var _gml_input_mouse_wheel_down = false
 static var _gml_input_keyboard_key = 0
 static var _gml_input_keyboard_lastkey = 0
 static var _gml_input_keyboard_string = ""
+static var _gml_input_gesture_events = []
+static var _gml_input_dispatch_trace = []
 
 
 static func gml_input_begin_frame():
+	return _gml_input_clear_frame_edges()
+
+
+static func gml_input_end_frame():
+	return _gml_input_clear_frame_edges()
+
+
+static func _gml_input_clear_frame_edges():
 	_gml_input_key_pressed = {}
 	_gml_input_key_released = {}
 	_gml_input_mouse_pressed = {}
@@ -26,6 +36,7 @@ static func gml_input_begin_frame():
 	_gml_input_gamepad_released = {}
 	_gml_input_mouse_wheel_up = false
 	_gml_input_mouse_wheel_down = false
+	_gml_input_gesture_events = []
 	return null
 
 
@@ -86,6 +97,92 @@ static func gml_input_set_mouse_wheel(up, down):
 static func gml_input_append_text(text):
 	_gml_input_keyboard_string += str(text)
 	return null
+
+
+static func gml_input_dispatch_trace():
+	return _gml_clone_value(_gml_input_dispatch_trace, 16)
+
+
+static func gml_input_dispatch_trace_clear():
+	_gml_input_dispatch_trace = []
+	return null
+
+
+static func gml_input_event_capture(event):
+	if event == null:
+		return null
+	if event is InputEventKey:
+		var key_code = int(event.keycode)
+		if key_code == 0:
+			key_code = int(event.physical_keycode)
+		if key_code != 0 and not bool(event.echo):
+			gml_input_set_key_state(key_code, bool(event.pressed))
+		if bool(event.pressed) and int(event.unicode) > 0:
+			gml_input_append_text(char(int(event.unicode)))
+		return null
+	if event is InputEventMouseButton:
+		gml_input_set_mouse_position(event.position.x, event.position.y)
+		if int(event.button_index) == MOUSE_BUTTON_WHEEL_UP:
+			gml_input_set_mouse_wheel(bool(event.pressed), _gml_input_mouse_wheel_down)
+			return null
+		if int(event.button_index) == MOUSE_BUTTON_WHEEL_DOWN:
+			gml_input_set_mouse_wheel(_gml_input_mouse_wheel_up, bool(event.pressed))
+			return null
+		gml_input_set_mouse_button_state(int(event.button_index), bool(event.pressed))
+		return null
+	if event is InputEventMouseMotion:
+		gml_input_set_mouse_position(event.position.x, event.position.y)
+		return null
+	if event is InputEventJoypadButton:
+		gml_input_set_gamepad_button_state(int(event.device), int(event.button_index), bool(event.pressed))
+		return null
+	if event is InputEventJoypadMotion:
+		gml_input_set_gamepad_axis_value(int(event.device), int(event.axis), _to_real(event.axis_value))
+		return null
+	if event is InputEventScreenTouch:
+		gml_input_set_mouse_position(event.position.x, event.position.y)
+		gml_input_set_mouse_button_state(MOUSE_BUTTON_LEFT, bool(event.pressed))
+		if bool(event.pressed):
+			gml_input_enqueue_gesture(0, _gml_input_touch_payload(event, "tap"), false)
+		return null
+	if event is InputEventScreenDrag:
+		gml_input_set_mouse_position(event.position.x, event.position.y)
+		gml_input_enqueue_gesture(2, _gml_input_touch_payload(event, "drag"), false)
+		return null
+	return null
+
+
+static func gml_input_enqueue_gesture(event_num, payload = null, global_event = false):
+	var resolved_payload = payload if payload is Dictionary else {}
+	_gml_input_gesture_events.append({
+		"event_type": 13,
+		"event_num": int(_to_real(event_num)),
+		"payload": _gml_input_normalize_gesture_payload(resolved_payload),
+		"global": gml_bool(global_event),
+	})
+	return null
+
+
+static func gml_input_dispatch_frame(instances = null):
+	var instance_snapshot = _gml_input_instance_snapshot(instances)
+	var dispatched = 0
+	for inst in instance_snapshot:
+		if not _gml_input_instance_valid(inst):
+			continue
+		if not inst.has_method("_gm_input_event_bindings"):
+			continue
+		var bindings = inst._gm_input_event_bindings()
+		if not (bindings is Array):
+			continue
+		for binding in bindings:
+			if not (binding is Dictionary):
+				continue
+			if not _gml_input_binding_matches(inst, binding):
+				continue
+			dispatched += _gml_input_dispatch_binding(inst, binding)
+	_gml_builtin_globals["event_data"] = {}
+	_gml_input_gesture_events = []
+	return dispatched
 
 
 static func gml_keyboard_check(key):
@@ -243,3 +340,242 @@ static func _gml_mouse_room_to_gui(position):
 	var scale_x = gui_size.x / app_size.x if app_size.x > 0.0 else 1.0
 	var scale_y = gui_size.y / app_size.y if app_size.y > 0.0 else 1.0
 	return Vector2(position.x * scale_x, position.y * scale_y)
+
+
+static func _gml_input_instance_snapshot(instances):
+	if instances is Array:
+		var provided = []
+		for inst in instances:
+			provided.append(inst)
+		return provided
+	var snapshot = []
+	for entry in _gml_live_instance_entries():
+		var inst = entry.get("instance")
+		if inst != null:
+			snapshot.append(inst)
+	return snapshot
+
+
+static func _gml_input_instance_valid(inst):
+	if inst == null:
+		return false
+	if inst is Object and not is_instance_valid(inst):
+		return false
+	return true
+
+
+static func _gml_input_binding_matches(inst, binding):
+	var event_type = int(_to_real(binding.get("event_type", -1)))
+	var event_num = int(_to_real(binding.get("event_num", 0)))
+	if event_type == 5:
+		return _gml_input_keyboard_held_matches(event_num)
+	if event_type == 9:
+		return _gml_input_keyboard_pressed_matches(event_num)
+	if event_type == 10:
+		return _gml_input_keyboard_released_matches(event_num)
+	if event_type == 6:
+		return _gml_input_mouse_event_matches(inst, event_num)
+	if event_type == 13:
+		return _gml_input_gesture_event_matches(inst, event_num, binding)
+	return false
+
+
+static func _gml_input_dispatch_binding(inst, binding):
+	var method_name = str(binding.get("method", ""))
+	if method_name == "" or not inst.has_method(method_name):
+		return 0
+	var event_type = int(_to_real(binding.get("event_type", -1)))
+	var event_num = int(_to_real(binding.get("event_num", 0)))
+	var previous_event_data = _gml_builtin_globals["event_data"] if _gml_builtin_globals.has("event_data") else {}
+	var payload = _gml_input_binding_payload(inst, binding)
+	_gml_builtin_globals["event_data"] = payload
+	_gml_input_dispatch_trace.append({
+		"instance": str(inst.name) if inst is Node else "",
+		"event_type": event_type,
+		"event_num": event_num,
+		"method": method_name,
+	})
+	inst.call(method_name)
+	_gml_builtin_globals["event_data"] = previous_event_data
+	return 1
+
+
+static func _gml_input_binding_payload(inst, binding):
+	var event_type = int(_to_real(binding.get("event_type", -1)))
+	if event_type != 13:
+		return {}
+	var event_num = int(_to_real(binding.get("event_num", 0)))
+	for gesture in _gml_input_gesture_events:
+		if not (gesture is Dictionary):
+			continue
+		if int(_to_real(gesture.get("event_num", -1))) != event_num:
+			continue
+		if gml_bool(gesture.get("global", false)) or _gml_input_instance_contains_mouse(inst):
+			var payload = gesture.get("payload", {})
+			return payload if payload is Dictionary else {}
+	return {}
+
+
+static func _gml_input_keyboard_held_matches(event_num):
+	if event_num == 0:
+		return not _gml_input_any_key_down()
+	if event_num == 1:
+		return _gml_input_any_key_down()
+	return gml_keyboard_check(event_num)
+
+
+static func _gml_input_keyboard_pressed_matches(event_num):
+	if event_num == 0:
+		return false
+	if event_num == 1:
+		return not _gml_input_key_pressed.is_empty()
+	return gml_keyboard_check_pressed(event_num)
+
+
+static func _gml_input_keyboard_released_matches(event_num):
+	if event_num == 0:
+		return false
+	if event_num == 1:
+		return not _gml_input_key_released.is_empty()
+	return gml_keyboard_check_released(event_num)
+
+
+static func _gml_input_any_key_down():
+	for value in _gml_input_key_current.values():
+		if bool(value):
+			return true
+	return Input.is_anything_pressed()
+
+
+static func _gml_input_mouse_event_matches(inst, event_num):
+	var button_event = _gml_input_mouse_event_button_and_phase(event_num)
+	if button_event["phase"] == "none":
+		return false
+	if not gml_bool(button_event["global"]) and not _gml_input_instance_contains_mouse(inst):
+		return false
+	var phase = str(button_event["phase"])
+	var button = int(_to_real(button_event["button"]))
+	if phase == "held":
+		return gml_mouse_check_button(button)
+	if phase == "pressed":
+		return gml_mouse_check_button_pressed(button)
+	if phase == "released":
+		return gml_mouse_check_button_released(button)
+	if phase == "no_button":
+		return not _gml_input_any_mouse_button_down()
+	if phase == "enter":
+		return _gml_input_instance_contains_mouse(inst)
+	if phase == "leave":
+		return false
+	if phase == "wheel_up":
+		return _gml_input_mouse_wheel_up
+	if phase == "wheel_down":
+		return _gml_input_mouse_wheel_down
+	return false
+
+
+static func _gml_input_mouse_event_button_and_phase(event_num):
+	var mapping = {
+		0: {"button": MOUSE_BUTTON_LEFT, "phase": "held", "global": false},
+		1: {"button": MOUSE_BUTTON_RIGHT, "phase": "held", "global": false},
+		2: {"button": MOUSE_BUTTON_MIDDLE, "phase": "held", "global": false},
+		3: {"button": -1, "phase": "no_button", "global": false},
+		4: {"button": MOUSE_BUTTON_LEFT, "phase": "pressed", "global": false},
+		5: {"button": MOUSE_BUTTON_RIGHT, "phase": "pressed", "global": false},
+		6: {"button": MOUSE_BUTTON_MIDDLE, "phase": "pressed", "global": false},
+		7: {"button": MOUSE_BUTTON_LEFT, "phase": "released", "global": false},
+		8: {"button": MOUSE_BUTTON_RIGHT, "phase": "released", "global": false},
+		9: {"button": MOUSE_BUTTON_MIDDLE, "phase": "released", "global": false},
+		10: {"button": -1, "phase": "enter", "global": false},
+		11: {"button": -1, "phase": "leave", "global": false},
+		50: {"button": MOUSE_BUTTON_LEFT, "phase": "held", "global": true},
+		51: {"button": MOUSE_BUTTON_RIGHT, "phase": "held", "global": true},
+		52: {"button": MOUSE_BUTTON_MIDDLE, "phase": "held", "global": true},
+		53: {"button": MOUSE_BUTTON_LEFT, "phase": "pressed", "global": true},
+		54: {"button": MOUSE_BUTTON_RIGHT, "phase": "pressed", "global": true},
+		55: {"button": MOUSE_BUTTON_MIDDLE, "phase": "pressed", "global": true},
+		56: {"button": MOUSE_BUTTON_LEFT, "phase": "released", "global": true},
+		57: {"button": MOUSE_BUTTON_RIGHT, "phase": "released", "global": true},
+		58: {"button": MOUSE_BUTTON_MIDDLE, "phase": "released", "global": true},
+		60: {"button": -1, "phase": "wheel_up", "global": true},
+		61: {"button": -1, "phase": "wheel_down", "global": true},
+	}
+	return mapping.get(int(_to_real(event_num)), {"button": -1, "phase": "none", "global": false})
+
+
+static func _gml_input_any_mouse_button_down():
+	for value in _gml_input_mouse_current.values():
+		if bool(value):
+			return true
+	return false
+
+
+static func _gml_input_instance_contains_mouse(inst):
+	if inst == null:
+		return false
+	if inst.has_method("_gm_input_contains_point"):
+		return bool(inst.call("_gm_input_contains_point", _gml_input_mouse_position.x, _gml_input_mouse_position.y))
+	if inst is Control:
+		return inst.get_global_rect().has_point(_gml_input_mouse_position)
+	if inst is Node2D:
+		var radius = 0.0
+		if inst.has_meta("gamemaker_collision_radius"):
+			radius = max(_to_real(inst.get_meta("gamemaker_collision_radius")), 0.0)
+		if radius > 0.0:
+			return inst.global_position.distance_to(_gml_input_mouse_position) <= radius
+	_gml_input_dispatch_trace.append({
+		"diagnostic": "missing_mouse_mask",
+		"instance": str(inst.name) if inst is Node else "",
+	})
+	return true
+
+
+static func _gml_input_gesture_event_matches(inst, event_num, binding):
+	for gesture in _gml_input_gesture_events:
+		if not (gesture is Dictionary):
+			continue
+		if int(_to_real(gesture.get("event_num", -1))) != int(_to_real(event_num)):
+			continue
+		if gml_bool(gesture.get("global", false)) or _gml_input_instance_contains_mouse(inst):
+			return true
+	return false
+
+
+static func _gml_input_normalize_gesture_payload(payload):
+	var result = {}
+	for key in payload.keys():
+		result[key] = payload[key]
+	if not result.has("posX"):
+		result["posX"] = _gml_input_mouse_position.x
+	if not result.has("posY"):
+		result["posY"] = _gml_input_mouse_position.y
+	if not result.has("rawposX"):
+		result["rawposX"] = result["posX"]
+	if not result.has("rawposY"):
+		result["rawposY"] = result["posY"]
+	var gui_position = _gml_mouse_room_to_gui(Vector2(_to_real(result["posX"]), _to_real(result["posY"])))
+	if not result.has("guiposX"):
+		result["guiposX"] = gui_position.x
+	if not result.has("guiposY"):
+		result["guiposY"] = gui_position.y
+	if not result.has("touch"):
+		result["touch"] = 0
+	if not result.has("gesture"):
+		result["gesture"] = 0
+	return result
+
+
+static func _gml_input_touch_payload(event, gesture_name):
+	var payload = {
+		"gesture": 0,
+		"touch": int(event.index),
+		"posX": event.position.x,
+		"posY": event.position.y,
+		"rawposX": event.position.x,
+		"rawposY": event.position.y,
+		"name": str(gesture_name),
+	}
+	var gui_position = _gml_mouse_room_to_gui(event.position)
+	payload["guiposX"] = gui_position.x
+	payload["guiposY"] = gui_position.y
+	return payload

--- a/src/conversion/objects.py
+++ b/src/conversion/objects.py
@@ -9,7 +9,7 @@ from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
 from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.events.base import EventMapping
-from src.conversion.event_mapping import map_event
+from src.conversion.event_mapping import is_input_event, map_event, map_input_event
 from src.conversion.gml_runtime import write_gml_runtime
 from src.conversion.gml_transpiler import (
     GMLSourceMap,
@@ -286,7 +286,7 @@ class ObjectConverter(BaseConverter):
         object_dir = os.path.join(self.gm_project_path, 'objects', object_name)
 
         for event in event_list or []:
-            mapping = map_event(event)
+            mapping = map_input_event(event) if is_input_event(event) else map_event(event)
             if mapping is None or not mapping.gml_filename:
                 continue
 
@@ -397,7 +397,7 @@ class ObjectConverter(BaseConverter):
 
         function_names: set[str] = set()
         for event in parsed_parent["event_list"]:
-            mapping = map_event(event)
+            mapping = map_input_event(event) if is_input_event(event) else map_event(event)
             if mapping is not None:
                 function_names.add(mapping.godot_func)
         return function_names
@@ -405,7 +405,7 @@ class ObjectConverter(BaseConverter):
     def _event_function_names(self, event_list: list[JsonDict]) -> set[str]:
         function_names: set[str] = set()
         for event in event_list:
-            mapping = map_event(event)
+            mapping = map_input_event(event) if is_input_event(event) else map_event(event)
             if mapping is not None:
                 function_names.add(mapping.godot_func)
         return function_names

--- a/src/conversion/runtime_managers.md
+++ b/src/conversion/runtime_managers.md
@@ -8,9 +8,9 @@ The generated autoloads are:
 - `GMAssets`: asset registry, texture groups, audio groups, and dynamic assets.
 - `GMRooms`: room order, current room, transitions, and layers.
 - `GMInstances`: live instances, handles, object indices, and creation order.
-- `GMEvents`: frame events, alarms, timelines, and sequences. This manager owns the generated `_process` frame pump and calls `GMRuntime.gml_event_scheduler_frame()` so Step phases do not depend on individual node callback order.
+- `GMEvents`: frame events, alarms, timelines, and sequences. This manager owns the generated `_process` frame pump, dispatches queued GMInput events, calls `GMRuntime.gml_event_scheduler_frame()`, then clears one-frame input edges so Step phases do not depend on individual node callback order.
 - `GMDraw`: draw state, surfaces, shader cache, and texture-group state.
-- `GMInput`: keyboard, mouse, gamepad, and gesture state.
+- `GMInput`: keyboard, mouse, gamepad, and gesture state. This manager owns the generated `_input(event)` capture hook; converted object scripts expose `_gm_input_event_bindings()` plus `_gm_input_*` methods for deterministic frame dispatch.
 - `GMAudio`: audio instances, groups, emitters, and listeners.
 - `GMAsync`: async_load, HTTP, buffer, and networking queues.
 - `GMPlatform`: service hooks, extension callback schemas, OS/debug, and GC state.

--- a/src/conversion/runtime_managers.py
+++ b/src/conversion/runtime_managers.py
@@ -18,6 +18,7 @@ class RuntimeManagerDefinition:
     dependencies: tuple[str, ...] = ()
     state_keys: tuple[str, ...] = ()
     frame_pump: bool = False
+    input_capture: bool = False
 
     @property
     def relative_path(self) -> str:
@@ -84,6 +85,7 @@ RUNTIME_MANAGER_DEFINITIONS: tuple[RuntimeManagerDefinition, ...] = (
         "input",
         dependencies=("GMRuntime", "GMEvents"),
         state_keys=("keyboard", "mouse", "gamepad", "gestures"),
+        input_capture=True,
     ),
     RuntimeManagerDefinition(
         "GMAudio",
@@ -146,7 +148,7 @@ def render_runtime_manager_script(definition: RuntimeManagerDefinition) -> str:
         "extends Node",
         "",
     ]
-    if definition.frame_pump:
+    if definition.frame_pump or definition.input_capture:
         lines.extend([
             'const GMRuntimeFacade = preload("res://gm2godot/gml_runtime.gd")',
             "",
@@ -173,7 +175,16 @@ def render_runtime_manager_script(definition: RuntimeManagerDefinition) -> str:
     if definition.frame_pump:
         lines.extend([
             "func _process(delta):",
+            "\tGMRuntimeFacade.gml_input_dispatch_frame()",
             "\tGMRuntimeFacade.gml_event_scheduler_frame(float(delta), 1)",
+            "\tGMRuntimeFacade.gml_input_end_frame()",
+            "",
+            "",
+        ])
+    if definition.input_capture:
+        lines.extend([
+            "func _input(event):",
+            "\tGMRuntimeFacade.gml_input_event_capture(event)",
             "",
             "",
         ])

--- a/src/conversion/script_generator.py
+++ b/src/conversion/script_generator.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Callable, TypeAlias, cast
 
-from src.conversion.event_mapping import INPUT_MERGED_MAPPING, is_input_event, map_event
+from src.conversion.event_mapping import is_input_event, map_event, map_input_event
 from src.conversion.events.base import EventMapping
 from src.conversion.events.features import get_script_features
 from src.conversion.gml_runtime import GML_RUNTIME_RESOURCE_PATH
@@ -19,6 +19,7 @@ _EmitPrelude: TypeAlias = Callable[[list[str], set[str]], None]
 _WrapBody: TypeAlias = Callable[[EventMapping, str, set[str]], str]
 
 _map_event = cast(_MapEvent, map_event)
+_map_input_event = cast(_MapEvent, map_input_event)
 _is_input_event = cast(_IsInputEvent, is_input_event)
 
 
@@ -501,6 +502,28 @@ def _wrap_draw_runtime_body(func: EventMapping, body: str) -> str:
     return f"{begin_line}\n{body}\n{end_line}"
 
 
+def _render_input_event_bindings_body(input_functions: Sequence[EventMapping]) -> str:
+    binding_lines = ["\treturn ["]
+    for func in input_functions:
+        match = re.match(r"^_gm_input_(keyboard|mouse|key_press|key_release|gesture)_(-?\d+)$", func.godot_func)
+        if match is None:
+            continue
+        family = match.group(1)
+        event_type = {
+            "keyboard": 5,
+            "mouse": 6,
+            "key_press": 9,
+            "key_release": 10,
+            "gesture": 13,
+        }[family]
+        event_num = int(match.group(2))
+        binding_lines.append(
+            f'\t\t{{"event_type": {event_type}, "event_num": {event_num}, "method": {_gd_string(func.godot_func)}}},'
+        )
+    binding_lines.append("\t]")
+    return "\n".join(binding_lines)
+
+
 def generate_script_content(
     event_list: Sequence[JsonDict] | None,
     code_bodies: _CodeBodies | None = None,
@@ -511,9 +534,10 @@ def generate_script_content(
 ) -> str:
     """Generate .gd script content with function stubs for each event.
 
-    Events are mapped to Godot callback functions. Input events (mouse,
-    keyboard) are merged into a single _input() function. Functions are
-    ordered canonically: lifecycle callbacks first, then custom functions.
+    Events are mapped to Godot callback functions. Input events become
+    source-backed _gm_input_* methods plus a binding table for GMInput.
+    Functions are ordered canonically: lifecycle callbacks first, then
+    generated input handlers, then custom functions.
 
     Args:
         event_list: List of event dicts from a parsed .yy file.
@@ -538,19 +562,29 @@ def generate_script_content(
         return _extends_line(base_script_path)
 
     functions: list[EventMapping] = []
-    has_input = False
+    input_functions: list[EventMapping] = []
 
     for event in event_list or []:
         if _is_input_event(event):
-            has_input = True
+            input_mapping = _map_input_event(event)
+            if input_mapping is not None:
+                input_functions.append(input_mapping)
             continue
 
         mapping = _map_event(event)
         if mapping is not None:
             functions.append(mapping)
 
-    if has_input:
-        functions.append(INPUT_MERGED_MAPPING)
+    if input_functions:
+        functions.append(EventMapping("_gm_input_event_bindings", "", 4, ""))
+        functions.extend(input_functions)
+
+    effective_code_bodies: dict[str, str] = dict(code_bodies or {})
+    if input_functions:
+        effective_code_bodies.setdefault(
+            "_gm_input_event_bindings",
+            _render_input_event_bindings_body(_deduplicate_functions(input_functions)),
+        )
 
     unique_functions = _deduplicate_functions(functions)
     function_names = {func.godot_func for func in unique_functions}
@@ -589,7 +623,7 @@ def generate_script_content(
 
     lines = [_extends_line(base_script_path)]
     runtime_const_inherited = base_script_path is not None and uses_object_runtime
-    if (_uses_gml_runtime(code_bodies) or uses_object_runtime or uses_draw_runtime) and not runtime_const_inherited:
+    if (_uses_gml_runtime(effective_code_bodies) or uses_object_runtime or uses_draw_runtime) and not runtime_const_inherited:
         lines.append(f'\n\nconst GMRuntime = preload("{GML_RUNTIME_RESOURCE_PATH}")\n')
     for feature in script_features:
         emit_prelude = cast(_EmitPrelude | None, getattr(feature, "emit_prelude", None))
@@ -612,7 +646,7 @@ def generate_script_content(
         lines.append(f"\n\nvar {variable_name}\n")
 
     for func in unique_functions:
-        body = _get_function_body(func, code_bodies)
+        body = _get_function_body(func, effective_code_bodies)
         for feature in script_features:
             wrap_body = cast(_WrapBody | None, getattr(feature, "wrap_body", None))
             if wrap_body is not None:

--- a/tests/conversion/events/test_gesture_events.py
+++ b/tests/conversion/events/test_gesture_events.py
@@ -6,7 +6,7 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(o
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
-from src.conversion.event_mapping import is_input_event, map_event
+from src.conversion.event_mapping import is_input_event, map_event, map_input_event
 from src.conversion.script_generator import generate_script_content
 
 
@@ -16,6 +16,7 @@ class TestGestureEvents(unittest.TestCase):
             with self.subTest(event_num=event_num):
                 self.assertTrue(is_input_event({"eventType": 13, "eventNum": event_num}))
                 self.assertIsNone(map_event({"eventType": 13, "eventNum": event_num}))
+                self.assertIsNotNone(map_input_event({"eventType": 13, "eventNum": event_num}))
 
     def test_generates_one_input_stub_for_gesture_family(self):
         content = generate_script_content([
@@ -23,8 +24,10 @@ class TestGestureEvents(unittest.TestCase):
             for event_num in range(13)
         ])
 
-        self.assertIn("func _input(event):", content)
-        self.assertEqual(content.count("func _input"), 1)
+        self.assertIn("func _gm_input_event_bindings():", content)
+        self.assertIn("func _gm_input_gesture_0():", content)
+        self.assertIn("func _gm_input_gesture_12():", content)
+        self.assertNotIn("func _input(event):", content)
 
 
 if __name__ == "__main__":

--- a/tests/conversion/events/test_keyboard_events.py
+++ b/tests/conversion/events/test_keyboard_events.py
@@ -6,7 +6,7 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(o
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
-from src.conversion.event_mapping import is_input_event, map_event
+from src.conversion.event_mapping import is_input_event, map_event, map_input_event
 from src.conversion.script_generator import generate_script_content
 
 
@@ -16,6 +16,7 @@ class TestKeyboardEvents(unittest.TestCase):
             with self.subTest(event_type=event_type):
                 self.assertTrue(is_input_event({"eventType": event_type, "eventNum": 65}))
                 self.assertIsNone(map_event({"eventType": event_type, "eventNum": 65}))
+                self.assertIsNotNone(map_input_event({"eventType": event_type, "eventNum": 65}))
 
     def test_keyboard_special_keys_merge_into_one_input_stub(self):
         content = generate_script_content([
@@ -25,8 +26,11 @@ class TestKeyboardEvents(unittest.TestCase):
             {"eventType": 10, "eventNum": 112},
         ])
 
-        self.assertIn("func _input(event):", content)
-        self.assertEqual(content.count("func _input"), 1)
+        self.assertIn("func _gm_input_event_bindings():", content)
+        self.assertIn("func _gm_input_keyboard_0():", content)
+        self.assertIn("func _gm_input_key_press_37():", content)
+        self.assertIn("func _gm_input_key_release_112():", content)
+        self.assertNotIn("func _input(event):", content)
 
 
 if __name__ == "__main__":

--- a/tests/conversion/events/test_mouse_events.py
+++ b/tests/conversion/events/test_mouse_events.py
@@ -6,7 +6,7 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(o
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
-from src.conversion.event_mapping import is_input_event, map_event
+from src.conversion.event_mapping import is_input_event, map_event, map_input_event
 from src.conversion.script_generator import generate_script_content
 
 
@@ -18,6 +18,7 @@ class TestMouseEvents(unittest.TestCase):
             with self.subTest(event_num=event_num):
                 self.assertTrue(is_input_event({"eventType": 6, "eventNum": event_num}))
                 self.assertIsNone(map_event({"eventType": 6, "eventNum": event_num}))
+                self.assertIsNotNone(map_input_event({"eventType": 6, "eventNum": event_num}))
 
     def test_generates_one_input_stub_for_mouse_family(self):
         content = generate_script_content([
@@ -25,8 +26,10 @@ class TestMouseEvents(unittest.TestCase):
             for event_num in list(range(12)) + list(range(50, 59)) + [60, 61]
         ])
 
-        self.assertIn("func _input(event):", content)
-        self.assertEqual(content.count("func _input"), 1)
+        self.assertIn("func _gm_input_event_bindings():", content)
+        self.assertIn("func _gm_input_mouse_0():", content)
+        self.assertIn("func _gm_input_mouse_61():", content)
+        self.assertNotIn("func _input(event):", content)
 
 
 if __name__ == "__main__":

--- a/tests/test_event_mapping.py
+++ b/tests/test_event_mapping.py
@@ -9,7 +9,7 @@ if PROJECT_ROOT not in sys.path:
 
 from src.conversion.event_mapping import (
     EventMapping, map_event as _map_event, is_input_event,
-    INPUT_MERGED_MAPPING,
+    INPUT_MERGED_MAPPING, map_input_event,
 )
 from src.conversion.type_defs import JsonDict
 
@@ -226,6 +226,34 @@ class TestMapEventInputReturnsNone(unittest.TestCase):
         for event_num in range(13):
             with self.subTest(event_num=event_num):
                 self.assertIsNone(map_event_optional({"eventType": 13, "eventNum": event_num}))
+
+
+class TestMapInputEvent(unittest.TestCase):
+    """Input events keep source-backed generated handlers for GMInput dispatch."""
+
+    def test_keyboard_mapping(self):
+        m = map_input_event({"eventType": 5, "eventNum": 65})
+        self.assertIsNotNone(m)
+        assert m is not None
+        self.assertEqual(m.godot_func, "_gm_input_keyboard_65")
+        self.assertEqual(m.gml_filename, "Keyboard_65.gml")
+
+    def test_key_press_mapping(self):
+        m = map_input_event({"eventType": 9, "eventNum": 32})
+        self.assertIsNotNone(m)
+        assert m is not None
+        self.assertEqual(m.godot_func, "_gm_input_key_press_32")
+        self.assertEqual(m.gml_filename, "KeyPress_32.gml")
+
+    def test_mouse_mapping(self):
+        m = map_input_event({"eventType": 6, "eventNum": 53})
+        self.assertIsNotNone(m)
+        assert m is not None
+        self.assertEqual(m.godot_func, "_gm_input_mouse_53")
+        self.assertEqual(m.gml_filename, "Mouse_53.gml")
+
+    def test_non_input_mapping_returns_none(self):
+        self.assertIsNone(map_input_event({"eventType": 0, "eventNum": 0}))
 
 
 class TestMapEventUnknown(unittest.TestCase):

--- a/tests/test_game_input_godot.py
+++ b/tests/test_game_input_godot.py
@@ -32,11 +32,56 @@ def _write_text(path: Path, content: str) -> None:
 
 
 def _write_smoke_scene(project_dir: Path) -> None:
+    input_probe_script = textwrap.dedent(
+        """\
+        extends Node2D
+
+        const GMRuntime = preload("res://gm2godot/gml_runtime.gd")
+
+        var id = GMRuntime.gml_instance_noone()
+        var events = []
+
+        func _ready():
+        \tid = GMRuntime.gml_instance_register(self, "o_input_probe", [])
+
+        func _exit_tree():
+        \tGMRuntime.gml_instance_unregister(id)
+
+        func _gm_input_contains_point(x, y):
+        \treturn x >= 0 and x <= 100 and y >= 0 and y <= 100
+
+        func _gm_input_event_bindings():
+        \treturn [
+        \t\t{"event_type": 5, "event_num": KEY_SPACE, "method": "_gm_input_keyboard_32"},
+        \t\t{"event_type": 9, "event_num": KEY_SPACE, "method": "_gm_input_key_press_32"},
+        \t\t{"event_type": 10, "event_num": KEY_SPACE, "method": "_gm_input_key_release_32"},
+        \t\t{"event_type": 6, "event_num": 53, "method": "_gm_input_mouse_53"},
+        \t\t{"event_type": 13, "event_num": 0, "method": "_gm_input_gesture_0"},
+        \t]
+
+        func _gm_input_keyboard_32():
+        \tevents.append("held")
+
+        func _gm_input_key_press_32():
+        \tevents.append("pressed")
+
+        func _gm_input_key_release_32():
+        \tevents.append("released")
+
+        func _gm_input_mouse_53():
+        \tevents.append("mouse_global_press")
+
+        func _gm_input_gesture_0():
+        \tvar data = GMRuntime.gml_builtin_global("event_data")
+        \tevents.append("tap:" + str(GMRuntime.gml_ds_map_find_value(data, "posX")))
+        """
+    )
     smoke_script = textwrap.dedent(
         """\
         extends Node2D
 
         const GMRuntime = preload("res://gm2godot/gml_runtime.gd")
+        const InputProbe = preload("res://input_probe.gd")
 
         func _check(condition, message):
         \tif not condition:
@@ -97,6 +142,32 @@ def _write_smoke_scene(project_dir: Path) -> None:
         \tGMRuntime.gml_keyboard_clear(0)
         \tif not _check(GMRuntime.gml_builtin_global("keyboard_string") == "", "keyboard_clear did not reset string"):
         \t\treturn
+        \tvar probe = InputProbe.new()
+        \tprobe.name = "Probe"
+        \tadd_child(probe)
+        \tGMRuntime.gml_input_begin_frame()
+        \tGMRuntime.gml_input_set_key_state(KEY_SPACE, true)
+        \tGMRuntime.gml_input_set_mouse_position(10, 10)
+        \tGMRuntime.gml_input_set_mouse_button_state(MOUSE_BUTTON_LEFT, true)
+        \tGMRuntime.gml_input_enqueue_gesture(0, {"posX": 42, "posY": 24}, true)
+        \tvar dispatched = GMRuntime.gml_input_dispatch_frame([probe])
+        \tif not _check(dispatched == 4, "input dispatch count mismatch"):
+        \t\treturn
+        \tif not _check(probe.events == ["held", "pressed", "mouse_global_press", "tap:42"], "input dispatch order mismatch: " + str(probe.events)):
+        \t\treturn
+        \tif not _check(GMRuntime.gml_ds_map_size(GMRuntime.gml_builtin_global("event_data")) == 0, "event_data was not reset"):
+        \t\treturn
+        \tprobe.events.clear()
+        \tGMRuntime.gml_input_begin_frame()
+        \tdispatched = GMRuntime.gml_input_dispatch_frame([probe])
+        \tif not _check(dispatched == 1 and probe.events == ["held"], "held input did not persist exactly one frame"):
+        \t\treturn
+        \tprobe.events.clear()
+        \tGMRuntime.gml_input_begin_frame()
+        \tGMRuntime.gml_input_set_key_state(KEY_SPACE, false)
+        \tdispatched = GMRuntime.gml_input_dispatch_frame([probe])
+        \tif not _check(dispatched == 1 and probe.events == ["released"], "release input did not dispatch"):
+        \t\treturn
         \tprint("GAME_INPUT_SMOKE_OK")
         \tget_tree().quit(0)
         """
@@ -111,6 +182,7 @@ def _write_smoke_scene(project_dir: Path) -> None:
         script = ExtResource("1")
         """
     )
+    _write_text(project_dir / "input_probe.gd", input_probe_script)
     _write_text(project_dir / "smoke.gd", smoke_script)
     _write_text(project_dir / "smoke.tscn", smoke_scene)
 

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -1140,6 +1140,9 @@ class TestGMLRuntimeScript(unittest.TestCase):
             "gml_keyboard_clear",
             "gml_keyboard_key_press",
             "gml_keyboard_key_release",
+            "gml_input_event_capture",
+            "gml_input_dispatch_frame",
+            "gml_input_enqueue_gesture",
             "gml_mouse_check_button",
             "gml_mouse_check_button_pressed",
             "gml_mouse_check_button_released",
@@ -2518,6 +2521,14 @@ class TestGMLRuntimeScript(unittest.TestCase):
         self.assertIn("static func gml_time_source_destroy(handle):", GML_RUNTIME_SCRIPT)
         self.assertIn("static func gml_time_source_get_state(handle):", GML_RUNTIME_SCRIPT)
         self.assertIn("static func gml_time_source_tick_all(delta_seconds, delta_frames):", GML_RUNTIME_SCRIPT)
+
+    def test_runtime_input_event_dispatch_helpers(self):
+        self.assertIn("static func gml_input_event_capture(event):", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_input_dispatch_frame(instances = null):", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_input_enqueue_gesture(event_num, payload = null, global_event = false):", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_input_end_frame():", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_input_dispatch_trace():", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func _gml_input_mouse_event_button_and_phase(event_num):", GML_RUNTIME_SCRIPT)
         self.assertIn("static func gml_call_later(period, units, callback, repeat = false):", GML_RUNTIME_SCRIPT)
         self.assertIn("static func gml_call_cancel(handle):", GML_RUNTIME_SCRIPT)
         self.assertIn('inst.call(method_name)', GML_RUNTIME_SCRIPT)

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -951,7 +951,7 @@ class TestScriptGeneration(unittest.TestCase):
         self.assertIn("func _on_destroy():", content)
 
     def test_input_events_merged(self):
-        """Mouse and keyboard events should merge into a single _input(event)."""
+        """Mouse and keyboard events should produce GMInput dispatch bindings."""
         self._setup_object("o_test", event_list=[
             {"eventType": 6, "eventNum": 4},   # Mouse left click
             {"eventType": 9, "eventNum": 32},   # KeyPress space
@@ -963,11 +963,14 @@ class TestScriptGeneration(unittest.TestCase):
         gd_path = os.path.join(self.godot_dir, "objects", "o_test", "o_test.gd")
         with open(gd_path, 'r', encoding='utf-8') as f:
             content = f.read()
-        self.assertIn("func _input(event):", content)
-        self.assertEqual(content.count("func _input"), 1, "Should have exactly one _input function")
+        self.assertIn("func _gm_input_event_bindings():", content)
+        self.assertIn("func _gm_input_mouse_4():", content)
+        self.assertIn("func _gm_input_key_press_32():", content)
+        self.assertIn("func _gm_input_key_release_13():", content)
+        self.assertNotIn("func _input(event):", content)
 
     def test_mouse_event_ranges_merged(self):
-        """All ev_mouse ranges should still merge into one _input(event)."""
+        """All ev_mouse ranges should be listed in one binding table."""
         self._setup_object("o_test", event_list=[
             {"eventType": 6, "eventNum": 0},
             {"eventType": 6, "eventNum": 11},
@@ -982,8 +985,33 @@ class TestScriptGeneration(unittest.TestCase):
         gd_path = os.path.join(self.godot_dir, "objects", "o_test", "o_test.gd")
         with open(gd_path, 'r', encoding='utf-8') as f:
             content = f.read()
-        self.assertIn("func _input(event):", content)
-        self.assertEqual(content.count("func _input"), 1)
+        self.assertIn("func _gm_input_event_bindings():", content)
+        self.assertIn("func _gm_input_mouse_0():", content)
+        self.assertIn("func _gm_input_mouse_61():", content)
+        self.assertNotIn("func _input(event):", content)
+
+    def test_input_event_code_files_transpile_to_dispatch_methods(self):
+        """Input .gml source should load into the event-specific GMInput method."""
+        self._setup_object("o_test", event_list=[
+            {"eventType": 9, "eventNum": 32},
+            {"eventType": 13, "eventNum": 0},
+        ])
+        with open(os.path.join(self.gm_dir, "objects", "o_test", "KeyPress_32.gml"), "w", encoding="utf-8") as f:
+            f.write("pressed_space = true;")
+        with open(os.path.join(self.gm_dir, "objects", "o_test", "Gesture_0.gml"), "w", encoding="utf-8") as f:
+            f.write('tap_x = event_data[? "posX"];')
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        gd_path = os.path.join(self.godot_dir, "objects", "o_test", "o_test.gd")
+        with open(gd_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        self.assertIn("func _gm_input_key_press_32():", content)
+        self.assertIn("\tpressed_space = true", content)
+        self.assertIn("func _gm_input_gesture_0():", content)
+        self.assertIn('tap_x = GMRuntime.gml_ds_map_find_value(GMRuntime.gml_builtin_global("event_data"), "posX")', content)
+        self.assertIn('{"event_type": 9, "event_num": 32, "method": "_gm_input_key_press_32"}', content)
 
     def test_script_attached_to_tscn(self):
         """The .tscn file should reference the .gd script."""
@@ -1038,7 +1066,7 @@ class TestScriptGeneration(unittest.TestCase):
             content = f.read()
         ready_pos = content.index("_ready")
         step_pos = content.index("_on_step")
-        input_pos = content.index("_input")
+        input_pos = content.index("_gm_input_event_bindings")
         alarm_pos = content.index("_on_alarm")
         self.assertLess(ready_pos, step_pos)
         self.assertLess(step_pos, input_pos)

--- a/tests/test_runtime_managers.py
+++ b/tests/test_runtime_managers.py
@@ -89,7 +89,22 @@ class TestRuntimeManagers(unittest.TestCase):
 
         self.assertIn('const GMRuntimeFacade = preload("res://gm2godot/gml_runtime.gd")', script)
         self.assertIn("func _process(delta):", script)
+        self.assertIn("GMRuntimeFacade.gml_input_dispatch_frame()", script)
         self.assertIn("GMRuntimeFacade.gml_event_scheduler_frame(float(delta), 1)", script)
+        self.assertIn("GMRuntimeFacade.gml_input_end_frame()", script)
+
+    def test_input_manager_captures_godot_input_events(self) -> None:
+        definition = next(
+            manager_definition
+            for manager_definition in runtime_manager_definitions()
+            if manager_definition.name == "GMInput"
+        )
+
+        script = render_runtime_manager_script(definition)
+
+        self.assertIn('const GMRuntimeFacade = preload("res://gm2godot/gml_runtime.gd")', script)
+        self.assertIn("func _input(event):", script)
+        self.assertIn("GMRuntimeFacade.gml_input_event_capture(event)", script)
 
     def test_write_runtime_managers_writes_each_manager_script(self) -> None:
         output_paths = write_runtime_managers(self.godot_dir)

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -257,15 +257,18 @@ class TestScriptGeneratorEvents(unittest.TestCase):
 
 
 class TestScriptGeneratorInputMerging(unittest.TestCase):
-    """Input events (mouse, keyboard) should merge into a single _input."""
+    """Input events should produce GMInput-dispatchable bindings."""
 
     def test_keyboard_event_produces_input(self):
         content = generate_script_content([{"eventType": 5, "eventNum": 65}])
-        self.assertIn("func _input(event):", content)
+        self.assertIn("func _gm_input_event_bindings():", content)
+        self.assertIn("func _gm_input_keyboard_65():", content)
+        self.assertNotIn("func _input(event):", content)
 
     def test_mouse_event_produces_input(self):
         content = generate_script_content([{"eventType": 6, "eventNum": 4}])
-        self.assertIn("func _input(event):", content)
+        self.assertIn("func _gm_input_mouse_4():", content)
+        self.assertIn('{"event_type": 6, "event_num": 4, "method": "_gm_input_mouse_4"}', content)
 
     def test_mouse_event_ranges_produce_input(self):
         content = generate_script_content([
@@ -276,16 +279,19 @@ class TestScriptGeneratorInputMerging(unittest.TestCase):
             {"eventType": 6, "eventNum": 60},
             {"eventType": 6, "eventNum": 61},
         ])
-        self.assertIn("func _input(event):", content)
-        self.assertEqual(content.count("func _input"), 1)
+        self.assertIn("func _gm_input_event_bindings():", content)
+        self.assertEqual(content.count("func _gm_input_mouse_"), 6)
+        self.assertNotIn("func _input(event):", content)
 
     def test_gesture_event_produces_input(self):
         content = generate_script_content([
             {"eventType": 13, "eventNum": event_num}
             for event_num in range(13)
         ])
-        self.assertIn("func _input(event):", content)
-        self.assertEqual(content.count("func _input"), 1)
+        self.assertIn("func _gm_input_event_bindings():", content)
+        self.assertIn("func _gm_input_gesture_0():", content)
+        self.assertIn("func _gm_input_gesture_12():", content)
+        self.assertNotIn("func _input(event):", content)
 
     def test_multiple_input_events_merged(self):
         content = generate_script_content([
@@ -295,8 +301,12 @@ class TestScriptGeneratorInputMerging(unittest.TestCase):
             {"eventType": 10, "eventNum": 13},
             {"eventType": 13, "eventNum": 3},
         ])
-        self.assertIn("func _input(event):", content)
-        self.assertEqual(content.count("func _input"), 1)
+        self.assertEqual(content.count("func _gm_input_event_bindings"), 1)
+        self.assertIn("func _gm_input_keyboard_65():", content)
+        self.assertIn("func _gm_input_mouse_4():", content)
+        self.assertIn("func _gm_input_key_press_32():", content)
+        self.assertIn("func _gm_input_key_release_13():", content)
+        self.assertIn("func _gm_input_gesture_3():", content)
 
     def test_input_mixed_with_lifecycle(self):
         content = generate_script_content([
@@ -304,7 +314,7 @@ class TestScriptGeneratorInputMerging(unittest.TestCase):
             {"eventType": 6, "eventNum": 4},
         ])
         self.assertIn("func _ready():", content)
-        self.assertIn("func _input(event):", content)
+        self.assertIn("func _gm_input_event_bindings():", content)
 
 
 class TestScriptGeneratorOrdering(unittest.TestCase):
@@ -319,7 +329,7 @@ class TestScriptGeneratorOrdering(unittest.TestCase):
         ])
         ready_pos = content.index("_ready")
         step_pos = content.index("_on_step")
-        input_pos = content.index("_input")
+        input_pos = content.index("_gm_input_event_bindings")
         alarm_pos = content.index("_on_alarm")
         self.assertLess(ready_pos, step_pos)
         self.assertLess(step_pos, input_pos)
@@ -341,7 +351,8 @@ class TestScriptGeneratorDeduplication(unittest.TestCase):
             {"eventType": 6, "eventNum": 0},
             {"eventType": 6, "eventNum": 4},
         ])
-        self.assertEqual(content.count("func _input"), 1)
+        self.assertEqual(content.count("func _gm_input_event_bindings"), 1)
+        self.assertEqual(content.count("func _gm_input_mouse_"), 2)
 
 
 class TestScriptGeneratorCodeBodies(unittest.TestCase):


### PR DESCRIPTION
Closes #596.

## Summary
- load Keyboard, Key Press, Key Release, Mouse, and Gesture .gml files into source-backed _gm_input_* methods
- add generated input binding tables and GMInput/GMEvents routing for deterministic frame-level dispatch
- capture Godot keyboard, mouse, gamepad, touch, and gesture state through GMRuntime helpers with event_data payload support
- document GMInput manager ownership and update input mapping/conversion coverage

## Tests
- ./venv/bin/python -m unittest tests.test_event_mapping tests.test_script_generator tests.test_objects tests.test_runtime_managers tests.test_gml_runtime tests.conversion.events.test_keyboard_events tests.conversion.events.test_mouse_events tests.conversion.events.test_gesture_events
- ./venv/bin/python -m unittest tests.test_game_input_godot -v
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest