### PR TITLE
Stabilize generated paths and validation reports

### DIFF
--- a/.github/workflows/godot-smoke.yml
+++ b/.github/workflows/godot-smoke.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           python -m unittest \
             tests.test_runtime_managers_godot \
+            tests.test_godot_validation \
             tests.test_room_game_flow_godot \
             tests.test_cameras_display_godot \
             tests.test_game_input_godot \

--- a/src/cli.py
+++ b/src/cli.py
@@ -18,6 +18,10 @@ from src.conversion.gml_transpiler import (
     generate_gml_api_compatibility_report,
     render_gml_manual_scope_markdown,
 )
+from src.conversion.godot_validation import (
+    validate_generated_godot_project,
+    write_godot_validation_report,
+)
 from src.conversion.platform_capabilities import (
     generate_platform_capability_report,
     render_platform_capability_markdown,
@@ -52,7 +56,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _run_convert(args)
 
     if args.command == "validate":
-        diagnostics = _validate_project(args.godot_project)
+        diagnostics = _validate_project(
+            args.godot_project,
+            godot_binary=args.godot_bin,
+            run_godot_validation=not args.skip_godot_validation,
+        )
         if args.report_dir:
             _write_static_reports(args.report_dir)
             diagnostics.write_reports(args.report_dir)
@@ -121,6 +129,16 @@ def _build_parser() -> argparse.ArgumentParser:
         "validate", help="Validate generated output reports and project presence."
     )
     validate_parser.add_argument("--godot-project", required=True, help="Godot project directory.")
+    validate_parser.add_argument(
+        "--godot-bin",
+        default=None,
+        help="Optional Godot executable for generated GDScript/scene/resource validation.",
+    )
+    validate_parser.add_argument(
+        "--skip-godot-validation",
+        action="store_true",
+        help="Skip headless Godot generated resource validation.",
+    )
     _add_report_args(validate_parser, required=False)
     _add_threshold_args(validate_parser)
 
@@ -220,7 +238,12 @@ def _analyze_project(gm_project_path: str, platform_name: str) -> DiagnosticColl
     return diagnostics
 
 
-def _validate_project(godot_project_path: str) -> DiagnosticCollector:
+def _validate_project(
+    godot_project_path: str,
+    *,
+    godot_binary: str | None = None,
+    run_godot_validation: bool = True,
+) -> DiagnosticCollector:
     diagnostics = DiagnosticCollector()
     if not os.path.isdir(godot_project_path):
         diagnostics.add(
@@ -261,6 +284,8 @@ def _validate_project(godot_project_path: str) -> DiagnosticCollector:
             f"Diagnostics report does not exist: {report_path}",
             source_path=report_path,
         )
+    if run_godot_validation:
+        _add_godot_validation_diagnostic(diagnostics, godot_project_path, godot_binary)
     return diagnostics
 
 
@@ -273,6 +298,42 @@ def _add_platform_diagnostic(
         f"Target platform filter: {platform_name}",
         resource_type="platform",
         resource=platform_name,
+    )
+
+
+def _add_godot_validation_diagnostic(
+    diagnostics: DiagnosticCollector,
+    godot_project_path: str,
+    godot_binary: str | None,
+) -> None:
+    report = validate_generated_godot_project(
+        godot_project_path,
+        godot_binary=godot_binary,
+    )
+    write_godot_validation_report(godot_project_path, report)
+    if report.status == "passed":
+        diagnostics.add(
+            "info",
+            "GM2GD-GODOT-VALIDATION",
+            report.message,
+            source_path=godot_project_path,
+        )
+        return
+    if report.status == "skipped":
+        diagnostics.add(
+            "info",
+            "GM2GD-GODOT-VALIDATION-SKIPPED",
+            report.message,
+            source_path=godot_project_path,
+            workaround="Install Godot and set GODOT_BIN, or pass --godot-bin to validate generated resources.",
+        )
+        return
+    diagnostics.add(
+        "error",
+        "GM2GD-GODOT-VALIDATION-FAILED",
+        report.message,
+        source_path=godot_project_path,
+        workaround="Open the generated project with the pinned Godot version and fix the first parser/resource error reported in gm2godot/godot_validation_report.json.",
     )
 
 

--- a/src/conversion/asset_registry.py
+++ b/src/conversion/asset_registry.py
@@ -12,6 +12,12 @@ from src.conversion.project_manifest import (
     load_gamemaker_project_manifest,
 )
 from src.conversion.gml_transpiler import GMLTranspileError, transpile_gml_code
+from src.conversion.generated_paths import (
+    generated_flat_resource_path,
+    generated_nested_resource_path,
+    generated_path_segment,
+    generated_resource_stem,
+)
 from src.conversion.type_defs import (
     ConversionRunning,
     JsonDict,
@@ -212,6 +218,7 @@ class AssetRegistryConverter(BaseConverter):
             ),
         )
         room_order_indices = self._room_order_indices(resources)
+        godot_paths = self._stable_godot_paths(resources)
         used_ids: set[int] = set()
         entries: list[AssetRegistryEntry] = []
 
@@ -226,7 +233,7 @@ class AssetRegistryConverter(BaseConverter):
                 asset_type=asset_type,
                 type_name=self.TYPE_NAME_BY_KIND[resource.kind],
                 source_path=resource.source_path,
-                godot_path=self._godot_path(resource),
+                godot_path=godot_paths[self._resource_key(resource)],
                 legacy_id=self._legacy_id(resource),
                 tags=self._extract_tags(resource.raw_data),
                 metadata=self._metadata(resource, room_order_indices),
@@ -406,29 +413,66 @@ class AssetRegistryConverter(BaseConverter):
             deduped.setdefault((resource.kind, resource.name), resource)
         return tuple(deduped.values())
 
-    def _godot_path(self, resource: _ProjectResource) -> str:
+    def _stable_godot_paths(
+        self,
+        resources: Iterable[_ProjectResource],
+    ) -> dict[tuple[str, str, str], str]:
+        paths: dict[tuple[str, str, str], str] = {}
+        used_paths: set[str] = set()
+        for resource in resources:
+            suffix_index = 0
+            base_path = ""
+            while True:
+                suffix = "" if suffix_index == 0 else f"_{suffix_index + 1}"
+                path = self._godot_path(resource, suffix=suffix)
+                if suffix_index == 0:
+                    base_path = path
+                elif path == base_path:
+                    path = self._suffix_resource_path(path, suffix)
+                folded_path = path.casefold()
+                if not folded_path or folded_path not in used_paths:
+                    break
+                suffix_index += 1
+            if path:
+                used_paths.add(folded_path)
+            paths[self._resource_key(resource)] = path
+        return paths
+
+    @staticmethod
+    def _resource_key(resource: _ProjectResource) -> tuple[str, str, str]:
+        return (resource.kind, resource.name, resource.source_path)
+
+    @staticmethod
+    def _suffix_resource_path(path: str, suffix: str) -> str:
+        if not suffix:
+            return path
+        stem, extension = os.path.splitext(path)
+        return f"{stem}{suffix}{extension}"
+
+    def _godot_path(self, resource: _ProjectResource, *, suffix: str = "") -> str:
         if resource.kind in self.STATIC_RESOURCE_EXTENSIONS:
             return self._nested_resource_path(
                 resource.kind,
                 self._get_subfolder_from_resource(resource),
                 resource.name,
                 self.STATIC_RESOURCE_EXTENSIONS[resource.kind],
+                suffix=suffix,
             )
         if resource.kind == "sounds":
-            return self._sound_godot_path(resource)
+            return self._sound_godot_path(resource, suffix=suffix)
         if resource.kind == "fonts":
-            return self._font_godot_path(resource)
+            return self._font_godot_path(resource, suffix=suffix)
         if resource.kind == "scripts":
-            return self._flat_resource_path("scripts", self._get_subfolder_from_resource(resource), resource.name, ".gd")
+            return self._flat_resource_path("scripts", self._get_subfolder_from_resource(resource), resource.name, ".gd", suffix=suffix)
         if resource.kind == "shaders":
-            return self._flat_resource_path("shaders", self._get_subfolder_from_resource(resource), resource.name, ".gdshader")
+            return self._flat_resource_path("shaders", self._get_subfolder_from_resource(resource), resource.name, ".gdshader", suffix=suffix)
         if resource.kind == "included_files":
             return "res://included_files/" + resource.name
         if resource.kind == "extensions":
             return extension_stub_resource_path(resource.name)
         return ""
 
-    def _sound_godot_path(self, resource: _ProjectResource) -> str:
+    def _sound_godot_path(self, resource: _ProjectResource, *, suffix: str = "") -> str:
         sound_file = resource.raw_data.get("soundFile")
         if not isinstance(sound_file, str) or not sound_file:
             return ""
@@ -436,10 +480,10 @@ class AssetRegistryConverter(BaseConverter):
         parts = ["sounds"]
         if self.organize_sounds_by_audio_group:
             audio_group = self._reference_name(resource.raw_data.get("audioGroupId"))
-            parts.append(audio_group or "audiogroup_default")
+            parts.append(generated_path_segment(audio_group or "audiogroup_default", "audiogroup_default"))
         subfolder = self._get_subfolder_from_resource(resource)
         parts.extend(part for part in subfolder.split("/") if part)
-        parts.extend([resource.name, sound_file])
+        parts.extend([generated_resource_stem(resource.name) + suffix, sound_file])
         return "res://" + "/".join(parts)
 
     def _metadata(
@@ -960,7 +1004,7 @@ class AssetRegistryConverter(BaseConverter):
 
     @staticmethod
     def _timeline_action_script_resource_path(timeline_name: str, frame: int) -> str:
-        safe_name = "".join(char if char.isalnum() or char == "_" else "_" for char in timeline_name)
+        safe_name = generated_resource_stem(timeline_name)
         return f"res://gm2godot/timelines/{safe_name}_{frame}.gd"
 
     @staticmethod
@@ -1008,7 +1052,7 @@ class AssetRegistryConverter(BaseConverter):
                 ordered.append(name)
         return {name: index for index, name in enumerate(ordered)}
 
-    def _font_godot_path(self, resource: _ProjectResource) -> str:
+    def _font_godot_path(self, resource: _ProjectResource, *, suffix: str = "") -> str:
         subfolder = self._get_subfolder_from_resource(resource)
         ttf_name = resource.raw_data.get("TTFName")
         include_ttf = bool(resource.raw_data.get("includeTTF", False))
@@ -1020,7 +1064,7 @@ class AssetRegistryConverter(BaseConverter):
         generated_path = self._find_generated_font_path(resource.name, subfolder)
         if generated_path is not None:
             return generated_path
-        return self._flat_resource_path("fonts", subfolder, resource.name, ".tres")
+        return self._flat_resource_path("fonts", subfolder, resource.name, ".tres", suffix=suffix)
 
     def _find_generated_font_path(self, font_name: str, subfolder: str) -> str | None:
         search_dir = os.path.join(self.godot_project_path, "fonts", *subfolder.split("/")) if subfolder else os.path.join(self.godot_project_path, "fonts")
@@ -1045,18 +1089,26 @@ class AssetRegistryConverter(BaseConverter):
         return self._get_subfolder_from_yy(resource.yy_path)
 
     @staticmethod
-    def _nested_resource_path(kind: str, subfolder: str, name: str, extension: str) -> str:
-        parts = [kind]
-        parts.extend(part for part in subfolder.split("/") if part)
-        parts.extend([name, name + extension])
-        return "res://" + "/".join(parts)
+    def _nested_resource_path(
+        kind: str,
+        subfolder: str,
+        name: str,
+        extension: str,
+        *,
+        suffix: str = "",
+    ) -> str:
+        return generated_nested_resource_path(kind, subfolder, name, extension, suffix=suffix)
 
     @staticmethod
-    def _flat_resource_path(kind: str, subfolder: str, name: str, extension: str) -> str:
-        parts = [kind]
-        parts.extend(part for part in subfolder.split("/") if part)
-        parts.append(name + extension)
-        return "res://" + "/".join(parts)
+    def _flat_resource_path(
+        kind: str,
+        subfolder: str,
+        name: str,
+        extension: str,
+        *,
+        suffix: str = "",
+    ) -> str:
+        return generated_flat_resource_path(kind, subfolder, name, extension, suffix=suffix)
 
     def _legacy_id(self, resource: _ProjectResource) -> str:
         for key in ("id", "resourceId", "guid"):

--- a/src/conversion/base_converter.py
+++ b/src/conversion/base_converter.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 
 from src.localization import get_localized
 from src.conversion.diagnostics import DiagnosticCollector
+from src.conversion.generated_paths import generated_subfolder_path
 from src.conversion.type_defs import ConversionRunning, JsonDict, LogCallback, ProgressCallback, StrPath
 
 
@@ -104,7 +105,7 @@ class BaseConverter(ABC):
             parts = parent_path.split('/')
             if len(parts) <= 1:
                 return ""
-            return '/'.join(parts[1:])
+            return generated_subfolder_path('/'.join(parts[1:]))
         except (KeyError, TypeError, AttributeError):
             return ""
 

--- a/src/conversion/conversion_manifest.py
+++ b/src/conversion/conversion_manifest.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from typing import Iterable
+
+from src.conversion.asset_registry import AssetRegistryConverter, AssetRegistryEntry
+from src.conversion.generated_paths import (
+    generated_flat_resource_path,
+    generated_nested_resource_path,
+    generated_resource_stem,
+    is_snake_case_path_segment,
+    res_path_segments,
+    snake_case_res_path,
+)
+from src.conversion.project_manifest import load_gamemaker_project_manifest
+from src.conversion.type_defs import JsonDict
+
+CONVERSION_MANIFEST_RELATIVE_PATH = os.path.join("gm2godot", "conversion_manifest.json")
+_GODOT_RESOURCE_EXTENSIONS = (".gd", ".gdshader", ".tscn", ".tres", ".json")
+
+
+@dataclass(frozen=True)
+class GeneratedFileEntry:
+    path: str
+    kind: str
+    sha256: str
+
+    def to_dict(self) -> JsonDict:
+        return {
+            "path": self.path,
+            "kind": self.kind,
+            "sha256": self.sha256,
+        }
+
+
+def write_conversion_manifest(
+    gm_project_path: str,
+    godot_project_path: str,
+    *,
+    target_platform: str,
+    enabled_converters: Iterable[str],
+) -> str:
+    manifest_path = os.path.join(godot_project_path, CONVERSION_MANIFEST_RELATIVE_PATH)
+    os.makedirs(os.path.dirname(manifest_path), exist_ok=True)
+    payload = build_conversion_manifest(
+        gm_project_path,
+        godot_project_path,
+        target_platform=target_platform,
+        enabled_converters=enabled_converters,
+    )
+    with open(manifest_path, "w", encoding="utf-8") as manifest_file:
+        json.dump(payload, manifest_file, indent=2, sort_keys=True)
+        manifest_file.write("\n")
+    return manifest_path
+
+
+def build_conversion_manifest(
+    gm_project_path: str,
+    godot_project_path: str,
+    *,
+    target_platform: str,
+    enabled_converters: Iterable[str],
+) -> JsonDict:
+    project_manifest = load_gamemaker_project_manifest(gm_project_path, target_platform=target_platform)
+    asset_entries = _asset_registry_entries(gm_project_path, godot_project_path)
+    generated_files = _generated_files(godot_project_path)
+    return {
+        "format_version": 1,
+        "target_platform": target_platform,
+        "enabled_converters": sorted(set(enabled_converters)),
+        "source_project": {
+            "name": project_manifest.project_name,
+            "yyp_path": _relative_source_path(project_manifest.yyp_path, gm_project_path),
+            "resource_type": project_manifest.resource_type,
+            "resource_version": project_manifest.resource_version,
+        },
+        "resources": [entry.to_godot_dict() for entry in asset_entries],
+        "generated_files": [entry.to_dict() for entry in generated_files],
+        "source_maps": [
+            entry.to_dict()
+            for entry in generated_files
+            if entry.path.endswith(".gmlmap.json")
+        ],
+        "path_diagnostics": _path_diagnostics(asset_entries),
+    }
+
+
+def _asset_registry_entries(
+    gm_project_path: str,
+    godot_project_path: str,
+) -> tuple[AssetRegistryEntry, ...]:
+    converter = AssetRegistryConverter(
+        gm_project_path,
+        godot_project_path,
+        log_callback=lambda _message: None,
+        progress_callback=lambda _value: None,
+        conversion_running=lambda: True,
+    )
+    return converter.build_entries()
+
+
+def _generated_files(godot_project_path: str) -> tuple[GeneratedFileEntry, ...]:
+    entries: list[GeneratedFileEntry] = []
+    for root, dirs, files in os.walk(godot_project_path):
+        dirs[:] = sorted(directory for directory in dirs if directory != ".godot")
+        for filename in sorted(files):
+            path = os.path.join(root, filename)
+            relative_path = os.path.relpath(path, godot_project_path).replace(os.sep, "/")
+            if relative_path == CONVERSION_MANIFEST_RELATIVE_PATH.replace(os.sep, "/"):
+                continue
+            if not _is_generated_manifest_file(relative_path):
+                continue
+            entries.append(
+                GeneratedFileEntry(
+                    path=relative_path,
+                    kind=_generated_file_kind(relative_path),
+                    sha256=_sha256_file(path),
+                )
+            )
+    entries.append(
+        GeneratedFileEntry(
+            path=CONVERSION_MANIFEST_RELATIVE_PATH.replace(os.sep, "/"),
+            kind="manifest",
+            sha256="self",
+        )
+    )
+    return tuple(sorted(entries, key=lambda entry: entry.path))
+
+
+def _is_generated_manifest_file(relative_path: str) -> bool:
+    if relative_path == "project.godot":
+        return True
+    return relative_path.endswith(_GODOT_RESOURCE_EXTENSIONS)
+
+
+def _generated_file_kind(relative_path: str) -> str:
+    if relative_path == "project.godot":
+        return "project"
+    if relative_path.endswith(".gmlmap.json"):
+        return "source_map"
+    if relative_path.endswith(".json"):
+        return "report"
+    if relative_path.endswith(".gd"):
+        return "gdscript"
+    if relative_path.endswith(".gdshader"):
+        return "shader"
+    if relative_path.endswith(".tscn"):
+        return "scene"
+    if relative_path.endswith(".tres"):
+        return "resource"
+    return "file"
+
+
+def _path_diagnostics(entries: tuple[AssetRegistryEntry, ...]) -> list[JsonDict]:
+    diagnostics: list[JsonDict] = []
+    paths_by_casefold: dict[str, list[AssetRegistryEntry]] = {}
+    base_paths_by_casefold: dict[str, list[tuple[AssetRegistryEntry, str]]] = {}
+    for entry in entries:
+        if not entry.godot_path:
+            continue
+        paths_by_casefold.setdefault(entry.godot_path.casefold(), []).append(entry)
+        base_path = _base_generated_path(entry)
+        if base_path:
+            base_paths_by_casefold.setdefault(base_path.casefold(), []).append((entry, base_path))
+        unsafe_segments = _unsafe_segments(entry.godot_path)
+        if unsafe_segments:
+            diagnostics.append({
+                "code": "GM2GD-PATH-NON-SNAKE-CASE",
+                "severity": "info",
+                "resource": entry.name,
+                "resource_type": entry.kind,
+                "godot_path": entry.godot_path,
+                "unsafe_segments": unsafe_segments,
+                "stable_suggestion": snake_case_res_path(entry.godot_path),
+                "message": "Generated path contains non-snake-case segments; source metadata preserves the original GameMaker name.",
+            })
+
+    for folded_path, colliding_items in sorted(base_paths_by_casefold.items()):
+        if len(colliding_items) < 2:
+            continue
+        diagnostics.append({
+            "code": "GM2GD-PATH-COLLISION-RENAMED",
+            "severity": "warning",
+            "base_godot_path_casefold": folded_path,
+            "resources": [
+                {
+                    "name": entry.name,
+                    "kind": entry.kind,
+                    "source_path": entry.source_path,
+                    "base_godot_path": base_path,
+                    "stable_godot_path": entry.godot_path,
+                }
+                for entry, base_path in sorted(
+                    colliding_items,
+                    key=lambda item: (item[0].kind, item[0].name, item[0].source_path),
+                )
+            ],
+            "message": "Multiple GameMaker resources map to the same Godot-friendly path; stable suffixes were applied deterministically.",
+        })
+
+    for folded_path, colliding_entries in sorted(paths_by_casefold.items()):
+        if len(colliding_entries) < 2:
+            continue
+        diagnostics.append({
+            "code": "GM2GD-PATH-CASE-COLLISION",
+            "severity": "warning",
+            "godot_path_casefold": folded_path,
+            "resources": [
+                {
+                    "name": entry.name,
+                    "kind": entry.kind,
+                    "source_path": entry.source_path,
+                    "godot_path": entry.godot_path,
+                }
+                for entry in sorted(colliding_entries, key=lambda item: (item.kind, item.name, item.source_path))
+            ],
+            "stable_suggestions": [
+                _collision_safe_path(entry.godot_path, index)
+                for index, entry in enumerate(sorted(colliding_entries, key=lambda item: (item.kind, item.name, item.source_path)))
+            ],
+            "message": "Generated paths collide on case-insensitive file systems; suggestions are deterministic for project-specific remapping.",
+        })
+    return diagnostics
+
+
+def _base_generated_path(entry: AssetRegistryEntry) -> str:
+    segments = res_path_segments(entry.godot_path)
+    if len(segments) < 2:
+        return ""
+    kind = segments[0]
+    if kind in {"sprites", "objects", "rooms", "tilesets", "paths"} and len(segments) >= 3:
+        extension = os.path.splitext(segments[-1])[1]
+        subfolder = "/".join(segments[1:-2])
+        return generated_nested_resource_path(kind, subfolder, entry.name, extension)
+    if kind in {"scripts", "shaders", "fonts"}:
+        extension = os.path.splitext(segments[-1])[1]
+        subfolder = "/".join(segments[1:-1])
+        return generated_flat_resource_path(kind, subfolder, entry.name, extension)
+    if kind == "sounds" and len(segments) >= 3:
+        base_segments = list(segments)
+        base_segments[-2] = generated_resource_stem(entry.name)
+        return "res://" + "/".join(base_segments)
+    return entry.godot_path
+
+
+def _unsafe_segments(res_path: str) -> list[str]:
+    segments = res_path_segments(res_path)
+    return [
+        segment
+        for segment in segments
+        if not is_snake_case_path_segment(segment)
+    ]
+
+
+def _collision_safe_path(res_path: str, index: int) -> str:
+    if index == 0:
+        return snake_case_res_path(res_path)
+    snake_path = snake_case_res_path(res_path)
+    stem, extension = os.path.splitext(snake_path)
+    return f"{stem}_{index + 1}{extension}"
+
+
+def _relative_source_path(path: str | None, gm_project_path: str) -> str:
+    if not path:
+        return ""
+    try:
+        return os.path.relpath(path, gm_project_path).replace(os.sep, "/")
+    except ValueError:
+        return path.replace(os.sep, "/")
+
+
+def _sha256_file(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()

--- a/src/conversion/converter.py
+++ b/src/conversion/converter.py
@@ -14,6 +14,7 @@ from src.conversion.rooms import RoomConverter
 from src.conversion.shaders import ShaderConverter
 from src.conversion.included_files import IncludedFilesConverter
 from src.conversion.project_settings import ProjectSettingsConverter
+from src.conversion.conversion_manifest import write_conversion_manifest
 from src.conversion.diagnostics import DiagnosticCollector, write_conversion_diagnostic_reports
 from src.conversion.type_defs import BoolSetting, LogCallback, ProgressCallback
 
@@ -159,6 +160,14 @@ class Converter:
             ).convert_all(), "Console_Convertor_AssetRegistry"),
         ]
 
+        enabled_converters = tuple(
+            sorted(
+                key
+                for key, setting in settings.items()
+                if key != "sound_group_folders" and setting.get()
+            )
+        )
+
         try:
             for setting_key, converter_fn, log_key in converters:
                 setting = settings.get(setting_key)
@@ -170,3 +179,9 @@ class Converter:
                     self.progress_callback(0)
         finally:
             write_conversion_diagnostic_reports(godot_path, self.diagnostics)
+            write_conversion_manifest(
+                gm_path,
+                godot_path,
+                target_platform=gm_platform,
+                enabled_converters=enabled_converters,
+            )

--- a/src/conversion/generated_paths.py
+++ b/src/conversion/generated_paths.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import os
+import re
+
+
+_CAMEL_ACRONYM_BOUNDARY_RE = re.compile(r"([A-Z]+)([A-Z][a-z])")
+_CAMEL_BOUNDARY_RE = re.compile(r"([a-z0-9])([A-Z])")
+_UNSAFE_SEGMENT_RE = re.compile(r"[^0-9A-Za-z]+")
+_SNAKE_SEGMENT_RE = re.compile(r"^[a-z_][a-z0-9_]*$")
+
+
+def generated_path_segment(value: str, fallback: str = "resource") -> str:
+    """Return a deterministic Godot-friendly path segment."""
+    separated = _CAMEL_ACRONYM_BOUNDARY_RE.sub(r"\1_\2", value)
+    separated = _CAMEL_BOUNDARY_RE.sub(r"\1_\2", separated)
+    segment = _UNSAFE_SEGMENT_RE.sub("_", separated).strip("_").lower()
+    segment = re.sub(r"_+", "_", segment)
+    if not segment:
+        segment = fallback
+    if segment[0].isdigit():
+        segment = "_" + segment
+    return segment
+
+
+def generated_resource_stem(name: str) -> str:
+    return generated_path_segment(name, "resource")
+
+
+def generated_subfolder_path(subfolder: str) -> str:
+    return "/".join(
+        generated_path_segment(segment, "folder")
+        for segment in subfolder.replace("\\", "/").split("/")
+        if segment
+    )
+
+
+def generated_nested_resource_path(
+    kind: str,
+    subfolder: str,
+    name: str,
+    extension: str,
+    *,
+    suffix: str = "",
+) -> str:
+    stem = generated_resource_stem(name) + suffix
+    parts = [kind]
+    parts.extend(part for part in generated_subfolder_path(subfolder).split("/") if part)
+    parts.extend([stem, stem + extension])
+    return "res://" + "/".join(parts)
+
+
+def generated_flat_resource_path(
+    kind: str,
+    subfolder: str,
+    name: str,
+    extension: str,
+    *,
+    suffix: str = "",
+) -> str:
+    stem = generated_resource_stem(name) + suffix
+    parts = [kind]
+    parts.extend(part for part in generated_subfolder_path(subfolder).split("/") if part)
+    parts.append(stem + extension)
+    return "res://" + "/".join(parts)
+
+
+def generated_resource_directory(
+    root: str,
+    subfolder: str,
+    name: str,
+    *,
+    suffix: str = "",
+) -> str:
+    parts = [root]
+    parts.extend(part for part in generated_subfolder_path(subfolder).split("/") if part)
+    parts.append(generated_resource_stem(name) + suffix)
+    return os.path.join(*parts)
+
+
+def res_path_segments(res_path: str) -> list[str]:
+    path = res_path[len("res://"):] if res_path.startswith("res://") else res_path
+    return [segment for segment in path.split("/") if segment]
+
+
+def is_snake_case_path_segment(segment: str) -> bool:
+    stem, extension = os.path.splitext(segment)
+    if not stem:
+        return False
+    if extension and extension != extension.lower():
+        return False
+    return _SNAKE_SEGMENT_RE.fullmatch(stem) is not None
+
+
+def snake_case_res_path(res_path: str) -> str:
+    prefix = "res://" if res_path.startswith("res://") else ""
+    return prefix + "/".join(_snake_case_file_segment(segment) for segment in res_path_segments(res_path))
+
+
+def _snake_case_file_segment(segment: str) -> str:
+    stem, extension = os.path.splitext(segment)
+    if not extension:
+        return generated_path_segment(segment)
+    return generated_path_segment(stem) + extension.lower()

--- a/src/conversion/godot_validation.py
+++ b/src/conversion/godot_validation.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from typing import Literal, TypeAlias
+
+from src.conversion.type_defs import JsonDict
+
+GODOT_VALIDATION_REPORT_RELATIVE_PATH = os.path.join(
+    "gm2godot", "godot_validation_report.json"
+)
+GodotValidationStatus: TypeAlias = Literal["passed", "failed", "skipped"]
+_LOADABLE_EXTENSIONS = (".gd", ".gdshader", ".tscn", ".tres")
+
+
+@dataclass(frozen=True)
+class GodotValidationReport:
+    status: GodotValidationStatus
+    godot_binary: str
+    project_path: str
+    resource_paths: tuple[str, ...]
+    returncode: int | None = None
+    output: str = ""
+    message: str = ""
+
+    def to_dict(self) -> JsonDict:
+        return {
+            "format_version": 1,
+            "status": self.status,
+            "godot_binary": self.godot_binary,
+            "project_path": self.project_path,
+            "resource_count": len(self.resource_paths),
+            "resource_paths": list(self.resource_paths),
+            "returncode": self.returncode,
+            "output": self.output,
+            "message": self.message,
+        }
+
+
+def find_godot_binary(explicit_path: str | None = None) -> str | None:
+    if explicit_path and os.path.isfile(explicit_path):
+        return explicit_path
+
+    env_path = os.environ.get("GODOT_BIN")
+    if env_path and os.path.isfile(env_path):
+        return env_path
+
+    path_binary = shutil.which("godot")
+    if path_binary is not None:
+        return path_binary
+
+    for candidate in (
+        "/Applications/Godot.app/Contents/MacOS/Godot",
+        "/tmp/godot-4.4.1-macos/Godot.app/Contents/MacOS/Godot",
+    ):
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def validate_generated_godot_project(
+    godot_project_path: str,
+    *,
+    godot_binary: str | None = None,
+    timeout: int = 60,
+) -> GodotValidationReport:
+    resolved_binary = find_godot_binary(godot_binary)
+    resource_paths = generated_godot_resource_paths(godot_project_path)
+    if resolved_binary is None:
+        return GodotValidationReport(
+            status="skipped",
+            godot_binary="",
+            project_path=godot_project_path,
+            resource_paths=resource_paths,
+            message="Godot binary not found; set GODOT_BIN or pass --godot-bin to run generated resource validation.",
+        )
+
+    if not os.path.isfile(os.path.join(godot_project_path, "project.godot")):
+        return GodotValidationReport(
+            status="failed",
+            godot_binary=resolved_binary,
+            project_path=godot_project_path,
+            resource_paths=resource_paths,
+            message="project.godot is missing; generated resources cannot be loaded through Godot.",
+        )
+
+    script = _validation_script(resource_paths)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        script_path = os.path.join(temp_dir, "gm2godot_validate.gd")
+        with open(script_path, "w", encoding="utf-8") as script_file:
+            script_file.write(script)
+        try:
+            result = subprocess.run(
+                [
+                    resolved_binary,
+                    "--headless",
+                    "--path",
+                    godot_project_path,
+                    "--script",
+                    script_path,
+                ],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            output = exc.output.decode("utf-8", errors="replace") if isinstance(exc.output, bytes) else str(exc.output or "")
+            return GodotValidationReport(
+                status="failed",
+                godot_binary=resolved_binary,
+                project_path=godot_project_path,
+                resource_paths=resource_paths,
+                output=output,
+                message=f"Headless Godot validation timed out after {timeout} seconds.",
+            )
+
+    return GodotValidationReport(
+        status="passed" if result.returncode == 0 else "failed",
+        godot_binary=resolved_binary,
+        project_path=godot_project_path,
+        resource_paths=resource_paths,
+        returncode=result.returncode,
+        output=result.stdout,
+        message=(
+            f"Headless Godot validation loaded {len(resource_paths)} generated resources."
+            if result.returncode == 0
+            else "Headless Godot validation failed while loading generated scripts/scenes/resources."
+        ),
+    )
+
+
+def write_godot_validation_report(
+    godot_project_path: str,
+    report: GodotValidationReport,
+) -> str:
+    report_path = os.path.join(godot_project_path, GODOT_VALIDATION_REPORT_RELATIVE_PATH)
+    os.makedirs(os.path.dirname(report_path), exist_ok=True)
+    with open(report_path, "w", encoding="utf-8") as report_file:
+        json.dump(report.to_dict(), report_file, indent=2, sort_keys=True)
+        report_file.write("\n")
+    return report_path
+
+
+def generated_godot_resource_paths(godot_project_path: str) -> tuple[str, ...]:
+    resource_paths: list[str] = []
+    if not os.path.isdir(godot_project_path):
+        return ()
+    for root, dirs, files in os.walk(godot_project_path):
+        dirs[:] = sorted(directory for directory in dirs if directory != ".godot")
+        for filename in sorted(files):
+            if not filename.endswith(_LOADABLE_EXTENSIONS):
+                continue
+            full_path = os.path.join(root, filename)
+            relative_path = os.path.relpath(full_path, godot_project_path).replace(os.sep, "/")
+            resource_paths.append("res://" + relative_path)
+    return tuple(sorted(resource_paths))
+
+
+def _validation_script(resource_paths: tuple[str, ...]) -> str:
+    resource_json = json.dumps(list(resource_paths), indent=2)
+    return (
+        "extends SceneTree\n\n"
+        f"const RESOURCE_PATHS = {resource_json}\n\n"
+        "func _initialize():\n"
+        "\tvar failures = []\n"
+        "\tfor resource_path in RESOURCE_PATHS:\n"
+        "\t\tvar resource = ResourceLoader.load(resource_path)\n"
+        "\t\tif resource == null:\n"
+        "\t\t\tfailures.append(resource_path)\n"
+        "\tif failures.is_empty():\n"
+        "\t\tprint(\"GM2GODOT_VALIDATION_OK \" + str(RESOURCE_PATHS.size()))\n"
+        "\t\tquit(0)\n"
+        "\t\treturn\n"
+        "\tfor failure in failures:\n"
+        "\t\tpush_error(\"GM2Godot generated resource failed to load: \" + str(failure))\n"
+        "\tquit(1)\n"
+    )

--- a/src/conversion/objects.py
+++ b/src/conversion/objects.py
@@ -10,6 +10,11 @@ from src.conversion.base_converter import BaseConverter
 from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.events.base import EventMapping
 from src.conversion.event_mapping import is_input_event, map_event, map_input_event
+from src.conversion.generated_paths import (
+    generated_nested_resource_path,
+    generated_resource_directory,
+    generated_resource_stem,
+)
 from src.conversion.gml_runtime import write_gml_runtime
 from src.conversion.gml_transpiler import (
     GMLSourceMap,
@@ -190,9 +195,7 @@ class ObjectConverter(BaseConverter):
         return None
 
     def _object_script_res_path(self, object_name: str, subfolder: str = "") -> str:
-        if subfolder:
-            return f"res://objects/{subfolder}/{object_name}/{object_name}.gd"
-        return f"res://objects/{object_name}/{object_name}.gd"
+        return generated_nested_resource_path("objects", subfolder, object_name, ".gd")
 
     def _get_object_subfolder(self, object_name: str) -> str:
         yy_path = os.path.join(self.gm_project_path, 'objects', object_name, object_name + '.yy')
@@ -205,10 +208,8 @@ class ObjectConverter(BaseConverter):
 
     def _sprite_scene_exists(self, sprite_name: str, sprite_subfolder: str = "") -> bool:
         """Check whether the converted sprite scene exists in the Godot project."""
-        if sprite_subfolder:
-            tscn_path = os.path.join(self.godot_project_path, 'sprites', sprite_subfolder, sprite_name, sprite_name + '.tscn')
-        else:
-            tscn_path = os.path.join(self.godot_project_path, 'sprites', sprite_name, sprite_name + '.tscn')
+        relative_path = generated_nested_resource_path("sprites", sprite_subfolder, sprite_name, ".tscn")[len("res://"):]
+        tscn_path = os.path.join(self.godot_project_path, *relative_path.split("/"))
         return os.path.isfile(tscn_path)
 
     def _get_available_sprite_scene_paths(self) -> dict[str, str]:
@@ -252,10 +253,7 @@ class ObjectConverter(BaseConverter):
         if has_sprite:
             sprite_id = str(next_id)
             next_id += 1
-            if sprite_subfolder:
-                sprite_path = f"res://sprites/{sprite_subfolder}/{sprite_name}/{sprite_name}.tscn"
-            else:
-                sprite_path = f"res://sprites/{sprite_name}/{sprite_name}.tscn"
+            sprite_path = generated_nested_resource_path("sprites", sprite_subfolder, sprite_name or "sprite", ".tscn")
             parts.append(f'\n[ext_resource type="PackedScene" path="{sprite_path}" id="{sprite_id}"]\n')
 
         if has_script:
@@ -463,10 +461,7 @@ class ObjectConverter(BaseConverter):
                     object_name=object_name, sprite_name=sprite_name))
                 sprite_name = None
 
-        if subfolder:
-            object_dir = os.path.join(self.godot_objects_path, subfolder, object_name)
-        else:
-            object_dir = os.path.join(self.godot_objects_path, object_name)
+        object_dir = generated_resource_directory(self.godot_objects_path, subfolder, object_name)
         script_res_path = self._object_script_res_path(object_name, subfolder)
 
         code_bodies, instance_variables, event_source_maps = self._load_event_code_bodies(
@@ -497,11 +492,12 @@ class ObjectConverter(BaseConverter):
 
         os.makedirs(object_dir, exist_ok=True)
 
-        tscn_path = os.path.join(object_dir, f"{object_name}.tscn")
+        object_stem = generated_resource_stem(object_name)
+        tscn_path = os.path.join(object_dir, f"{object_stem}.tscn")
         with open(tscn_path, 'w', encoding='utf-8') as f:
             f.write(scene_content)
 
-        gd_path = os.path.join(object_dir, f"{object_name}.gd")
+        gd_path = os.path.join(object_dir, f"{object_stem}.gd")
         with open(gd_path, 'w', encoding='utf-8') as f:
             f.write(script_content)
         self._write_object_source_map(gd_path, script_content, code_bodies, event_source_maps)

--- a/src/conversion/resource_index.py
+++ b/src/conversion/resource_index.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field, replace
 from typing import Any, ClassVar, cast
 
 from src.conversion.base_converter import BaseConverter
+from src.conversion.generated_paths import generated_nested_resource_path
 from src.conversion.project_manifest import (
     GameMakerProjectManifest,
     ProjectResourceReference,
@@ -126,6 +127,7 @@ class GameMakerResourceIndex(BaseConverter):
 
         if self.yyp_data is not None:
             self._index_yyp_resources()
+            self._stabilize_resource_paths()
             self._parse_indexed_rooms()
             self._apply_yyp_room_order(self.yyp_data)
             self._resolve_room_inheritance()
@@ -139,6 +141,7 @@ class GameMakerResourceIndex(BaseConverter):
                     "No GameMaker project .yyp found; falling back to disk scan."
                 )
             self._index_disk_resources()
+            self._stabilize_resource_paths()
             self._parse_indexed_rooms()
             self._resolve_room_inheritance()
             self.used_room_order_fallback = True
@@ -641,15 +644,35 @@ class GameMakerResourceIndex(BaseConverter):
             tags=resource_ref.tags if resource_ref is not None else (),
         )
 
+    def _stabilize_resource_paths(self) -> None:
+        used_paths: set[str] = set()
+        for kind in self.RESOURCE_EXTENSIONS:
+            resources = self.resources.get(kind, {})
+            for name in sorted(resources):
+                resource = resources[name]
+                suffix_index = 0
+                while True:
+                    suffix = "" if suffix_index == 0 else f"_{suffix_index + 1}"
+                    path = self.godot_res_path(kind, name, resource.subfolder, suffix=suffix)
+                    folded_path = path.casefold()
+                    if folded_path not in used_paths:
+                        break
+                    suffix_index += 1
+                used_paths.add(folded_path)
+                resources[name] = replace(resource, godot_path=path)
+
     @classmethod
-    def godot_res_path(cls, kind: str, name: str, subfolder: str = "") -> str:
+    def godot_res_path(
+        cls,
+        kind: str,
+        name: str,
+        subfolder: str = "",
+        *,
+        suffix: str = "",
+    ) -> str:
         """Build a generated res:// path using existing converter conventions."""
         extension = cls.RESOURCE_EXTENSIONS[kind]
-        path_parts = ["res:/", kind]
-        if subfolder:
-            path_parts.extend(part for part in subfolder.split("/") if part)
-        path_parts.extend([name, name + extension])
-        return "/".join(path_parts)
+        return generated_nested_resource_path(kind, subfolder, name, extension, suffix=suffix)
 
     @staticmethod
     def _kind_from_yyp_path(yyp_path: str) -> str:

--- a/src/conversion/runtime_managers.md
+++ b/src/conversion/runtime_managers.md
@@ -19,6 +19,8 @@ The generated autoloads are:
 
 The CLI static report pipeline writes `gm2godot/platform_capability_report.json` and `.md`. These reports list target-specific permission, export-preset, and optional plugin checks for browser hooks, mobile microphone/camera/sensor APIs, Steam, IAP, cloud, push notifications, Xbox Live, and live wallpaper integrations.
 
+Converted projects also receive `gm2godot/conversion_manifest.json`, a deterministic generated-output manifest with resource source paths, generated Godot paths, source-map files, file hashes, and diagnostics for path collisions that required stable generated suffixes. `GM2Godot validate` can write `gm2godot/godot_validation_report.json` by loading generated `.gd`, `.tscn`, `.tres`, and `.gdshader` resources through headless Godot when `GODOT_BIN` or `--godot-bin` is available.
+
 The `GMRuntime` autoload records each manager in `manager_registry_snapshot()` and exposes `manager_order()`. Each manager owns named state buckets so future runtime slices can move domain state out of the static compatibility facade without changing generated GML helper call sites.
 
 Collision events are dispatched by the central scheduler after motion/path updates and before End Step, matching the relevant GameMaker event-order window: https://manual.gamemaker.io/monthly/en/The_Asset_Editors/Object_Properties/Event_Order.htm. Dispatch uses generated Godot collision shape bounds, which aligns with Godot's 2D physics shape model: https://docs.godotengine.org/en/stable/tutorials/physics/physics_introduction.html. Pixel-perfect precise masks remain reported as a runtime fidelity limitation through the existing precise-collision warning path.

--- a/src/conversion/shaders.py
+++ b/src/conversion/shaders.py
@@ -5,6 +5,7 @@ import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from src.conversion.base_converter import BaseConverter
+from src.conversion.generated_paths import generated_resource_stem, generated_subfolder_path
 from src.conversion.type_defs import ConversionRunning, LogCallback, ProgressCallback, StrPath
 from src.localization import get_localized
 
@@ -65,11 +66,13 @@ class ShaderConverter(BaseConverter):
         if not self.conversion_running():
             return None
         filename = os.path.basename(input_path)
-        output_name = os.path.splitext(filename)[0] + '.gdshader'
-        if subfolder:
-            output_dir = os.path.join(self.godot_shaders_path, subfolder)
-        else:
-            output_dir = self.godot_shaders_path
+        output_name = generated_resource_stem(os.path.splitext(filename)[0]) + '.gdshader'
+        safe_subfolder = generated_subfolder_path(subfolder)
+        output_dir = (
+            os.path.join(self.godot_shaders_path, *safe_subfolder.split("/"))
+            if safe_subfolder
+            else self.godot_shaders_path
+        )
         os.makedirs(output_dir, exist_ok=True)
         output_path = os.path.join(output_dir, output_name)
         self.convert_shader(input_path, output_path)

--- a/src/conversion/sounds.py
+++ b/src/conversion/sounds.py
@@ -10,6 +10,7 @@ from typing import TypedDict, cast
 # Import localization manager
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
+from src.conversion.generated_paths import generated_path_segment, generated_resource_stem, generated_subfolder_path
 from src.conversion.type_defs import ConversionRunning, JsonDict, LogCallback, ProgressCallback, StrPath
 
 
@@ -87,12 +88,13 @@ class SoundConverter(BaseConverter):
         output_parts: list[str] = []
 
         if self.organize_by_audio_group:
-            output_parts.append(audio_group or 'audiogroup_default')
+            output_parts.append(generated_path_segment(audio_group or 'audiogroup_default', 'audiogroup_default'))
 
-        if subfolder:
-            output_parts.extend(part for part in subfolder.split('/') if part)
+        safe_subfolder = generated_subfolder_path(subfolder)
+        if safe_subfolder:
+            output_parts.extend(part for part in safe_subfolder.split('/') if part)
 
-        output_parts.append(sound_name)
+        output_parts.append(generated_resource_stem(sound_name))
 
         output_dir = os.path.join(self.godot_sounds_path, *output_parts)
         res_subfolder = '/'.join(output_parts)

--- a/src/conversion/sprites.py
+++ b/src/conversion/sprites.py
@@ -10,6 +10,7 @@ from typing import TypedDict, cast
 
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
+from src.conversion.generated_paths import generated_nested_resource_path, generated_resource_directory, generated_resource_stem
 from src.conversion.type_defs import ConversionRunning, JsonDict, LogCallback, ProgressCallback, StrPath
 
 
@@ -82,9 +83,8 @@ class SpriteConverter(BaseConverter):
     @staticmethod
     def _sprite_res_path(subfolder: str, sprite_name: str) -> str:
         """Build a res://sprites/... path, avoiding double slashes."""
-        if subfolder:
-            return f"res://sprites/{subfolder}/{sprite_name}"
-        return f"res://sprites/{sprite_name}"
+        scene_path = generated_nested_resource_path("sprites", subfolder, sprite_name, ".tscn")
+        return scene_path.rsplit("/", 1)[0]
 
     def _find_all_sprite_images(self) -> defaultdict[str, list[str]]:
         sprite_folder = os.path.join(self.gm_project_path, 'sprites')
@@ -318,9 +318,10 @@ class SpriteConverter(BaseConverter):
 
         tscn_content = ''.join(parts)
 
-        tscn_dir = os.path.join(self.godot_sprites_path, subfolder, sprite_name) if subfolder else os.path.join(self.godot_sprites_path, sprite_name)
+        sprite_stem = generated_resource_stem(sprite_name)
+        tscn_dir = generated_resource_directory(self.godot_sprites_path, subfolder, sprite_name)
         os.makedirs(tscn_dir, exist_ok=True)
-        tscn_path = os.path.join(tscn_dir, f"{sprite_name}.tscn")
+        tscn_path = os.path.join(tscn_dir, f"{sprite_stem}.tscn")
         with open(tscn_path, 'w', encoding='utf-8') as f:
             f.write(tscn_content)
 
@@ -374,9 +375,10 @@ class SpriteConverter(BaseConverter):
 
         tscn_content = ''.join(parts)
 
-        tscn_dir = os.path.join(self.godot_sprites_path, subfolder, sprite_name) if subfolder else os.path.join(self.godot_sprites_path, sprite_name)
+        sprite_stem = generated_resource_stem(sprite_name)
+        tscn_dir = generated_resource_directory(self.godot_sprites_path, subfolder, sprite_name)
         os.makedirs(tscn_dir, exist_ok=True)
-        tscn_path = os.path.join(tscn_dir, f"{sprite_name}.tscn")
+        tscn_path = os.path.join(tscn_dir, f"{sprite_stem}.tscn")
         with open(tscn_path, 'w', encoding='utf-8') as f:
             f.write(tscn_content)
 
@@ -458,8 +460,9 @@ class SpriteConverter(BaseConverter):
         if not self.conversion_running():
             return None
 
-        new_filename = f"{sprite_name}_{index}.png" if images_count > 1 else f"{sprite_name}.png"
-        sprite_dir = os.path.join(self.godot_sprites_path, subfolder, sprite_name) if subfolder else os.path.join(self.godot_sprites_path, sprite_name)
+        sprite_stem = generated_resource_stem(sprite_name)
+        new_filename = f"{sprite_stem}_{index}.png" if images_count > 1 else f"{sprite_stem}.png"
+        sprite_dir = generated_resource_directory(self.godot_sprites_path, subfolder, sprite_name)
         godot_sprite_path = os.path.join(sprite_dir, new_filename)
 
         if len(gm_sprite_paths) == 1:
@@ -507,7 +510,7 @@ class SpriteConverter(BaseConverter):
         # Pre-create all sprite directories
         for sprite_name in sprite_images:
             subfolder = sprite_subfolders.get(sprite_name, "")
-            sprite_dir = os.path.join(self.godot_sprites_path, subfolder, sprite_name) if subfolder else os.path.join(self.godot_sprites_path, sprite_name)
+            sprite_dir = generated_resource_directory(self.godot_sprites_path, subfolder, sprite_name)
             os.makedirs(sprite_dir, exist_ok=True)
 
         # Flatten all work items

--- a/src/conversion/tilesets.py
+++ b/src/conversion/tilesets.py
@@ -9,6 +9,11 @@ from typing import Literal, NotRequired, TypedDict, cast
 
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
+from src.conversion.generated_paths import (
+    generated_nested_resource_path,
+    generated_resource_directory,
+    generated_resource_stem,
+)
 from src.conversion.type_defs import ConversionRunning, JsonDict, LogCallback, ProgressCallback, StrPath
 
 
@@ -186,10 +191,7 @@ class TileSetConverter(BaseConverter):
         tilexoff = tileset_data["tilexoff"]
         tileyoff = tileset_data["tileyoff"]
 
-        if subfolder:
-            res_path = f"res://tilesets/{subfolder}/{tileset_name}/{tileset_name}.png"
-        else:
-            res_path = f"res://tilesets/{tileset_name}/{tileset_name}.png"
+        res_path = generated_nested_resource_path("tilesets", subfolder, tileset_name, ".png")
 
         lines: list[str] = []
         lines.append('[gd_resource type="TileSet" format=3]')
@@ -258,19 +260,17 @@ class TileSetConverter(BaseConverter):
                     "sprite_name": sprite_name}
 
         # Create output directory
-        if subfolder:
-            output_dir = os.path.join(self.godot_tilesets_path, subfolder, tileset_name)
-        else:
-            output_dir = os.path.join(self.godot_tilesets_path, tileset_name)
+        output_dir = generated_resource_directory(self.godot_tilesets_path, subfolder, tileset_name)
         os.makedirs(output_dir, exist_ok=True)
 
         # Copy the sprite image as the tileset texture
-        dest_image = os.path.join(output_dir, tileset_name + '.png')
+        tileset_stem = generated_resource_stem(tileset_name)
+        dest_image = os.path.join(output_dir, tileset_stem + '.png')
         shutil.copy2(image_path, dest_image)
 
         # Generate and write the .tres file
         tres_content = self._generate_tileset_tres(tileset_name, tileset_data, subfolder)
-        tres_path = os.path.join(output_dir, tileset_name + '.tres')
+        tres_path = os.path.join(output_dir, tileset_stem + '.tres')
         with open(tres_path, 'w', encoding='utf-8') as f:
             f.write(tres_content)
         self._warn_preserved_metadata(tileset_name, tileset_data)

--- a/tests/fixtures/golden/basic_scripts/expected_snapshot.json
+++ b/tests/fixtures/golden/basic_scripts/expected_snapshot.json
@@ -1,9 +1,9 @@
 {
   "files": {
-    "gm2godot/gml_script_registry.gd": "extends RefCounted\n\nstatic func gml_script_registry_entries():\n\treturn [\n\t\t{\n\t\t\t\"id\": 179646376,\n\t\t\t\"name\": \"scr_add\",\n\t\t\t\"callable\": preload(\"res://scripts/Game/scr_add.gd\").new().gm2godot_callable(),\n\t\t\t\"legacy_arguments\": true,\n\t\t},\n\t\t{\n\t\t\t\"id\": 950140064,\n\t\t\t\"name\": \"scr_stats\",\n\t\t\t\"callable\": preload(\"res://scripts/Game/scr_stats.gd\").new().gm2godot_callable(),\n\t\t\t\"legacy_arguments\": false,\n\t\t},\n\t]\n",
+    "gm2godot/gml_script_registry.gd": "extends RefCounted\n\nstatic func gml_script_registry_entries():\n\treturn [\n\t\t{\n\t\t\t\"id\": 179646376,\n\t\t\t\"name\": \"scr_add\",\n\t\t\t\"callable\": preload(\"res://scripts/game/scr_add.gd\").new().gm2godot_callable(),\n\t\t\t\"legacy_arguments\": true,\n\t\t},\n\t\t{\n\t\t\t\"id\": 950140064,\n\t\t\t\"name\": \"scr_stats\",\n\t\t\t\"callable\": preload(\"res://scripts/game/scr_stats.gd\").new().gm2godot_callable(),\n\t\t\t\"legacy_arguments\": false,\n\t\t},\n\t]\n",
     "project.godot": "[application]\nconfig/name=\"Golden Fixture\"\n\n[autoload]\nGMRuntime=\"*res://gm2godot/managers/gm_runtime_manager.gd\"\nGMAssets=\"*res://gm2godot/managers/gm_assets.gd\"\nGMRooms=\"*res://gm2godot/managers/gm_rooms.gd\"\nGMInstances=\"*res://gm2godot/managers/gm_instances.gd\"\nGMEvents=\"*res://gm2godot/managers/gm_events.gd\"\nGMDraw=\"*res://gm2godot/managers/gm_draw.gd\"\nGMInput=\"*res://gm2godot/managers/gm_input.gd\"\nGMAudio=\"*res://gm2godot/managers/gm_audio.gd\"\nGMAsync=\"*res://gm2godot/managers/gm_async.gd\"\nGMPlatform=\"*res://gm2godot/managers/gm_platform.gd\"\n",
-    "scripts/Game/scr_add.gd": "extends RefCounted\n\n# GM2Godot source: <GM_PROJECT>/scripts/scr_add/scr_add.gml\n# GM2Godot event: script:scr_add\n\nconst GMRuntime = preload(\"res://gm2godot/gml_runtime.gd\")\n\nfunc _gm_script_call():\n\treturn GMRuntime.gml_add(GMRuntime.gml_argument(0), GMRuntime.gml_argument(1))\n\treturn GMRuntime.gml_undefined()\n\nfunc gm2godot_callable():\n\treturn GMRuntime.gml_method(self, Callable(self, \"_gm_script_call\"))\n",
-    "scripts/Game/scr_stats.gd": "extends RefCounted\n\n# GM2Godot source: <GM_PROJECT>/scripts/scr_stats/scr_stats.gml\n# GM2Godot event: script:scr_stats\n\nconst GMRuntime = preload(\"res://gm2godot/gml_runtime.gd\")\n\nfunc _gm_script_call(a = null, b = null):\n\tif a == null: a = GMRuntime.gml_undefined()\n\tif b == null or GMRuntime.is_undefined(b): b = 4\n\tvar values = [a]\n\tGMRuntime.gml_array_push(values, [GMRuntime.gml_min([4, 1, 2]), GMRuntime.gml_max([4, 1, 2]), GMRuntime.gml_choose([7, 8, 9])])\n\treturn GMRuntime.gml_add(GMRuntime.gml_add(GMRuntime.gml_add(GMRuntime.gml_array_get(values, 0), GMRuntime.gml_array_get(values, 1)), GMRuntime.gml_array_get(values, 2)), b)\n\treturn GMRuntime.gml_undefined()\n\nfunc gm2godot_callable():\n\treturn GMRuntime.gml_method(self, Callable(self, \"_gm_script_call\"))\n"
+    "scripts/game/scr_add.gd": "extends RefCounted\n\n# GM2Godot source: <GM_PROJECT>/scripts/scr_add/scr_add.gml\n# GM2Godot event: script:scr_add\n\nconst GMRuntime = preload(\"res://gm2godot/gml_runtime.gd\")\n\nfunc _gm_script_call():\n\treturn GMRuntime.gml_add(GMRuntime.gml_argument(0), GMRuntime.gml_argument(1))\n\treturn GMRuntime.gml_undefined()\n\nfunc gm2godot_callable():\n\treturn GMRuntime.gml_method(self, Callable(self, \"_gm_script_call\"))\n",
+    "scripts/game/scr_stats.gd": "extends RefCounted\n\n# GM2Godot source: <GM_PROJECT>/scripts/scr_stats/scr_stats.gml\n# GM2Godot event: script:scr_stats\n\nconst GMRuntime = preload(\"res://gm2godot/gml_runtime.gd\")\n\nfunc _gm_script_call(a = null, b = null):\n\tif a == null: a = GMRuntime.gml_undefined()\n\tif b == null or GMRuntime.is_undefined(b): b = 4\n\tvar values = [a]\n\tGMRuntime.gml_array_push(values, [GMRuntime.gml_min([4, 1, 2]), GMRuntime.gml_max([4, 1, 2]), GMRuntime.gml_choose([7, 8, 9])])\n\treturn GMRuntime.gml_add(GMRuntime.gml_add(GMRuntime.gml_add(GMRuntime.gml_array_get(values, 0), GMRuntime.gml_array_get(values, 1)), GMRuntime.gml_array_get(values, 2)), b)\n\treturn GMRuntime.gml_undefined()\n\nfunc gm2godot_callable():\n\treturn GMRuntime.gml_method(self, Callable(self, \"_gm_script_call\"))\n"
   },
   "fixture": "basic_scripts",
   "hashes": {
@@ -45,7 +45,7 @@
         "warning": 0
       }
     },
-    "scripts/Game/scr_add.gd.gmlmap.json": {
+    "scripts/game/scr_add.gd.gmlmap.json": {
       "entries": [
         {
           "event": "script:scr_add",
@@ -61,7 +61,7 @@
       "source_path": "<GM_PROJECT>/scripts/scr_add/scr_add.gml",
       "version": 1
     },
-    "scripts/Game/scr_stats.gd.gmlmap.json": {
+    "scripts/game/scr_stats.gd.gmlmap.json": {
       "entries": [
         {
           "event": "script:scr_stats",

--- a/tests/test_asset_registry.py
+++ b/tests/test_asset_registry.py
@@ -217,7 +217,7 @@ class TestAssetRegistryConverter(unittest.TestCase):
         by_name = {entry.name: entry for entry in entries}
 
         self.assertEqual(by_name["s_player"].asset_type, "sprite")
-        self.assertEqual(by_name["s_player"].godot_path, "res://sprites/Actors/s_player/s_player.tscn")
+        self.assertEqual(by_name["s_player"].godot_path, "res://sprites/actors/s_player/s_player.tscn")
         self.assertEqual(by_name["s_player"].tags, ("player", "visible"))
         sprite_metadata = by_name["s_player"].metadata
         self.assertIsNotNone(sprite_metadata)
@@ -226,7 +226,7 @@ class TestAssetRegistryConverter(unittest.TestCase):
         self.assertEqual(by_name["snd_jump"].asset_type, "sound")
         self.assertEqual(
             by_name["snd_jump"].godot_path,
-            "res://sounds/audio_sfx/SFX/snd_jump/snd_jump.ogg",
+            "res://sounds/audio_sfx/sfx/snd_jump/snd_jump.ogg",
         )
         sound_metadata = by_name["snd_jump"].metadata
         self.assertIsNotNone(sound_metadata)
@@ -234,7 +234,7 @@ class TestAssetRegistryConverter(unittest.TestCase):
         self.assertEqual(sound_metadata["audio_group"], "audio_sfx")
         self.assertEqual(sound_metadata["sound_file"], "snd_jump.ogg")
         self.assertEqual(sound_metadata["volume"], 1.0)
-        self.assertEqual(by_name["r_title"].godot_path, "res://rooms/Menus/r_title/r_title.tscn")
+        self.assertEqual(by_name["r_title"].godot_path, "res://rooms/menus/r_title/r_title.tscn")
         room_metadata = by_name["r_title"].metadata
         self.assertIsNotNone(room_metadata)
         assert room_metadata is not None
@@ -242,13 +242,13 @@ class TestAssetRegistryConverter(unittest.TestCase):
         self.assertEqual(room_metadata["width"], 1024)
         self.assertEqual(room_metadata["height"], 768)
         self.assertFalse(room_metadata["persistent"])
-        self.assertEqual(by_name["o_player"].godot_path, "res://objects/Actors/o_player/o_player.tscn")
-        self.assertEqual(by_name["scr_spawn"].godot_path, "res://scripts/Game/scr_spawn.gd")
-        self.assertEqual(by_name["fnt_ui"].godot_path, "res://fonts/UI/fnt_ui.tres")
+        self.assertEqual(by_name["o_player"].godot_path, "res://objects/actors/o_player/o_player.tscn")
+        self.assertEqual(by_name["scr_spawn"].godot_path, "res://scripts/game/scr_spawn.gd")
+        self.assertEqual(by_name["fnt_ui"].godot_path, "res://fonts/ui/fnt_ui.tres")
         self.assertEqual(by_name["path_patrol"].asset_type, "path")
         self.assertEqual(
             by_name["path_patrol"].godot_path,
-            "res://paths/Movement/path_patrol/path_patrol.tscn",
+            "res://paths/movement/path_patrol/path_patrol.tscn",
         )
         self.assertEqual(by_name["ac_fade"].asset_type, "animation_curve")
         self.assertEqual(by_name["seq_intro"].asset_type, "sequence")

--- a/tests/test_base_converter.py
+++ b/tests/test_base_converter.py
@@ -247,11 +247,11 @@ class TestGetSubfolderFromYY(unittest.TestCase):
 
     def test_nested_path(self):
         yy_path = self._write_yy("folders/Sprites/Player/Abilities.yy")
-        self.assertEqual(self.converter._get_subfolder_from_yy(yy_path), "Player/Abilities")
+        self.assertEqual(self.converter._get_subfolder_from_yy(yy_path), "player/abilities")
 
     def test_deeply_nested_path(self):
         yy_path = self._write_yy("folders/Objects/Game/Enemies/Bosses.yy")
-        self.assertEqual(self.converter._get_subfolder_from_yy(yy_path), "Game/Enemies/Bosses")
+        self.assertEqual(self.converter._get_subfolder_from_yy(yy_path), "game/enemies/bosses")
 
     def test_root_level_path(self):
         yy_path = self._write_yy("folders/Sprites.yy")
@@ -259,7 +259,7 @@ class TestGetSubfolderFromYY(unittest.TestCase):
 
     def test_single_subfolder(self):
         yy_path = self._write_yy("folders/Objects/CLASSIC.yy")
-        self.assertEqual(self.converter._get_subfolder_from_yy(yy_path), "CLASSIC")
+        self.assertEqual(self.converter._get_subfolder_from_yy(yy_path), "classic")
 
     def test_missing_parent_field(self):
         yy_path = os.path.join(self.tmp_dir, "no_parent.yy")

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -23,6 +23,7 @@ class TestCIWorkflows(unittest.TestCase):
         self.assertIn("GODOT_VERSION: 4.4.1-stable", content)
         self.assertIn("GODOT_BIN=$godot_bin", content)
         self.assertIn("actions/cache@v4", content)
+        self.assertIn("tests.test_godot_validation", content)
         self.assertIn("tests.test_cameras_display_godot", content)
         self.assertIn("tests.test_room_game_flow_godot", content)
         self.assertIn("tests.test_physics_runtime_godot", content)

--- a/tests/test_conversion_manifest.py
+++ b/tests/test_conversion_manifest.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from typing import cast
+
+from src import cli
+from src.conversion.conversion_manifest import (
+    CONVERSION_MANIFEST_RELATIVE_PATH,
+    build_conversion_manifest,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_ROOT = PROJECT_ROOT / "tests" / "fixtures" / "golden" / "basic_scripts"
+
+
+class TestConversionManifest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = Path(tempfile.mkdtemp())
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.temp_dir)
+
+    def test_convert_emits_deterministic_manifest_with_source_and_path_metadata(self) -> None:
+        godot_dir = self.temp_dir / "godot"
+        godot_dir.mkdir()
+        (godot_dir / "project.godot").write_text(
+            '[application]\nconfig/name="Manifest Fixture"\n',
+            encoding="utf-8",
+        )
+
+        exit_code = cli.main(
+            [
+                "convert",
+                "--gm-project",
+                str(FIXTURE_ROOT),
+                "--godot-project",
+                str(godot_dir),
+                "--target-platform",
+                "windows",
+                "--only",
+                "scripts",
+                "--max-warnings",
+                "0",
+            ]
+        )
+
+        self.assertEqual(exit_code, 0)
+        manifest_path = godot_dir / CONVERSION_MANIFEST_RELATIVE_PATH
+        self.assertTrue(manifest_path.is_file())
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        resources = cast(list[dict[str, object]], manifest["resources"])
+        generated_files = cast(list[dict[str, object]], manifest["generated_files"])
+
+        self.assertEqual(manifest["target_platform"], "windows")
+        self.assertEqual(manifest["enabled_converters"], ["scripts"])
+        self.assertTrue(
+            any(
+                resource["name"] == "scr_add"
+                and resource["source_path"] == "scripts/scr_add/scr_add.yy"
+                and resource["godot_path"] == "res://scripts/game/scr_add.gd"
+                for resource in resources
+            )
+        )
+        self.assertTrue(
+            any(
+                generated["path"] == "scripts/game/scr_add.gd.gmlmap.json"
+                and generated["kind"] == "source_map"
+                for generated in generated_files
+            )
+        )
+        self.assertEqual(manifest["path_diagnostics"], [])
+
+    def test_manifest_reports_collision_safe_generated_paths(self) -> None:
+        gm_dir = self.temp_dir / "gm"
+        godot_dir = self.temp_dir / "godot"
+        gm_dir.mkdir()
+        godot_dir.mkdir()
+        (gm_dir / "CollisionTest.yyp").write_text(
+            json.dumps(
+                {
+                    "resources": [
+                        {"id": {"name": "Scr Spawn", "path": "scripts/Scr Spawn/Scr Spawn.yy"}},
+                        {"id": {"name": "scr_spawn", "path": "scripts/scr_spawn/scr_spawn.yy"}},
+                    ],
+                    "RoomOrderNodes": [],
+                    "resourceType": "GMProject",
+                }
+            ),
+            encoding="utf-8",
+        )
+        for script_name in ("Scr Spawn", "scr_spawn"):
+            script_dir = gm_dir / "scripts" / script_name
+            script_dir.mkdir(parents=True)
+            (script_dir / f"{script_name}.yy").write_text(
+                json.dumps(
+                    {
+                        "%Name": script_name,
+                        "name": script_name,
+                        "parent": {"name": "Scripts", "path": "folders/Scripts.yy"},
+                        "resourceType": "GMScript",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+        manifest = build_conversion_manifest(
+            str(gm_dir),
+            str(godot_dir),
+            target_platform="windows",
+            enabled_converters=["scripts"],
+        )
+        resources = cast(list[dict[str, object]], manifest["resources"])
+
+        self.assertEqual(
+            {
+                str(resource["name"]): str(resource["godot_path"])
+                for resource in resources
+            },
+            {
+                "Scr Spawn": "res://scripts/scr_spawn.gd",
+                "scr_spawn": "res://scripts/scr_spawn_2.gd",
+            },
+        )
+        self.assertTrue(
+            any(
+                diagnostic["code"] == "GM2GD-PATH-COLLISION-RENAMED"
+                for diagnostic in cast(list[dict[str, object]], manifest["path_diagnostics"])
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -388,7 +388,7 @@ class TestFontConverterSubfolders(unittest.TestCase):
         )
         converter.convert_all()
 
-        expected = os.path.join(self.godot_dir, "fonts", "UI", "fnt_ui.tres")
+        expected = os.path.join(self.godot_dir, "fonts", "ui", "fnt_ui.tres")
         self.assertTrue(os.path.isfile(expected),
                         f"Expected font at {expected}")
 

--- a/tests/test_godot_validation.py
+++ b/tests/test_godot_validation.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from src import cli
+from src.conversion.godot_validation import (
+    GODOT_VALIDATION_REPORT_RELATIVE_PATH,
+    find_godot_binary,
+    generated_godot_resource_paths,
+    validate_generated_godot_project,
+)
+
+
+class TestGodotValidation(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = Path(tempfile.mkdtemp())
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.temp_dir)
+
+    def _write_project(self) -> Path:
+        project_dir = self.temp_dir / "godot"
+        project_dir.mkdir()
+        (project_dir / "project.godot").write_text(
+            '[application]\nconfig/name="Validation Fixture"\nrun/main_scene="res://main.tscn"\n',
+            encoding="utf-8",
+        )
+        (project_dir / "main.gd").write_text(
+            "extends Node\n\nfunc _ready():\n\tpass\n",
+            encoding="utf-8",
+        )
+        (project_dir / "main.tscn").write_text(
+            "\n".join(
+                [
+                    "[gd_scene load_steps=2 format=3]",
+                    "",
+                    '[ext_resource type="Script" path="res://main.gd" id="main_script"]',
+                    "",
+                    '[node name="Main" type="Node"]',
+                    'script = ExtResource("main_script")',
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        return project_dir
+
+    def test_resource_path_discovery_is_deterministic(self) -> None:
+        project_dir = self._write_project()
+
+        self.assertEqual(
+            generated_godot_resource_paths(str(project_dir)),
+            ("res://main.gd", "res://main.tscn"),
+        )
+
+    @unittest.skipIf(find_godot_binary() is None, "Godot binary not available")
+    def test_headless_godot_validation_loads_generated_resources(self) -> None:
+        project_dir = self._write_project()
+
+        report = validate_generated_godot_project(str(project_dir))
+
+        self.assertEqual(report.status, "passed", report.output)
+        self.assertIn("GM2GODOT_VALIDATION_OK", report.output)
+        self.assertEqual(report.resource_paths, ("res://main.gd", "res://main.tscn"))
+
+    @unittest.skipIf(find_godot_binary() is None, "Godot binary not available")
+    def test_cli_validate_writes_godot_validation_report(self) -> None:
+        project_dir = self._write_project()
+        (project_dir / "gm2godot").mkdir()
+        (project_dir / "gm2godot" / "conversion_diagnostics.json").write_text(
+            '{"summary":{"info":0,"warning":0,"error":0,"total":0},"diagnostics":[]}\n',
+            encoding="utf-8",
+        )
+
+        exit_code = cli.main(["validate", "--godot-project", str(project_dir)])
+
+        self.assertEqual(exit_code, 0)
+        report_path = project_dir / GODOT_VALIDATION_REPORT_RELATIVE_PATH
+        self.assertTrue(report_path.is_file())
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        self.assertEqual(report["status"], "passed")
+        self.assertEqual(report["resource_count"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_golden_conversion.py
+++ b/tests/test_golden_conversion.py
@@ -71,13 +71,13 @@ def _snapshot_output(godot_dir: Path, gm_project_dir: Path) -> dict[str, object]
     text_files = [
         "project.godot",
         "gm2godot/gml_script_registry.gd",
-        "scripts/Game/scr_add.gd",
-        "scripts/Game/scr_stats.gd",
+        "scripts/game/scr_add.gd",
+        "scripts/game/scr_stats.gd",
     ]
     json_files = [
         "gm2godot/conversion_diagnostics.json",
-        "scripts/Game/scr_add.gd.gmlmap.json",
-        "scripts/Game/scr_stats.gd.gmlmap.json",
+        "scripts/game/scr_add.gd.gmlmap.json",
+        "scripts/game/scr_stats.gd.gmlmap.json",
     ]
     hash_files = [
         "gm2godot/gml_runtime.gd",

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -122,7 +122,7 @@ class TestNoteConverterSubfolders(unittest.TestCase):
         converter = self._make_converter()
         converter.convert_all()
 
-        expected = os.path.join(self.godot_dir, "notes", "Design", "my_note", "my_note.txt")
+        expected = os.path.join(self.godot_dir, "notes", "design", "my_note", "my_note.txt")
         self.assertTrue(os.path.isfile(expected),
                         f"Expected note at {expected}")
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -402,9 +402,9 @@ class TestObjectConverterSubfolders(unittest.TestCase):
         converter = self._make_converter()
         converter.convert_all()
 
-        tscn_path = os.path.join(self.godot_dir, "objects", "Game", "Enemies", "o_boss", "o_boss.tscn")
+        tscn_path = os.path.join(self.godot_dir, "objects", "game", "enemies", "o_boss", "o_boss.tscn")
         self.assertTrue(os.path.isfile(tscn_path),
-                        "Object should be in objects/Game/Enemies/o_boss/")
+                        "Object should be in objects/game/enemies/o_boss/")
 
     def test_object_with_sprite_in_subfolder(self):
         """Object should resolve sprite cross-reference with correct subfolder path."""
@@ -424,7 +424,7 @@ class TestObjectConverterSubfolders(unittest.TestCase):
             f.write(sprite_yy)
 
         # Create converted sprite scene at the subfolder location
-        _create_fake_sprite_scene(self.godot_dir, "s_player", subfolder="Player")
+        _create_fake_sprite_scene(self.godot_dir, "s_player", subfolder="player")
 
         converter = self._make_converter()
         converter.convert_all()
@@ -433,7 +433,7 @@ class TestObjectConverterSubfolders(unittest.TestCase):
         with open(tscn_path, 'r', encoding='utf-8') as f:
             content = f.read()
 
-        self.assertIn('res://sprites/Player/s_player/s_player.tscn', content)
+        self.assertIn('res://sprites/player/s_player/s_player.tscn', content)
 
     def test_root_level_object_stays_flat(self):
         """Object with root-level parent should stay in flat structure."""

--- a/tests/test_resource_index.py
+++ b/tests/test_resource_index.py
@@ -298,19 +298,19 @@ class TestGameMakerResourceIndex(unittest.TestCase):
 
         self.assertEqual(
             index.resolve_godot_path("rooms", "r_intro"),
-            "res://rooms/Game/Intro/r_intro/r_intro.tscn",
+            "res://rooms/game/intro/r_intro/r_intro.tscn",
         )
         self.assertEqual(
             index.resolve_godot_path("objects", "o_player"),
-            "res://objects/Game/Actors/o_player/o_player.tscn",
+            "res://objects/game/actors/o_player/o_player.tscn",
         )
         self.assertEqual(
             index.resolve_godot_path("sprites", "s_player"),
-            "res://sprites/Game/Actors/s_player/s_player.tscn",
+            "res://sprites/game/actors/s_player/s_player.tscn",
         )
         self.assertEqual(
             index.resolve_godot_path("tilesets", "ts_ground"),
-            "res://tilesets/World/ts_ground/ts_ground.tres",
+            "res://tilesets/world/ts_ground/ts_ground.tres",
         )
 
     def test_handles_trailing_commas_in_yyp_and_room_yy(self) -> None:

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -377,8 +377,8 @@ class TestRoomConverter(unittest.TestCase):
         self.assertTrue(os.path.isfile(os.path.join(
             self.godot_dir,
             "rooms",
-            "Game",
-            "Intro",
+            "game",
+            "intro",
             "r_intro",
             "r_intro.tscn",
         )))
@@ -889,7 +889,7 @@ class TestRoomConverter(unittest.TestCase):
     def test_instance_layer_resolves_object_subfolder_path(self):
         self._write_yyp(["r_subfolder"], extra_resources=[("objects", "o_player")])
         self._write_object("o_player", parent_path="folders/Objects/Game/Actors.yy")
-        self._write_object_scene("o_player", "Game", "Actors")
+        self._write_object_scene("o_player", "game", "actors")
         self._write_room("r_subfolder", layers=[
             {
                 "%Name": "Instances",
@@ -902,7 +902,7 @@ class TestRoomConverter(unittest.TestCase):
         content = self._read_scene("r_subfolder")
 
         self.assertIn(
-            'path="res://objects/Game/Actors/o_player/o_player.tscn"',
+            'path="res://objects/game/actors/o_player/o_player.tscn"',
             content,
         )
 
@@ -1476,7 +1476,7 @@ class TestRoomConverter(unittest.TestCase):
             content = f.read()
 
         self.assertIn(
-            'run/main_scene="res://rooms/Game/Intro/r_intro/r_intro.tscn"',
+            'run/main_scene="res://rooms/game/intro/r_intro/r_intro.tscn"',
             content,
         )
         self.assertIn('config/name="Existing"', content)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -110,10 +110,10 @@ class TestScriptConverter(unittest.TestCase):
         registry_path = self._converter().convert_all()
 
         self.assertEqual(registry_path, str(self.godot_dir / SCRIPT_REGISTRY_RELATIVE_PATH))
-        legacy_script = (self.godot_dir / "scripts" / "Game" / "scr_add.gd").read_text(encoding="utf-8")
-        modern_script = (self.godot_dir / "scripts" / "Game" / "scr_modern.gd").read_text(encoding="utf-8")
+        legacy_script = (self.godot_dir / "scripts" / "game" / "scr_add.gd").read_text(encoding="utf-8")
+        modern_script = (self.godot_dir / "scripts" / "game" / "scr_modern.gd").read_text(encoding="utf-8")
         legacy_source_map = json.loads(
-            (self.godot_dir / "scripts" / "Game" / "scr_add.gd.gmlmap.json").read_text(encoding="utf-8")
+            (self.godot_dir / "scripts" / "game" / "scr_add.gd.gmlmap.json").read_text(encoding="utf-8")
         )
         registry = (self.godot_dir / SCRIPT_REGISTRY_RELATIVE_PATH).read_text(encoding="utf-8")
 
@@ -131,9 +131,9 @@ class TestScriptConverter(unittest.TestCase):
         self.assertIn("func gm2godot_callable():", modern_script)
         self.assertIn("func _gm_script_call(a = null, b = null):", modern_script)
         self.assertIn("if b == null or GMRuntime.is_undefined(b): b = 4", modern_script)
-        self.assertIn('preload("res://scripts/Game/scr_add.gd").new().gm2godot_callable()', registry)
+        self.assertIn('preload("res://scripts/game/scr_add.gd").new().gm2godot_callable()', registry)
         self.assertIn('"legacy_arguments": true', registry)
-        self.assertIn('preload("res://scripts/Game/scr_modern.gd").new().gm2godot_callable()', registry)
+        self.assertIn('preload("res://scripts/game/scr_modern.gd").new().gm2godot_callable()', registry)
         self.assertIn('"legacy_arguments": false', registry)
 
     def test_converts_scripts_with_mapped_extension_calls(self) -> None:
@@ -163,7 +163,7 @@ class TestScriptConverter(unittest.TestCase):
 
         self._converter().convert_all()
 
-        legacy_script = (self.godot_dir / "scripts" / "Game" / "scr_add.gd").read_text(encoding="utf-8")
+        legacy_script = (self.godot_dir / "scripts" / "game" / "scr_add.gd").read_text(encoding="utf-8")
         self.assertIn('AdBridge.show_rewarded("zone_1")', legacy_script)
 
     def test_applies_macro_configuration_to_script_sources(self) -> None:
@@ -179,7 +179,7 @@ class TestScriptConverter(unittest.TestCase):
 
         self._converter(macro_configuration="Android").convert_all()
 
-        modern_script = (self.godot_dir / "scripts" / "Game" / "scr_modern.gd").read_text(encoding="utf-8")
+        modern_script = (self.godot_dir / "scripts" / "game" / "scr_modern.gd").read_text(encoding="utf-8")
         self.assertIn("return 11", modern_script)
         self.assertNotIn("return 22", modern_script)
 

--- a/tests/test_shaders.py
+++ b/tests/test_shaders.py
@@ -169,7 +169,7 @@ class TestShaderConverterSubfolders(unittest.TestCase):
         )
         converter.convert_all()
 
-        expected = os.path.join(self.godot_dir, "shaders", "Effects", "sh_blur.gdshader")
+        expected = os.path.join(self.godot_dir, "shaders", "effects", "sh_blur.gdshader")
         self.assertTrue(os.path.isfile(expected),
                         f"Expected shader at {expected}")
 

--- a/tests/test_simple_topdown_conversion.py
+++ b/tests/test_simple_topdown_conversion.py
@@ -140,7 +140,7 @@ class TestSimpleTopDownConversion(unittest.TestCase):
         self.assertIn('script = ExtResource', content)
 
     def test_starting_room_instantiates_player(self):
-        content = self._read_generated_file("rooms", "r_StartingRoom.tscn")
+        content = self._read_generated_file("rooms", "r_starting_room.tscn")
 
         self.assertIn('metadata/gamemaker_room_width = 1366', content)
         self.assertIn('metadata/gamemaker_room_height = 768', content)
@@ -152,7 +152,7 @@ class TestSimpleTopDownConversion(unittest.TestCase):
             content = f.read()
 
         self.assertIn('run/main_scene=', content)
-        self.assertIn('r_StartingRoom.tscn', content)
+        self.assertIn('r_starting_room.tscn', content)
         self.assertIn('GMEvents="*res://gm2godot/managers/gm_events.gd"', content)
 
     def test_no_tracebacks_in_logs(self):

--- a/tests/test_sounds.py
+++ b/tests/test_sounds.py
@@ -383,7 +383,7 @@ class TestSoundConverterSubfolders(unittest.TestCase):
         converter = self._make_converter()
         converter.convert_all()
 
-        expected = os.path.join(self.godot_dir, "sounds", "SFX", "explosion", "explosion.wav")
+        expected = os.path.join(self.godot_dir, "sounds", "sfx", "explosion", "explosion.wav")
         self.assertTrue(os.path.isfile(expected),
                         f"Expected {expected} in subfolder")
 
@@ -395,11 +395,11 @@ class TestSoundConverterSubfolders(unittest.TestCase):
         converter = self._make_converter()
         converter.convert_all()
 
-        import_path = os.path.join(self.godot_dir, "sounds", "SFX", "explosion", "explosion.wav.import")
+        import_path = os.path.join(self.godot_dir, "sounds", "sfx", "explosion", "explosion.wav.import")
         self.assertTrue(os.path.isfile(import_path))
         with open(import_path, 'r', encoding='utf-8') as f:
             content = f.read()
-        self.assertIn('source_file="res://sounds/SFX/explosion/explosion.wav"', content)
+        self.assertIn('source_file="res://sounds/sfx/explosion/explosion.wav"', content)
 
     def test_root_level_sound(self):
         _make_sound_yy(self.gm_dir, "beep")
@@ -421,7 +421,7 @@ class TestSoundConverterSubfolders(unittest.TestCase):
         converter.convert_all()
 
         expected = os.path.join(
-            self.godot_dir, "sounds", "audiogroup_music", "SFX", "theme", "theme.wav"
+            self.godot_dir, "sounds", "audiogroup_music", "sfx", "theme", "theme.wav"
         )
         self.assertTrue(os.path.isfile(expected),
                         f"Expected {expected} in grouped folder hierarchy")
@@ -436,13 +436,13 @@ class TestSoundConverterSubfolders(unittest.TestCase):
         converter.convert_all()
 
         import_path = os.path.join(
-            self.godot_dir, "sounds", "audiogroup_music", "SFX", "theme", "theme.wav.import"
+            self.godot_dir, "sounds", "audiogroup_music", "sfx", "theme", "theme.wav.import"
         )
         self.assertTrue(os.path.isfile(import_path))
         with open(import_path, "r", encoding="utf-8") as f:
             content = f.read()
         self.assertIn(
-            'source_file="res://sounds/audiogroup_music/SFX/theme/theme.wav"',
+            'source_file="res://sounds/audiogroup_music/sfx/theme/theme.wav"',
             content,
         )
 

--- a/tests/test_tcc_conversion.py
+++ b/tests/test_tcc_conversion.py
@@ -14,6 +14,7 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from src.conversion.converter import CONVERSION_CATEGORIES, Converter
+from src.conversion.generated_paths import generated_resource_stem
 from src.gui.setting_value import SettingValue
 
 
@@ -95,18 +96,24 @@ class TestTCCConversion(unittest.TestCase):
         for _root, dirs, _ in os.walk(sprites_dir):
             all_dirs.update(dirs)
         for name in ("s_C1AIcon", "s_C2AIcon", "s_C3AIcon"):
-            self.assertIn(name, all_dirs, f"Expected sprites/{name}/ directory (nested)")
+            expected = generated_resource_stem(name)
+            self.assertIn(expected, all_dirs, f"Expected sprites/{expected}/ directory (nested)")
 
     def test_sprites_contain_png_files(self):
         sprites_dir = os.path.join(self.godot_dir, "sprites")
         sprite_path = None
         for root, dirs, _ in os.walk(sprites_dir):
-            if "s_C1AIcon" in dirs:
-                sprite_path = os.path.join(root, "s_C1AIcon")
+            expected = generated_resource_stem("s_C1AIcon")
+            if expected in dirs:
+                sprite_path = os.path.join(root, expected)
                 break
         if sprite_path and os.path.isdir(sprite_path):
             pngs = [f for f in os.listdir(sprite_path) if f.endswith(".png")]
-            self.assertGreater(len(pngs), 0, "Expected at least one PNG in s_C1AIcon/")
+            self.assertGreater(
+                len(pngs),
+                0,
+                f"Expected at least one PNG in {generated_resource_stem('s_C1AIcon')}/",
+            )
 
     def test_sprites_count(self):
         sprites_dir = os.path.join(self.godot_dir, "sprites")

--- a/tests/test_tilesets.py
+++ b/tests/test_tilesets.py
@@ -359,7 +359,7 @@ class TestTileSetConverterSubfolders(unittest.TestCase):
         )
         converter.convert_all()
 
-        tres_path = os.path.join(self.godot_dir, "tilesets", "World", "ts_terrain", "ts_terrain.tres")
+        tres_path = os.path.join(self.godot_dir, "tilesets", "world", "ts_terrain", "ts_terrain.tres")
         self.assertTrue(os.path.isfile(tres_path),
                         f"Expected tileset at {tres_path}")
 
@@ -372,11 +372,11 @@ class TestTileSetConverterSubfolders(unittest.TestCase):
         )
         converter.convert_all()
 
-        tres_path = os.path.join(self.godot_dir, "tilesets", "World", "ts_terrain", "ts_terrain.tres")
+        tres_path = os.path.join(self.godot_dir, "tilesets", "world", "ts_terrain", "ts_terrain.tres")
         with open(tres_path, 'r', encoding='utf-8') as f:
             content = f.read()
 
-        self.assertIn('res://tilesets/World/ts_terrain/ts_terrain.png', content)
+        self.assertIn('res://tilesets/world/ts_terrain/ts_terrain.png', content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- standardize generated Godot resource paths through shared snake_case path helpers and stable suffixes for collisions
- emit gm2godot/conversion_manifest.json with source metadata, generated file hashes, source maps, and path diagnostics
- add headless Godot generated resource validation to CLI validate and CI smoke coverage

Closes #607

## Verification
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest
- ./venv/bin/python -m unittest tests.test_sprites tests.test_tilesets tests.test_shaders tests.test_sounds tests.test_fonts tests.test_objects tests.test_rooms tests.test_asset_registry tests.test_conversion_manifest tests.test_godot_validation tests.test_cli tests.test_ci_workflows tests.test_golden_conversion