### PR TITLE
Add deterministic async queue

### DIFF
--- a/src/conversion/events/mappings/other_async_http.py
+++ b/src/conversion/events/mappings/other_async_http.py
@@ -2,5 +2,5 @@ from src.conversion.events.base import EventMapping, StaticMappings
 
 
 STATIC_MAPPINGS: StaticMappings = {
-    (7, 62): EventMapping("_on_http_request_completed", "", 14, "Other_62.gml"),
+    (7, 62): EventMapping("_on_async_http", "", 14, "Other_62.gml"),
 }

--- a/src/conversion/gml_runtime_parts/segments/66_buffers.gd
+++ b/src/conversion/gml_runtime_parts/segments/66_buffers.gd
@@ -18,9 +18,6 @@ const GML_BUFFER_BOOL = 9
 const GML_BUFFER_STRING = 10
 const GML_BUFFER_TEXT = 11
 
-static var _gml_buffer_async_next_id = 1
-
-
 class GMLBuffer:
 	var data = PackedByteArray()
 	var cursor = 0
@@ -198,7 +195,7 @@ static func gml_buffer_load(path):
 
 static func gml_buffer_save_async(buffer_id, path, offset = 0, size = -1):
 	var buffer = _gml_buffer_resolve(buffer_id)
-	var async_id = _gml_buffer_next_async_id()
+	var async_id = gml_async_next_request_id()
 	var status = -1
 	if buffer != null:
 		var byte_count = _to_int64_value(size)
@@ -223,7 +220,7 @@ static func gml_buffer_save_async(buffer_id, path, offset = 0, size = -1):
 
 
 static func gml_buffer_load_async(path):
-	var async_id = _gml_buffer_next_async_id()
+	var async_id = gml_async_next_request_id()
 	var buffer = gml_buffer_load(path)
 	gml_async_dispatch("save_load", {
 		"id": async_id,
@@ -285,12 +282,6 @@ static func _gml_buffer_resolve(buffer_id):
 	if gml_handle_is_valid(handle) and handle.reference is GMLBuffer:
 		return handle.reference
 	return null
-
-
-static func _gml_buffer_next_async_id():
-	var async_id = _gml_buffer_async_next_id
-	_gml_buffer_async_next_id += 1
-	return async_id
 
 
 static func _gml_buffer_hash(buffer_id, offset, size, hash_type):

--- a/src/conversion/gml_runtime_parts/segments/67_async_runtime.gd
+++ b/src/conversion/gml_runtime_parts/segments/67_async_runtime.gd
@@ -1,6 +1,123 @@
 static var _gml_async_next_request_id_value = 1
 static var _gml_async_event_log = []
+static var _gml_async_queue = []
+static var _gml_async_next_queue_sequence = 1
+static var _gml_async_dispatch_sequence = 0
+static var _gml_async_active_depth = 0
+static var _gml_async_flush_scheduled = false
+static var _gml_async_unsupported_diagnostics = []
 static var _gml_async_pending_http = {}
+
+const GML_ASYNC_HANDLER_DEFAULTS = {
+	"http": "_on_async_http",
+	"networking": "_on_async_networking",
+	"dialog": "_on_async_dialog",
+	"image_loaded": "_on_async_image_loaded",
+	"sound_loaded": "_on_async_sound_loaded",
+	"save_load": "_on_async_save_load",
+	"steam": "_on_async_steam",
+	"in_app_purchase": "_on_async_in_app_purchase",
+	"cloud_save": "_on_async_cloud_save",
+	"social": "_on_async_social",
+	"push_notification": "_on_async_push_notification",
+	"system": "_on_async_system",
+	"audio_recording": "_on_audio_recording_async",
+	"audio_playback": "_on_audio_playback_async",
+	"audio_playback_ended": "_on_audio_playback_ended_async",
+	"extension": "_on_async_extension",
+}
+
+const GML_ASYNC_HANDLER_ALIASES = {
+	"http": ["_on_http_request_completed"],
+}
+
+const GML_ASYNC_PAYLOAD_SCHEMAS = {
+	"default": {
+		"required": ["id", "event_type"],
+		"optional": ["status", "result", "diagnostic"],
+		"lifetime": "async_load is set only while a matching Async event callback is running and is cleared before dispatch returns.",
+	},
+	"http": {
+		"required": ["id", "event_type", "status", "result", "url"],
+		"optional": ["http_status", "body", "body_raw", "headers", "response_headers", "network_result", "diagnostic"],
+		"handler": "_on_async_http",
+	},
+	"networking": {
+		"required": ["id", "event_type", "type", "socket", "protocol"],
+		"optional": ["message_type", "network_type", "buffer", "size", "ip", "port", "status", "diagnostic"],
+		"handler": "_on_async_networking",
+	},
+	"dialog": {
+		"required": ["id", "event_type", "status"],
+		"optional": ["result", "button", "value", "diagnostic"],
+		"handler": "_on_async_dialog",
+	},
+	"save_load": {
+		"required": ["id", "event_type", "status", "filename"],
+		"optional": ["buffer", "result", "diagnostic"],
+		"handler": "_on_async_save_load",
+	},
+	"image_loaded": {
+		"required": ["id", "event_type", "status"],
+		"optional": ["filename", "asset_index", "sprite_index", "diagnostic"],
+		"handler": "_on_async_image_loaded",
+	},
+	"sound_loaded": {
+		"required": ["id", "event_type", "status"],
+		"optional": ["filename", "asset_index", "sound_index", "diagnostic"],
+		"handler": "_on_async_sound_loaded",
+	},
+	"audio_recording": {
+		"required": ["id", "event_type", "status"],
+		"optional": ["buffer", "channel", "diagnostic"],
+		"handler": "_on_audio_recording_async",
+	},
+	"audio_playback": {
+		"required": ["id", "event_type", "status"],
+		"optional": ["queue_id", "sound_id", "diagnostic"],
+		"handler": "_on_audio_playback_async",
+	},
+	"audio_playback_ended": {
+		"required": ["id", "event_type", "status"],
+		"optional": ["queue_id", "sound_id", "diagnostic"],
+		"handler": "_on_audio_playback_ended_async",
+	},
+	"steam": {
+		"required": ["id", "event_type", "status"],
+		"optional": ["result", "diagnostic"],
+		"handler": "_on_async_steam",
+	},
+	"in_app_purchase": {
+		"required": ["id", "event_type", "status"],
+		"optional": ["product_id", "result", "diagnostic"],
+		"handler": "_on_async_in_app_purchase",
+	},
+	"cloud_save": {
+		"required": ["id", "event_type", "status"],
+		"optional": ["filename", "result", "diagnostic"],
+		"handler": "_on_async_cloud_save",
+	},
+	"social": {
+		"required": ["id", "event_type", "status"],
+		"optional": ["result", "diagnostic"],
+		"handler": "_on_async_social",
+	},
+	"push_notification": {
+		"required": ["id", "event_type"],
+		"optional": ["message", "payload", "status", "diagnostic"],
+		"handler": "_on_async_push_notification",
+	},
+	"system": {
+		"required": ["id", "event_type", "status"],
+		"optional": ["result", "diagnostic"],
+		"handler": "_on_async_system",
+	},
+	"extension": {
+		"required": ["id", "event_type", "extension", "callback"],
+		"optional": ["schema", "status", "result", "diagnostic"],
+		"handler": "_on_async_extension",
+	},
+}
 
 
 static func gml_async_next_request_id():
@@ -9,25 +126,84 @@ static func gml_async_next_request_id():
 	return request_id
 
 
-static func gml_async_dispatch(kind, payload, handler_name):
-	var resolved_payload = payload if payload is Dictionary else {}
-	if not resolved_payload.has("id"):
-		resolved_payload["id"] = gml_async_next_request_id()
-	resolved_payload["event_type"] = str(kind)
-	_gml_builtin_globals["async_load"] = resolved_payload
-	_gml_async_event_log.append({
-		"kind": str(kind),
-		"handler": str(handler_name),
-		"payload": resolved_payload
-	})
-	var main_loop = Engine.get_main_loop()
-	if main_loop is SceneTree:
-		_gml_async_dispatch_node(main_loop.root, str(handler_name))
-	return resolved_payload["id"]
+static func gml_async_dispatch(kind, payload, handler_name = ""):
+	var request_id = _gml_async_enqueue(kind, payload, handler_name, false)
+	if _gml_async_active_depth == 0:
+		gml_async_queue_flush()
+	else:
+		_gml_async_schedule_flush()
+	return request_id
+
+
+static func gml_async_enqueue(kind, payload, handler_name = ""):
+	return _gml_async_enqueue(kind, payload, handler_name, true)
+
+
+static func gml_async_queue_flush(max_events = -1):
+	var limit = _to_int64_value(max_events)
+	var dispatched = 0
+	_gml_async_flush_scheduled = false
+	while not _gml_async_queue.is_empty():
+		if limit >= 0 and dispatched >= limit:
+			break
+		var event = _gml_async_queue.pop_front()
+		_gml_async_deliver(event)
+		dispatched += 1
+	return dispatched
+
+
+static func gml_async_queue_size():
+	return _gml_async_queue.size()
+
+
+static func gml_async_queue_snapshot():
+	return _gml_clone_value(_gml_async_queue, 16)
 
 
 static func gml_async_event_log():
 	return _gml_clone_value(_gml_async_event_log, 16)
+
+
+static func gml_async_event_log_clear():
+	_gml_async_event_log.clear()
+	return null
+
+
+static func gml_async_payload_schema(kind = ""):
+	var key = str(kind)
+	if key == "":
+		return _gml_clone_value(GML_ASYNC_PAYLOAD_SCHEMAS, 16)
+	return _gml_clone_value(GML_ASYNC_PAYLOAD_SCHEMAS.get(key, GML_ASYNC_PAYLOAD_SCHEMAS["default"]), 16)
+
+
+static func gml_async_unsupported_diagnostics():
+	return _gml_clone_value(_gml_async_unsupported_diagnostics, 16)
+
+
+static func gml_async_dispatch_unsupported(kind, api_name, service_name = "", handler_name = "", detail = ""):
+	var resolved_kind = str(kind)
+	if resolved_kind == "":
+		resolved_kind = "system"
+	var message = "Unsupported async API: " + str(api_name)
+	if str(service_name) != "":
+		message += " for service " + str(service_name)
+	if str(detail) != "":
+		message += ". " + str(detail)
+	var diagnostic = {
+		"severity": "unsupported",
+		"api": str(api_name),
+		"service": str(service_name),
+		"event_type": resolved_kind,
+		"message": message,
+		"detail": str(detail),
+	}
+	_gml_async_unsupported_diagnostics.append(diagnostic)
+	return gml_async_dispatch(resolved_kind, {
+		"id": gml_async_next_request_id(),
+		"status": -1,
+		"result": "unsupported",
+		"diagnostic": diagnostic,
+	}, handler_name)
 
 
 static func gml_http_get(url):
@@ -88,13 +264,106 @@ static func _gml_http_complete(request_id, url, result, response_code, response_
 	}, "_on_async_http")
 
 
-static func _gml_async_dispatch_node(node, handler_name):
-	if node == null:
+static func _gml_async_enqueue(kind, payload, handler_name, schedule_flush):
+	var resolved_kind = str(kind)
+	var resolved_payload = _gml_async_normalize_payload(resolved_kind, payload)
+	var request_id = resolved_payload["id"]
+	var event = {
+		"kind": resolved_kind,
+		"handler": _gml_async_resolve_handler(resolved_kind, handler_name),
+		"payload": resolved_payload,
+		"queue_sequence": _gml_async_next_queue_sequence,
+	}
+	_gml_async_next_queue_sequence += 1
+	_gml_async_queue.append(event)
+	if schedule_flush:
+		_gml_async_schedule_flush()
+	return request_id
+
+
+static func _gml_async_normalize_payload(kind, payload):
+	var resolved_payload = _gml_clone_value(payload, 16) if payload is Dictionary else {}
+	if not resolved_payload.has("id"):
+		resolved_payload["id"] = gml_async_next_request_id()
+	resolved_payload["event_type"] = str(kind)
+	return resolved_payload
+
+
+static func _gml_async_resolve_handler(kind, handler_name):
+	var resolved_handler = str(handler_name)
+	if resolved_handler != "":
+		return resolved_handler
+	return str(GML_ASYNC_HANDLER_DEFAULTS.get(str(kind), "_on_async_" + str(kind)))
+
+
+static func _gml_async_handler_names(kind, handler_name):
+	var names = []
+	var primary = str(handler_name)
+	if primary != "":
+		names.append(primary)
+	var default_handler = _gml_async_resolve_handler(kind, "")
+	if default_handler != "" and not names.has(default_handler):
+		names.append(default_handler)
+	var aliases = GML_ASYNC_HANDLER_ALIASES.get(str(kind), [])
+	if aliases is Array:
+		for alias in aliases:
+			var alias_name = str(alias)
+			if alias_name != "" and not names.has(alias_name):
+				names.append(alias_name)
+	return names
+
+
+static func _gml_async_schedule_flush():
+	if _gml_async_flush_scheduled or _gml_async_queue.is_empty():
 		return
-	if node.has_method(handler_name):
-		node.call(handler_name)
+	var main_loop = Engine.get_main_loop()
+	if not (main_loop is SceneTree):
+		return
+	_gml_async_flush_scheduled = true
+	main_loop.process_frame.connect(func():
+		gml_async_queue_flush()
+	, CONNECT_ONE_SHOT)
+
+
+static func _gml_async_deliver(event):
+	_gml_async_dispatch_sequence += 1
+	var payload = event.get("payload", {})
+	var kind = str(event.get("kind", ""))
+	var handler_name = str(event.get("handler", ""))
+	var handler_names = _gml_async_handler_names(kind, handler_name)
+	var listener_count = 0
+	_gml_async_active_depth += 1
+	_gml_builtin_globals["async_load"] = payload
+	var main_loop = Engine.get_main_loop()
+	if main_loop is SceneTree:
+		listener_count = _gml_async_dispatch_node(main_loop.root, handler_names)
+	_gml_async_active_depth -= 1
+	_gml_async_event_log.append({
+		"kind": kind,
+		"handler": handler_name,
+		"handlers": handler_names,
+		"payload": _gml_clone_value(payload, 16),
+		"queue_sequence": event.get("queue_sequence", 0),
+		"dispatch_sequence": _gml_async_dispatch_sequence,
+		"listener_count": listener_count,
+	})
+	if _gml_async_active_depth == 0:
+		_gml_builtin_globals["async_load"] = {}
+	return listener_count
+
+
+static func _gml_async_dispatch_node(node, handler_names):
+	if node == null:
+		return 0
+	var count = 0
+	for handler_name in handler_names:
+		if node.has_method(str(handler_name)):
+			node.call(str(handler_name))
+			count += 1
+			break
 	for child in node.get_children():
-		_gml_async_dispatch_node(child, handler_name)
+		count += _gml_async_dispatch_node(child, handler_names)
+	return count
 
 
 static func _gml_http_headers(headers):

--- a/src/conversion/gml_runtime_parts/segments/73_platform_services.gd
+++ b/src/conversion/gml_runtime_parts/segments/73_platform_services.gd
@@ -92,6 +92,7 @@ static func gml_platform_service_call(service_name, api_name, args = []):
 
 
 static func gml_platform_service_unsupported(api_name, service_name, detail = ""):
+	var contract = _gml_platform_service_contract(str(service_name), str(api_name))
 	var message = (
 		"GML platform-service API "
 		+ str(api_name)
@@ -101,6 +102,15 @@ static func gml_platform_service_unsupported(api_name, service_name, detail = ""
 	)
 	if str(detail) != "":
 		message += " " + str(detail)
+	var async_kind = str(contract.get("async_kind", ""))
+	if async_kind != "":
+		gml_async_dispatch_unsupported(
+			async_kind,
+			api_name,
+			service_name,
+			str(contract.get("handler", "")),
+			message,
+		)
 	return gml_error(message)
 
 

--- a/src/conversion/runtime_managers.md
+++ b/src/conversion/runtime_managers.md
@@ -12,7 +12,7 @@ The generated autoloads are:
 - `GMDraw`: draw state, surfaces, shader cache, and texture-group state. This manager owns the generated draw-phase pump for Pre Draw, Draw Begin, Draw, Draw End, Post Draw, and GUI phases.
 - `GMInput`: keyboard, mouse, gamepad, and gesture state. This manager owns the generated `_input(event)` capture hook; converted object scripts expose `_gm_input_event_bindings()` plus `_gm_input_*` methods for deterministic frame dispatch.
 - `GMAudio`: audio instances, groups, emitters, and listeners.
-- `GMAsync`: async_load, HTTP, buffer, and networking queues.
+- `GMAsync`: async_load, HTTP, buffer, networking, platform, and extension queues. This manager owns the generated async queue pump so callback delivery is FIFO and `async_load` is scoped to each Async event.
 - `GMPlatform`: service hooks, extension callback schemas, OS/debug, and GC state.
 
 `project.godot` registers the managers in that order in `[autoload]`. Godot loads autoload nodes before the main scene and evaluates them in project order, which gives the runtime a stable startup sequence for later event, room, draw, input, audio, async, and platform migrations.

--- a/src/conversion/runtime_managers.py
+++ b/src/conversion/runtime_managers.py
@@ -20,6 +20,7 @@ class RuntimeManagerDefinition:
     frame_pump: bool = False
     input_capture: bool = False
     draw_pump: bool = False
+    async_pump: bool = False
 
     @property
     def relative_path(self) -> str:
@@ -104,6 +105,7 @@ RUNTIME_MANAGER_DEFINITIONS: tuple[RuntimeManagerDefinition, ...] = (
         "async",
         dependencies=("GMRuntime", "GMEvents"),
         state_keys=("async_load", "event_log", "http", "buffers", "networking"),
+        async_pump=True,
     ),
     RuntimeManagerDefinition(
         "GMPlatform",
@@ -150,7 +152,7 @@ def render_runtime_manager_script(definition: RuntimeManagerDefinition) -> str:
         "extends Node",
         "",
     ]
-    if definition.frame_pump or definition.input_capture or definition.draw_pump:
+    if definition.frame_pump or definition.input_capture or definition.draw_pump or definition.async_pump:
         lines.extend([
             'const GMRuntimeFacade = preload("res://gm2godot/gml_runtime.gd")',
             "",
@@ -194,6 +196,13 @@ def render_runtime_manager_script(definition: RuntimeManagerDefinition) -> str:
         lines.extend([
             "func _process(_delta):",
             "\tGMRuntimeFacade.gml_draw_event_dispatch_frame()",
+            "",
+            "",
+        ])
+    if definition.async_pump:
+        lines.extend([
+            "func _process(_delta):",
+            "\tGMRuntimeFacade.gml_async_queue_flush()",
             "",
             "",
         ])

--- a/tests/conversion/events/test_async_http.py
+++ b/tests/conversion/events/test_async_http.py
@@ -15,7 +15,7 @@ class TestAsyncHttpEvent(unittest.TestCase):
         mapping = map_event({"eventType": 7, "eventNum": 62})
         assert mapping is not None
 
-        self.assertEqual(mapping.godot_func, "_on_http_request_completed")
+        self.assertEqual(mapping.godot_func, "_on_async_http")
         self.assertEqual(mapping.params, "")
         self.assertEqual(mapping.sort_key, 14)
         self.assertEqual(mapping.gml_filename, "Other_62.gml")
@@ -23,7 +23,7 @@ class TestAsyncHttpEvent(unittest.TestCase):
     def test_generates_async_http_handler_stub(self):
         content = generate_script_content([{"eventType": 7, "eventNum": 62}])
 
-        self.assertIn("func _on_http_request_completed():", content)
+        self.assertIn("func _on_async_http():", content)
         self.assertIn("\tpass", content)
         self.assertNotIn("func _on_other_62():", content)
 

--- a/tests/test_async_queue_godot.py
+++ b/tests/test_async_queue_godot.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from src.conversion.gml_runtime import write_gml_runtime
+
+
+def _find_godot_binary() -> str | None:
+    env_path = os.environ.get("GODOT_BIN")
+    if env_path and os.path.isfile(env_path):
+        return env_path
+
+    path_binary = shutil.which("godot")
+    if path_binary is not None:
+        return path_binary
+
+    mac_binary = "/Applications/Godot.app/Contents/MacOS/Godot"
+    if os.path.isfile(mac_binary):
+        return mac_binary
+    return None
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class TestAsyncQueueGodotSmoke(unittest.TestCase):
+    def test_async_queue_flushes_fifo_and_scopes_async_load(self) -> None:
+        godot_binary = _find_godot_binary()
+        if godot_binary is None:
+            self.skipTest("Godot binary not available")
+
+        listener_script = textwrap.dedent(
+            """\
+            extends Node
+
+            const GMRuntime = preload("res://gm2godot/gml_runtime.gd")
+
+            var label = ""
+            var sink = []
+
+            func _on_async_http():
+            \tvar payload = GMRuntime.gml_builtin_global("async_load")
+            \tsink.append(label + ":" + str(payload["id"]) + ":" + str(payload["event_type"]))
+            """
+        )
+        legacy_listener_script = textwrap.dedent(
+            """\
+            extends Node
+
+            const GMRuntime = preload("res://gm2godot/gml_runtime.gd")
+
+            var sink = []
+
+            func _on_http_request_completed():
+            \tvar payload = GMRuntime.gml_builtin_global("async_load")
+            \tsink.append("legacy:" + str(payload["id"]))
+            """
+        )
+        smoke_script = textwrap.dedent(
+            """\
+            extends Node2D
+
+            const GMRuntime = preload("res://gm2godot/gml_runtime.gd")
+            const ListenerScript = preload("res://listener.gd")
+            const LegacyListenerScript = preload("res://legacy_listener.gd")
+
+            var order = []
+            var legacy_order = []
+
+            func _check(condition, message):
+            \tif not condition:
+            \t\tpush_error(str(message))
+            \t\tget_tree().quit(1)
+            \t\treturn false
+            \treturn true
+
+            func _ready():
+            \tcall_deferred("_run")
+
+            func _run():
+            \tGMRuntime.gml_async_event_log_clear()
+            \tvar first = _listener("A")
+            \tvar second = _listener("B")
+            \tadd_child(first)
+            \tadd_child(second)
+
+            \tvar first_id = GMRuntime.gml_async_enqueue("http", {"id": 101, "status": 200, "result": "one", "url": "/one"})
+            \tvar second_id = GMRuntime.gml_async_enqueue("http", {"id": 102, "status": 201, "result": "two", "url": "/two"})
+            \tif not _check(first_id == 101 and second_id == 102, "enqueue returned wrong ids"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_async_queue_size() == 2, "queue size mismatch before flush"):
+            \t\treturn
+            \tif not _check(order.is_empty(), "enqueue dispatched before flush"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_builtin_global("async_load").is_empty(), "async_load set before flush"):
+            \t\treturn
+
+            \tvar flushed = GMRuntime.gml_async_queue_flush()
+            \tif not _check(flushed == 2, "flush count mismatch"):
+            \t\treturn
+            \tif not _check(order == ["A:101:http", "B:101:http", "A:102:http", "B:102:http"], "listener FIFO order mismatch: " + str(order)):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_builtin_global("async_load").is_empty(), "async_load leaked after flush"):
+            \t\treturn
+
+            \tvar log = GMRuntime.gml_async_event_log()
+            \tif not _check(log.size() == 2, "event log size mismatch"):
+            \t\treturn
+            \tif not _check(log[0]["queue_sequence"] < log[1]["queue_sequence"], "queue sequence did not increase"):
+            \t\treturn
+            \tif not _check(log[0]["dispatch_sequence"] == 1 and log[1]["dispatch_sequence"] == 2, "dispatch sequence mismatch"):
+            \t\treturn
+            \tif not _check(log[0]["listener_count"] == 2 and log[1]["listener_count"] == 2, "listener count mismatch"):
+            \t\treturn
+
+            \tremove_child(first)
+            \tremove_child(second)
+            \tfirst.queue_free()
+            \tsecond.queue_free()
+            \tvar legacy = Node.new()
+            \tlegacy.set_script(LegacyListenerScript)
+            \tlegacy.sink = legacy_order
+            \tadd_child(legacy)
+            \tGMRuntime.gml_async_dispatch("http", {"id": 103, "status": 200, "result": "legacy", "url": "/legacy"})
+            \tif not _check(legacy_order == ["legacy:103"], "legacy HTTP alias did not dispatch"):
+            \t\treturn
+
+            \tvar schema = GMRuntime.gml_async_payload_schema("http")
+            \tif not _check(schema["required"].has("url") and schema["optional"].has("network_result"), "HTTP async schema missing keys"):
+            \t\treturn
+            \tvar all_schemas = GMRuntime.gml_async_payload_schema()
+            \tif not _check(all_schemas["default"]["lifetime"].contains("async_load is set only"), "default async lifecycle schema missing"):
+            \t\treturn
+
+            \tvar diagnostic_id = GMRuntime.gml_async_dispatch_unsupported("cloud_save", "cloud_synchronise", "cloud", "", "missing test hook")
+            \tvar diagnostics = GMRuntime.gml_async_unsupported_diagnostics()
+            \tif not _check(diagnostics.size() == 1 and diagnostics[0]["api"] == "cloud_synchronise", "unsupported diagnostic missing"):
+            \t\treturn
+            \tlog = GMRuntime.gml_async_event_log()
+            \tvar diagnostic_event = log[log.size() - 1]
+            \tif not _check(diagnostic_event["payload"]["id"] == diagnostic_id, "diagnostic request id mismatch"):
+            \t\treturn
+            \tif not _check(diagnostic_event["payload"]["status"] == -1, "diagnostic status mismatch"):
+            \t\treturn
+            \tif not _check(diagnostic_event["handler"] == "_on_async_cloud_save", "diagnostic handler mismatch"):
+            \t\treturn
+
+            \tprint("ASYNC_QUEUE_SMOKE_OK")
+            \tget_tree().quit(0)
+
+            func _listener(label):
+            \tvar node = Node.new()
+            \tnode.set_script(ListenerScript)
+            \tnode.label = label
+            \tnode.sink = order
+            \treturn node
+            """
+        )
+        smoke_scene = textwrap.dedent(
+            """\
+            [gd_scene load_steps=2 format=3]
+
+            [ext_resource type="Script" path="res://smoke.gd" id="smoke_script"]
+
+            [node name="Smoke" type="Node2D"]
+            script = ExtResource("smoke_script")
+            """
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            project_dir = Path(tmp)
+            _write_text(project_dir / "project.godot", "[application]\n")
+            write_gml_runtime(str(project_dir))
+            _write_text(project_dir / "listener.gd", listener_script)
+            _write_text(project_dir / "legacy_listener.gd", legacy_listener_script)
+            _write_text(project_dir / "smoke.gd", smoke_script)
+            _write_text(project_dir / "smoke.tscn", smoke_scene)
+
+            result = subprocess.run(
+                [godot_binary, "--headless", "--path", str(project_dir), "smoke.tscn"],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                timeout=30,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("ASYNC_QUEUE_SMOKE_OK", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_buffers_godot.py
+++ b/tests/test_buffers_godot.py
@@ -115,12 +115,16 @@ class TestBuffersGodotSmoke(unittest.TestCase):
             \t\treturn
 
             \tvar async_id = GMRuntime.gml_buffer_save_async(text, "save/async_buffer.bin")
-            \tvar async_load = GMRuntime.gml_builtin_global("async_load")
-            \tif not _check(async_load["id"] == async_id and async_load["status"] == 0, "buffer_save_async async_load mismatch"):
+            \tvar async_log = GMRuntime.gml_async_event_log()
+            \tvar async_load = async_log[async_log.size() - 1]["payload"]
+            \tif not _check(async_load["id"] == async_id and async_load["status"] == 0, "buffer_save_async payload mismatch"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_builtin_global("async_load").is_empty(), "async_load leaked after buffer_save_async"):
             \t\treturn
             \tvar load_async_id = GMRuntime.gml_buffer_load_async("save/async_buffer.bin")
-            \tasync_load = GMRuntime.gml_builtin_global("async_load")
-            \tif not _check(async_load["id"] == load_async_id and async_load["status"] == 0, "buffer_load_async async_load mismatch"):
+            \tasync_log = GMRuntime.gml_async_event_log()
+            \tasync_load = async_log[async_log.size() - 1]["payload"]
+            \tif not _check(async_load["id"] == load_async_id and async_load["status"] == 0, "buffer_load_async payload mismatch"):
             \t\treturn
             \tif not _check(GMRuntime.gml_buffer_peek(async_load["buffer"], 0, 11) == "abc", "buffer_load_async buffer mismatch"):
             \t\treturn

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -1365,7 +1365,15 @@ class TestGMLRuntimeScript(unittest.TestCase):
             "gml_buffer_crc32",
             "gml_async_next_request_id",
             "gml_async_dispatch",
+            "gml_async_enqueue",
+            "gml_async_queue_flush",
+            "gml_async_queue_size",
+            "gml_async_queue_snapshot",
             "gml_async_event_log",
+            "gml_async_event_log_clear",
+            "gml_async_payload_schema",
+            "gml_async_unsupported_diagnostics",
+            "gml_async_dispatch_unsupported",
             "gml_http_get",
             "gml_http_post_string",
             "gml_http_request",
@@ -2854,6 +2862,14 @@ class TestGMLRuntimeScript(unittest.TestCase):
         self.assertIn("static func gml_cloud_synchronise", GML_RUNTIME_SCRIPT)
         self.assertIn('if key == "browser_width":', GML_RUNTIME_SCRIPT)
         self.assertIn('if key == "webgl_enabled":', GML_RUNTIME_SCRIPT)
+
+    def test_runtime_contains_async_queue_lifecycle_helpers(self):
+        self.assertIn("static var _gml_async_queue = []", GML_RUNTIME_SCRIPT)
+        self.assertIn("const GML_ASYNC_PAYLOAD_SCHEMAS", GML_RUNTIME_SCRIPT)
+        self.assertIn('"lifetime": "async_load is set only while', GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_async_queue_flush", GML_RUNTIME_SCRIPT)
+        self.assertIn('"_on_async_http"', GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_async_dispatch_unsupported", GML_RUNTIME_SCRIPT)
 
     def test_write_gml_runtime_writes_support_script(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_platform_services_godot.py
+++ b/tests/test_platform_services_godot.py
@@ -83,6 +83,9 @@ class TestPlatformServicesGodotSmoke(unittest.TestCase):
             \tvar missing_iap = GMRuntime.gml_platform_service_call("iap", "iap_activate", [])
             \tif not _check(GMRuntime.is_undefined(missing_iap), "missing hook did not return undefined"):
             \t\treturn
+            \tvar unsupported = GMRuntime.gml_async_unsupported_diagnostics()
+            \tif not _check(not unsupported.is_empty() and unsupported[unsupported.size() - 1]["api"] == "iap_activate", "missing IAP async diagnostic failed"):
+            \t\treturn
 
             \tGMRuntime.gml_platform_service_register("steam", {
             \t\t"steam_is_initialized": func(): return true,

--- a/tests/test_runtime_managers.py
+++ b/tests/test_runtime_managers.py
@@ -119,6 +119,19 @@ class TestRuntimeManagers(unittest.TestCase):
         self.assertIn("func _process(_delta):", script)
         self.assertIn("GMRuntimeFacade.gml_draw_event_dispatch_frame()", script)
 
+    def test_async_manager_pumps_async_queue(self) -> None:
+        definition = next(
+            manager_definition
+            for manager_definition in runtime_manager_definitions()
+            if manager_definition.name == "GMAsync"
+        )
+
+        script = render_runtime_manager_script(definition)
+
+        self.assertIn('const GMRuntimeFacade = preload("res://gm2godot/gml_runtime.gd")', script)
+        self.assertIn("func _process(_delta):", script)
+        self.assertIn("GMRuntimeFacade.gml_async_queue_flush()", script)
+
     def test_write_runtime_managers_writes_each_manager_script(self) -> None:
         output_paths = write_runtime_managers(self.godot_dir)
 


### PR DESCRIPTION
Closes #599.

## Summary
- route async dispatch through a FIFO queue with stable queue/dispatch sequencing, scoped async_load lifetime, payload schema helpers, and event-log snapshots
- align Async HTTP generated callback names with the runtime dispatcher while preserving a legacy handler alias
- wire GMAsync to flush the queue and emit structured unsupported diagnostics for platform async contracts
- centralize buffer async request IDs and add headless Godot queue/lifecycle coverage

## Tests
- ./venv/bin/python -m unittest tests.conversion.events.test_async_http tests.test_runtime_managers tests.test_gml_runtime tests.test_async_queue_godot tests.test_buffers_godot tests.test_async_http_godot tests.test_networking_godot tests.test_platform_services_godot -v
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest