### PR TITLE
Add pinned Godot headless smoke CI

### DIFF
--- a/.github/workflows/godot-smoke.yml
+++ b/.github/workflows/godot-smoke.yml
@@ -1,0 +1,66 @@
+name: Godot Headless Smoke
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  GODOT_VERSION: 4.4.1-stable
+  GODOT_ARCHIVE: Godot_v4.4.1-stable_linux.x86_64.zip
+  GODOT_BINARY: Godot_v4.4.1-stable_linux.x86_64
+
+jobs:
+  godot-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install test dependencies
+        run: pip install Pillow
+
+      - name: Cache pinned Godot
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/gm2godot/godot-${{ env.GODOT_VERSION }}
+          key: godot-${{ runner.os }}-${{ env.GODOT_VERSION }}
+
+      - name: Install pinned Godot
+        run: |
+          set -euo pipefail
+          godot_dir="$HOME/.cache/gm2godot/godot-${GODOT_VERSION}"
+          godot_bin="${godot_dir}/${GODOT_BINARY}"
+          if [ ! -x "$godot_bin" ]; then
+            mkdir -p "$godot_dir"
+            curl --fail --location --retry 3 \
+              "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}/${GODOT_ARCHIVE}" \
+              --output "${RUNNER_TEMP}/${GODOT_ARCHIVE}"
+            unzip -q "${RUNNER_TEMP}/${GODOT_ARCHIVE}" -d "$godot_dir"
+            chmod +x "$godot_bin"
+          fi
+          echo "GODOT_BIN=$godot_bin" >> "$GITHUB_ENV"
+          "$godot_bin" --version
+
+      - name: Run headless Godot smoke tests
+        run: |
+          python -m unittest \
+            tests.test_runtime_managers_godot \
+            tests.test_room_game_flow_godot \
+            tests.test_cameras_display_godot \
+            tests.test_game_input_godot \
+            tests.test_draw_basic_godot \
+            tests.test_draw_sprite_text_godot \
+            tests.test_draw_surfaces_godot \
+            tests.test_motion_helpers_godot \
+            tests.test_collision_queries_godot \
+            tests.test_layers_runtime_godot \
+            tests.test_physics_runtime_godot \
+            tests.test_async_http_godot

--- a/src/conversion/gml_runtime_parts/segments/35_maths_numbers.gd
+++ b/src/conversion/gml_runtime_parts/segments/35_maths_numbers.gd
@@ -104,7 +104,7 @@ static func gml_lerp(a, b, amount):
 	return _to_real(a) + ((_to_real(b) - _to_real(a)) * _to_real(amount))
 
 
-static func gml_min(...values):
+static func gml_min(values):
 	if values.size() == 0:
 		return gml_error("GML min requires at least one value")
 	var best = values[0]
@@ -118,7 +118,7 @@ static func gml_min(...values):
 	return best
 
 
-static func gml_max(...values):
+static func gml_max(values):
 	if values.size() == 0:
 		return gml_error("GML max requires at least one value")
 	var best = values[0]
@@ -289,7 +289,7 @@ static func gml_irandom_range(minimum, maximum):
 	return _gml_random_int_range(int(_to_real(minimum)), int(_to_real(maximum)))
 
 
-static func gml_choose(...values):
+static func gml_choose(values):
 	if values.size() == 0:
 		return gml_error("GML choose requires at least one value")
 	return values[gml_irandom(values.size() - 1)]

--- a/src/conversion/gml_runtime_parts/segments/40_arrays_structs_variables.gd
+++ b/src/conversion/gml_runtime_parts/segments/40_arrays_structs_variables.gd
@@ -19,7 +19,7 @@ static func gml_array_set(array_value, index, value):
 	return value
 
 
-static func gml_array_push(array_value, ...values):
+static func gml_array_push(array_value, values):
 	if GML_ARRAY_COPY_ON_WRITE_ENABLED:
 		return gml_error(GML_ARRAY_COPY_ON_WRITE_DIAGNOSTIC)
 	if typeof(array_value) != TYPE_ARRAY:
@@ -72,7 +72,7 @@ static func gml_array_resize(array_value, size):
 
 
 static func gml_array_push_back(array_value, value):
-	return gml_array_push(array_value, value)
+	return gml_array_push(array_value, [value])
 
 
 static func gml_array_pop(array_value):

--- a/src/conversion/gml_transpiler_parts/emitter.py
+++ b/src/conversion/gml_transpiler_parts/emitter.py
@@ -700,6 +700,13 @@ def _emit_descriptor_call(
         )
         return f"GMRuntime.{descriptor.lowering_target}({emitted_first}, [{emitted_rest}])"
 
+    if descriptor.lowering_kind == "runtime_variadic_all":
+        emitted_args = ", ".join(
+            _emit_expression(arg, local_names, scope_context=scope_context)[0]
+            for arg in args
+        )
+        return f"GMRuntime.{descriptor.lowering_target}([{emitted_args}])"
+
     if descriptor.lowering_kind == "runtime_platform_service_api":
         emitted_args = ", ".join(
             _emit_expression(arg, local_names, scope_context=scope_context)[0]

--- a/src/conversion/gml_transpiler_parts/gml_function_dispatch.py
+++ b/src/conversion/gml_transpiler_parts/gml_function_dispatch.py
@@ -58,6 +58,7 @@ GMLFunctionLoweringKind: TypeAlias = Literal[
     "runtime_sequence_api",
     "runtime_self_default",
     "runtime_time_api",
+    "runtime_variadic_all",
     "runtime_variadic_1",
     "with_targets",
 ]
@@ -1310,7 +1311,10 @@ def _build_function_descriptors() -> dict[str, GMLFunctionDescriptor]:
 
     for name, target in _ARRAY_RUNTIME_FUNCTIONS.items():
         min_args, max_args = _ARRAY_ARITY[name]
-        descriptors[name] = _descriptor(name, min_args, max_args, "runtime", target)
+        lowering_kind: GMLFunctionLoweringKind = "runtime"
+        if name == "array_push":
+            lowering_kind = "runtime_variadic_1"
+        descriptors[name] = _descriptor(name, min_args, max_args, lowering_kind, target)
 
     for name, target in _STRING_RUNTIME_FUNCTIONS.items():
         min_args, max_args = _STRING_ARITY[name]
@@ -1318,7 +1322,10 @@ def _build_function_descriptors() -> dict[str, GMLFunctionDescriptor]:
 
     for name, target in _MATH_RUNTIME_FUNCTIONS.items():
         min_args, max_args = _MATH_ARITY[name]
-        descriptors[name] = _descriptor(name, min_args, max_args, "runtime", target)
+        lowering_kind: GMLFunctionLoweringKind = "runtime"
+        if name in ("min", "max", "choose"):
+            lowering_kind = "runtime_variadic_all"
+        descriptors[name] = _descriptor(name, min_args, max_args, lowering_kind, target)
 
     for name, target in _FILE_RUNTIME_FUNCTIONS.items():
         min_args, max_args = _FILE_ARITY[name]

--- a/tests/fixtures/golden/basic_scripts/BasicScripts.yyp
+++ b/tests/fixtures/golden/basic_scripts/BasicScripts.yyp
@@ -1,0 +1,18 @@
+{
+  "resources": [
+    {
+      "id": {
+        "name": "scr_add",
+        "path": "scripts/scr_add/scr_add.yy"
+      }
+    },
+    {
+      "id": {
+        "name": "scr_stats",
+        "path": "scripts/scr_stats/scr_stats.yy"
+      }
+    }
+  ],
+  "RoomOrderNodes": [],
+  "resourceType": "GMProject"
+}

--- a/tests/fixtures/golden/basic_scripts/expected_snapshot.json
+++ b/tests/fixtures/golden/basic_scripts/expected_snapshot.json
@@ -1,0 +1,99 @@
+{
+  "files": {
+    "gm2godot/gml_script_registry.gd": "extends RefCounted\n\nstatic func gml_script_registry_entries():\n\treturn [\n\t\t{\n\t\t\t\"id\": 179646376,\n\t\t\t\"name\": \"scr_add\",\n\t\t\t\"callable\": preload(\"res://scripts/Game/scr_add.gd\").new().gm2godot_callable(),\n\t\t\t\"legacy_arguments\": true,\n\t\t},\n\t\t{\n\t\t\t\"id\": 950140064,\n\t\t\t\"name\": \"scr_stats\",\n\t\t\t\"callable\": preload(\"res://scripts/Game/scr_stats.gd\").new().gm2godot_callable(),\n\t\t\t\"legacy_arguments\": false,\n\t\t},\n\t]\n",
+    "project.godot": "[application]\nconfig/name=\"Golden Fixture\"\n\n[autoload]\nGMRuntime=\"*res://gm2godot/managers/gm_runtime_manager.gd\"\nGMAssets=\"*res://gm2godot/managers/gm_assets.gd\"\nGMRooms=\"*res://gm2godot/managers/gm_rooms.gd\"\nGMInstances=\"*res://gm2godot/managers/gm_instances.gd\"\nGMEvents=\"*res://gm2godot/managers/gm_events.gd\"\nGMDraw=\"*res://gm2godot/managers/gm_draw.gd\"\nGMInput=\"*res://gm2godot/managers/gm_input.gd\"\nGMAudio=\"*res://gm2godot/managers/gm_audio.gd\"\nGMAsync=\"*res://gm2godot/managers/gm_async.gd\"\nGMPlatform=\"*res://gm2godot/managers/gm_platform.gd\"\n",
+    "scripts/Game/scr_add.gd": "extends RefCounted\n\n# GM2Godot source: <GM_PROJECT>/scripts/scr_add/scr_add.gml\n# GM2Godot event: script:scr_add\n\nconst GMRuntime = preload(\"res://gm2godot/gml_runtime.gd\")\n\nfunc _gm_script_call():\n\treturn GMRuntime.gml_add(GMRuntime.gml_argument(0), GMRuntime.gml_argument(1))\n\treturn GMRuntime.gml_undefined()\n\nfunc gm2godot_callable():\n\treturn GMRuntime.gml_method(self, Callable(self, \"_gm_script_call\"))\n",
+    "scripts/Game/scr_stats.gd": "extends RefCounted\n\n# GM2Godot source: <GM_PROJECT>/scripts/scr_stats/scr_stats.gml\n# GM2Godot event: script:scr_stats\n\nconst GMRuntime = preload(\"res://gm2godot/gml_runtime.gd\")\n\nfunc _gm_script_call(a = null, b = null):\n\tif a == null: a = GMRuntime.gml_undefined()\n\tif b == null or GMRuntime.is_undefined(b): b = 4\n\tvar values = [a]\n\tGMRuntime.gml_array_push(values, [GMRuntime.gml_min([4, 1, 2]), GMRuntime.gml_max([4, 1, 2]), GMRuntime.gml_choose([7, 8, 9])])\n\treturn GMRuntime.gml_add(GMRuntime.gml_add(GMRuntime.gml_add(GMRuntime.gml_array_get(values, 0), GMRuntime.gml_array_get(values, 1)), GMRuntime.gml_array_get(values, 2)), b)\n\treturn GMRuntime.gml_undefined()\n\nfunc gm2godot_callable():\n\treturn GMRuntime.gml_method(self, Callable(self, \"_gm_script_call\"))\n"
+  },
+  "fixture": "basic_scripts",
+  "hashes": {
+    "gm2godot/gml_runtime.gd": "sha256:3eb7d907d6f79a0b8024ddd83625fe533105ed974a6bf5bd6162c8f6d8fff693",
+    "gm2godot/managers/gm_assets.gd": "sha256:ba3484b8ab88635c0c4e8ce93b1a47b8a6707eddc5de78c16d3dd4a5b51d3b59",
+    "gm2godot/managers/gm_async.gd": "sha256:828d94a3261d873b779e0729a692dbb4afca83ae0cde3913cf7fbf3d0a0d97de",
+    "gm2godot/managers/gm_audio.gd": "sha256:ffb84c7dfee53c765ba846d348609ba9eba97ee433b3d52187c39a0c12d0f05e",
+    "gm2godot/managers/gm_draw.gd": "sha256:d4214689547f4b049d86076f6b40ba791c2a646e8adbe4c9be9a7aabfd90b3d2",
+    "gm2godot/managers/gm_events.gd": "sha256:12f9c652aba9615553f03aaae04f903f72823e415a01b11e5bf416254db732ee",
+    "gm2godot/managers/gm_input.gd": "sha256:9b6acda37e0fc1bbe369c14cb86233710429ef0db53a157ab3dffa422a37f69f",
+    "gm2godot/managers/gm_instances.gd": "sha256:32a8c3c00351cc61e068e69aff6b9cd3e38d4b645a70d096d9128d38f3b6f867",
+    "gm2godot/managers/gm_platform.gd": "sha256:18041dfa5d80380dbd2e3c931713af040a5a1a392f2adf6e889ccfe91e32eff4",
+    "gm2godot/managers/gm_rooms.gd": "sha256:925175dccadca68d5fa9d6af4bfa8115179002dd9480ab364101acba5e98782e",
+    "gm2godot/managers/gm_runtime_manager.gd": "sha256:667950a25725c49d7be7daa6638477deb4f676646d93834e85b5d01a7f82719c"
+  },
+  "json_files": {
+    "gm2godot/conversion_diagnostics.json": {
+      "diagnostics": [
+        {
+          "api": null,
+          "code": "GM2GD-CLI-TARGET-PLATFORM",
+          "column": null,
+          "event": null,
+          "issue_number": null,
+          "line": null,
+          "manifest_entry": null,
+          "message": "Target platform filter: windows",
+          "resource": "windows",
+          "resource_type": "platform",
+          "severity": "info",
+          "source_path": null,
+          "workaround": null
+        }
+      ],
+      "summary": {
+        "error": 0,
+        "info": 1,
+        "total": 1,
+        "warning": 0
+      }
+    },
+    "scripts/Game/scr_add.gd.gmlmap.json": {
+      "entries": [
+        {
+          "event": "script:scr_add",
+          "generated_line": 9,
+          "generated_text": "return GMRuntime.gml_add(GMRuntime.gml_argument(0), GMRuntime.gml_argument(1))",
+          "source_column": 1,
+          "source_line": 1,
+          "source_path": "<GM_PROJECT>/scripts/scr_add/scr_add.gml",
+          "source_text": "return argument0 + argument1;"
+        }
+      ],
+      "event": "script:scr_add",
+      "source_path": "<GM_PROJECT>/scripts/scr_add/scr_add.gml",
+      "version": 1
+    },
+    "scripts/Game/scr_stats.gd.gmlmap.json": {
+      "entries": [
+        {
+          "event": "script:scr_stats",
+          "generated_line": 11,
+          "generated_text": "var values = [a]",
+          "source_column": 5,
+          "source_line": 2,
+          "source_path": "<GM_PROJECT>/scripts/scr_stats/scr_stats.gml",
+          "source_text": "var values = [a];"
+        },
+        {
+          "event": "script:scr_stats",
+          "generated_line": 12,
+          "generated_text": "GMRuntime.gml_array_push(values, [GMRuntime.gml_min([4, 1, 2]), GMRuntime.gml_max([4, 1, 2]), GMRuntime.gml_choose([7, 8, 9])])",
+          "source_column": 5,
+          "source_line": 3,
+          "source_path": "<GM_PROJECT>/scripts/scr_stats/scr_stats.gml",
+          "source_text": "array_push(values, min(4, 1, 2), max(4, 1, 2), choose(7, 8, 9));"
+        },
+        {
+          "event": "script:scr_stats",
+          "generated_line": 13,
+          "generated_text": "return GMRuntime.gml_add(GMRuntime.gml_add(GMRuntime.gml_add(GMRuntime.gml_array_get(values, 0), GMRuntime.gml_array_get(values, 1)), GMRuntime.gml_array_get(values, 2)), b)",
+          "source_column": 5,
+          "source_line": 4,
+          "source_path": "<GM_PROJECT>/scripts/scr_stats/scr_stats.gml",
+          "source_text": "return values[0] + values[1] + values[2] + b;"
+        }
+      ],
+      "event": "script:scr_stats",
+      "source_path": "<GM_PROJECT>/scripts/scr_stats/scr_stats.gml",
+      "version": 1
+    }
+  }
+}

--- a/tests/fixtures/golden/basic_scripts/scripts/scr_add/scr_add.gml
+++ b/tests/fixtures/golden/basic_scripts/scripts/scr_add/scr_add.gml
@@ -1,0 +1,1 @@
+return argument0 + argument1;

--- a/tests/fixtures/golden/basic_scripts/scripts/scr_add/scr_add.yy
+++ b/tests/fixtures/golden/basic_scripts/scripts/scr_add/scr_add.yy
@@ -1,0 +1,9 @@
+{
+  "%Name": "scr_add",
+  "name": "scr_add",
+  "parent": {
+    "name": "Game",
+    "path": "folders/Scripts/Game.yy"
+  },
+  "resourceType": "GMScript"
+}

--- a/tests/fixtures/golden/basic_scripts/scripts/scr_stats/scr_stats.gml
+++ b/tests/fixtures/golden/basic_scripts/scripts/scr_stats/scr_stats.gml
@@ -1,0 +1,5 @@
+function scr_stats(a, b = 4) {
+    var values = [a];
+    array_push(values, min(4, 1, 2), max(4, 1, 2), choose(7, 8, 9));
+    return values[0] + values[1] + values[2] + b;
+}

--- a/tests/fixtures/golden/basic_scripts/scripts/scr_stats/scr_stats.yy
+++ b/tests/fixtures/golden/basic_scripts/scripts/scr_stats/scr_stats.yy
@@ -1,0 +1,9 @@
+{
+  "%Name": "scr_stats",
+  "name": "scr_stats",
+  "parent": {
+    "name": "Game",
+    "path": "folders/Scripts/Game.yy"
+  },
+  "resourceType": "GMScript"
+}

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -8,6 +8,14 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestCIWorkflows(unittest.TestCase):
+    def test_unit_workflow_runs_discovery_for_golden_and_threshold_gates(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "tests.yml"
+        content = workflow.read_text(encoding="utf-8")
+
+        self.assertIn("python -m unittest discover tests/ -v", content)
+        self.assertTrue((PROJECT_ROOT / "tests" / "test_golden_conversion.py").is_file())
+        self.assertTrue((PROJECT_ROOT / "tests" / "test_cli.py").is_file())
+
     def test_godot_smoke_workflow_pins_binary_and_runs_headless_smokes(self) -> None:
         workflow = PROJECT_ROOT / ".github" / "workflows" / "godot-smoke.yml"
         content = workflow.read_text(encoding="utf-8")

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestCIWorkflows(unittest.TestCase):
+    def test_godot_smoke_workflow_pins_binary_and_runs_headless_smokes(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "godot-smoke.yml"
+        content = workflow.read_text(encoding="utf-8")
+
+        self.assertIn("GODOT_VERSION: 4.4.1-stable", content)
+        self.assertIn("GODOT_BIN=$godot_bin", content)
+        self.assertIn("actions/cache@v4", content)
+        self.assertIn("tests.test_cameras_display_godot", content)
+        self.assertIn("tests.test_room_game_flow_godot", content)
+        self.assertIn("tests.test_physics_runtime_godot", content)
+        self.assertIn("python -m unittest", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gml_api_manifest.py
+++ b/tests/test_gml_api_manifest.py
@@ -442,9 +442,15 @@ class TestGMLAPIManifest(unittest.TestCase):
         self.assertEqual(descriptor.category, "Arrays")
         self.assertEqual(descriptor.min_args, 2)
         self.assertIsNone(descriptor.max_args)
-        self.assertEqual(descriptor.lowering_kind, "runtime")
+        self.assertEqual(descriptor.lowering_kind, "runtime_variadic_1")
         self.assertEqual(descriptor.lowering_target, "gml_array_push")
         self.assertEqual(descriptor.issue_url, "https://github.com/Infiland/GM2Godot/issues/502")
+
+        min_descriptor = get_gml_function_descriptor("min")
+        self.assertIsNotNone(min_descriptor)
+        assert min_descriptor is not None
+        self.assertEqual(min_descriptor.lowering_kind, "runtime_variadic_all")
+        self.assertEqual(min_descriptor.lowering_target, "gml_min")
 
         platform_descriptor = get_gml_function_descriptor("steam_set_achievement")
         self.assertIsNotNone(platform_descriptor)

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -232,8 +232,8 @@ RUNTIME_VALUE_PARITY_CASES: tuple[RuntimeValueParityCase, ...] = (
     RuntimeValueParityCase("frac(1.75)", "GMRuntime.gml_frac(1.75)"),
     RuntimeValueParityCase("clamp(7, 0, 5)", "GMRuntime.gml_clamp(7, 0, 5)"),
     RuntimeValueParityCase("lerp(10, 20, 0.25)", "GMRuntime.gml_lerp(10, 20, 0.25)"),
-    RuntimeValueParityCase("min(3, 1, 2)", "GMRuntime.gml_min(3, 1, 2)"),
-    RuntimeValueParityCase("max(3, 1, 2)", "GMRuntime.gml_max(3, 1, 2)"),
+    RuntimeValueParityCase("min(3, 1, 2)", "GMRuntime.gml_min([3, 1, 2])"),
+    RuntimeValueParityCase("max(3, 1, 2)", "GMRuntime.gml_max([3, 1, 2])"),
     RuntimeValueParityCase("dcos(180)", "GMRuntime.gml_dcos(180)"),
     RuntimeValueParityCase("darctan2(1, 0)", "GMRuntime.gml_darctan2(1, 0)"),
     RuntimeValueParityCase("point_direction(0, 0, 0, -10)", "GMRuntime.gml_point_direction(0, 0, 0, -10)"),
@@ -244,7 +244,7 @@ RUNTIME_VALUE_PARITY_CASES: tuple[RuntimeValueParityCase, ...] = (
     RuntimeValueParityCase("dot_product(1, 2, 3, 4)", "GMRuntime.gml_dot_product(1, 2, 3, 4)"),
     RuntimeValueParityCase("random(10)", "GMRuntime.gml_random(10)"),
     RuntimeValueParityCase("irandom_range(2, 5)", "GMRuntime.gml_irandom_range(2, 5)"),
-    RuntimeValueParityCase("choose(1, 2, 3)", "GMRuntime.gml_choose(1, 2, 3)"),
+    RuntimeValueParityCase("choose(1, 2, 3)", "GMRuntime.gml_choose([1, 2, 3])"),
     RuntimeValueParityCase("random_set_seed(123)", "GMRuntime.gml_random_set_seed(123)"),
     RuntimeValueParityCase("random_get_seed()", "GMRuntime.gml_random_get_seed()"),
     RuntimeValueParityCase("working_directory", 'GMRuntime.gml_builtin_global("working_directory")'),
@@ -529,7 +529,7 @@ RUNTIME_VALUE_PARITY_CASES: tuple[RuntimeValueParityCase, ...] = (
         'GMRuntime.gml_array_get(GMRuntime.gml_builtin_array("view_xview"), 0)',
     ),
     RuntimeValueParityCase("array_equals([NaN], [NaN])", "GMRuntime.gml_array_equals([NAN], [NAN])"),
-    RuntimeValueParityCase("array_push(items, 2, 3)", "GMRuntime.gml_array_push(items, 2, 3)"),
+    RuntimeValueParityCase("array_push(items, 2, 3)", "GMRuntime.gml_array_push(items, [2, 3])"),
     RuntimeValueParityCase('asset_get_index("s_player")', 'GMRuntime.gml_asset_get_index("s_player")'),
     RuntimeValueParityCase("asset_get_type(sprite_index)", "GMRuntime.gml_asset_get_type(sprite_index)"),
     RuntimeValueParityCase("asset_get_ids()", "GMRuntime.gml_asset_get_ids()"),
@@ -2263,7 +2263,7 @@ class TestGMLRuntimeScript(unittest.TestCase):
         self.assertNotIn("array_value.duplicate", GML_RUNTIME_SCRIPT)
 
     def test_runtime_array_push_mutates_reference_without_copying(self):
-        self.assertIn("static func gml_array_push(array_value, ...values):", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_array_push(array_value, values):", GML_RUNTIME_SCRIPT)
         self.assertIn('return gml_unsupported_type_error("GML array_push", array_value)', GML_RUNTIME_SCRIPT)
         self.assertIn('return gml_error("GML array_push requires at least one value")', GML_RUNTIME_SCRIPT)
         self.assertIn("for value in values:", GML_RUNTIME_SCRIPT)

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -382,7 +382,7 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
         )
         self.assertEqual(
             transpile_gml_expression("array_push(items, 2, 3)"),
-            "GMRuntime.gml_array_push(items, 2, 3)",
+            "GMRuntime.gml_array_push(items, [2, 3])",
         )
 
     def test_undefined_equality_uses_runtime_type_table(self):
@@ -3008,7 +3008,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             ),
             "var try_to_modify_array = GMRuntime.gml_method(self, func(argument0 = null): "
             "if argument0 == null: argument0 = GMRuntime.gml_undefined(); "
-            "GMRuntime.gml_array_push(argument0, 2))\n"
+            "GMRuntime.gml_array_push(argument0, [2]))\n"
             "items = [1]\n"
             "try_to_modify_array(items)\n"
             "value = GMRuntime.gml_array_get(items, 1)",
@@ -3712,7 +3712,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             "GMRuntime.gml_random_set_seed(123)\n"
             "a = GMRuntime.gml_random(10)\n"
             "b = GMRuntime.gml_irandom_range(2, 5)\n"
-            "c = GMRuntime.gml_choose('a', 'b', 'c')\n"
+            "c = GMRuntime.gml_choose(['a', 'b', 'c'])\n"
             "d = GMRuntime.gml_random_get_seed()",
         )
 

--- a/tests/test_golden_conversion.py
+++ b/tests/test_golden_conversion.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import cast
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src import cli
+
+
+FIXTURE_ROOT = PROJECT_ROOT / "tests" / "fixtures" / "golden" / "basic_scripts"
+SNAPSHOT_PATH = FIXTURE_ROOT / "expected_snapshot.json"
+
+
+class TestGoldenConversion(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self) -> None:
+        self.temp_dir = Path(tempfile.mkdtemp())
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.temp_dir)
+
+    def test_basic_scripts_conversion_matches_golden_snapshot(self) -> None:
+        godot_dir = self.temp_dir / "godot"
+        report_dir = self.temp_dir / "reports"
+        godot_dir.mkdir()
+        (godot_dir / "project.godot").write_text(
+            '[application]\nconfig/name="Golden Fixture"\n',
+            encoding="utf-8",
+        )
+
+        exit_code = cli.main(
+            [
+                "convert",
+                "--gm-project",
+                str(FIXTURE_ROOT),
+                "--godot-project",
+                str(godot_dir),
+                "--target-platform",
+                "windows",
+                "--only",
+                "scripts",
+                "--report-dir",
+                str(report_dir),
+                "--max-warnings",
+                "0",
+                "--max-errors",
+                "0",
+                "--max-unsupported",
+                "0",
+            ]
+        )
+
+        self.assertEqual(exit_code, 0)
+        actual = _snapshot_output(godot_dir, FIXTURE_ROOT)
+        expected = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(actual, expected)
+
+
+def _snapshot_output(godot_dir: Path, gm_project_dir: Path) -> dict[str, object]:
+    text_files = [
+        "project.godot",
+        "gm2godot/gml_script_registry.gd",
+        "scripts/Game/scr_add.gd",
+        "scripts/Game/scr_stats.gd",
+    ]
+    json_files = [
+        "gm2godot/conversion_diagnostics.json",
+        "scripts/Game/scr_add.gd.gmlmap.json",
+        "scripts/Game/scr_stats.gd.gmlmap.json",
+    ]
+    hash_files = [
+        "gm2godot/gml_runtime.gd",
+        *(
+            _relative_path(path, godot_dir)
+            for path in sorted((godot_dir / "gm2godot" / "managers").glob("*.gd"))
+        ),
+    ]
+
+    return {
+        "fixture": "basic_scripts",
+        "files": {
+            path: _normalize_text((godot_dir / path).read_text(encoding="utf-8"), godot_dir, gm_project_dir)
+            for path in text_files
+        },
+        "json_files": {
+            path: _normalize_json(
+                json.loads((godot_dir / path).read_text(encoding="utf-8")),
+                godot_dir,
+                gm_project_dir,
+            )
+            for path in json_files
+        },
+        "hashes": {
+            path: "sha256:" + hashlib.sha256((godot_dir / path).read_bytes()).hexdigest()
+            for path in hash_files
+        },
+    }
+
+
+def _normalize_json(value: object, godot_dir: Path, gm_project_dir: Path) -> object:
+    if isinstance(value, dict):
+        typed_dict = cast(dict[object, object], value)
+        return {
+            str(key): _normalize_json(child, godot_dir, gm_project_dir)
+            for key, child in sorted(typed_dict.items(), key=lambda item: str(item[0]))
+        }
+    if isinstance(value, list):
+        return [
+            _normalize_json(child, godot_dir, gm_project_dir)
+            for child in cast(list[object], value)
+        ]
+    if isinstance(value, str):
+        return _normalize_text(value, godot_dir, gm_project_dir)
+    return value
+
+
+def _normalize_text(value: str, godot_dir: Path, gm_project_dir: Path) -> str:
+    normalized = value.replace(str(godot_dir), "<GODOT_PROJECT>")
+    normalized = normalized.replace(str(gm_project_dir), "<GM_PROJECT>")
+    return normalized.replace(os.sep, "/")
+
+
+def _relative_path(path: Path, root: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_math_random_godot.py
+++ b/tests/test_math_random_godot.py
@@ -73,9 +73,9 @@ class TestMathRandomGodotSmoke(unittest.TestCase):
             \t\treturn
             \tif not _near(GMRuntime.gml_lerp(10, 20, 0.25), 12.5, "lerp mismatch"):
             \t\treturn
-            \tif not _check(GMRuntime.gml_min(3, 1, 2) == 1, "min mismatch"):
+            \tif not _check(GMRuntime.gml_min([3, 1, 2]) == 1, "min mismatch"):
             \t\treturn
-            \tif not _check(GMRuntime.gml_max(3, 1, 2) == 3, "max mismatch"):
+            \tif not _check(GMRuntime.gml_max([3, 1, 2]) == 3, "max mismatch"):
             \t\treturn
             \tif not _near(GMRuntime.gml_dcos(180), -1.0, "dcos mismatch"):
             \t\treturn
@@ -111,7 +111,7 @@ class TestMathRandomGodotSmoke(unittest.TestCase):
             \tvar first_irandom = GMRuntime.gml_irandom(5)
             \tvar first_range = GMRuntime.gml_random_range(5, 10)
             \tvar first_irange = GMRuntime.gml_irandom_range(2, 4)
-            \tvar first_choice = GMRuntime.gml_choose("a", "b", "c")
+            \tvar first_choice = GMRuntime.gml_choose(["a", "b", "c"])
             \tvar first_seed = GMRuntime.gml_random_get_seed()
 
             \tif not _check(first_random >= 0 and first_random < 10, "random out of range"):
@@ -134,7 +134,7 @@ class TestMathRandomGodotSmoke(unittest.TestCase):
             \t\treturn
             \tif not _check(GMRuntime.gml_irandom_range(2, 4) == first_irange, "irandom_range seed replay mismatch"):
             \t\treturn
-            \tif not _check(GMRuntime.gml_choose("a", "b", "c") == first_choice, "choose seed replay mismatch"):
+            \tif not _check(GMRuntime.gml_choose(["a", "b", "c"]) == first_choice, "choose seed replay mismatch"):
             \t\treturn
             \tif not _check(GMRuntime.gml_random_get_seed() == first_seed, "random_get_seed replay mismatch"):
             \t\treturn


### PR DESCRIPTION
## Summary
- add a pinned Godot 4.4.1 headless smoke workflow with cache-backed installation
- run curated generated-Godot smoke tests in CI with `GODOT_BIN` set so they do not silently skip
- fix generated runtime/transpiler variadic helpers so the pinned Godot 4.4.1 parser accepts `gml_runtime.gd`
- add a committed golden GameMaker fixture with normalized generated-output snapshots, runtime/manager hashes, diagnostics output, and zero-warning/zero-unsupported thresholds
- add workflow guard tests for both the Godot smoke job and the unittest-discovered golden/threshold gates

## Verification
- `GODOT_BIN=/tmp/godot-4.4.1-macos/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_golden_conversion tests.test_ci_workflows tests.test_cli tests.test_gml_runtime tests.test_gml_transpiler tests.test_math_random_godot`
- `GODOT_BIN=/tmp/godot-4.4.1-macos/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_runtime_managers_godot tests.test_room_game_flow_godot tests.test_cameras_display_godot tests.test_game_input_godot tests.test_draw_basic_godot tests.test_draw_sprite_text_godot tests.test_draw_surfaces_godot tests.test_motion_helpers_godot tests.test_collision_queries_godot tests.test_layers_runtime_godot tests.test_physics_runtime_godot tests.test_async_http_godot`
- `./venv/bin/pyright --warnings`
- `./venv/bin/python -m unittest`

Closes #609
