### PR TITLE
Add collision event dispatch

### DIFF
--- a/src/conversion/gml_runtime_parts/segments/45_collision_queries.gd
+++ b/src/conversion/gml_runtime_parts/segments/45_collision_queries.gd
@@ -1,3 +1,6 @@
+static var _gml_collision_event_trace = []
+
+
 static func gml_place_meeting(current_self, x, y, target):
 	return gml_handle_is_valid(gml_instance_place(current_self, x, y, target))
 
@@ -94,6 +97,46 @@ static func gml_collision_circle_list(current_self, x, y, radius, target, precis
 	return _gml_collision_append_hits_to_list(list_id, hits, ordered)
 
 
+static func gml_collision_event_trace():
+	return _gml_clone_value(_gml_collision_event_trace, 16)
+
+
+static func gml_collision_event_trace_clear():
+	_gml_collision_event_trace = []
+	return null
+
+
+static func gml_collision_event_dispatch_frame(instances = null, frame = -1):
+	var targets = instances if instances is Array else _gml_collision_live_instances()
+	_gml_event_scheduler_record_phase("collision", "", null, frame)
+	var dispatched = 0
+	for inst in targets:
+		if not _gml_collision_instance_valid(inst):
+			continue
+		if not inst.has_method("_gm_collision_event_bindings"):
+			continue
+		var bindings = inst._gm_collision_event_bindings()
+		if not (bindings is Array):
+			continue
+		for binding in bindings:
+			if not (binding is Dictionary):
+				continue
+			for other_inst in targets:
+				if not _gml_collision_instance_valid(inst):
+					break
+				if not _gml_collision_instance_valid(other_inst):
+					continue
+				if _gml_collision_same_instance(inst, other_inst):
+					continue
+				if not _gml_collision_binding_target_matches(other_inst, binding):
+					continue
+				if not _gml_collision_pair_intersects(inst, other_inst):
+					continue
+				_gml_collision_restore_solid_contact(inst, other_inst)
+				dispatched += _gml_collision_dispatch_binding(inst, other_inst, binding, frame)
+	return dispatched
+
+
 static func _gml_collision_warn_precise_approximation(precise):
 	if not gml_bool(precise):
 		return
@@ -101,6 +144,98 @@ static func _gml_collision_warn_precise_approximation(precise):
 		return
 	_gml_collision_precise_warning_emitted = true
 	push_warning("GML precise collision masks are approximated with generated collision shape bounds")
+
+
+static func _gml_collision_live_instances():
+	var instances = []
+	for entry in _gml_live_instance_entries():
+		var inst = entry["instance"]
+		if _gml_collision_instance_valid(inst):
+			instances.append(inst)
+	return instances
+
+
+static func _gml_collision_instance_valid(inst):
+	return inst != null and is_instance_valid(inst)
+
+
+static func _gml_collision_binding_target_matches(other_inst, binding):
+	var target_object = str(binding.get("target_object", ""))
+	if target_object == "":
+		return true
+	var entry: Variant = _gml_instance_entry(other_inst)
+	if entry == null:
+		return false
+	if str(entry.get("object_name", "")) == target_object:
+		return true
+	for selector_name in entry.get("selector_names", []):
+		if str(selector_name) == target_object:
+			return true
+	return false
+
+
+static func _gml_collision_pair_intersects(left, right):
+	var left_rects = _gml_collision_rects_for_instance(left)
+	if left_rects.is_empty():
+		return false
+	var right_rects = _gml_collision_rects_for_instance(right)
+	if right_rects.is_empty():
+		return false
+	for left_rect in left_rects:
+		for right_rect in right_rects:
+			if left_rect.intersects(right_rect, true):
+				return true
+	return false
+
+
+static func _gml_collision_restore_solid_contact(inst, other_inst):
+	if not _gml_collision_instance_solid(other_inst):
+		return null
+	if not (inst is Node2D):
+		return null
+	var previous = Vector2(
+		_gml_motion_real(inst, "xprevious", inst.global_position.x),
+		_gml_motion_real(inst, "yprevious", inst.global_position.y)
+	)
+	if previous == inst.global_position:
+		return null
+	_gml_motion_set_position(inst, previous)
+	_gml_collision_event_trace.append({
+		"event": "solid_rollback",
+		"instance": str(inst.name) if inst is Node else "",
+		"other": str(other_inst.name) if other_inst is Node else "",
+		"x": previous.x,
+		"y": previous.y,
+	})
+	return null
+
+
+static func _gml_collision_instance_solid(inst):
+	var value = gml_struct_get(inst, "solid")
+	if is_undefined(value):
+		return false
+	return gml_bool(value)
+
+
+static func _gml_collision_dispatch_binding(inst, other_inst, binding, frame):
+	var method_name = str(binding.get("method", ""))
+	if method_name == "" or not inst.has_method(method_name):
+		return 0
+	var previous_other = gml_struct_get(inst, "other")
+	gml_struct_set(inst, "other", other_inst)
+	_gml_collision_event_trace.append({
+		"event": "collision",
+		"frame": frame,
+		"instance": str(inst.name) if inst is Node else "",
+		"other": str(other_inst.name) if other_inst is Node else "",
+		"method": method_name,
+		"target_object": str(binding.get("target_object", "")),
+	})
+	_gml_event_scheduler_record_phase("collision", method_name, inst, frame)
+	inst.call(method_name)
+	if _gml_collision_instance_valid(inst):
+		gml_struct_set(inst, "other", previous_other)
+	return 1
 
 
 static func _gml_collision_first_point_hit(point, target, current_self, notme):

--- a/src/conversion/gml_runtime_parts/segments/56_time_alarms.gd
+++ b/src/conversion/gml_runtime_parts/segments/56_time_alarms.gd
@@ -16,6 +16,7 @@ const GML_EVENT_PHASE_ORDER = [
 	"alarms",
 	"step",
 	"motion",
+	"collision",
 	"end_step"
 ]
 
@@ -61,6 +62,7 @@ static func gml_event_scheduler_frame(delta_seconds = 0.0, delta_frames = 1):
 	gml_event_scheduler_tick_alarms(_gml_event_scheduler_live_instances(), frames, frame)
 	gml_event_scheduler_dispatch_phase("step", "_on_step", _gml_event_scheduler_live_instances(), frame)
 	_gml_event_scheduler_dispatch_motion(_gml_event_scheduler_live_instances(), frame)
+	gml_collision_event_dispatch_frame(_gml_event_scheduler_live_instances(), frame)
 	gml_event_scheduler_dispatch_phase("end_step", "_on_end_step", _gml_event_scheduler_live_instances(), frame)
 	return frame
 

--- a/src/conversion/runtime_managers.md
+++ b/src/conversion/runtime_managers.md
@@ -19,6 +19,8 @@ The generated autoloads are:
 
 The `GMRuntime` autoload records each manager in `manager_registry_snapshot()` and exposes `manager_order()`. Each manager owns named state buckets so future runtime slices can move domain state out of the static compatibility facade without changing generated GML helper call sites.
 
+Collision events are dispatched by the central scheduler after motion/path updates and before End Step, matching the relevant GameMaker event-order window: https://manual.gamemaker.io/monthly/en/The_Asset_Editors/Object_Properties/Event_Order.htm. Dispatch uses generated Godot collision shape bounds, which aligns with Godot's 2D physics shape model: https://docs.godotengine.org/en/stable/tutorials/physics/physics_introduction.html. Pixel-perfect precise masks remain reported as a runtime fidelity limitation through the existing precise-collision warning path.
+
 ## Compatibility
 
 The manager layer is enabled by default when `write_gml_runtime()` runs and `project.godot` exists. Existing generated scripts remain compatible because they still preload and call `res://gm2godot/gml_runtime.gd`.

--- a/src/conversion/script_generator.py
+++ b/src/conversion/script_generator.py
@@ -410,6 +410,7 @@ def _emit_object_runtime_prelude(
 ) -> None:
     member_lines = (
         "\n\nvar id = GMRuntime.gml_instance_noone()"
+        "\nvar other = GMRuntime.gml_instance_noone()"
         f"\nvar object_index = GMRuntime.gml_asset_get_index({_gd_string(object_runtime.object_name)})"
         "\nvar depth = 0"
         f"\nvar solid = {str(object_runtime.solid).lower()}"
@@ -524,6 +525,21 @@ def _render_input_event_bindings_body(input_functions: Sequence[EventMapping]) -
     return "\n".join(binding_lines)
 
 
+def _render_collision_event_bindings_body(collision_bindings: Sequence[tuple[str, str]]) -> str:
+    binding_lines = ["\treturn ["]
+    seen: set[tuple[str, str]] = set()
+    for target_object, method_name in collision_bindings:
+        key = (target_object, method_name)
+        if key in seen:
+            continue
+        seen.add(key)
+        binding_lines.append(
+            f'\t\t{{"target_object": {_gd_string(target_object)}, "method": {_gd_string(method_name)}}},'
+        )
+    binding_lines.append("\t]")
+    return "\n".join(binding_lines)
+
+
 def generate_script_content(
     event_list: Sequence[JsonDict] | None,
     code_bodies: _CodeBodies | None = None,
@@ -563,6 +579,7 @@ def generate_script_content(
 
     functions: list[EventMapping] = []
     input_functions: list[EventMapping] = []
+    collision_bindings: list[tuple[str, str]] = []
 
     for event in event_list or []:
         if _is_input_event(event):
@@ -574,16 +591,31 @@ def generate_script_content(
         mapping = _map_event(event)
         if mapping is not None:
             functions.append(mapping)
+            if int(event.get("eventType", -1)) == 4:
+                collision_obj = event.get("collisionObjectId")
+                target_object = ""
+                if isinstance(collision_obj, dict):
+                    collision_data = cast(JsonDict, collision_obj)
+                    target_name = collision_data.get("name", "")
+                    target_object = str(target_name) if target_name is not None else ""
+                collision_bindings.append((target_object, mapping.godot_func))
 
     if input_functions:
         functions.append(EventMapping("_gm_input_event_bindings", "", 4, ""))
         functions.extend(input_functions)
+    if collision_bindings:
+        functions.append(EventMapping("_gm_collision_event_bindings", "", 13, ""))
 
     effective_code_bodies: dict[str, str] = dict(code_bodies or {})
     if input_functions:
         effective_code_bodies.setdefault(
             "_gm_input_event_bindings",
             _render_input_event_bindings_body(_deduplicate_functions(input_functions)),
+        )
+    if collision_bindings:
+        effective_code_bodies.setdefault(
+            "_gm_collision_event_bindings",
+            _render_collision_event_bindings_body(collision_bindings),
         )
 
     unique_functions = _deduplicate_functions(functions)

--- a/tests/conversion/events/test_collision_events.py
+++ b/tests/conversion/events/test_collision_events.py
@@ -43,6 +43,9 @@ class TestCollisionEvents(unittest.TestCase):
             {"eventType": 4, "eventNum": 0},
         ])
 
+        self.assertIn("func _gm_collision_event_bindings():", content)
+        self.assertIn('{"target_object": "o_enemy", "method": "_on_collision_o_enemy"}', content)
+        self.assertIn('{"target_object": "", "method": "_on_collision"}', content)
         self.assertIn("func _on_collision_o_enemy():", content)
         self.assertIn("func _on_collision():", content)
 

--- a/tests/test_collision_events_godot.py
+++ b/tests/test_collision_events_godot.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from src.conversion.gml_runtime import write_gml_runtime
+
+
+def _find_godot_binary() -> str | None:
+    env_path = os.environ.get("GODOT_BIN")
+    if env_path and os.path.isfile(env_path):
+        return env_path
+
+    path_binary = shutil.which("godot")
+    if path_binary is not None:
+        return path_binary
+
+    mac_binary = "/Applications/Godot.app/Contents/MacOS/Godot"
+    if os.path.isfile(mac_binary):
+        return mac_binary
+    return None
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_smoke_scene(project_dir: Path) -> None:
+    probe_script = textwrap.dedent(
+        """\
+        extends Node2D
+
+        const GMRuntime = preload("res://gm2godot/gml_runtime.gd")
+
+        var id = GMRuntime.gml_instance_noone()
+        var other = GMRuntime.gml_instance_noone()
+        var object_name = ""
+        var parent_names = []
+        var solid = false
+        var trace = []
+        var xprevious = 0.0
+        var yprevious = 0.0
+
+        func configure(instance_name, gm_object_name, gm_parent_names, is_solid, trace_ref, world_position):
+        \tname = str(instance_name)
+        \tobject_name = str(gm_object_name)
+        \tparent_names = gm_parent_names
+        \tsolid = bool(is_solid)
+        \ttrace = trace_ref
+        \tglobal_position = world_position
+        \txprevious = world_position.x
+        \typrevious = world_position.y
+
+        func _ready():
+        \t_ensure_collision_shape()
+        \tid = GMRuntime.gml_instance_register(self, object_name, parent_names)
+
+        func _exit_tree():
+        \tGMRuntime.gml_instance_unregister(id)
+
+        func _ensure_collision_shape():
+        \tif get_child_count() > 0:
+        \t\treturn
+        \tvar shape_node = CollisionShape2D.new()
+        \tvar rect = RectangleShape2D.new()
+        \trect.size = Vector2(16, 16)
+        \tshape_node.shape = rect
+        \tadd_child(shape_node)
+
+        func _gm_collision_event_bindings():
+        \tif object_name != "o_player":
+        \t\treturn []
+        \treturn [
+        \t\t{"target_object": "o_wall_parent", "method": "_on_collision_o_wall_parent"},
+        \t]
+
+        func _on_collision_o_wall_parent():
+        \ttrace.append(name + ":hit:" + str(other.name) + ":x=" + str(int(global_position.x)))
+        \tGMRuntime.gml_instance_destroy(other)
+        """
+    )
+    smoke_script = textwrap.dedent(
+        """\
+        extends Node2D
+
+        const GMRuntime = preload("res://gm2godot/gml_runtime.gd")
+        const CollisionProbe = preload("res://collision_probe.gd")
+
+        func _check(condition, message):
+        \tif not condition:
+        \t\tpush_error(str(message))
+        \t\tget_tree().quit(1)
+        \t\treturn false
+        \treturn true
+
+        func _ready():
+        \tvar trace = []
+        \tvar player = CollisionProbe.new()
+        \tplayer.configure("Player", "o_player", [], false, trace, Vector2(20, 0))
+        \tplayer.xprevious = 0
+        \tplayer.yprevious = 0
+        \tadd_child(player)
+        \tvar wall = CollisionProbe.new()
+        \twall.configure("Wall", "o_wall_child", ["o_wall_parent"], true, trace, Vector2(20, 0))
+        \tadd_child(wall)
+
+        \tGMRuntime.gml_collision_event_trace_clear()
+        \tvar dispatched = GMRuntime.gml_collision_event_dispatch_frame([player, wall], 7)
+        \tif not _check(dispatched == 1, "collision dispatch count mismatch: " + str(dispatched)):
+        \t\treturn
+        \tif not _check(trace == ["Player:hit:Wall:x=0"], "collision trace mismatch: " + str(trace)):
+        \t\treturn
+        \tif not _check(not GMRuntime.gml_handle_is_valid(wall.id), "destroyed collision other handle remained valid"):
+        \t\treturn
+        \tif not _check(not GMRuntime.gml_handle_is_valid(player.other), "other was not restored after dispatch"):
+        \t\treturn
+        \tvar runtime_trace = GMRuntime.gml_collision_event_trace()
+        \tif not _check(runtime_trace[0]["event"] == "solid_rollback", "solid rollback trace missing"):
+        \t\treturn
+        \tif not _check(runtime_trace[1]["method"] == "_on_collision_o_wall_parent", "collision method trace missing"):
+        \t\treturn
+        \tprint("COLLISION_EVENT_SMOKE_OK")
+        \tget_tree().quit(0)
+        """
+    )
+    smoke_scene = textwrap.dedent(
+        """\
+        [gd_scene load_steps=2 format=3]
+
+        [ext_resource type="Script" path="res://smoke.gd" id="1"]
+
+        [node name="Smoke" type="Node2D"]
+        script = ExtResource("1")
+        """
+    )
+    _write_text(project_dir / "collision_probe.gd", probe_script)
+    _write_text(project_dir / "smoke.gd", smoke_script)
+    _write_text(project_dir / "smoke.tscn", smoke_scene)
+
+
+class TestCollisionEventGodotSmoke(unittest.TestCase):
+    def test_collision_dispatch_parent_other_solid_and_destroy(self) -> None:
+        godot_binary = _find_godot_binary()
+        if godot_binary is None:
+            self.skipTest("Godot binary not available")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir)
+            _write_text(
+                project_dir / "project.godot",
+                '[application]\nconfig/name="CollisionEventSmoke"\nrun/main_scene="res://smoke.tscn"\n',
+            )
+            write_gml_runtime(str(project_dir))
+            _write_smoke_scene(project_dir)
+
+            godot_env = dict(os.environ)
+            godot_env["HOME"] = str(project_dir)
+            result = subprocess.run(
+                [
+                    godot_binary,
+                    "--headless",
+                    "--log-file",
+                    str(project_dir / "godot.log"),
+                    "--path",
+                    str(project_dir),
+                    "--scene",
+                    "res://smoke.tscn",
+                    "--quit-after",
+                    "10",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=20,
+                check=False,
+                env=godot_env,
+            )
+            output = result.stdout + result.stderr
+
+        self.assertEqual(result.returncode, 0, output)
+        self.assertIn("COLLISION_EVENT_SMOKE_OK", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_event_scheduler_godot.py
+++ b/tests/test_event_scheduler_godot.py
@@ -162,7 +162,7 @@ class TestEventSchedulerGodotSmoke(unittest.TestCase):
             \t\t\tfirst_step_phase = i
             \tif not _check(first_alarm_phase > 0 and first_alarm_phase < first_step_phase, "alarms did not run before Step"):
             \t\treturn
-            \tif not _check(GMRuntime.gml_event_scheduler_phase_order() == ["begin_step", "time_sources", "alarms", "step", "motion", "end_step"], "phase order mismatch"):
+            \tif not _check(GMRuntime.gml_event_scheduler_phase_order() == ["begin_step", "time_sources", "alarms", "step", "motion", "collision", "end_step"], "phase order mismatch"):
             \t\treturn
 
             \ttrace.clear()

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -2522,6 +2522,13 @@ class TestGMLRuntimeScript(unittest.TestCase):
         self.assertIn("static func gml_time_source_get_state(handle):", GML_RUNTIME_SCRIPT)
         self.assertIn("static func gml_time_source_tick_all(delta_seconds, delta_frames):", GML_RUNTIME_SCRIPT)
 
+    def test_runtime_collision_event_dispatch_helpers(self):
+        self.assertIn("static func gml_collision_event_dispatch_frame(instances = null, frame = -1):", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_collision_event_trace():", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func _gml_collision_binding_target_matches(other_inst, binding):", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func _gml_collision_restore_solid_contact(inst, other_inst):", GML_RUNTIME_SCRIPT)
+        self.assertIn('"collision",', GML_RUNTIME_SCRIPT)
+
     def test_runtime_input_event_dispatch_helpers(self):
         self.assertIn("static func gml_input_event_capture(event):", GML_RUNTIME_SCRIPT)
         self.assertIn("static func gml_input_dispatch_frame(instances = null):", GML_RUNTIME_SCRIPT)

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -931,6 +931,8 @@ class TestScriptGeneration(unittest.TestCase):
         gd_path = os.path.join(self.godot_dir, "objects", "o_test", "o_test.gd")
         with open(gd_path, 'r', encoding='utf-8') as f:
             content = f.read()
+        self.assertIn("func _gm_collision_event_bindings():", content)
+        self.assertIn('{"target_object": "o_bullet", "method": "_on_collision_o_bullet"}', content)
         self.assertIn("func _on_collision_o_bullet():", content)
 
     def test_script_with_multiple_events(self):

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -46,6 +46,7 @@ class TestScriptGeneratorBasic(unittest.TestCase):
 
         self.assertIn('const GMRuntime = preload("res://gm2godot/gml_runtime.gd")', content)
         self.assertIn("var id = GMRuntime.gml_instance_noone()", content)
+        self.assertIn("var other = GMRuntime.gml_instance_noone()", content)
         self.assertIn('var object_index = GMRuntime.gml_asset_get_index("o_child")', content)
         self.assertIn("func _gm_register_instance():\n\tif GMRuntime.gml_handle_is_valid(id):", content)
         self.assertIn('GMRuntime.gml_instance_register(self, "o_child", ["o_parent"])', content)
@@ -75,6 +76,7 @@ class TestScriptGeneratorBasic(unittest.TestCase):
         self.assertTrue(content.startswith('extends "res://objects/o_parent/o_parent.gd"'))
         self.assertNotIn("const GMRuntime = preload", content)
         self.assertNotIn("\n\nvar id =", content)
+        self.assertNotIn("\nvar other =", content)
         self.assertNotIn("\nvar object_index =", content)
         self.assertNotIn("\nvar depth = 0", content)
         self.assertIn(
@@ -146,6 +148,8 @@ class TestScriptGeneratorEvents(unittest.TestCase):
             "eventType": 4, "eventNum": 0,
             "collisionObjectId": {"name": "o_bullet"},
         }])
+        self.assertIn("func _gm_collision_event_bindings():", content)
+        self.assertIn('{"target_object": "o_bullet", "method": "_on_collision_o_bullet"}', content)
         self.assertIn("func _on_collision_o_bullet():", content)
 
     def test_timeline_builtin_variables_are_declared(self):


### PR DESCRIPTION
Closes #597.

## Summary
- generate _gm_collision_event_bindings() metadata for object collision events
- dispatch collision callbacks from the central scheduler after motion and before End Step
- support parent-object collision targeting, other, solid rollback, and destruction during collision callbacks
- document precise-mask fallback to generated Godot collision shape bounds

## Tests
- ./venv/bin/python -m unittest tests.test_collision_events_godot tests.test_event_scheduler_godot tests.conversion.events.test_collision_events tests.test_script_generator tests.test_objects tests.test_gml_runtime -v
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest