### PR TITLE
Add Part 2 fixture corpus coverage

### DIFF
--- a/src/conversion/asset_registry.py
+++ b/src/conversion/asset_registry.py
@@ -336,7 +336,7 @@ class AssetRegistryConverter(BaseConverter):
 
             yy_path = os.path.normpath(os.path.join(self.gm_project_path, raw_path))
             if not os.path.isfile(yy_path):
-                self._safe_log(f"Skipping missing GameMaker asset {name}: {yy_path}")
+                self._safe_log(f"Warning: Skipping missing GameMaker asset {name}: {yy_path}")
                 continue
 
             resources.append(

--- a/src/conversion/resource_index.py
+++ b/src/conversion/resource_index.py
@@ -274,7 +274,7 @@ class GameMakerResourceIndex(BaseConverter):
             yy_path = os.path.normpath(os.path.join(self.gm_project_path, yyp_path))
             if not os.path.isfile(yy_path):
                 self._safe_log(
-                    f"Skipping missing GameMaker resource {name}: {yy_path}"
+                    f"Warning: Skipping missing GameMaker resource {name}: {yy_path}"
                 )
                 continue
 

--- a/tests/fixtures/part2/README.md
+++ b/tests/fixtures/part2/README.md
@@ -2,6 +2,8 @@
 
 This directory tracks the staged compatibility fixtures for issue #518. Each fixture has a minimal GameMaker source expectation in `source/`, manifest entries for the runtime/API surface it exercises, and one or more headless Godot assertion paths in `fixtures.json`.
 
+`corpus.json` tracks the Milestone 7 issue #610 coverage budget. It links the committed `projects/resource_matrix/` `.yyp/.yy` fixture project, malformed fixture projects, golden trace specs, and visual regression specs to the unit/Godot smoke tests that enforce each coverage area.
+
 The fixture catalog covers the required P0 buckets:
 
 - `movement_collisions`: top-down movement, instance registration, blocking collision, and collision query assertions.
@@ -12,5 +14,7 @@ The fixture catalog covers the required P0 buckets:
 - `async_http`: HTTP GET/POST/custom requests, async event dispatch, and async buffer save.
 - `camera_view`: camera helper state, legacy view array synchronization, Camera2D transforms, and GUI display sizing.
 - `multi_view_viewports`: multi-view viewport rectangles, view mouse coordinate conversion, view-surface state, and backend diagnostics.
+
+The resource matrix project covers shaders, materials, paths, timelines, sequences, particles, physics, tilemaps, views/layer inheritance, extensions, macros/configs, included files, fonts, texture groups, audio groups, and platform options.
 
 Unsupported APIs discovered by a fixture must be added to that fixture's `unsupported_api_issue_refs` list with the manifest API name and issue number. Empty lists mean the current fixture path did not encounter a new unsupported API.

--- a/tests/fixtures/part2/corpus.json
+++ b/tests/fixtures/part2/corpus.json
@@ -1,0 +1,224 @@
+{
+  "issue": 610,
+  "resource_matrix_project": "projects/resource_matrix/ResourceMatrix.yyp",
+  "required_resource_areas": [
+    {
+      "area": "shaders",
+      "resource_type": "GMShader",
+      "game_maker_resource_path": "projects/resource_matrix/shaders/shd_matrix/shd_matrix.yy",
+      "source_path": "source/resource_matrix.gml",
+      "assertion_paths": ["tests/test_shaders.py::TestShaderConverterBasic.test_creates_gdshader_file"]
+    },
+    {
+      "area": "materials",
+      "resource_type": "GMMaterial",
+      "game_maker_resource_path": "projects/resource_matrix/materials/mat_canvas/mat_canvas.yy",
+      "source_path": "source/resource_matrix.gml",
+      "assertion_paths": ["tests/test_rooms.py::TestRoomConverter.test_effect_layer_preserves_effect_metadata"]
+    },
+    {
+      "area": "paths",
+      "resource_type": "GMPath",
+      "game_maker_resource_path": "projects/resource_matrix/paths/path_patrol/path_patrol.yy",
+      "source_path": "source/resource_matrix.gml",
+      "assertion_paths": ["tests/test_path_registry.py::TestPathRegistry.test_builds_path_registry_entries_from_gamemaker_paths"]
+    },
+    {
+      "area": "timelines",
+      "resource_type": "GMTimeline",
+      "game_maker_resource_path": "projects/resource_matrix/timelines/tl_intro/tl_intro.yy",
+      "source_path": "source/resource_matrix.gml",
+      "assertion_paths": ["tests/test_sequences_timelines_godot.py::TestSequencesTimelinesGodotSmoke.test_sequence_timeline_runtime_smoke_scene"]
+    },
+    {
+      "area": "sequences",
+      "resource_type": "GMSequence",
+      "game_maker_resource_path": "projects/resource_matrix/sequences/seq_intro/seq_intro.yy",
+      "source_path": "source/resource_matrix.gml",
+      "assertion_paths": ["tests/test_sequences_timelines_godot.py::TestSequencesTimelinesGodotSmoke.test_sequence_timeline_runtime_smoke_scene"]
+    },
+    {
+      "area": "particles",
+      "resource_type": "GMParticleSystem",
+      "game_maker_resource_path": "projects/resource_matrix/particles/ps_dust/ps_dust.yy",
+      "source_path": "source/resource_matrix.gml",
+      "assertion_paths": ["tests/test_particles_runtime_godot.py::TestParticlesRuntimeGodotSmoke.test_particle_lifecycle_handles_and_nodes_are_cleaned_up"]
+    },
+    {
+      "area": "physics",
+      "resource_type": "GMObject",
+      "game_maker_resource_path": "projects/resource_matrix/objects/o_physics_box/o_physics_box.yy",
+      "source_path": "source/resource_matrix.gml",
+      "assertion_paths": ["tests/test_physics_runtime_godot.py::TestPhysicsRuntimeGodotSmoke.test_fixture_binding_and_impulse_apply_to_rigidbody2d"]
+    },
+    {
+      "area": "tilemaps",
+      "resource_type": "GMTileSet",
+      "game_maker_resource_path": "projects/resource_matrix/tilesets/ts_ground/ts_ground.yy",
+      "source_path": "source/resource_matrix.gml",
+      "assertion_paths": ["tests/test_rooms.py::TestRoomConverter.test_tile_layer_emits_tilemaplayer_with_decoded_cells"]
+    },
+    {
+      "area": "views_layer_inheritance",
+      "resource_type": "GMRoom",
+      "game_maker_resource_path": "projects/resource_matrix/rooms/r_child/r_child.yy",
+      "source_path": "source/resource_matrix.gml",
+      "assertion_paths": [
+        "tests/test_rooms.py::TestRoomConverter.test_room_inheritance_resolves_settings_and_layers",
+        "tests/test_rooms.py::TestRoomConverter.test_multiple_visible_views_disable_additional_cameras_and_warn"
+      ]
+    },
+    {
+      "area": "extensions",
+      "resource_type": "GMExtension",
+      "game_maker_resource_path": "projects/resource_matrix/extensions/ext_analytics/ext_analytics.yy",
+      "source_path": "source/resource_matrix.gml",
+      "assertion_paths": ["tests/test_extension_registry.py::TestExtensionRegistry.test_parses_extension_metadata_and_reports_mapping_diagnostics"]
+    },
+    {
+      "area": "macros_configs",
+      "resource_type": "GMScript",
+      "game_maker_resource_path": "projects/resource_matrix/scripts/scr_macros/scr_macros.yy",
+      "source_path": "source/resource_matrix.gml",
+      "assertion_paths": ["tests/test_gml_transpiler.py::TestGMLExpressionTranspiler.test_transpiles_macro_declarations_and_configuration_overrides"]
+    },
+    {
+      "area": "included_files",
+      "resource_type": "GMIncludedFile",
+      "game_maker_resource_path": "projects/resource_matrix/datafiles/config/defaults.json",
+      "source_path": "source/resource_matrix.gml",
+      "assertion_paths": ["tests/test_included_files.py::TestIncludedFilesConverterNestedDirs.test_preserves_directory_structure"]
+    },
+    {
+      "area": "fonts",
+      "resource_type": "GMFont",
+      "game_maker_resource_path": "projects/resource_matrix/fonts/fnt_ui/fnt_ui.yy",
+      "source_path": "source/resource_matrix.gml",
+      "assertion_paths": ["tests/test_fonts.py::TestFontConverterSubfolders.test_font_in_subfolder"]
+    },
+    {
+      "area": "texture_groups",
+      "resource_type": "GMTextureGroup",
+      "game_maker_resource_path": "projects/resource_matrix/texturegroups/texturegroup_world.yy",
+      "source_path": "source/resource_matrix.gml",
+      "assertion_paths": ["tests/test_sprites.py::TestSpriteConverterBasic.test_converts_sprite_to_godot_dir"]
+    },
+    {
+      "area": "audio_groups",
+      "resource_type": "GMAudioGroup",
+      "game_maker_resource_path": "projects/resource_matrix/audiogroups/audiogroup_sfx.yy",
+      "source_path": "source/resource_matrix.gml",
+      "assertion_paths": ["tests/test_sounds.py::TestSoundConverterAudioGroupMap.test_generates_audio_group_map_file"]
+    },
+    {
+      "area": "options",
+      "resource_type": "GMWindowsOptions",
+      "game_maker_resource_path": "projects/resource_matrix/options/windows/options_windows.yy",
+      "source_path": "source/resource_matrix.gml",
+      "assertion_paths": ["tests/test_project_settings.py::TestUpdateProjectSettingsFromManifest.test_updates_project_godot_from_typed_options_and_reports_gaps"]
+    }
+  ],
+  "golden_trace_specs": [
+    {
+      "id": "event_order",
+      "expected_trace": ["begin_step", "time_sources", "alarms", "step", "motion", "collision", "end_step"],
+      "assertion_paths": ["tests/test_event_scheduler_godot.py::TestEventSchedulerGodotSmoke.test_scheduler_phase_order_alarms_and_mutation_queue"]
+    },
+    {
+      "id": "alarms",
+      "expected_trace": ["alarm[0]", "alarm[1]", "delta_time"],
+      "assertion_paths": ["tests/test_time_alarms_godot.py::TestTimeAlarmsGodotSmoke.test_alarm_countdown_and_time_source_scheduler"]
+    },
+    {
+      "id": "input",
+      "expected_trace": ["pressed", "held", "released", "mouse_gui"],
+      "assertion_paths": ["tests/test_game_input_godot.py::TestGameInputGodotSmoke.test_input_bridge_tracks_edges_and_coordinates"]
+    },
+    {
+      "id": "collision",
+      "expected_trace": ["place_meeting", "collision_rectangle", "collision_event"],
+      "assertion_paths": ["tests/test_collision_queries_godot.py::TestCollisionQueriesGodotSmoke.test_runtime_collision_queries_against_generated_shapes"]
+    },
+    {
+      "id": "draw_order",
+      "expected_trace": ["pre_draw", "draw_begin", "draw", "draw_end", "post_draw", "draw_gui"],
+      "assertion_paths": ["tests/test_draw_event_dispatch_godot.py::TestDrawEventDispatchGodotSmoke.test_draw_dispatch_order_default_draw_and_surface_stack"]
+    },
+    {
+      "id": "async",
+      "expected_trace": ["http_get", "http_post", "buffer_save_async", "async_load"],
+      "assertion_paths": ["tests/test_async_http_godot.py::TestAsyncHttpGodotSmoke.test_http_requests_dispatch_async_load_to_generated_handlers"]
+    },
+    {
+      "id": "rooms_persistence_lifecycle",
+      "expected_trace": ["room_start", "room_end", "persistent_survives", "room_restart"],
+      "assertion_paths": ["tests/test_room_game_flow_godot.py::TestRoomGameFlowGodotSmoke.test_room_runtime_transitions_lifecycle_and_persistent_nodes"]
+    },
+    {
+      "id": "physics",
+      "expected_trace": ["fixture_bind", "impulse", "rigidbody2d"],
+      "assertion_paths": ["tests/test_physics_runtime_godot.py::TestPhysicsRuntimeGodotSmoke.test_fixture_binding_and_impulse_apply_to_rigidbody2d"]
+    },
+    {
+      "id": "data_structures",
+      "expected_trace": ["ds_list", "ds_map", "ds_grid", "file_text", "ini", "json"],
+      "assertion_paths": ["tests/test_ds_collections_godot.py::TestDSCollectionsGodotSmoke.test_ds_collections_runtime"]
+    }
+  ],
+  "visual_regression_specs": [
+    {
+      "id": "surfaces",
+      "feature": "surface clear/copy pixels",
+      "pixel_check": true,
+      "assertion_paths": ["tests/test_draw_surfaces_godot.py::TestDrawSurfacesGodotSmoke.test_surface_runtime_handles_targets_and_application_surface"]
+    },
+    {
+      "id": "blend_alpha",
+      "feature": "sprite image_blend and image_alpha",
+      "pixel_check": true,
+      "assertion_paths": ["tests/test_draw_sprite_text_godot.py::TestDrawSpriteTextGodotSmoke.test_room_instance_transform_metadata_hydrates_sprite_runtime"]
+    },
+    {
+      "id": "gui_scaling_cameras",
+      "feature": "GUI size and view coordinate transforms",
+      "pixel_check": false,
+      "assertion_paths": ["tests/test_cameras_display_godot.py::TestCamerasDisplayGodotSmoke.test_multiview_viewport_state_and_diagnostics"]
+    },
+    {
+      "id": "tile_layer_data",
+      "feature": "TileMapLayer decoded cells",
+      "pixel_check": false,
+      "assertion_paths": ["tests/test_rooms.py::TestRoomConverter.test_tile_layer_emits_tilemaplayer_with_decoded_cells"]
+    }
+  ],
+  "malformed_fixture_projects": [
+    {
+      "id": "malformed_yyp",
+      "project_path": "projects/malformed_yyp/MalformedProject.yyp",
+      "expected_diagnostic_code": "GM2GD-WARNING",
+      "expected_log_fragment": "Could not parse GameMaker project .yyp",
+      "continued_outputs": [
+        "gm2godot/conversion_diagnostics.json",
+        "gm2godot/conversion_manifest.json",
+        "gm2godot/architecture_policy.json"
+      ]
+    },
+    {
+      "id": "missing_yy",
+      "project_path": "projects/missing_yy/MissingResource.yyp",
+      "expected_diagnostic_code": "GM2GD-WARNING",
+      "expected_log_fragment": "Skipping missing GameMaker asset",
+      "continued_outputs": [
+        "gm2godot/conversion_diagnostics.json",
+        "gm2godot/conversion_manifest.json",
+        "gm2godot/architecture_policy.json"
+      ]
+    }
+  ],
+  "coverage_budget": {
+    "required_resource_area_count": 16,
+    "minimum_golden_trace_count": 9,
+    "minimum_visual_regression_count": 4,
+    "minimum_malformed_fixture_count": 2
+  }
+}

--- a/tests/fixtures/part2/projects/malformed_yyp/MalformedProject.yyp
+++ b/tests/fixtures/part2/projects/malformed_yyp/MalformedProject.yyp
@@ -1,0 +1,1 @@
+{"resources": [}

--- a/tests/fixtures/part2/projects/missing_yy/MissingResource.yyp
+++ b/tests/fixtures/part2/projects/missing_yy/MissingResource.yyp
@@ -1,0 +1,9 @@
+{
+  "%Name": "MissingResource",
+  "name": "MissingResource",
+  "resourceType": "GMProject",
+  "resources": [
+    {"id": {"name": "spr_missing", "path": "sprites/spr_missing/spr_missing.yy"}}
+  ],
+  "RoomOrderNodes": []
+}

--- a/tests/fixtures/part2/projects/resource_matrix/ResourceMatrix.yyp
+++ b/tests/fixtures/part2/projects/resource_matrix/ResourceMatrix.yyp
@@ -1,0 +1,32 @@
+{
+  "%Name": "ResourceMatrix",
+  "name": "ResourceMatrix",
+  "resourceType": "GMProject",
+  "AudioGroups": [
+    {"%Name": "audiogroup_default", "name": "audiogroup_default", "resourceType": "GMAudioGroup"},
+    {"%Name": "audiogroup_sfx", "name": "audiogroup_sfx", "resourceType": "GMAudioGroup"}
+  ],
+  "TextureGroups": [
+    {"%Name": "Default", "name": "Default", "resourceType": "GMTextureGroup"},
+    {"%Name": "texturegroup_world", "name": "texturegroup_world", "resourceType": "GMTextureGroup"}
+  ],
+  "resources": [
+    {"id": {"name": "spr_checker", "path": "sprites/spr_checker/spr_checker.yy"}},
+    {"id": {"name": "snd_click", "path": "sounds/snd_click/snd_click.yy"}},
+    {"id": {"name": "fnt_ui", "path": "fonts/fnt_ui/fnt_ui.yy"}},
+    {"id": {"name": "shd_matrix", "path": "shaders/shd_matrix/shd_matrix.yy"}},
+    {"id": {"name": "path_patrol", "path": "paths/path_patrol/path_patrol.yy"}},
+    {"id": {"name": "tl_intro", "path": "timelines/tl_intro/tl_intro.yy"}},
+    {"id": {"name": "seq_intro", "path": "sequences/seq_intro/seq_intro.yy"}},
+    {"id": {"name": "ps_dust", "path": "particles/ps_dust/ps_dust.yy"}},
+    {"id": {"name": "ts_ground", "path": "tilesets/ts_ground/ts_ground.yy"}},
+    {"id": {"name": "o_physics_box", "path": "objects/o_physics_box/o_physics_box.yy"}},
+    {"id": {"name": "scr_macros", "path": "scripts/scr_macros/scr_macros.yy"}},
+    {"id": {"name": "r_parent", "path": "rooms/r_parent/r_parent.yy"}},
+    {"id": {"name": "r_child", "path": "rooms/r_child/r_child.yy"}},
+    {"id": {"name": "ext_analytics", "path": "extensions/ext_analytics/ext_analytics.yy"}}
+  ],
+  "RoomOrderNodes": [
+    {"roomId": {"name": "r_child", "path": "rooms/r_child/r_child.yy"}}
+  ]
+}

--- a/tests/fixtures/part2/projects/resource_matrix/audiogroups/audiogroup_sfx.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/audiogroups/audiogroup_sfx.yy
@@ -1,0 +1,7 @@
+{
+  "$GMAudioGroup": "v1",
+  "%Name": "audiogroup_sfx",
+  "name": "audiogroup_sfx",
+  "resourceType": "GMAudioGroup",
+  "targets": 9223372036854775807
+}

--- a/tests/fixtures/part2/projects/resource_matrix/configs/debug.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/configs/debug.yy
@@ -1,0 +1,7 @@
+{
+  "$GMConfig": "v1",
+  "%Name": "Debug",
+  "name": "Debug",
+  "resourceType": "GMConfig",
+  "children": []
+}

--- a/tests/fixtures/part2/projects/resource_matrix/datafiles/config/defaults.json
+++ b/tests/fixtures/part2/projects/resource_matrix/datafiles/config/defaults.json
@@ -1,0 +1,4 @@
+{
+  "difficulty": "normal",
+  "lives": 3
+}

--- a/tests/fixtures/part2/projects/resource_matrix/extensions/ext_analytics/ext_analytics.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/extensions/ext_analytics/ext_analytics.yy
@@ -1,0 +1,18 @@
+{
+  "$GMExtension": "v1",
+  "%Name": "ext_analytics",
+  "name": "ext_analytics",
+  "resourceType": "GMExtension",
+  "version": "1.0.0",
+  "platforms": ["windows"],
+  "macros": [{"name": "ANALYTICS_ENABLED", "value": "1"}],
+  "files": [
+    {
+      "filename": "analytics.dll",
+      "platform": "windows",
+      "functions": [
+        {"name": "analytics_track", "externalName": "AnalyticsTrack", "argCount": 2, "returnType": "double"}
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/part2/projects/resource_matrix/fonts/fnt_ui/fnt_ui.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/fonts/fnt_ui/fnt_ui.yy
@@ -1,0 +1,11 @@
+{
+  "$GMFont": "v1",
+  "%Name": "fnt_ui",
+  "name": "fnt_ui",
+  "resourceType": "GMFont",
+  "fontName": "Arial",
+  "size": 14,
+  "bold": false,
+  "italic": false,
+  "parent": {"name": "Fonts", "path": "folders/Fonts/UI.yy"}
+}

--- a/tests/fixtures/part2/projects/resource_matrix/materials/mat_canvas/mat_canvas.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/materials/mat_canvas/mat_canvas.yy
@@ -1,0 +1,8 @@
+{
+  "$GMMaterial": "v1",
+  "%Name": "mat_canvas",
+  "name": "mat_canvas",
+  "resourceType": "GMMaterial",
+  "shader": {"name": "shd_matrix", "path": "shaders/shd_matrix/shd_matrix.yy"},
+  "parent": {"name": "Materials", "path": "folders/Materials.yy"}
+}

--- a/tests/fixtures/part2/projects/resource_matrix/objects/o_physics_box/o_physics_box.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/objects/o_physics_box/o_physics_box.yy
@@ -1,0 +1,15 @@
+{
+  "$GMObject": "v1",
+  "%Name": "o_physics_box",
+  "name": "o_physics_box",
+  "resourceType": "GMObject",
+  "spriteId": {"name": "spr_checker", "path": "sprites/spr_checker/spr_checker.yy"},
+  "physicsObject": true,
+  "physicsSensor": false,
+  "physicsShape": 1,
+  "physicsDensity": 0.5,
+  "physicsFriction": 0.2,
+  "physicsRestitution": 0.1,
+  "eventList": [],
+  "parent": {"name": "Objects", "path": "folders/Objects.yy"}
+}

--- a/tests/fixtures/part2/projects/resource_matrix/options/main/options_main.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/options/main/options_main.yy
@@ -1,0 +1,7 @@
+{
+  "$GMMainOptions": "v1",
+  "%Name": "Main",
+  "name": "Main",
+  "resourceType": "GMMainOptions",
+  "option_game_speed": 60
+}

--- a/tests/fixtures/part2/projects/resource_matrix/options/windows/options_windows.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/options/windows/options_windows.yy
@@ -1,0 +1,11 @@
+{
+  "$GMWindowsOptions": "v1",
+  "%Name": "Windows",
+  "name": "Windows",
+  "resourceType": "GMWindowsOptions",
+  "option_windows_display_name": "Resource Matrix",
+  "option_windows_version": "0.0.1",
+  "option_windows_vsync": true,
+  "option_windows_resize_window": true,
+  "option_windows_interpolate_pixels": false
+}

--- a/tests/fixtures/part2/projects/resource_matrix/particles/ps_dust/ps_dust.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/particles/ps_dust/ps_dust.yy
@@ -1,0 +1,8 @@
+{
+  "$GMParticleSystem": "v1",
+  "%Name": "ps_dust",
+  "name": "ps_dust",
+  "resourceType": "GMParticleSystem",
+  "emitters": [],
+  "parent": {"name": "Particles", "path": "folders/Particles.yy"}
+}

--- a/tests/fixtures/part2/projects/resource_matrix/paths/path_patrol/path_patrol.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/paths/path_patrol/path_patrol.yy
@@ -1,0 +1,15 @@
+{
+  "$GMPath": "v1",
+  "%Name": "path_patrol",
+  "name": "path_patrol",
+  "resourceType": "GMPath",
+  "closed": true,
+  "kind": 1,
+  "precision": 4,
+  "points": [
+    {"x": 0.0, "y": 0.0, "speed": 100.0},
+    {"x": 64.0, "y": 0.0, "speed": 100.0},
+    {"x": 64.0, "y": 64.0, "speed": 100.0}
+  ],
+  "parent": {"name": "Paths", "path": "folders/Paths.yy"}
+}

--- a/tests/fixtures/part2/projects/resource_matrix/rooms/r_child/r_child.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/rooms/r_child/r_child.yy
@@ -1,0 +1,50 @@
+{
+  "$GMRoom": "v1",
+  "%Name": "r_child",
+  "name": "r_child",
+  "resourceType": "GMRoom",
+  "creationCodeFile": "",
+  "inheritCode": false,
+  "inheritCreationOrder": false,
+  "inheritLayers": true,
+  "isDnd": false,
+  "parent": {"name": "Rooms", "path": "folders/Rooms.yy"},
+  "parentRoom": {"name": "r_parent", "path": "rooms/r_parent/r_parent.yy"},
+  "roomSettings": {"Width": 640, "Height": 360, "persistent": true, "inheritRoomSettings": false},
+  "physicsSettings": {"PhysicsWorld": true, "PhysicsWorldGravityX": 0.0, "PhysicsWorldGravityY": 10.0, "PhysicsWorldPixToMetres": 0.1, "inheritPhysicsSettings": true},
+  "viewSettings": {"enableViews": true},
+  "views": [
+    {"visible": true, "xview": 0, "yview": 0, "wview": 320, "hview": 180, "xport": 0, "yport": 0, "wport": 640, "hport": 360},
+    {"visible": true, "xview": 320, "yview": 0, "wview": 320, "hview": 180, "xport": 640, "yport": 0, "wport": 640, "hport": 360}
+  ],
+  "instanceCreationOrder": [
+    {"name": "inst_box", "path": "rooms/r_child/r_child.yy"}
+  ],
+  "layers": [
+    {
+      "%Name": "ChildInstances",
+      "name": "ChildInstances",
+      "resourceType": "GMRInstanceLayer",
+      "depth": 0,
+      "instances": [
+        {"name": "inst_box", "objectId": {"name": "o_physics_box", "path": "objects/o_physics_box/o_physics_box.yy"}, "x": 32, "y": 32}
+      ]
+    },
+    {
+      "%Name": "GroundTiles",
+      "name": "GroundTiles",
+      "resourceType": "GMRTileLayer",
+      "depth": 100,
+      "tilesetId": {"name": "ts_ground", "path": "tilesets/ts_ground/ts_ground.yy"},
+      "tiles": {"SerialiseWidth": 2, "SerialiseHeight": 2, "TileDataFormat": 0, "TileCompressedData": [1, 0, 0, 2]}
+    },
+    {
+      "%Name": "FX",
+      "name": "FX",
+      "resourceType": "GMREffectLayer",
+      "effectType": "_filter_colourise",
+      "properties": [{"name": "g_TintCol", "type": 1, "value": "16777215"}]
+    }
+  ],
+  "volume": 1.0
+}

--- a/tests/fixtures/part2/projects/resource_matrix/rooms/r_parent/r_parent.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/rooms/r_parent/r_parent.yy
@@ -1,0 +1,24 @@
+{
+  "$GMRoom": "v1",
+  "%Name": "r_parent",
+  "name": "r_parent",
+  "resourceType": "GMRoom",
+  "creationCodeFile": "",
+  "inheritCode": false,
+  "inheritCreationOrder": false,
+  "inheritLayers": false,
+  "isDnd": false,
+  "parent": {"name": "Rooms", "path": "folders/Rooms.yy"},
+  "parentRoom": null,
+  "roomSettings": {"Width": 320, "Height": 180, "persistent": false, "inheritRoomSettings": false},
+  "physicsSettings": {"PhysicsWorld": true, "PhysicsWorldGravityX": 0.0, "PhysicsWorldGravityY": 10.0, "PhysicsWorldPixToMetres": 0.1, "inheritPhysicsSettings": false},
+  "viewSettings": {"enableViews": true},
+  "views": [
+    {"visible": true, "xview": 0, "yview": 0, "wview": 160, "hview": 90, "xport": 0, "yport": 0, "wport": 320, "hport": 180}
+  ],
+  "instanceCreationOrder": [],
+  "layers": [
+    {"%Name": "ParentInstances", "name": "ParentInstances", "resourceType": "GMRInstanceLayer", "depth": 0, "instances": []}
+  ],
+  "volume": 1.0
+}

--- a/tests/fixtures/part2/projects/resource_matrix/scripts/scr_macros/scr_macros.gml
+++ b/tests/fixtures/part2/projects/resource_matrix/scripts/scr_macros/scr_macros.gml
@@ -1,0 +1,6 @@
+/// Fixture: macro and config preprocessing.
+#macro MATRIX_SPEED 4
+
+function scr_macros() {
+    return MATRIX_SPEED;
+}

--- a/tests/fixtures/part2/projects/resource_matrix/scripts/scr_macros/scr_macros.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/scripts/scr_macros/scr_macros.yy
@@ -1,0 +1,8 @@
+{
+  "$GMScript": "v1",
+  "%Name": "scr_macros",
+  "name": "scr_macros",
+  "resourceType": "GMScript",
+  "isCompatibility": false,
+  "parent": {"name": "Scripts", "path": "folders/Scripts.yy"}
+}

--- a/tests/fixtures/part2/projects/resource_matrix/sequences/seq_intro/seq_intro.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/sequences/seq_intro/seq_intro.yy
@@ -1,0 +1,11 @@
+{
+  "$GMSequence": "v1",
+  "%Name": "seq_intro",
+  "name": "seq_intro",
+  "resourceType": "GMSequence",
+  "length": 30.0,
+  "playback": 1,
+  "playbackSpeed": 30.0,
+  "tracks": [],
+  "parent": {"name": "Sequences", "path": "folders/Sequences.yy"}
+}

--- a/tests/fixtures/part2/projects/resource_matrix/shaders/shd_matrix/shd_matrix.fsh
+++ b/tests/fixtures/part2/projects/resource_matrix/shaders/shd_matrix/shd_matrix.fsh
@@ -1,0 +1,7 @@
+precision highp float;
+varying vec2 v_vTexcoord;
+uniform sampler2D gm_BaseTexture;
+
+void main() {
+    gl_FragColor = texture2D(gm_BaseTexture, v_vTexcoord);
+}

--- a/tests/fixtures/part2/projects/resource_matrix/shaders/shd_matrix/shd_matrix.vsh
+++ b/tests/fixtures/part2/projects/resource_matrix/shaders/shd_matrix/shd_matrix.vsh
@@ -1,0 +1,5 @@
+attribute vec3 in_Position;
+
+void main() {
+    gl_Position = vec4(in_Position, 1.0);
+}

--- a/tests/fixtures/part2/projects/resource_matrix/shaders/shd_matrix/shd_matrix.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/shaders/shd_matrix/shd_matrix.yy
@@ -1,0 +1,8 @@
+{
+  "$GMShader": "v1",
+  "%Name": "shd_matrix",
+  "name": "shd_matrix",
+  "resourceType": "GMShader",
+  "type": 1,
+  "parent": {"name": "Shaders", "path": "folders/Shaders.yy"}
+}

--- a/tests/fixtures/part2/projects/resource_matrix/sounds/snd_click/snd_click.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/sounds/snd_click/snd_click.yy
@@ -1,0 +1,11 @@
+{
+  "$GMSound": "v1",
+  "%Name": "snd_click",
+  "name": "snd_click",
+  "resourceType": "GMSound",
+  "soundFile": "snd_click.wav",
+  "audioGroupId": {"name": "audiogroup_sfx", "path": "audiogroups/audiogroup_sfx.yy"},
+  "volume": 1.0,
+  "preload": true,
+  "parent": {"name": "Sounds", "path": "folders/Sounds.yy"}
+}

--- a/tests/fixtures/part2/projects/resource_matrix/sprites/spr_checker/spr_checker.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/sprites/spr_checker/spr_checker.yy
@@ -1,0 +1,21 @@
+{
+  "$GMSprite": "v1",
+  "%Name": "spr_checker",
+  "name": "spr_checker",
+  "resourceType": "GMSprite",
+  "width": 16,
+  "height": 16,
+  "bboxMode": 0,
+  "collisionKind": 1,
+  "bbox_left": 0,
+  "bbox_right": 15,
+  "bbox_top": 0,
+  "bbox_bottom": 15,
+  "origin": 0,
+  "xorigin": 0,
+  "yorigin": 0,
+  "textureGroupId": {"name": "texturegroup_world", "path": "texturegroups/texturegroup_world.yy"},
+  "frames": [],
+  "layers": [],
+  "parent": {"name": "Sprites", "path": "folders/Sprites.yy"}
+}

--- a/tests/fixtures/part2/projects/resource_matrix/texturegroups/texturegroup_world.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/texturegroups/texturegroup_world.yy
@@ -1,0 +1,9 @@
+{
+  "$GMTextureGroup": "v1",
+  "%Name": "texturegroup_world",
+  "name": "texturegroup_world",
+  "resourceType": "GMTextureGroup",
+  "targets": 9223372036854775807,
+  "autocrop": true,
+  "border": 2
+}

--- a/tests/fixtures/part2/projects/resource_matrix/tilesets/ts_ground/ts_ground.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/tilesets/ts_ground/ts_ground.yy
@@ -1,0 +1,16 @@
+{
+  "$GMTileSet": "v1",
+  "%Name": "ts_ground",
+  "name": "ts_ground",
+  "resourceType": "GMTileSet",
+  "spriteId": {"name": "spr_checker", "path": "sprites/spr_checker/spr_checker.yy"},
+  "tileWidth": 16,
+  "tileHeight": 16,
+  "tile_count": 4,
+  "out_columns": 2,
+  "tilexoff": 0,
+  "tileyoff": 0,
+  "tilehsep": 0,
+  "tilevsep": 0,
+  "parent": {"name": "Tile Sets", "path": "folders/Tile Sets.yy"}
+}

--- a/tests/fixtures/part2/projects/resource_matrix/timelines/tl_intro/tl_intro.yy
+++ b/tests/fixtures/part2/projects/resource_matrix/timelines/tl_intro/tl_intro.yy
@@ -1,0 +1,10 @@
+{
+  "$GMTimeline": "v1",
+  "%Name": "tl_intro",
+  "name": "tl_intro",
+  "resourceType": "GMTimeline",
+  "momentList": [
+    {"moment": 1, "evnt": {"isDnD": false, "eventNum": 0}}
+  ],
+  "parent": {"name": "Timelines", "path": "folders/Timelines.yy"}
+}

--- a/tests/fixtures/part2/source/resource_matrix.gml
+++ b/tests/fixtures/part2/source/resource_matrix.gml
@@ -1,0 +1,11 @@
+/// Fixture: resource matrix coverage for Milestone 7 issue #610.
+#macro MATRIX_SPEED 4
+
+shader_set(shd_matrix);
+path_start(path_patrol, MATRIX_SPEED, path_action_stop, false);
+timeline_index = tl_intro;
+audio_play_sound(snd_click, 0, false);
+physics_apply_impulse(x, y, 1, 0);
+part_system_create();
+draw_set_color(c_white);
+draw_text(8, 8, "matrix");

--- a/tests/test_part2_fixture_corpus.py
+++ b/tests/test_part2_fixture_corpus.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from typing import TypedDict, cast
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.conversion.conversion_manifest import CONVERSION_MANIFEST_RELATIVE_PATH
+from src.conversion.architecture_policy import ARCHITECTURE_POLICY_RELATIVE_PATH
+from src.conversion.converter import Converter
+from src.conversion.diagnostics import DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH
+
+
+FIXTURE_ROOT = PROJECT_ROOT / "tests" / "fixtures" / "part2"
+CORPUS_PATH = FIXTURE_ROOT / "corpus.json"
+REQUIRED_RESOURCE_AREAS = {
+    "shaders",
+    "materials",
+    "paths",
+    "timelines",
+    "sequences",
+    "particles",
+    "physics",
+    "tilemaps",
+    "views_layer_inheritance",
+    "extensions",
+    "macros_configs",
+    "included_files",
+    "fonts",
+    "texture_groups",
+    "audio_groups",
+    "options",
+}
+REQUIRED_TRACE_IDS = {
+    "event_order",
+    "alarms",
+    "input",
+    "collision",
+    "draw_order",
+    "async",
+    "rooms_persistence_lifecycle",
+    "physics",
+    "data_structures",
+}
+
+
+class CorpusResourceArea(TypedDict):
+    area: str
+    resource_type: str
+    game_maker_resource_path: str
+    source_path: str
+    assertion_paths: list[str]
+
+
+class CorpusTraceSpec(TypedDict):
+    id: str
+    expected_trace: list[str]
+    assertion_paths: list[str]
+
+
+class CorpusVisualSpec(TypedDict):
+    id: str
+    feature: str
+    pixel_check: bool
+    assertion_paths: list[str]
+
+
+class CorpusMalformedFixture(TypedDict):
+    id: str
+    project_path: str
+    expected_diagnostic_code: str
+    expected_log_fragment: str
+    continued_outputs: list[str]
+
+
+class CorpusCoverageBudget(TypedDict):
+    required_resource_area_count: int
+    minimum_golden_trace_count: int
+    minimum_visual_regression_count: int
+    minimum_malformed_fixture_count: int
+
+
+class Part2Corpus(TypedDict):
+    issue: int
+    resource_matrix_project: str
+    required_resource_areas: list[CorpusResourceArea]
+    golden_trace_specs: list[CorpusTraceSpec]
+    visual_regression_specs: list[CorpusVisualSpec]
+    malformed_fixture_projects: list[CorpusMalformedFixture]
+    coverage_budget: CorpusCoverageBudget
+
+
+class _Setting:
+    def __init__(self, value: bool) -> None:
+        self._value = value
+
+    def get(self) -> bool:
+        return self._value
+
+
+def _load_corpus() -> Part2Corpus:
+    with CORPUS_PATH.open(encoding="utf-8") as file:
+        return cast(Part2Corpus, json.load(file))
+
+
+class TestPart2FixtureCorpus(unittest.TestCase):
+    def test_resource_matrix_covers_required_milestone_areas(self) -> None:
+        corpus = _load_corpus()
+        areas = corpus["required_resource_areas"]
+        budget = corpus["coverage_budget"]
+
+        self.assertEqual(corpus["issue"], 610)
+        self.assertEqual({entry["area"] for entry in areas}, REQUIRED_RESOURCE_AREAS)
+        self.assertGreaterEqual(len(areas), budget["required_resource_area_count"])
+        self.assertTrue((FIXTURE_ROOT / corpus["resource_matrix_project"]).is_file())
+
+        for entry in areas:
+            with self.subTest(area=entry["area"]):
+                resource_path = FIXTURE_ROOT / entry["game_maker_resource_path"]
+                source_path = FIXTURE_ROOT / entry["source_path"]
+                self.assertTrue(resource_path.is_file(), resource_path)
+                self.assertTrue(source_path.is_file(), source_path)
+                self.assertIn("Fixture:", source_path.read_text(encoding="utf-8"))
+                self.assertGreaterEqual(len(entry["assertion_paths"]), 1)
+                for assertion_path in entry["assertion_paths"]:
+                    self._assert_test_path_exists(assertion_path)
+
+                if resource_path.suffix == ".yy":
+                    data = json.loads(resource_path.read_text(encoding="utf-8"))
+                    self.assertEqual(data["resourceType"], entry["resource_type"])
+
+    def test_resource_matrix_yyp_links_committed_resources(self) -> None:
+        corpus = _load_corpus()
+        yyp_path = FIXTURE_ROOT / corpus["resource_matrix_project"]
+        yyp_data = cast(dict[str, object], json.loads(yyp_path.read_text(encoding="utf-8")))
+        resources = cast(list[object], yyp_data["resources"])
+        yyp_resource_paths: set[str] = set()
+        for resource in resources:
+            if not isinstance(resource, dict):
+                continue
+            typed_resource = cast(dict[object, object], resource)
+            resource_id = typed_resource.get("id")
+            if not isinstance(resource_id, dict):
+                continue
+            typed_resource_id = cast(dict[object, object], resource_id)
+            path = typed_resource_id.get("path")
+            if isinstance(path, str):
+                yyp_resource_paths.add(path)
+
+        self.assertIn("AudioGroups", yyp_data)
+        self.assertIn("TextureGroups", yyp_data)
+        for entry in corpus["required_resource_areas"]:
+            resource_path = entry["game_maker_resource_path"].removeprefix("projects/resource_matrix/")
+            if resource_path.endswith(".yy") and not resource_path.startswith(("options/", "audiogroups/", "texturegroups/", "materials/")):
+                self.assertIn(resource_path, yyp_resource_paths)
+
+    def test_golden_trace_specs_have_executable_assertion_paths(self) -> None:
+        corpus = _load_corpus()
+        traces = corpus["golden_trace_specs"]
+        budget = corpus["coverage_budget"]
+
+        self.assertEqual({trace["id"] for trace in traces}, REQUIRED_TRACE_IDS)
+        self.assertGreaterEqual(len(traces), budget["minimum_golden_trace_count"])
+        for trace in traces:
+            with self.subTest(trace=trace["id"]):
+                self.assertGreaterEqual(len(trace["expected_trace"]), 1)
+                for assertion_path in trace["assertion_paths"]:
+                    self._assert_test_path_exists(assertion_path)
+
+    def test_visual_regression_specs_reference_pixel_or_render_assertions(self) -> None:
+        corpus = _load_corpus()
+        visuals = corpus["visual_regression_specs"]
+        budget = corpus["coverage_budget"]
+
+        self.assertGreaterEqual(len(visuals), budget["minimum_visual_regression_count"])
+        self.assertTrue(any(spec["pixel_check"] for spec in visuals))
+        for spec in visuals:
+            with self.subTest(visual=spec["id"]):
+                self.assertTrue(spec["feature"])
+                for assertion_path in spec["assertion_paths"]:
+                    test_path = self._assert_test_path_exists(assertion_path)
+                    source = test_path.read_text(encoding="utf-8")
+                    if spec["pixel_check"]:
+                        self.assertRegex(source, r"get_pixel|Color\(")
+
+    def test_malformed_fixtures_record_diagnostics_and_continue_outputs(self) -> None:
+        corpus = _load_corpus()
+        self.assertGreaterEqual(
+            len(corpus["malformed_fixture_projects"]),
+            corpus["coverage_budget"]["minimum_malformed_fixture_count"],
+        )
+
+        for malformed in corpus["malformed_fixture_projects"]:
+            with self.subTest(fixture=malformed["id"]):
+                gm_project = FIXTURE_ROOT / malformed["project_path"]
+                gm_dir = gm_project.parent
+                godot_dir = Path(tempfile.mkdtemp())
+                logs: list[str] = []
+                statuses: list[str] = []
+                conversion_running = threading.Event()
+                conversion_running.set()
+                try:
+                    (godot_dir / "project.godot").write_text(
+                        '[application]\nconfig/name="Malformed Fixture"\n',
+                        encoding="utf-8",
+                    )
+                    converter = Converter(
+                        log_callback=lambda message: logs.append(str(message)),
+                        progress_callback=lambda _value: None,
+                        status_callback=lambda message: statuses.append(str(message)),
+                        conversion_running=conversion_running,
+                        max_workers=1,
+                    )
+                    converter.convert(
+                        str(gm_dir),
+                        "windows",
+                        str(godot_dir),
+                        {"asset_registry": _Setting(True)},
+                    )
+
+                    for relative_path in malformed["continued_outputs"]:
+                        self.assertTrue((godot_dir / relative_path).is_file(), relative_path)
+                    diagnostics = json.loads(
+                        (godot_dir / DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH).read_text(encoding="utf-8")
+                    )
+                    codes = [diagnostic["code"] for diagnostic in diagnostics["diagnostics"]]
+                    self.assertIn(malformed["expected_diagnostic_code"], codes)
+                    self.assertTrue((godot_dir / CONVERSION_MANIFEST_RELATIVE_PATH).is_file())
+                    self.assertTrue((godot_dir / ARCHITECTURE_POLICY_RELATIVE_PATH).is_file())
+                    self.assertTrue(
+                        any(malformed["expected_log_fragment"] in log for log in logs),
+                        logs,
+                    )
+                finally:
+                    shutil.rmtree(godot_dir)
+
+    def _assert_test_path_exists(self, assertion_path: str) -> Path:
+        module_path, separator, target = assertion_path.partition("::")
+        self.assertEqual(separator, "::", assertion_path)
+        class_name, method_separator, method_name = target.partition(".")
+        self.assertEqual(method_separator, ".", assertion_path)
+
+        test_path = PROJECT_ROOT / module_path
+        self.assertTrue(test_path.is_file(), test_path)
+        source = test_path.read_text(encoding="utf-8")
+        self.assertRegex(source, rf"(?m)^class\s+{re.escape(class_name)}\b")
+        self.assertRegex(source, rf"(?m)^\s+def\s+{re.escape(method_name)}\b")
+        return test_path
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/todo-list/07-testing-codebase-improvements.md
+++ b/todo-list/07-testing-codebase-improvements.md
@@ -27,13 +27,13 @@ This file tracks engineering work that will make full transpilation safer to bui
 - [ ] Add generated scene/resource load validation through Godot headless.
 - [ ] Add external-project conversion assertions for unsupported/transpile-warning counts.
 - [ ] Add failure thresholds for unsupported APIs, invalid generated code, missing assets, and skipped resources.
-- [ ] Add committed minimal `.yyp/.yy` fixture project corpus.
+- [x] Add committed minimal `.yyp/.yy` fixture project corpus.
 - [ ] Add end-to-end golden conversion tests over fixture projects.
 - [ ] Snapshot selected generated `project.godot`, `.tscn`, `.gd`, registry, and runtime outputs.
 - [ ] Normalize nondeterministic IDs and paths in snapshots.
 - [ ] Add deterministic output tests for ordering, ext_resource IDs, object/room ordering, and dictionary traversal.
 - [ ] Add manifest-to-runtime/emitter consistency tests.
-- [ ] Add manifest-to-fixture coverage budgets.
+- [x] Add manifest-to-fixture coverage budgets.
 - [ ] Add durable unsupported-feature report artifacts as JSON and Markdown.
 
 ## P0: Diagnostics And User Reports
@@ -94,22 +94,22 @@ This file tracks engineering work that will make full transpilation safer to bui
 
 ## P1: Real GameMaker Fixtures
 
-- [ ] Add fixture projects for shaders and materials.
-- [ ] Add fixture projects for paths.
-- [ ] Add fixture projects for timelines and sequences.
-- [ ] Add fixture projects for particles.
-- [ ] Add fixture projects for physics.
-- [ ] Add fixture projects for tilemaps.
-- [ ] Add fixture projects for views and layer inheritance.
-- [ ] Add fixture projects for extension functions.
-- [ ] Add fixture projects for macros and configs.
-- [ ] Add fixture projects for included files.
-- [ ] Add fixture projects for fonts.
-- [ ] Add fixture projects for texture groups.
-- [ ] Add fixture projects for audio groups.
-- [ ] Add fixture projects for options and platform settings.
+- [x] Add fixture projects for shaders and materials.
+- [x] Add fixture projects for paths.
+- [x] Add fixture projects for timelines and sequences.
+- [x] Add fixture projects for particles.
+- [x] Add fixture projects for physics.
+- [x] Add fixture projects for tilemaps.
+- [x] Add fixture projects for views and layer inheritance.
+- [x] Add fixture projects for extension functions.
+- [x] Add fixture projects for macros and configs.
+- [x] Add fixture projects for included files.
+- [x] Add fixture projects for fonts.
+- [x] Add fixture projects for texture groups.
+- [x] Add fixture projects for audio groups.
+- [x] Add fixture projects for options and platform settings.
 - [ ] Add multiple GameMaker version fixtures if supporting more than the currently documented version.
-- [ ] Add malformed/missing `.yy` fixtures.
+- [x] Add malformed/missing `.yy` fixtures.
 - [ ] Add fixtures that prove conversion can continue after unsupported features while preserving diagnostics.
 
 ## P2: Pyright, Lint, And Code Health


### PR DESCRIPTION
Closes #610.

## Summary
- add a committed Part 2 resource-matrix GameMaker fixture project covering shaders, materials, paths, timelines, sequences, particles, physics, tilemaps, views/layer inheritance, extensions, macros/configs, included files, fonts, texture groups, audio groups, and platform options
- add corpus coverage budgets for resource areas, golden traces, visual regression specs, and malformed/missing-resource fixtures
- add corpus tests that verify fixture files, resource types, linked assertion paths, visual/pixel checks, and malformed conversion diagnostics/continued outputs
- promote missing resource skips in the resource index and asset registry to structured warning diagnostics

## Tests
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest tests.test_part2_fixture_corpus tests.test_part2_fixture_catalog tests.test_asset_registry tests.test_resource_index
- ./venv/bin/python -m unittest
- git diff --check