### PR TITLE
Report platform capability requirements

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -18,6 +18,10 @@ from src.conversion.gml_transpiler import (
     generate_gml_api_compatibility_report,
     render_gml_manual_scope_markdown,
 )
+from src.conversion.platform_capabilities import (
+    generate_platform_capability_report,
+    render_platform_capability_markdown,
+)
 
 
 @dataclass(frozen=True)
@@ -40,7 +44,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     if args.command == "analyze":
         diagnostics = _analyze_project(args.gm_project, args.platform)
-        _write_static_reports(args.report_dir)
+        _write_static_reports(args.report_dir, args.platform)
         diagnostics.write_reports(args.report_dir)
         return _threshold_exit_code(diagnostics, args)
 
@@ -179,7 +183,7 @@ def _run_convert(args: argparse.Namespace) -> int:
     for message in logs:
         print(message)
     if args.report_dir:
-        _write_static_reports(args.report_dir)
+        _write_static_reports(args.report_dir, args.platform)
         converter.diagnostics.write_reports(args.report_dir)
     return _threshold_exit_code(converter.diagnostics, args)
 
@@ -345,13 +349,23 @@ def _settings_for_args(args: argparse.Namespace) -> dict[str, CLISetting]:
     return settings
 
 
-def _write_static_reports(report_dir: str) -> None:
+def _write_static_reports(report_dir: str, target_platform: str | None = None) -> None:
     report_root = os.path.join(report_dir, "gm2godot")
     os.makedirs(report_root, exist_ok=True)
     with open(os.path.join(report_root, "gml_manual_scope.md"), "w", encoding="utf-8") as manual_file:
         manual_file.write(render_gml_manual_scope_markdown())
     with open(os.path.join(report_root, "gml_api_compatibility.md"), "w", encoding="utf-8") as api_file:
         api_file.write(_render_api_compatibility_markdown())
+    with open(os.path.join(report_root, "platform_capability_report.json"), "w", encoding="utf-8") as capability_file:
+        json.dump(
+            generate_platform_capability_report(target_platform),
+            capability_file,
+            indent=2,
+            sort_keys=True,
+        )
+        capability_file.write("\n")
+    with open(os.path.join(report_root, "platform_capability_report.md"), "w", encoding="utf-8") as capability_markdown:
+        capability_markdown.write(render_platform_capability_markdown(target_platform))
 
 
 def _render_api_compatibility_markdown() -> str:

--- a/src/conversion/platform_capabilities.py
+++ b/src/conversion/platform_capabilities.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Literal, TypeAlias
+
+PlatformCapabilityKind: TypeAlias = Literal[
+    "export_preset",
+    "permission",
+    "plugin",
+    "runtime",
+]
+PlatformCapabilityStatus: TypeAlias = Literal[
+    "reported",
+    "requires_export_preset",
+    "requires_permission",
+    "requires_plugin",
+    "unsupported",
+]
+
+
+@dataclass(frozen=True)
+class PlatformCapabilityCheck:
+    target: str
+    kind: PlatformCapabilityKind
+    capability: str
+    status: PlatformCapabilityStatus
+    apis: tuple[str, ...]
+    godot_export_keys: tuple[str, ...]
+    gm2godot_surface: str
+    check: str
+    recommendation: str
+    issue_number: int = 606
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "target": self.target,
+            "kind": self.kind,
+            "capability": self.capability,
+            "status": self.status,
+            "apis": list(self.apis),
+            "godot_export_keys": list(self.godot_export_keys),
+            "gm2godot_surface": self.gm2godot_surface,
+            "check": self.check,
+            "recommendation": self.recommendation,
+            "issue_number": self.issue_number,
+        }
+
+
+_DESKTOP_TARGETS = ("windows", "macos", "linux")
+
+_CAPABILITY_CHECKS: tuple[PlatformCapabilityCheck, ...] = (
+    PlatformCapabilityCheck(
+        target="all",
+        kind="runtime",
+        capability="os_debug_gc",
+        status="reported",
+        apis=(
+            "os_type",
+            "os_get_info",
+            "show_debug_message_ext",
+            "gc_collect",
+            "weak_ref_alive",
+        ),
+        godot_export_keys=(),
+        gm2godot_surface="GMRuntime OS/debug/GC helpers and gml_api_compatibility.md",
+        check="Verify generated compatibility reports list OS/debug/GC APIs as implemented, partial, planned, or unsupported.",
+        recommendation="Use conversion diagnostics for unsupported OS/compiler APIs instead of leaving unresolved GML calls.",
+    ),
+    PlatformCapabilityCheck(
+        target="all",
+        kind="runtime",
+        capability="video_playback",
+        status="reported",
+        apis=(
+            "video_open",
+            "video_draw",
+            "video_get_status",
+            "video_close",
+        ),
+        godot_export_keys=(),
+        gm2godot_surface="GMRuntime video compatibility state and video_runtime_diagnostics",
+        check="Report unsupported camera or non-Godot VideoStream sources at runtime.",
+        recommendation="Use Ogg Theora or provide a GDExtension-backed VideoStream for formats not handled by Godot.",
+    ),
+    PlatformCapabilityCheck(
+        target="web",
+        kind="export_preset",
+        capability="browser_bridge",
+        status="requires_export_preset",
+        apis=(
+            "browser_width",
+            "browser_height",
+            "browser_input_capture",
+            "url_get_domain",
+            "url_open",
+            "url_open_ext",
+            "url_open_full",
+            "webgl_enabled",
+        ),
+        godot_export_keys=("html/export_icon", "html/canvas_resize_policy"),
+        gm2godot_surface="GMRuntime web platform hook",
+        check="Web exports need a browser bridge hook when GameMaker code depends on DOM, window target, or canvas policy.",
+        recommendation="Register a web platform service hook or keep the deterministic desktop fallbacks documented in the compatibility report.",
+    ),
+    PlatformCapabilityCheck(
+        target="web",
+        kind="plugin",
+        capability="html5_dom_cors",
+        status="requires_plugin",
+        apis=(
+            "clickable_add",
+            "clickable_add_ext",
+            "analytics_event",
+            "analytics_event_ext",
+            "http_get_request_crossorigin",
+            "http_set_request_crossorigin",
+        ),
+        godot_export_keys=("html/head_include",),
+        gm2godot_surface="GMRuntime platform service hook: web",
+        check="HTML5 DOM, analytics, and CORS helpers need project-specific JavaScript bridge code.",
+        recommendation="Map these APIs through an extension function mapping or register a reviewed web hook.",
+    ),
+    PlatformCapabilityCheck(
+        target="android",
+        kind="permission",
+        capability="microphone",
+        status="requires_permission",
+        apis=("audio_start_recording", "audio_get_recorder_count"),
+        godot_export_keys=("permissions/record_audio",),
+        gm2godot_surface="GMAudio diagnostics and async audio recording payload",
+        check="Microphone capture requires an Android export permission plus project AudioEffectCapture setup.",
+        recommendation="Enable RECORD_AUDIO in the export preset and provide a capture bus before relying on recording data.",
+    ),
+    PlatformCapabilityCheck(
+        target="ios",
+        kind="permission",
+        capability="microphone",
+        status="requires_permission",
+        apis=("audio_start_recording", "audio_get_recorder_count"),
+        godot_export_keys=("privacy/microphone_usage_description",),
+        gm2godot_surface="GMAudio diagnostics and async audio recording payload",
+        check="Microphone capture requires an iOS privacy usage string and project AudioEffectCapture setup.",
+        recommendation="Set the iOS microphone usage description and provide a capture bus before relying on recording data.",
+    ),
+    PlatformCapabilityCheck(
+        target="mobile",
+        kind="permission",
+        capability="camera",
+        status="requires_permission",
+        apis=("video_open", "os_check_permission", "os_request_permission"),
+        godot_export_keys=(
+            "permissions/camera",
+            "privacy/camera_usage_description",
+        ),
+        gm2godot_surface="GMRuntime video diagnostics",
+        check="Camera-backed video sources require a target camera permission and a capture bridge.",
+        recommendation="Provide a platform capture plugin and route camera permissions through project export settings.",
+    ),
+    PlatformCapabilityCheck(
+        target="mobile",
+        kind="permission",
+        capability="motion_sensors",
+        status="requires_permission",
+        apis=(
+            "device_get_tilt_x",
+            "device_get_tilt_y",
+            "device_get_tilt_z",
+            "os_check_permission",
+            "os_request_permission",
+        ),
+        godot_export_keys=(
+            "permissions/access_fine_location",
+            "privacy/motion_usage_description",
+        ),
+        gm2godot_surface="GML API compatibility diagnostics",
+        check="Device sensor APIs are rejected unless a target sensor bridge and permissions are supplied.",
+        recommendation="Replace unsupported sensor calls or provide a platform plugin that exposes equivalent data.",
+    ),
+    PlatformCapabilityCheck(
+        target="desktop",
+        kind="runtime",
+        capability="clipboard_url_shell",
+        status="reported",
+        apis=(
+            "clipboard_has_text",
+            "clipboard_get_text",
+            "clipboard_set_text",
+            "url_open",
+            "url_open_ext",
+            "url_open_full",
+        ),
+        godot_export_keys=(),
+        gm2godot_surface="DisplayServer clipboard and OS.shell_open fallbacks",
+        check="Desktop clipboard and URL helpers use Godot runtime services and report fallback limitations.",
+        recommendation="Review conversion diagnostics for targets without native clipboard or shell-open support.",
+    ),
+    PlatformCapabilityCheck(
+        target="steam",
+        kind="plugin",
+        capability="steam_sdk",
+        status="requires_plugin",
+        apis=(
+            "steam_is_initialized",
+            "steam_set_achievement",
+            "steam_get_achievement",
+            "steam_upload_score",
+            "steam_download_scores",
+        ),
+        godot_export_keys=(),
+        gm2godot_surface="GMRuntime platform service hook: steam",
+        check="Steam APIs require a Godot Steam addon or GDExtension hook.",
+        recommendation="Register a Steam platform hook so async Steam results are dispatched through GMAsync.",
+    ),
+    PlatformCapabilityCheck(
+        target="store",
+        kind="plugin",
+        capability="iap",
+        status="requires_plugin",
+        apis=(
+            "iap_activate",
+            "iap_acquire",
+            "iap_consume",
+            "iap_restore_all",
+        ),
+        godot_export_keys=("permissions/billing",),
+        gm2godot_surface="GMRuntime platform service hook: iap",
+        check="In-app purchase APIs require a store billing plugin and export entitlement setup.",
+        recommendation="Register an IAP hook that returns GMAsync in_app_purchase payloads for purchase lifecycle events.",
+    ),
+    PlatformCapabilityCheck(
+        target="services",
+        kind="plugin",
+        capability="cloud_push_ads_analytics",
+        status="requires_plugin",
+        apis=(
+            "cloud_synchronise",
+            "cloud_string_save",
+            "cloud_file_save",
+            "push_notifications_extension",
+            "analytics_event",
+            "analytics_event_ext",
+        ),
+        godot_export_keys=("permissions/post_notifications",),
+        gm2godot_surface="GMRuntime platform service and extension async hooks",
+        check="Cloud, push notification, ads, and analytics behavior is extension-backed.",
+        recommendation="Use extension mappings plus async schema registration so callbacks route through GMAsync.",
+    ),
+    PlatformCapabilityCheck(
+        target="uwp_xbox",
+        kind="plugin",
+        capability="xboxlive",
+        status="requires_plugin",
+        apis=(
+            "xboxlive_user_is_signed_in",
+            "xboxlive_achievements_set_progress",
+            "xboxlive_stats_get_leaderboard",
+            "xboxlive_matchmaking_create",
+        ),
+        godot_export_keys=("xbox/services_config_id", "xbox/title_id"),
+        gm2godot_surface="GMRuntime platform service hook: xboxlive",
+        check="Xbox Live and UWP APIs require closed platform SDK access and export runner integration.",
+        recommendation="Register an Xbox Live hook for account, achievement, leaderboard, and matchmaking payloads.",
+    ),
+    PlatformCapabilityCheck(
+        target="live_wallpaper",
+        kind="plugin",
+        capability="wallpaper",
+        status="requires_plugin",
+        apis=("wallpaper_set_config", "wallpaper_set_subscriptions"),
+        godot_export_keys=("android/package/use_custom_build",),
+        gm2godot_surface="GMRuntime platform service hook: wallpaper",
+        check="Live wallpaper APIs require the Android live wallpaper companion integration.",
+        recommendation="Provide a wallpaper hook and use generated async wallpaper event handlers for callbacks.",
+    ),
+)
+
+
+def iter_platform_capability_checks(
+    target_platform: str | None = None,
+) -> tuple[PlatformCapabilityCheck, ...]:
+    if target_platform is None:
+        return _CAPABILITY_CHECKS
+
+    target = target_platform.casefold()
+    aliases = _target_aliases(target)
+    return tuple(check for check in _CAPABILITY_CHECKS if check.target in aliases)
+
+
+def generate_platform_capability_report(
+    target_platform: str | None = None,
+) -> dict[str, object]:
+    checks = iter_platform_capability_checks(target_platform)
+    return {
+        "report": "platform_capability_report",
+        "version": 1,
+        "issue_number": 606,
+        "selected_target": target_platform,
+        "summary": {
+            "total": len(checks),
+            "by_target": _count_values(check.target for check in checks),
+            "by_kind": _count_values(check.kind for check in checks),
+            "by_status": _count_values(check.status for check in checks),
+        },
+        "checks": [check.to_dict() for check in checks],
+    }
+
+
+def render_platform_capability_markdown(
+    target_platform: str | None = None,
+) -> str:
+    checks = iter_platform_capability_checks(target_platform)
+    target_label = target_platform or "all targets"
+    lines = [
+        "# Platform Capability Report",
+        "",
+        f"Selected target: `{target_label}`",
+        "",
+        "| Target | Kind | Capability | Status | APIs | Check |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for check in checks:
+        lines.append(
+            f"| {check.target} | {check.kind} | {check.capability} | {check.status} | "
+            f"{', '.join(check.apis)} | {check.check} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _target_aliases(target: str) -> set[str]:
+    aliases = {"all", target}
+    if target in _DESKTOP_TARGETS:
+        aliases.add("desktop")
+        aliases.add("services")
+        aliases.add("steam")
+        aliases.add("store")
+    if target in {"android", "ios"}:
+        aliases.add("mobile")
+        aliases.add("store")
+        aliases.add("services")
+    if target == "web":
+        aliases.add("services")
+    return aliases
+
+
+def _count_values(values: Iterable[str]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for value in values:
+        counts[value] = counts.get(value, 0) + 1
+    return counts

--- a/src/conversion/runtime_managers.md
+++ b/src/conversion/runtime_managers.md
@@ -17,6 +17,8 @@ The generated autoloads are:
 
 `project.godot` registers the managers in that order in `[autoload]`. Godot loads autoload nodes before the main scene and evaluates them in project order, which gives the runtime a stable startup sequence for later event, room, draw, input, audio, async, and platform migrations.
 
+The CLI static report pipeline writes `gm2godot/platform_capability_report.json` and `.md`. These reports list target-specific permission, export-preset, and optional plugin checks for browser hooks, mobile microphone/camera/sensor APIs, Steam, IAP, cloud, push notifications, Xbox Live, and live wallpaper integrations.
+
 The `GMRuntime` autoload records each manager in `manager_registry_snapshot()` and exposes `manager_order()`. Each manager owns named state buckets so future runtime slices can move domain state out of the static compatibility facade without changing generated GML helper call sites.
 
 Collision events are dispatched by the central scheduler after motion/path updates and before End Step, matching the relevant GameMaker event-order window: https://manual.gamemaker.io/monthly/en/The_Asset_Editors/Object_Properties/Event_Order.htm. Dispatch uses generated Godot collision shape bounds, which aligns with Godot's 2D physics shape model: https://docs.godotengine.org/en/stable/tutorials/physics/physics_introduction.html. Pixel-perfect precise masks remain reported as a runtime fidelity limitation through the existing precise-collision warning path.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,11 +33,25 @@ class TestCLIReports(unittest.TestCase):
         self.assertTrue(os.path.isfile(os.path.join(report_root, "conversion_diagnostics.md")))
         self.assertTrue(os.path.isfile(os.path.join(report_root, "gml_manual_scope.md")))
         self.assertTrue(os.path.isfile(os.path.join(report_root, "gml_api_compatibility.md")))
+        self.assertTrue(os.path.isfile(os.path.join(report_root, "platform_capability_report.json")))
+        self.assertTrue(os.path.isfile(os.path.join(report_root, "platform_capability_report.md")))
 
         with open(os.path.join(report_root, "conversion_diagnostics.json"), "r", encoding="utf-8") as report_file:
             report = json.load(report_file)
 
         self.assertEqual(report["summary"]["total"], 0)
+
+        with open(os.path.join(report_root, "platform_capability_report.json"), "r", encoding="utf-8") as report_file:
+            capability_report = json.load(report_file)
+
+        self.assertEqual(capability_report["issue_number"], 606)
+        self.assertTrue(
+            any(
+                check["capability"] == "microphone"
+                and "audio_start_recording" in check["apis"]
+                for check in capability_report["checks"]
+            )
+        )
 
     def test_analyze_only_writes_platform_diagnostic_without_conversion_output(self) -> None:
         gm_dir = os.path.join(self.temp_dir, "gm")
@@ -66,6 +80,13 @@ class TestCLIReports(unittest.TestCase):
         self.assertIn("GM2GD-CLI-TARGET-PLATFORM", codes)
         self.assertIn("GM2GD-ANALYZE-MISSING-YYP", codes)
         self.assertTrue(any("linux" in diagnostic["message"] for diagnostic in report["diagnostics"]))
+        with open(
+            os.path.join(report_dir, "gm2godot", "platform_capability_report.json"),
+            "r",
+            encoding="utf-8",
+        ) as capability_file:
+            capability_report = json.load(capability_file)
+        self.assertEqual(capability_report["selected_target"], "linux")
 
     def test_validate_applies_thresholds_to_existing_diagnostics_report(self) -> None:
         godot_dir = os.path.join(self.temp_dir, "godot")

--- a/tests/test_platform_capabilities.py
+++ b/tests/test_platform_capabilities.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import unittest
+from typing import cast
+
+from src.conversion.platform_capabilities import (
+    generate_platform_capability_report,
+    iter_platform_capability_checks,
+    render_platform_capability_markdown,
+)
+
+
+class TestPlatformCapabilities(unittest.TestCase):
+    def test_desktop_target_report_filters_common_and_desktop_checks(self) -> None:
+        checks = iter_platform_capability_checks("windows")
+        targets = {check.target for check in checks}
+
+        self.assertIn("all", targets)
+        self.assertIn("desktop", targets)
+        self.assertIn("steam", targets)
+        self.assertIn("services", targets)
+        self.assertNotIn("android", targets)
+        self.assertTrue(
+            any("clipboard_set_text" in check.apis for check in checks)
+        )
+
+    def test_mobile_report_names_permissions_services_and_export_keys(self) -> None:
+        report = generate_platform_capability_report("android")
+        checks = cast(list[dict[str, object]], report["checks"])
+
+        self.assertEqual(report["selected_target"], "android")
+        self.assertTrue(
+            any(
+                check["kind"] == "permission"
+                and check["capability"] == "microphone"
+                and "audio_start_recording" in cast(list[str], check["apis"])
+                and "permissions/record_audio"
+                in cast(list[str], check["godot_export_keys"])
+                for check in checks
+            )
+        )
+        self.assertTrue(
+            any(
+                check["target"] == "store"
+                and check["capability"] == "iap"
+                and "iap_activate" in cast(list[str], check["apis"])
+                for check in checks
+            )
+        )
+        self.assertTrue(
+            any(
+                check["target"] == "services"
+                and "push_notifications_extension" in cast(list[str], check["apis"])
+                for check in checks
+            )
+        )
+
+    def test_all_target_report_covers_plugin_and_unsupported_surfaces(self) -> None:
+        report = generate_platform_capability_report()
+        checks = cast(list[dict[str, object]], report["checks"])
+
+        self.assertEqual(report["issue_number"], 606)
+        self.assertTrue(
+            any(
+                check["target"] == "steam"
+                and check["status"] == "requires_plugin"
+                and "steam_set_achievement" in cast(list[str], check["apis"])
+                for check in checks
+            )
+        )
+        self.assertTrue(
+            any(
+                check["capability"] == "motion_sensors"
+                and check["status"] == "requires_permission"
+                and "device_get_tilt_x" in cast(list[str], check["apis"])
+                for check in checks
+            )
+        )
+
+    def test_markdown_report_includes_selected_target(self) -> None:
+        markdown = render_platform_capability_markdown("web")
+
+        self.assertIn("Selected target: `web`", markdown)
+        self.assertIn("browser_bridge", markdown)
+        self.assertIn("html5_dom_cors", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add generated platform capability reports for permission, export preset, runtime, and optional service/plugin checks
- include selected-target filtering for analyze/convert reports while preserving an all-target static report
- document the new report artifact and cover it with CLI/report tests

Closes #606.

## Verification
- ./venv/bin/python -m unittest tests.test_platform_capabilities tests.test_cli tests.test_gml_api_manifest tests.test_platform_services_godot tests.test_os_debug_gc_godot
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest
- GODOT_BIN=/tmp/godot-4.4.1-macos/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_platform_services_godot tests.test_os_debug_gc_godot