### PR TITLE
Close movement, collision, path, and physics runtime coverage

### DIFF
--- a/tests/test_physics_runtime_godot.py
+++ b/tests/test_physics_runtime_godot.py
@@ -88,12 +88,24 @@ class TestPhysicsRuntimeGodotSmoke(unittest.TestCase):
             \t\treturn
             \tif not _check(abs(body.linear_damp - 0.3) < 0.001 and abs(body.angular_damp - 0.4) < 0.001, "fixture damping not applied"):
             \t\treturn
+            \tvar sensor_fixture = GMRuntime.gml_physics_fixture_create()
+            \tGMRuntime.gml_physics_fixture_set_circle_shape(sensor_fixture, 6)
+            \tGMRuntime.gml_physics_fixture_set_sensor(sensor_fixture, true)
+            \tif not _check(GMRuntime.gml_physics_fixture_bind(sensor_fixture, body_b), "sensor fixture bind failed"):
+            \t\treturn
+            \tvar sensor_shape = body_b.get_node_or_null("_gm_physics_fixture_" + str(sensor_fixture.index))
+            \tif not _check(sensor_shape is CollisionShape2D, "sensor fixture did not create CollisionShape2D"):
+            \t\treturn
+            \tif not _check(sensor_shape.shape is CircleShape2D and sensor_shape.disabled, "sensor fixture did not preserve circle/disabled state"):
+            \t\treturn
 
             \tGMRuntime.gml_physics_apply_impulse(0, 0, 20, 0, body)
             \tawait get_tree().physics_frame
             \tif not _check(body.linear_velocity.x > 0.0, "impulse did not affect body velocity"):
             \t\treturn
             \tGMRuntime.gml_physics_apply_force(0, 0, 5, 0, body)
+            \tGMRuntime.gml_physics_apply_local_force(0, 0, 0, 5, body)
+            \tGMRuntime.gml_physics_apply_local_impulse(0, 0, 0, 2, body)
             \tGMRuntime.gml_physics_apply_angular_impulse(1, body)
             \tGMRuntime.gml_physics_apply_torque(0.5, body)
             \tvar distance_joint = GMRuntime.gml_physics_joint_distance_create(body, body_b, 0, 0, 32, 0, false)
@@ -125,6 +137,7 @@ class TestPhysicsRuntimeGodotSmoke(unittest.TestCase):
             \t\treturn
 
             \tGMRuntime.gml_physics_fixture_delete(fixture)
+            \tGMRuntime.gml_physics_fixture_delete(sensor_fixture)
             \tprint("PHYSICS_RUNTIME_SMOKE_OK")
             \tget_tree().quit(0)
             """


### PR DESCRIPTION
## Summary
- extend the headless physics runtime smoke with fixture sensor binding, circle shape preservation, disabled sensor collision state, and local force/impulse calls
- closes the remaining #605 runtime coverage gap while existing movement, collision-list, path, MP-grid, joint, and mass-property smokes cover the other acceptance points

## Verification
- `GODOT_BIN=/tmp/godot-4.4.1-macos/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_physics_runtime_godot tests.test_motion_helpers_godot tests.test_collision_queries_godot tests.test_paths_motion_godot tests.test_gml_runtime`
- `./venv/bin/pyright --warnings`
- `./venv/bin/python -m unittest`

Closes #605
