### PR TITLE
Add draw phase dispatch

### DIFF
--- a/src/conversion/gml_runtime_parts/segments/48_drawing_basic_forms.gd
+++ b/src/conversion/gml_runtime_parts/segments/48_drawing_basic_forms.gd
@@ -22,8 +22,19 @@ const GML_TEXTUREGROUP_STATUS_UNLOADED = 0
 const GML_TEXTUREGROUP_STATUS_LOADING = 1
 const GML_TEXTUREGROUP_STATUS_LOADED = 2
 const GML_TEXTUREGROUP_STATUS_FETCHED = 3
+const GML_DRAW_EVENT_PHASES = [
+	{"phase": "pre_draw", "method": "_on_pre_draw"},
+	{"phase": "draw_begin", "method": "_on_draw_begin"},
+	{"phase": "draw", "method": "_draw"},
+	{"phase": "draw_end", "method": "_on_draw_end"},
+	{"phase": "post_draw", "method": "_on_post_draw"},
+	{"phase": "draw_gui_begin", "method": "_on_draw_gui_begin"},
+	{"phase": "draw_gui", "method": "_on_draw_gui"},
+	{"phase": "draw_gui_end", "method": "_on_draw_gui_end"},
+]
 
 static var _gml_draw_context_stack = []
+static var _gml_draw_event_trace = []
 static var _gml_draw_sprite_cache = {}
 static var _gml_draw_font_cache = {}
 static var _gml_draw_tileset_cache = {}
@@ -75,6 +86,45 @@ static func gml_draw_end():
 	_gml_draw_state = context["state"]
 	_gml_draw_apply_gpu_state(context["target"])
 	return null
+
+
+static func gml_draw_event_phase_order():
+	var phases = []
+	for phase in GML_DRAW_EVENT_PHASES:
+		phases.append(phase["phase"])
+	return phases
+
+
+static func gml_draw_event_trace():
+	return _gml_clone_value(_gml_draw_event_trace, 16)
+
+
+static func gml_draw_event_trace_clear():
+	_gml_draw_event_trace = []
+	return null
+
+
+static func gml_draw_event_dispatch_frame(instances = null):
+	if gml_application_surface_is_enabled():
+		_gml_application_surface_ensure()
+	var targets = _gml_draw_sorted_instances(instances)
+	var dispatched = 0
+	for phase in GML_DRAW_EVENT_PHASES:
+		var phase_name = str(phase["phase"])
+		var method_name = str(phase["method"])
+		_gml_draw_record_event(phase_name, "", null, "phase")
+		for inst in targets:
+			if not _gml_draw_instance_visible(inst):
+				continue
+			if method_name == "_draw" and not inst.has_method(method_name):
+				_gml_draw_record_event(phase_name, "draw_self", inst, "default")
+				dispatched += 1
+				continue
+			if inst.has_method(method_name):
+				_gml_draw_record_event(phase_name, method_name, inst, "custom")
+				inst.call(method_name)
+				dispatched += 1
+	return dispatched
 
 
 static func gml_draw_self(instance):
@@ -732,6 +782,72 @@ static func _gml_draw_current_context_target():
 	if _gml_draw_context_stack.is_empty():
 		return null
 	return _gml_draw_context_stack[_gml_draw_context_stack.size() - 1]["target"]
+
+
+static func _gml_draw_sorted_instances(instances):
+	var targets = []
+	if instances is Array:
+		for inst in instances:
+			if inst != null and is_instance_valid(inst):
+				targets.append(inst)
+	else:
+		for entry in _gml_live_instance_entries():
+			var inst = entry["instance"]
+			if inst != null and is_instance_valid(inst):
+				targets.append(inst)
+	targets.sort_custom(_gml_draw_instance_order_less)
+	return targets
+
+
+static func _gml_draw_instance_order_less(left, right):
+	var left_depth = _gml_draw_instance_depth(left)
+	var right_depth = _gml_draw_instance_depth(right)
+	if left_depth == right_depth:
+		return _gml_draw_instance_creation_order(left) < _gml_draw_instance_creation_order(right)
+	return left_depth > right_depth
+
+
+static func _gml_draw_instance_depth(inst):
+	var value = gml_struct_get(inst, "depth")
+	if not is_undefined(value):
+		return int(_to_real(value))
+	if inst is CanvasItem:
+		return -int(inst.z_index)
+	return 0
+
+
+static func _gml_draw_instance_creation_order(inst):
+	var entry: Variant = _gml_instance_entry(inst)
+	if entry == null:
+		return 0
+	return int(entry.get("creation_order", 0))
+
+
+static func _gml_draw_instance_visible(inst):
+	if inst == null or not is_instance_valid(inst):
+		return false
+	var value = gml_struct_get(inst, "visible")
+	if not is_undefined(value):
+		if not gml_bool(value):
+			return false
+	if inst is CanvasItem and not inst.visible:
+		return false
+	return true
+
+
+static func _gml_draw_record_event(phase, method_name, inst, kind):
+	var entry = {
+		"phase": str(phase),
+		"method": str(method_name),
+		"kind": str(kind),
+		"instance": "",
+		"depth": 0,
+	}
+	if inst != null:
+		entry["instance"] = str(inst.name) if inst is Node else str(inst)
+		entry["depth"] = _gml_draw_instance_depth(inst)
+	_gml_draw_event_trace.append(entry)
+	return null
 
 
 static func _gml_draw_current_color():

--- a/src/conversion/gml_runtime_parts/segments/49_drawing_surfaces.gd
+++ b/src/conversion/gml_runtime_parts/segments/49_drawing_surfaces.gd
@@ -76,6 +76,11 @@ static func gml_surface_reset_target():
 	return true
 
 
+static func gml_surface_target_stack_depth():
+	_gml_surface_active_handle()
+	return _gml_surface_target_stack.size()
+
+
 static func gml_surface_get_width(surface):
 	var resolved_surface = _gml_surface_resolve(surface)
 	if resolved_surface == null:

--- a/src/conversion/runtime_managers.md
+++ b/src/conversion/runtime_managers.md
@@ -9,7 +9,7 @@ The generated autoloads are:
 - `GMRooms`: room order, current room, transitions, and layers.
 - `GMInstances`: live instances, handles, object indices, and creation order.
 - `GMEvents`: frame events, alarms, timelines, and sequences. This manager owns the generated `_process` frame pump, dispatches queued GMInput events, calls `GMRuntime.gml_event_scheduler_frame()`, then clears one-frame input edges so Step phases do not depend on individual node callback order.
-- `GMDraw`: draw state, surfaces, shader cache, and texture-group state.
+- `GMDraw`: draw state, surfaces, shader cache, and texture-group state. This manager owns the generated draw-phase pump for Pre Draw, Draw Begin, Draw, Draw End, Post Draw, and GUI phases.
 - `GMInput`: keyboard, mouse, gamepad, and gesture state. This manager owns the generated `_input(event)` capture hook; converted object scripts expose `_gm_input_event_bindings()` plus `_gm_input_*` methods for deterministic frame dispatch.
 - `GMAudio`: audio instances, groups, emitters, and listeners.
 - `GMAsync`: async_load, HTTP, buffer, and networking queues.

--- a/src/conversion/runtime_managers.py
+++ b/src/conversion/runtime_managers.py
@@ -19,6 +19,7 @@ class RuntimeManagerDefinition:
     state_keys: tuple[str, ...] = ()
     frame_pump: bool = False
     input_capture: bool = False
+    draw_pump: bool = False
 
     @property
     def relative_path(self) -> str:
@@ -77,6 +78,7 @@ RUNTIME_MANAGER_DEFINITIONS: tuple[RuntimeManagerDefinition, ...] = (
         "draw",
         dependencies=("GMRuntime", "GMAssets", "GMRooms", "GMInstances"),
         state_keys=("draw_state", "surfaces", "shader_cache", "texture_groups"),
+        draw_pump=True,
     ),
     RuntimeManagerDefinition(
         "GMInput",
@@ -148,7 +150,7 @@ def render_runtime_manager_script(definition: RuntimeManagerDefinition) -> str:
         "extends Node",
         "",
     ]
-    if definition.frame_pump or definition.input_capture:
+    if definition.frame_pump or definition.input_capture or definition.draw_pump:
         lines.extend([
             'const GMRuntimeFacade = preload("res://gm2godot/gml_runtime.gd")',
             "",
@@ -185,6 +187,13 @@ def render_runtime_manager_script(definition: RuntimeManagerDefinition) -> str:
         lines.extend([
             "func _input(event):",
             "\tGMRuntimeFacade.gml_input_event_capture(event)",
+            "",
+            "",
+        ])
+    if definition.draw_pump:
+        lines.extend([
+            "func _process(_delta):",
+            "\tGMRuntimeFacade.gml_draw_event_dispatch_frame()",
             "",
             "",
         ])

--- a/tests/test_draw_event_dispatch_godot.py
+++ b/tests/test_draw_event_dispatch_godot.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from src.conversion.gml_runtime import write_gml_runtime
+
+
+def _find_godot_binary() -> str | None:
+    env_path = os.environ.get("GODOT_BIN")
+    if env_path and os.path.isfile(env_path):
+        return env_path
+
+    path_binary = shutil.which("godot")
+    if path_binary is not None:
+        return path_binary
+
+    mac_binary = "/Applications/Godot.app/Contents/MacOS/Godot"
+    if os.path.isfile(mac_binary):
+        return mac_binary
+    return None
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_smoke_scene(project_dir: Path) -> None:
+    probe_script = textwrap.dedent(
+        """\
+        extends Node2D
+
+        const GMRuntime = preload("res://gm2godot/gml_runtime.gd")
+
+        var id = GMRuntime.gml_instance_noone()
+        var depth = 0
+        var trace = []
+        var custom_draw = true
+
+        func configure(instance_name, depth_value, trace_ref, use_custom_draw = true, is_visible = true):
+        \tname = str(instance_name)
+        \tdepth = int(depth_value)
+        \ttrace = trace_ref
+        \tcustom_draw = bool(use_custom_draw)
+        \tvisible = bool(is_visible)
+
+        func _ready():
+        \tid = GMRuntime.gml_instance_register(self, "o_draw_probe", [])
+
+        func _exit_tree():
+        \tGMRuntime.gml_instance_unregister(id)
+
+        func _on_pre_draw():
+        \ttrace.append(name + ":pre")
+
+        func _on_draw_begin():
+        \ttrace.append(name + ":begin")
+
+        func _draw():
+        \tif custom_draw:
+        \t\ttrace.append(name + ":draw")
+
+        func _on_draw_end():
+        \ttrace.append(name + ":end")
+
+        func _on_post_draw():
+        \ttrace.append(name + ":post")
+
+        func _on_draw_gui_begin():
+        \ttrace.append(name + ":gui_begin")
+
+        func _on_draw_gui():
+        \ttrace.append(name + ":gui")
+
+        func _on_draw_gui_end():
+        \ttrace.append(name + ":gui_end")
+        """
+    )
+    default_probe_script = textwrap.dedent(
+        """\
+        extends Node2D
+
+        const GMRuntime = preload("res://gm2godot/gml_runtime.gd")
+
+        var id = GMRuntime.gml_instance_noone()
+        var depth = 0
+        var trace = []
+
+        func configure(instance_name, depth_value, trace_ref):
+        \tname = str(instance_name)
+        \tdepth = int(depth_value)
+        \ttrace = trace_ref
+
+        func _ready():
+        \tid = GMRuntime.gml_instance_register(self, "o_default_draw_probe", [])
+
+        func _exit_tree():
+        \tGMRuntime.gml_instance_unregister(id)
+
+        func _on_pre_draw():
+        \ttrace.append(name + ":pre")
+
+        func _on_draw_begin():
+        \ttrace.append(name + ":begin")
+
+        func _on_draw_end():
+        \ttrace.append(name + ":end")
+        """
+    )
+    smoke_script = textwrap.dedent(
+        """\
+        extends Node2D
+
+        const GMRuntime = preload("res://gm2godot/gml_runtime.gd")
+        const DrawProbe = preload("res://draw_probe.gd")
+        const DefaultProbe = preload("res://default_draw_probe.gd")
+
+        func _check(condition, message):
+        \tif not condition:
+        \t\tpush_error(str(message))
+        \t\tget_tree().quit(1)
+        \t\treturn false
+        \treturn true
+
+        func _ready():
+        \tvar trace = []
+        \tvar front = DrawProbe.new()
+        \tfront.configure("Front", -100, trace)
+        \tadd_child(front)
+        \tvar back = DrawProbe.new()
+        \tback.configure("Back", 100, trace)
+        \tadd_child(back)
+        \tvar hidden = DrawProbe.new()
+        \thidden.configure("Hidden", 50, trace, true, false)
+        \tadd_child(hidden)
+        \tvar defaulted = DefaultProbe.new()
+        \tdefaulted.configure("Default", 0, trace)
+        \tadd_child(defaulted)
+
+        \tGMRuntime.gml_draw_event_trace_clear()
+        \tvar dispatched = GMRuntime.gml_draw_event_dispatch_frame([front, back, hidden, defaulted])
+        \tif not _check(dispatched == 20, "draw dispatch count mismatch: " + str(dispatched)):
+        \t\treturn
+        \tvar expected_prefix = [
+        \t\t"Back:pre",
+        \t\t"Default:pre",
+        \t\t"Front:pre",
+        \t\t"Back:begin",
+        \t\t"Default:begin",
+        \t\t"Front:begin",
+        \t]
+        \tif not _check(trace.slice(0, expected_prefix.size()) == expected_prefix, "draw depth/order mismatch: " + str(trace)):
+        \t\treturn
+        \tif not _check(not trace.has("Hidden:draw"), "hidden instance received draw"):
+        \t\treturn
+        \tif not _check(trace.find("Back:post") < trace.find("Back:gui_begin"), "GUI phase ran before Post Draw"):
+        \t\treturn
+        \tvar runtime_trace = GMRuntime.gml_draw_event_trace()
+        \tvar default_seen = false
+        \tfor entry in runtime_trace:
+        \t\tif entry["kind"] == "default" and entry["instance"] == "Default":
+        \t\t\tdefault_seen = true
+        \tif not _check(default_seen, "default draw path was not recorded"):
+        \t\treturn
+        \tif not _check(GMRuntime.gml_surface_exists(GMRuntime.gml_builtin_global("application_surface")), "application surface was not created"):
+        \t\treturn
+        \tvar surf = GMRuntime.gml_surface_create(8, 8)
+        \tif not _check(GMRuntime.gml_surface_set_target(surf), "surface target could not be set"):
+        \t\treturn
+        \tif not _check(GMRuntime.gml_surface_target_stack_depth() == 1, "surface target stack depth did not increment"):
+        \t\treturn
+        \tGMRuntime.gml_surface_reset_target()
+        \tif not _check(GMRuntime.gml_surface_target_stack_depth() == 0, "surface target stack depth did not reset"):
+        \t\treturn
+        \tGMRuntime.gml_surface_free(surf)
+        \tif not _check(not GMRuntime.gml_surface_exists(surf), "surface remained valid after free"):
+        \t\treturn
+        \tif not _check(GMRuntime.gml_draw_event_phase_order() == ["pre_draw", "draw_begin", "draw", "draw_end", "post_draw", "draw_gui_begin", "draw_gui", "draw_gui_end"], "draw phase order mismatch"):
+        \t\treturn
+        \tprint("DRAW_EVENT_DISPATCH_SMOKE_OK")
+        \tget_tree().quit(0)
+        """
+    )
+    smoke_scene = textwrap.dedent(
+        """\
+        [gd_scene load_steps=2 format=3]
+
+        [ext_resource type="Script" path="res://smoke.gd" id="1"]
+
+        [node name="Smoke" type="Node2D"]
+        script = ExtResource("1")
+        """
+    )
+    _write_text(project_dir / "draw_probe.gd", probe_script)
+    _write_text(project_dir / "default_draw_probe.gd", default_probe_script)
+    _write_text(project_dir / "smoke.gd", smoke_script)
+    _write_text(project_dir / "smoke.tscn", smoke_scene)
+
+
+class TestDrawEventDispatchGodotSmoke(unittest.TestCase):
+    def test_draw_dispatch_order_default_draw_and_surface_stack(self) -> None:
+        godot_binary = _find_godot_binary()
+        if godot_binary is None:
+            self.skipTest("Godot binary not available")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir)
+            _write_text(
+                project_dir / "project.godot",
+                '[application]\nconfig/name="DrawEventDispatchSmoke"\nrun/main_scene="res://smoke.tscn"\n',
+            )
+            write_gml_runtime(str(project_dir))
+            _write_smoke_scene(project_dir)
+
+            godot_env = dict(os.environ)
+            godot_env["HOME"] = str(project_dir)
+            result = subprocess.run(
+                [
+                    godot_binary,
+                    "--headless",
+                    "--log-file",
+                    str(project_dir / "godot.log"),
+                    "--path",
+                    str(project_dir),
+                    "--scene",
+                    "res://smoke.tscn",
+                    "--quit-after",
+                    "10",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=20,
+                check=False,
+                env=godot_env,
+            )
+            output = result.stdout + result.stderr
+
+        self.assertEqual(result.returncode, 0, output)
+        self.assertIn("DRAW_EVENT_DISPATCH_SMOKE_OK", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -1082,6 +1082,8 @@ class TestGMLRuntimeScript(unittest.TestCase):
             "gml_mp_grid_path",
             "gml_draw_begin",
             "gml_draw_end",
+            "gml_draw_event_dispatch_frame",
+            "gml_draw_event_phase_order",
             "gml_draw_self",
             "gml_draw_sprite",
             "gml_draw_sprite_ext",
@@ -1110,6 +1112,7 @@ class TestGMLRuntimeScript(unittest.TestCase):
             "gml_surface_free",
             "gml_surface_set_target",
             "gml_surface_reset_target",
+            "gml_surface_target_stack_depth",
             "gml_surface_get_width",
             "gml_surface_get_height",
             "gml_draw_surface",
@@ -2528,6 +2531,14 @@ class TestGMLRuntimeScript(unittest.TestCase):
         self.assertIn("static func _gml_collision_binding_target_matches(other_inst, binding):", GML_RUNTIME_SCRIPT)
         self.assertIn("static func _gml_collision_restore_solid_contact(inst, other_inst):", GML_RUNTIME_SCRIPT)
         self.assertIn('"collision",', GML_RUNTIME_SCRIPT)
+
+    def test_runtime_draw_event_dispatch_helpers(self):
+        self.assertIn("const GML_DRAW_EVENT_PHASES = [", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_draw_event_dispatch_frame(instances = null):", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_draw_event_phase_order():", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_draw_event_trace():", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_surface_target_stack_depth():", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func _gml_draw_instance_order_less(left, right):", GML_RUNTIME_SCRIPT)
 
     def test_runtime_input_event_dispatch_helpers(self):
         self.assertIn("static func gml_input_event_capture(event):", GML_RUNTIME_SCRIPT)

--- a/tests/test_runtime_managers.py
+++ b/tests/test_runtime_managers.py
@@ -106,6 +106,19 @@ class TestRuntimeManagers(unittest.TestCase):
         self.assertIn("func _input(event):", script)
         self.assertIn("GMRuntimeFacade.gml_input_event_capture(event)", script)
 
+    def test_draw_manager_pumps_draw_dispatch(self) -> None:
+        definition = next(
+            manager_definition
+            for manager_definition in runtime_manager_definitions()
+            if manager_definition.name == "GMDraw"
+        )
+
+        script = render_runtime_manager_script(definition)
+
+        self.assertIn('const GMRuntimeFacade = preload("res://gm2godot/gml_runtime.gd")', script)
+        self.assertIn("func _process(_delta):", script)
+        self.assertIn("GMRuntimeFacade.gml_draw_event_dispatch_frame()", script)
+
     def test_write_runtime_managers_writes_each_manager_script(self) -> None:
         output_paths = write_runtime_managers(self.godot_dir)
 


### PR DESCRIPTION
Closes #598.

## Summary
- add GMDraw frame dispatch for Pre Draw, Draw Begin, Draw, Draw End, Post Draw, and GUI phases
- sort draw dispatch by GameMaker depth and skip invisible instances
- record default Draw versus custom Draw behavior and keep application surface/target stack lifecycle observable
- wire GMDraw manager to pump draw dispatch and document manager ownership

## Tests
- ./venv/bin/python -m unittest tests.test_draw_event_dispatch_godot tests.test_runtime_managers tests.test_gml_runtime tests.test_script_generator tests.conversion.events.test_draw_events -v
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest