### PR TITLE
Refactor conversion architecture boundaries

### DIFF
--- a/src/conversion/conversion_architecture.md
+++ b/src/conversion/conversion_architecture.md
@@ -1,0 +1,50 @@
+# Conversion Architecture
+
+This document records the boundaries used by the converter orchestration and
+the GML transpiler. It is intentionally implementation-facing: tests assert the
+module names and responsibilities below so future refactors keep these seams
+visible.
+
+## Conversion Run Context
+
+`conversion_context.ConversionContext` is the typed run state shared by the
+orchestrator and conversion step factories. It carries source and target paths,
+target platform, callbacks, the running flag, diagnostics, worker settings, and
+the enabled converter set. New converter wiring should receive this context
+instead of adding another parallel list of constructor arguments.
+
+## Conversion Plan
+
+`conversion_plan.CONVERSION_STEPS` is the single dependency graph for
+converter execution. Each step has a stable key, a group (`project`, `assets`,
+or `wip`), a localized log key, and optional dependencies. The planner orders
+enabled steps topologically but does not auto-enable dependencies; user settings
+still define the conversion surface.
+
+## Resource Models
+
+`resource_models.parse_gamemaker_resource_models()` parses `.yyp` and `.yy`
+metadata into typed intermediate models without accepting a Godot output path
+and without writing files. The model layer currently covers project metadata,
+sprites, sounds, fonts, objects, rooms, room layers, scripts, shaders, tilesets,
+paths, sequences, timelines, generic remaining resources, and diagnostics.
+Converters can adopt these models incrementally as resource-specific renderers
+are separated from discovery and parsing.
+
+## GML Pipeline Phases
+
+The GML transpiler has three explicit phase families:
+
+- Parser phase: `gml_transpiler_parts.tokens`,
+  `gml_transpiler_parts.expression_parser`, `statement_parser`, and `model`
+  turn source text into typed token and AST structures.
+- Semantic analysis phase: `preprocessor`, `gml_function_dispatch`,
+  `gml_api_manifest`, `extension_functions`, and `asset_lowering` resolve
+  configuration, API support, arity, extension mappings, and asset-argument
+  lowering rules.
+- GDScript emission phase: `emitter`, `expression_service`, and `api` render
+  validated AST or statement output to GDScript and source-map metadata.
+
+Asset-specific lowering metadata lives in `asset_lowering` so the generic
+expression emitter does not own the GameMaker API argument tables.
+

--- a/src/conversion/conversion_context.py
+++ b/src/conversion/conversion_context.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Protocol
+
+from src.conversion.diagnostics import DiagnosticCollector
+from src.conversion.type_defs import BoolSetting, ConversionRunning, LogCallback, ProgressCallback
+
+
+class RunningFlag(Protocol):
+    def is_set(self) -> bool: ...
+
+
+@dataclass(frozen=True)
+class ConversionContext:
+    """Typed shared state for a single conversion run."""
+
+    gm_project_path: str
+    godot_project_path: str
+    target_platform: str
+    log_callback: LogCallback
+    progress_callback: ProgressCallback
+    status_callback: LogCallback
+    conversion_running: ConversionRunning
+    update_log_callback: LogCallback
+    compact_logging: bool
+    max_workers: int | None
+    diagnostics: DiagnosticCollector
+    enabled_converters: tuple[str, ...]
+    group_sounds_by_audio_group: bool = False
+
+    def is_running(self) -> bool:
+        return self.conversion_running()
+
+
+def enabled_converter_keys(settings: Mapping[str, BoolSetting]) -> tuple[str, ...]:
+    """Return enabled conversion step keys, excluding non-step UI settings."""
+    return tuple(
+        sorted(
+            key
+            for key, setting in settings.items()
+            if key != "sound_group_folders" and setting.get()
+        )
+    )
+
+
+def sound_group_folders_enabled(settings: Mapping[str, BoolSetting]) -> bool:
+    sound_group_setting = settings.get("sound_group_folders")
+    return bool(sound_group_setting is not None and sound_group_setting.get())
+

--- a/src/conversion/conversion_plan.py
+++ b/src/conversion/conversion_plan.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Literal, Sequence
+
+
+ConversionGroup = Literal["project", "assets", "wip"]
+
+
+@dataclass(frozen=True)
+class ConversionStep:
+    """One conversion action and its dependency metadata."""
+
+    key: str
+    group: ConversionGroup
+    log_key: str
+    dependencies: tuple[str, ...] = field(default_factory=tuple)
+
+
+CONVERSION_STEPS: tuple[ConversionStep, ...] = (
+    ConversionStep("game_icon", "project", "Console_Convertor_Icon"),
+    ConversionStep("project_name", "project", "Console_Convertor_Name"),
+    ConversionStep("project_settings", "project", "Console_Convertor_Settings", ("project_name",)),
+    ConversionStep("audio_buses", "project", "Console_Convertor_AudioBus", ("project_settings",)),
+    ConversionStep("sprites", "assets", "Console_Convertor_Sprites"),
+    ConversionStep("fonts", "assets", "Console_Convertor_Fonts"),
+    ConversionStep("tilesets", "wip", "Console_Convertor_Tilesets", ("sprites",)),
+    ConversionStep("sounds", "assets", "Console_Convertor_Sounds"),
+    ConversionStep("notes", "project", "Console_Convertor_Notes"),
+    ConversionStep("shaders", "wip", "Console_Convertor_Shaders"),
+    ConversionStep("included_files", "assets", "Console_Convertor_IncludedFiles"),
+    ConversionStep("scripts", "assets", "Console_Convertor_Scripts", ("included_files",)),
+    ConversionStep("objects", "assets", "Console_Convertor_Objects", ("sprites", "scripts")),
+    ConversionStep("rooms", "assets", "Console_Convertor_Rooms", ("objects", "tilesets", "scripts")),
+    ConversionStep(
+        "asset_registry",
+        "assets",
+        "Console_Convertor_AssetRegistry",
+        (
+            "sprites",
+            "fonts",
+            "tilesets",
+            "sounds",
+            "shaders",
+            "included_files",
+            "scripts",
+            "objects",
+            "rooms",
+        ),
+    ),
+)
+
+
+def conversion_step_map(
+    steps: Sequence[ConversionStep] = CONVERSION_STEPS,
+) -> dict[str, ConversionStep]:
+    return {step.key: step for step in steps}
+
+
+def validate_conversion_step_graph(
+    steps: Sequence[ConversionStep] = CONVERSION_STEPS,
+) -> tuple[str, ...]:
+    """Return dependency graph validation errors without raising."""
+    step_by_key = conversion_step_map(steps)
+    errors: list[str] = []
+    if len(step_by_key) != len(steps):
+        errors.append("Conversion step keys must be unique.")
+    for step in steps:
+        for dependency in step.dependencies:
+            if dependency not in step_by_key:
+                errors.append(f"Conversion step {step.key!r} depends on unknown step {dependency!r}.")
+    try:
+        build_conversion_plan((step.key for step in steps), steps=steps)
+    except ValueError as exc:
+        errors.append(str(exc))
+    return tuple(errors)
+
+
+def build_conversion_plan(
+    enabled_keys: Iterable[str],
+    *,
+    steps: Sequence[ConversionStep] = CONVERSION_STEPS,
+) -> tuple[ConversionStep, ...]:
+    """Return enabled conversion steps in dependency order.
+
+    Dependencies only order steps that are already enabled. The planner does not
+    auto-enable dependencies because UI settings still control the conversion
+    surface.
+    """
+    step_by_key = conversion_step_map(steps)
+    enabled = {key for key in enabled_keys if key in step_by_key}
+    ordered: list[ConversionStep] = []
+    temporary: set[str] = set()
+    permanent: set[str] = set()
+
+    def visit(key: str) -> None:
+        if key in permanent:
+            return
+        if key in temporary:
+            cycle = " -> ".join([*temporary, key])
+            raise ValueError(f"Conversion dependency cycle detected: {cycle}")
+        temporary.add(key)
+        step = step_by_key[key]
+        for dependency in step.dependencies:
+            if dependency in enabled:
+                visit(dependency)
+        temporary.remove(key)
+        permanent.add(key)
+        ordered.append(step)
+
+    for step in steps:
+        if step.key in enabled:
+            visit(step.key)
+
+    return tuple(ordered)
+
+
+def group_conversion_plan(plan: Iterable[ConversionStep]) -> dict[ConversionGroup, tuple[ConversionStep, ...]]:
+    grouped: dict[ConversionGroup, list[ConversionStep]] = {
+        "project": [],
+        "assets": [],
+        "wip": [],
+    }
+    for step in plan:
+        grouped[step.group].append(step)
+    return {
+        group: tuple(group_steps)
+        for group, group_steps in grouped.items()
+        if group_steps
+    }

--- a/src/conversion/converter.py
+++ b/src/conversion/converter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Mapping, Protocol, TypeAlias
+from typing import Callable, Mapping, TypeAlias
 
 from src.conversion.sprites import SpriteConverter
 from src.conversion.sounds import SoundConverter
@@ -15,7 +15,14 @@ from src.conversion.shaders import ShaderConverter
 from src.conversion.included_files import IncludedFilesConverter
 from src.conversion.project_settings import ProjectSettingsConverter
 from src.conversion.architecture_policy import write_architecture_policy_report
+from src.conversion.conversion_context import (
+    ConversionContext,
+    RunningFlag,
+    enabled_converter_keys,
+    sound_group_folders_enabled,
+)
 from src.conversion.conversion_manifest import write_conversion_manifest
+from src.conversion.conversion_plan import build_conversion_plan
 from src.conversion.diagnostics import DiagnosticCollector, write_conversion_diagnostic_reports
 from src.conversion.type_defs import BoolSetting, LogCallback, ProgressCallback
 
@@ -27,10 +34,6 @@ CONVERSION_CATEGORIES: dict[str, list[str]] = {
     "project": ["game_icon", "project_name", "project_settings", "audio_buses", "notes"],
     "wip": ["shaders", "tilesets"],
 }
-
-
-class RunningFlag(Protocol):
-    def is_set(self) -> bool: ...
 
 
 ConverterFn: TypeAlias = Callable[[], object]
@@ -57,138 +60,192 @@ class Converter:
         self.diagnostics = DiagnosticCollector()
         self.log_callback = self.diagnostics.wrap_log_callback(self._raw_log_callback)
         self.update_log_callback = self.diagnostics.wrap_log_callback(self._raw_update_log_callback)
-
-        group_sounds_by_audio_group = False
-        if "sound_group_folders" in settings:
-            group_sounds_by_audio_group = settings["sound_group_folders"].get()
-
-        project_settings = ProjectSettingsConverter(
-            gm_path, godot_path, self.log_callback,
-            self.progress_callback, self.conversion_running.is_set,
-            gm_platform=gm_platform,
-            max_workers=self.max_workers,
-            diagnostics=self.diagnostics,
-        )
-
-        converters: list[tuple[str, ConverterFn, str]] = [
-            ("game_icon", project_settings.convert_icon, "Console_Convertor_Icon"),
-            ("project_name", project_settings.update_project_name, "Console_Convertor_Name"),
-            ("project_settings", project_settings.update_project_settings, "Console_Convertor_Settings"),
-            ("audio_buses", project_settings.generate_audio_bus_layout, "Console_Convertor_AudioBus"),
-            ("sprites", lambda: SpriteConverter(
-                gm_path, godot_path, self.log_callback,
-                self.progress_callback, self.conversion_running.is_set,
-                update_log_callback=self.update_log_callback,
-                compact_logging=self.compact_logging,
-                max_workers=self.max_workers,
-            ).convert_all(), "Console_Convertor_Sprites"),
-            ("fonts", lambda: FontConverter(
-                gm_path, godot_path, self.log_callback,
-                self.progress_callback, self.conversion_running.is_set,
-                update_log_callback=self.update_log_callback,
-                compact_logging=self.compact_logging,
-                max_workers=self.max_workers,
-            ).convert_all(), "Console_Convertor_Fonts"),
-            ("tilesets", lambda: TileSetConverter(
-                gm_path, godot_path, self.log_callback,
-                self.progress_callback, self.conversion_running.is_set,
-                update_log_callback=self.update_log_callback,
-                compact_logging=self.compact_logging,
-                max_workers=self.max_workers,
-            ).convert_all(), "Console_Convertor_Tilesets"),
-            ("sounds", lambda: SoundConverter(
-                gm_path, godot_path, self.log_callback,
-                self.progress_callback, self.conversion_running.is_set,
-                update_log_callback=self.update_log_callback,
-                compact_logging=self.compact_logging,
-                max_workers=self.max_workers,
-                organize_by_audio_group=group_sounds_by_audio_group,
-            ).convert_all(), "Console_Convertor_Sounds"),
-            ("notes", lambda: NoteConverter(
-                gm_path, godot_path, self.log_callback,
-                self.progress_callback, self.conversion_running.is_set,
-                update_log_callback=self.update_log_callback,
-                compact_logging=self.compact_logging,
-                max_workers=self.max_workers,
-            ).convert_all(), "Console_Convertor_Notes"),
-            ("shaders", lambda: ShaderConverter(
-                gm_path, godot_path, self.log_callback,
-                self.progress_callback, self.conversion_running.is_set,
-                update_log_callback=self.update_log_callback,
-                compact_logging=self.compact_logging,
-                max_workers=self.max_workers,
-            ).convert_all(), "Console_Convertor_Shaders"),
-            ("included_files", lambda: IncludedFilesConverter(
-                gm_path, godot_path, self.log_callback,
-                self.progress_callback, self.conversion_running.is_set,
-                update_log_callback=self.update_log_callback,
-                compact_logging=self.compact_logging,
-                max_workers=self.max_workers,
-            ).convert_all(), "Console_Convertor_IncludedFiles"),
-            ("scripts", lambda: ScriptConverter(
-                gm_path, godot_path, self.log_callback,
-                self.progress_callback, self.conversion_running.is_set,
-                update_log_callback=self.update_log_callback,
-                compact_logging=self.compact_logging,
-                max_workers=self.max_workers,
-                diagnostics=self.diagnostics,
-                macro_configuration=gm_platform,
-            ).convert_all(), "Console_Convertor_Scripts"),
-            ("objects", lambda: ObjectConverter(
-                gm_path, godot_path, self.log_callback,
-                self.progress_callback, self.conversion_running.is_set,
-                update_log_callback=self.update_log_callback,
-                compact_logging=self.compact_logging,
-                max_workers=self.max_workers,
-                diagnostics=self.diagnostics,
-                macro_configuration=gm_platform,
-            ).convert_all(), "Console_Convertor_Objects"),
-            ("rooms", lambda: RoomConverter(
-                gm_path, godot_path, self.log_callback,
-                self.progress_callback, self.conversion_running.is_set,
-                update_log_callback=self.update_log_callback,
-                compact_logging=self.compact_logging,
-                max_workers=self.max_workers,
-                diagnostics=self.diagnostics,
-            ).convert_all(), "Console_Convertor_Rooms"),
-            ("asset_registry", lambda: AssetRegistryConverter(
-                gm_path, godot_path, self.log_callback,
-                self.progress_callback, self.conversion_running.is_set,
-                update_log_callback=self.update_log_callback,
-                compact_logging=self.compact_logging,
-                max_workers=self.max_workers,
-                organize_sounds_by_audio_group=group_sounds_by_audio_group,
-            ).convert_all(), "Console_Convertor_AssetRegistry"),
-        ]
-
-        enabled_converters = tuple(
-            sorted(
-                key
-                for key, setting in settings.items()
-                if key != "sound_group_folders" and setting.get()
-            )
-        )
+        context = self._create_context(gm_path, gm_platform, godot_path, settings)
+        runners = self._build_step_runners(context)
+        plan = build_conversion_plan(context.enabled_converters)
 
         try:
-            for setting_key, converter_fn, log_key in converters:
-                setting = settings.get(setting_key)
-                if setting is not None and setting.get() and self.conversion_running.is_set():
-                    log_message = get_localized(log_key)
-                    self.log_callback(log_message)
-                    self.status_callback(log_message)
-                    converter_fn()
-                    self.progress_callback(0)
+            for step in plan:
+                if not context.is_running():
+                    break
+                converter_fn = runners.get(step.key)
+                if converter_fn is None:
+                    continue
+                log_message = get_localized(step.log_key)
+                context.log_callback(log_message)
+                context.status_callback(log_message)
+                converter_fn()
+                context.progress_callback(0)
         finally:
-            write_conversion_diagnostic_reports(godot_path, self.diagnostics)
+            write_conversion_diagnostic_reports(context.godot_project_path, context.diagnostics)
             write_architecture_policy_report(
-                gm_path,
-                godot_path,
-                target_platform=gm_platform,
-                enabled_converters=enabled_converters,
+                context.gm_project_path,
+                context.godot_project_path,
+                target_platform=context.target_platform,
+                enabled_converters=context.enabled_converters,
             )
             write_conversion_manifest(
-                gm_path,
-                godot_path,
-                target_platform=gm_platform,
-                enabled_converters=enabled_converters,
+                context.gm_project_path,
+                context.godot_project_path,
+                target_platform=context.target_platform,
+                enabled_converters=context.enabled_converters,
             )
+
+    def _create_context(
+        self,
+        gm_path: str,
+        gm_platform: str,
+        godot_path: str,
+        settings: Mapping[str, BoolSetting],
+    ) -> ConversionContext:
+        return ConversionContext(
+            gm_project_path=gm_path,
+            godot_project_path=godot_path,
+            target_platform=gm_platform,
+            log_callback=self.log_callback,
+            progress_callback=self.progress_callback,
+            status_callback=self.status_callback,
+            conversion_running=self.conversion_running.is_set,
+            update_log_callback=self.update_log_callback,
+            compact_logging=self.compact_logging,
+            max_workers=self.max_workers,
+            diagnostics=self.diagnostics,
+            enabled_converters=enabled_converter_keys(settings),
+            group_sounds_by_audio_group=sound_group_folders_enabled(settings),
+        )
+
+    def _build_step_runners(self, context: ConversionContext) -> dict[str, ConverterFn]:
+        project_settings = ProjectSettingsConverter(
+            context.gm_project_path,
+            context.godot_project_path,
+            context.log_callback,
+            context.progress_callback,
+            context.is_running,
+            gm_platform=context.target_platform,
+            max_workers=context.max_workers,
+            diagnostics=context.diagnostics,
+        )
+
+        return {
+            "game_icon": project_settings.convert_icon,
+            "project_name": project_settings.update_project_name,
+            "project_settings": project_settings.update_project_settings,
+            "audio_buses": project_settings.generate_audio_bus_layout,
+            "sprites": lambda: SpriteConverter(
+                context.gm_project_path,
+                context.godot_project_path,
+                context.log_callback,
+                context.progress_callback,
+                context.is_running,
+                update_log_callback=context.update_log_callback,
+                compact_logging=context.compact_logging,
+                max_workers=context.max_workers,
+            ).convert_all(),
+            "fonts": lambda: FontConverter(
+                context.gm_project_path,
+                context.godot_project_path,
+                context.log_callback,
+                context.progress_callback,
+                context.is_running,
+                update_log_callback=context.update_log_callback,
+                compact_logging=context.compact_logging,
+                max_workers=context.max_workers,
+            ).convert_all(),
+            "tilesets": lambda: TileSetConverter(
+                context.gm_project_path,
+                context.godot_project_path,
+                context.log_callback,
+                context.progress_callback,
+                context.is_running,
+                update_log_callback=context.update_log_callback,
+                compact_logging=context.compact_logging,
+                max_workers=context.max_workers,
+            ).convert_all(),
+            "sounds": lambda: SoundConverter(
+                context.gm_project_path,
+                context.godot_project_path,
+                context.log_callback,
+                context.progress_callback,
+                context.is_running,
+                update_log_callback=context.update_log_callback,
+                compact_logging=context.compact_logging,
+                max_workers=context.max_workers,
+                organize_by_audio_group=context.group_sounds_by_audio_group,
+            ).convert_all(),
+            "notes": lambda: NoteConverter(
+                context.gm_project_path,
+                context.godot_project_path,
+                context.log_callback,
+                context.progress_callback,
+                context.is_running,
+                update_log_callback=context.update_log_callback,
+                compact_logging=context.compact_logging,
+                max_workers=context.max_workers,
+            ).convert_all(),
+            "shaders": lambda: ShaderConverter(
+                context.gm_project_path,
+                context.godot_project_path,
+                context.log_callback,
+                context.progress_callback,
+                context.is_running,
+                update_log_callback=context.update_log_callback,
+                compact_logging=context.compact_logging,
+                max_workers=context.max_workers,
+            ).convert_all(),
+            "included_files": lambda: IncludedFilesConverter(
+                context.gm_project_path,
+                context.godot_project_path,
+                context.log_callback,
+                context.progress_callback,
+                context.is_running,
+                update_log_callback=context.update_log_callback,
+                compact_logging=context.compact_logging,
+                max_workers=context.max_workers,
+            ).convert_all(),
+            "scripts": lambda: ScriptConverter(
+                context.gm_project_path,
+                context.godot_project_path,
+                context.log_callback,
+                context.progress_callback,
+                context.is_running,
+                update_log_callback=context.update_log_callback,
+                compact_logging=context.compact_logging,
+                max_workers=context.max_workers,
+                diagnostics=context.diagnostics,
+                macro_configuration=context.target_platform,
+            ).convert_all(),
+            "objects": lambda: ObjectConverter(
+                context.gm_project_path,
+                context.godot_project_path,
+                context.log_callback,
+                context.progress_callback,
+                context.is_running,
+                update_log_callback=context.update_log_callback,
+                compact_logging=context.compact_logging,
+                max_workers=context.max_workers,
+                diagnostics=context.diagnostics,
+                macro_configuration=context.target_platform,
+            ).convert_all(),
+            "rooms": lambda: RoomConverter(
+                context.gm_project_path,
+                context.godot_project_path,
+                context.log_callback,
+                context.progress_callback,
+                context.is_running,
+                update_log_callback=context.update_log_callback,
+                compact_logging=context.compact_logging,
+                max_workers=context.max_workers,
+                diagnostics=context.diagnostics,
+            ).convert_all(),
+            "asset_registry": lambda: AssetRegistryConverter(
+                context.gm_project_path,
+                context.godot_project_path,
+                context.log_callback,
+                context.progress_callback,
+                context.is_running,
+                update_log_callback=context.update_log_callback,
+                compact_logging=context.compact_logging,
+                max_workers=context.max_workers,
+                organize_sounds_by_audio_group=context.group_sounds_by_audio_group,
+            ).convert_all(),
+        }

--- a/src/conversion/gml_transpiler_parts/asset_lowering.py
+++ b/src/conversion/gml_transpiler_parts/asset_lowering.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import Literal
+
+
+AssetLoweringDomain = Literal["audio", "draw", "path", "room", "script", "sequence_timeline"]
+
+
+_PATH_ASSET_ARG_INDICES: dict[str, frozenset[int]] = {
+    "path_get_length": frozenset({0}),
+    "path_start": frozenset({0}),
+    "mp_grid_path": frozenset({1}),
+}
+
+_DRAW_ASSET_ARG_INDICES: dict[str, frozenset[int]] = {
+    "draw_sprite": frozenset({0}),
+    "draw_sprite_ext": frozenset({0}),
+    "draw_sprite_part": frozenset({0}),
+    "draw_sprite_part_ext": frozenset({0}),
+    "draw_sprite_general": frozenset({0}),
+    "draw_sprite_pos": frozenset({0}),
+    "draw_sprite_tiled": frozenset({0}),
+    "draw_sprite_tiled_ext": frozenset({0}),
+    "draw_tile": frozenset({0}),
+    "draw_set_font": frozenset({0}),
+    "sprite_get_texture": frozenset({0}),
+    "sprite_get_uvs": frozenset({0}),
+    "sprite_prefetch": frozenset({0}),
+    "sprite_flush": frozenset({0}),
+    "texturegroup_set_mode": frozenset({2}),
+    "shader_set": frozenset({0}),
+    "shader_get_name": frozenset({0}),
+    "shader_is_compiled": frozenset({0}),
+    "shader_get_uniform": frozenset({0}),
+    "shader_get_sampler_index": frozenset({0}),
+    "part_system_create": frozenset({0}),
+    "part_system_create_layer": frozenset({2}),
+    "part_type_sprite": frozenset({1}),
+    "camera_create_view": frozenset({5}),
+}
+
+_AUDIO_ASSET_ARG_INDICES: dict[str, frozenset[int]] = {
+    "audio_play_sound": frozenset({0}),
+    "audio_play_sound_at": frozenset({0}),
+    "audio_play_sound_on": frozenset({1}),
+    "audio_stop_sound": frozenset({0}),
+    "audio_pause_sound": frozenset({0}),
+    "audio_resume_sound": frozenset({0}),
+    "audio_is_playing": frozenset({0}),
+    "audio_is_paused": frozenset({0}),
+    "audio_sound_gain": frozenset({0}),
+    "audio_sound_get_gain": frozenset({0}),
+    "audio_sound_pitch": frozenset({0}),
+    "audio_sound_get_pitch": frozenset({0}),
+    "audio_sound_loop": frozenset({0}),
+    "audio_sound_get_loop": frozenset({0}),
+    "audio_sound_set_listener_mask": frozenset({0}),
+    "audio_sound_get_listener_mask": frozenset({0}),
+    "audio_sound_get_asset": frozenset({0}),
+    "audio_play_in_sync_group": frozenset({1}),
+    "sound_play": frozenset({0}),
+    "sound_loop": frozenset({0}),
+    "sound_stop": frozenset({0}),
+    "sound_pause": frozenset({0}),
+    "sound_resume": frozenset({0}),
+    "sound_isplaying": frozenset({0}),
+    "sound_volume": frozenset({0}),
+    "sound_pitch": frozenset({0}),
+}
+
+_SCRIPT_ASSET_ARG_INDICES: dict[str, frozenset[int]] = {
+    "script_execute": frozenset({0}),
+    "script_exists": frozenset({0}),
+    "script_get_name": frozenset({0}),
+    "script_get_callable": frozenset({0}),
+}
+
+_ROOM_ASSET_ARG_INDICES: dict[str, frozenset[int]] = {
+    "room_goto": frozenset({0}),
+    "room_exists": frozenset({0}),
+    "room_get_name": frozenset({0}),
+    "room_get_info": frozenset({0}),
+}
+
+_SEQUENCE_TIMELINE_ASSET_ARG_INDICES: dict[str, frozenset[int]] = {
+    "timeline_exists": frozenset({0}),
+    "timeline_get_name": frozenset({0}),
+    "timeline_moment_add_script": frozenset({0, 2}),
+    "timeline_moment_clear": frozenset({0}),
+    "timeline_clear": frozenset({0}),
+    "timeline_size": frozenset({0}),
+    "timeline_max_moment": frozenset({0}),
+    "sequence_exists": frozenset({0}),
+    "sequence_get": frozenset({0}),
+    "sequence_destroy": frozenset({0}),
+    "layer_sequence_create": frozenset({3}),
+}
+
+_DOMAIN_INDICES: dict[AssetLoweringDomain, dict[str, frozenset[int]]] = {
+    "audio": _AUDIO_ASSET_ARG_INDICES,
+    "draw": _DRAW_ASSET_ARG_INDICES,
+    "path": _PATH_ASSET_ARG_INDICES,
+    "room": _ROOM_ASSET_ARG_INDICES,
+    "script": _SCRIPT_ASSET_ARG_INDICES,
+    "sequence_timeline": _SEQUENCE_TIMELINE_ASSET_ARG_INDICES,
+}
+
+
+def asset_argument_indices(function_name: str, domain: AssetLoweringDomain) -> frozenset[int]:
+    return _DOMAIN_INDICES[domain].get(function_name, frozenset())
+
+
+def first_argument_is_script_asset(function_name: str) -> bool:
+    return 0 in asset_argument_indices(function_name, "script")
+

--- a/src/conversion/gml_transpiler_parts/emitter.py
+++ b/src/conversion/gml_transpiler_parts/emitter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 from typing import Iterable
 
+from .asset_lowering import asset_argument_indices, first_argument_is_script_asset
 from .constants import (
     _ARITHMETIC_RUNTIME_FUNCTIONS,
     _BINARY_PRECEDENCE,
@@ -93,97 +94,6 @@ _COLLISION_SELECTOR_ARG_INDICES: dict[str, frozenset[int]] = {
     "collision_line_list": frozenset({4}),
     "collision_circle_list": frozenset({3}),
 }
-
-_PATH_ASSET_ARG_INDICES: dict[str, frozenset[int]] = {
-    "path_get_length": frozenset({0}),
-    "path_start": frozenset({0}),
-    "mp_grid_path": frozenset({1}),
-}
-
-_DRAW_ASSET_ARG_INDICES: dict[str, frozenset[int]] = {
-    "draw_sprite": frozenset({0}),
-    "draw_sprite_ext": frozenset({0}),
-    "draw_sprite_part": frozenset({0}),
-    "draw_sprite_part_ext": frozenset({0}),
-    "draw_sprite_general": frozenset({0}),
-    "draw_sprite_pos": frozenset({0}),
-    "draw_sprite_tiled": frozenset({0}),
-    "draw_sprite_tiled_ext": frozenset({0}),
-    "draw_tile": frozenset({0}),
-    "draw_set_font": frozenset({0}),
-    "sprite_get_texture": frozenset({0}),
-    "sprite_get_uvs": frozenset({0}),
-    "sprite_prefetch": frozenset({0}),
-    "sprite_flush": frozenset({0}),
-    "texturegroup_set_mode": frozenset({2}),
-    "shader_set": frozenset({0}),
-    "shader_get_name": frozenset({0}),
-    "shader_is_compiled": frozenset({0}),
-    "shader_get_uniform": frozenset({0}),
-    "shader_get_sampler_index": frozenset({0}),
-    "part_system_create": frozenset({0}),
-    "part_system_create_layer": frozenset({2}),
-    "part_type_sprite": frozenset({1}),
-    "camera_create_view": frozenset({5}),
-}
-
-_AUDIO_ASSET_ARG_INDICES: dict[str, frozenset[int]] = {
-    "audio_play_sound": frozenset({0}),
-    "audio_play_sound_at": frozenset({0}),
-    "audio_play_sound_on": frozenset({1}),
-    "audio_stop_sound": frozenset({0}),
-    "audio_pause_sound": frozenset({0}),
-    "audio_resume_sound": frozenset({0}),
-    "audio_is_playing": frozenset({0}),
-    "audio_is_paused": frozenset({0}),
-    "audio_sound_gain": frozenset({0}),
-    "audio_sound_get_gain": frozenset({0}),
-    "audio_sound_pitch": frozenset({0}),
-    "audio_sound_get_pitch": frozenset({0}),
-    "audio_sound_loop": frozenset({0}),
-    "audio_sound_get_loop": frozenset({0}),
-    "audio_sound_set_listener_mask": frozenset({0}),
-    "audio_sound_get_listener_mask": frozenset({0}),
-    "audio_sound_get_asset": frozenset({0}),
-    "audio_play_in_sync_group": frozenset({1}),
-    "sound_play": frozenset({0}),
-    "sound_loop": frozenset({0}),
-    "sound_stop": frozenset({0}),
-    "sound_pause": frozenset({0}),
-    "sound_resume": frozenset({0}),
-    "sound_isplaying": frozenset({0}),
-    "sound_volume": frozenset({0}),
-    "sound_pitch": frozenset({0}),
-}
-
-_SCRIPT_ASSET_ARG_INDICES: dict[str, frozenset[int]] = {
-    "script_execute": frozenset({0}),
-    "script_exists": frozenset({0}),
-    "script_get_name": frozenset({0}),
-    "script_get_callable": frozenset({0}),
-}
-
-_ROOM_ASSET_ARG_INDICES: dict[str, frozenset[int]] = {
-    "room_goto": frozenset({0}),
-    "room_exists": frozenset({0}),
-    "room_get_name": frozenset({0}),
-    "room_get_info": frozenset({0}),
-}
-
-_SEQUENCE_TIMELINE_ASSET_ARG_INDICES: dict[str, frozenset[int]] = {
-    "timeline_exists": frozenset({0}),
-    "timeline_get_name": frozenset({0}),
-    "timeline_moment_add_script": frozenset({0, 2}),
-    "timeline_moment_clear": frozenset({0}),
-    "timeline_clear": frozenset({0}),
-    "timeline_size": frozenset({0}),
-    "timeline_max_moment": frozenset({0}),
-    "sequence_exists": frozenset({0}),
-    "sequence_get": frozenset({0}),
-    "sequence_destroy": frozenset({0}),
-    "layer_sequence_create": frozenset({3}),
-}
-
 
 def _emit_name(
     value: str,
@@ -690,7 +600,7 @@ def _emit_descriptor_call(
         return f"GMRuntime.{descriptor.lowering_target}({', '.join(emitted_args)})"
 
     if descriptor.lowering_kind == "runtime_variadic_1":
-        if 0 in _SCRIPT_ASSET_ARG_INDICES.get(descriptor.name, frozenset()):
+        if first_argument_is_script_asset(descriptor.name):
             emitted_first = _emit_asset_argument(args[0], local_names, scope_context=scope_context)
         else:
             emitted_first = _emit_expression(args[0], local_names, scope_context=scope_context)[0]
@@ -720,7 +630,7 @@ def _emit_descriptor_call(
             f")"
         )
 
-    script_asset_indices = _SCRIPT_ASSET_ARG_INDICES.get(descriptor.name, frozenset())
+    script_asset_indices = asset_argument_indices(descriptor.name, "script")
     emitted_args = ", ".join(
         _emit_asset_argument(arg, local_names, scope_context=scope_context)
         if index in script_asset_indices
@@ -760,7 +670,7 @@ def _emit_instance_api_args(
     selector_indices = _INSTANCE_SELECTOR_ARG_INDICES.get(descriptor.name)
     if selector_indices is None:
         selector_indices = _COLLISION_SELECTOR_ARG_INDICES.get(descriptor.name, frozenset())
-    asset_indices = _PATH_ASSET_ARG_INDICES.get(descriptor.name, frozenset())
+    asset_indices = asset_argument_indices(descriptor.name, "path")
     emitted_args: list[str] = []
     for index, arg in enumerate(args):
         if index in selector_indices or index in asset_indices:
@@ -782,7 +692,7 @@ def _emit_draw_api_args(
     local_names: Iterable[str],
     scope_context: _ScopeContext,
 ) -> list[str]:
-    asset_indices = _DRAW_ASSET_ARG_INDICES.get(descriptor.name, frozenset())
+    asset_indices = asset_argument_indices(descriptor.name, "draw")
     emitted_args: list[str] = []
     for index, arg in enumerate(args):
         if index in asset_indices:
@@ -798,7 +708,7 @@ def _emit_audio_api_args(
     local_names: Iterable[str],
     scope_context: _ScopeContext,
 ) -> list[str]:
-    asset_indices = _AUDIO_ASSET_ARG_INDICES.get(descriptor.name, frozenset())
+    asset_indices = asset_argument_indices(descriptor.name, "audio")
     emitted_args: list[str] = []
     for index, arg in enumerate(args):
         if index in asset_indices:
@@ -814,7 +724,7 @@ def _emit_room_api_args(
     local_names: Iterable[str],
     scope_context: _ScopeContext,
 ) -> list[str]:
-    asset_indices = _ROOM_ASSET_ARG_INDICES.get(descriptor.name, frozenset())
+    asset_indices = asset_argument_indices(descriptor.name, "room")
     emitted_args: list[str] = []
     for index, arg in enumerate(args):
         if index in asset_indices:
@@ -830,7 +740,7 @@ def _emit_sequence_api_args(
     local_names: Iterable[str],
     scope_context: _ScopeContext,
 ) -> list[str]:
-    asset_indices = _SEQUENCE_TIMELINE_ASSET_ARG_INDICES.get(descriptor.name, frozenset())
+    asset_indices = asset_argument_indices(descriptor.name, "sequence_timeline")
     emitted_args: list[str] = []
     for index, arg in enumerate(args):
         if index in asset_indices:

--- a/src/conversion/resource_models.py
+++ b/src/conversion/resource_models.py
@@ -1,0 +1,514 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Literal, cast
+
+from src.conversion.generated_paths import generated_subfolder_path
+from src.conversion.project_manifest import GameMakerProjectManifest, ProjectResourceReference, load_gamemaker_project_manifest
+from src.conversion.type_defs import JsonDict, JsonList
+
+
+ResourceModelSeverity = Literal["warning", "error"]
+
+
+def _empty_json_dict() -> JsonDict:
+    return cast(JsonDict, {})
+
+
+@dataclass(frozen=True)
+class ResourceModelDiagnostic:
+    severity: ResourceModelSeverity
+    code: str
+    message: str
+    source_path: str = ""
+    resource_name: str = ""
+    resource_kind: str = ""
+
+
+@dataclass(frozen=True)
+class ProjectModel:
+    name: str
+    yyp_path: str | None
+    resource_type: str
+    resource_version: str
+    resource_count: int
+    audio_group_names: tuple[str, ...] = ()
+    texture_group_names: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ResourceModel:
+    name: str
+    kind: str
+    resource_type: str
+    yy_path: str
+    yyp_path: str
+    order: int
+    subfolder: str = ""
+    raw_data: JsonDict = field(default_factory=_empty_json_dict)
+
+
+@dataclass(frozen=True)
+class SpriteModel(ResourceModel):
+    width: int = 0
+    height: int = 0
+    origin: int = 0
+
+
+@dataclass(frozen=True)
+class SoundModel(ResourceModel):
+    sound_file: str = ""
+    audio_group: str = ""
+
+
+@dataclass(frozen=True)
+class FontModel(ResourceModel):
+    font_name: str = ""
+    size: float = 0.0
+
+
+@dataclass(frozen=True)
+class ObjectModel(ResourceModel):
+    sprite_name: str | None = None
+    parent_object_name: str | None = None
+    event_count: int = 0
+    persistent: bool = False
+    solid: bool = False
+
+
+@dataclass(frozen=True)
+class RoomLayerModel:
+    room_name: str
+    name: str
+    resource_type: str
+    depth: int | None
+    order: int
+    raw_data: JsonDict = field(default_factory=_empty_json_dict)
+
+
+@dataclass(frozen=True)
+class RoomModel(ResourceModel):
+    width: int = 0
+    height: int = 0
+    persistent: bool = False
+    inherit_layers: bool = False
+    parent_room_name: str | None = None
+    layers: tuple[RoomLayerModel, ...] = ()
+
+
+@dataclass(frozen=True)
+class ScriptModel(ResourceModel):
+    gml_path: str | None = None
+
+
+@dataclass(frozen=True)
+class ShaderModel(ResourceModel):
+    vertex_path: str | None = None
+    fragment_path: str | None = None
+
+
+@dataclass(frozen=True)
+class TileSetModel(ResourceModel):
+    sprite_name: str | None = None
+    tile_width: int = 0
+    tile_height: int = 0
+
+
+@dataclass(frozen=True)
+class PathModel(ResourceModel):
+    point_count: int = 0
+    closed: bool = False
+
+
+@dataclass(frozen=True)
+class SequenceModel(ResourceModel):
+    track_count: int = 0
+
+
+@dataclass(frozen=True)
+class TimelineModel(ResourceModel):
+    moment_count: int = 0
+
+
+@dataclass(frozen=True)
+class GameMakerResourceModels:
+    project: ProjectModel
+    sprites: tuple[SpriteModel, ...] = ()
+    sounds: tuple[SoundModel, ...] = ()
+    fonts: tuple[FontModel, ...] = ()
+    objects: tuple[ObjectModel, ...] = ()
+    rooms: tuple[RoomModel, ...] = ()
+    layers: tuple[RoomLayerModel, ...] = ()
+    scripts: tuple[ScriptModel, ...] = ()
+    shaders: tuple[ShaderModel, ...] = ()
+    tilesets: tuple[TileSetModel, ...] = ()
+    paths: tuple[PathModel, ...] = ()
+    sequences: tuple[SequenceModel, ...] = ()
+    timelines: tuple[TimelineModel, ...] = ()
+    other_resources: tuple[ResourceModel, ...] = ()
+    diagnostics: tuple[ResourceModelDiagnostic, ...] = ()
+
+
+def _empty_sprite_models() -> list[SpriteModel]:
+    return []
+
+
+def _empty_sound_models() -> list[SoundModel]:
+    return []
+
+
+def _empty_font_models() -> list[FontModel]:
+    return []
+
+
+def _empty_object_models() -> list[ObjectModel]:
+    return []
+
+
+def _empty_room_models() -> list[RoomModel]:
+    return []
+
+
+def _empty_script_models() -> list[ScriptModel]:
+    return []
+
+
+def _empty_shader_models() -> list[ShaderModel]:
+    return []
+
+
+def _empty_tileset_models() -> list[TileSetModel]:
+    return []
+
+
+def _empty_path_models() -> list[PathModel]:
+    return []
+
+
+def _empty_sequence_models() -> list[SequenceModel]:
+    return []
+
+
+def _empty_timeline_models() -> list[TimelineModel]:
+    return []
+
+
+def _empty_resource_models() -> list[ResourceModel]:
+    return []
+
+
+def parse_gamemaker_resource_models(gm_project_path: str) -> GameMakerResourceModels:
+    """Parse typed resource metadata without writing Godot output files."""
+    manifest = load_gamemaker_project_manifest(gm_project_path)
+    diagnostics = [
+        ResourceModelDiagnostic(
+            severity=diagnostic.severity,
+            code=diagnostic.code,
+            message=diagnostic.message,
+            source_path=diagnostic.source.path if diagnostic.source is not None else "",
+        )
+        for diagnostic in manifest.diagnostics
+    ]
+    parsed = _ParsedResourceModelBuckets()
+
+    for reference in manifest.resources:
+        model, model_diagnostics = _parse_resource_model(gm_project_path, reference)
+        diagnostics.extend(model_diagnostics)
+        if model is not None:
+            parsed.add(model)
+
+    return GameMakerResourceModels(
+        project=_project_model(manifest),
+        sprites=tuple(parsed.sprites),
+        sounds=tuple(parsed.sounds),
+        fonts=tuple(parsed.fonts),
+        objects=tuple(parsed.objects),
+        rooms=tuple(parsed.rooms),
+        layers=tuple(layer for room in parsed.rooms for layer in room.layers),
+        scripts=tuple(parsed.scripts),
+        shaders=tuple(parsed.shaders),
+        tilesets=tuple(parsed.tilesets),
+        paths=tuple(parsed.paths),
+        sequences=tuple(parsed.sequences),
+        timelines=tuple(parsed.timelines),
+        other_resources=tuple(parsed.other_resources),
+        diagnostics=tuple(diagnostics),
+    )
+
+
+@dataclass
+class _ParsedResourceModelBuckets:
+    sprites: list[SpriteModel] = field(default_factory=_empty_sprite_models)
+    sounds: list[SoundModel] = field(default_factory=_empty_sound_models)
+    fonts: list[FontModel] = field(default_factory=_empty_font_models)
+    objects: list[ObjectModel] = field(default_factory=_empty_object_models)
+    rooms: list[RoomModel] = field(default_factory=_empty_room_models)
+    scripts: list[ScriptModel] = field(default_factory=_empty_script_models)
+    shaders: list[ShaderModel] = field(default_factory=_empty_shader_models)
+    tilesets: list[TileSetModel] = field(default_factory=_empty_tileset_models)
+    paths: list[PathModel] = field(default_factory=_empty_path_models)
+    sequences: list[SequenceModel] = field(default_factory=_empty_sequence_models)
+    timelines: list[TimelineModel] = field(default_factory=_empty_timeline_models)
+    other_resources: list[ResourceModel] = field(default_factory=_empty_resource_models)
+
+    def add(self, model: ResourceModel) -> None:
+        if isinstance(model, SpriteModel):
+            self.sprites.append(model)
+        elif isinstance(model, SoundModel):
+            self.sounds.append(model)
+        elif isinstance(model, FontModel):
+            self.fonts.append(model)
+        elif isinstance(model, ObjectModel):
+            self.objects.append(model)
+        elif isinstance(model, RoomModel):
+            self.rooms.append(model)
+        elif isinstance(model, ScriptModel):
+            self.scripts.append(model)
+        elif isinstance(model, ShaderModel):
+            self.shaders.append(model)
+        elif isinstance(model, TileSetModel):
+            self.tilesets.append(model)
+        elif isinstance(model, PathModel):
+            self.paths.append(model)
+        elif isinstance(model, SequenceModel):
+            self.sequences.append(model)
+        elif isinstance(model, TimelineModel):
+            self.timelines.append(model)
+        else:
+            self.other_resources.append(model)
+
+
+def _project_model(manifest: GameMakerProjectManifest) -> ProjectModel:
+    return ProjectModel(
+        name=manifest.project_name,
+        yyp_path=manifest.yyp_path,
+        resource_type=manifest.resource_type,
+        resource_version=manifest.resource_version,
+        resource_count=len(manifest.resources),
+        audio_group_names=tuple(group.name for group in manifest.audio_groups if group.name),
+        texture_group_names=tuple(group.name for group in manifest.texture_groups if group.name),
+    )
+
+
+def _parse_resource_model(
+    gm_project_path: str,
+    reference: ProjectResourceReference,
+) -> tuple[ResourceModel | None, tuple[ResourceModelDiagnostic, ...]]:
+    yy_path = os.path.join(gm_project_path, *reference.path.replace("\\", "/").split("/"))
+    raw_data = _read_lenient_json_file(yy_path)
+    if raw_data is None:
+        return None, (
+            ResourceModelDiagnostic(
+                severity="warning",
+                code="GM2GD-RESOURCE-YY-MISSING",
+                message=f"Could not parse GameMaker resource .yy: {yy_path}",
+                source_path=yy_path,
+                resource_name=reference.name,
+                resource_kind=reference.kind,
+            ),
+        )
+
+    base = _base_kwargs(reference, yy_path, raw_data)
+    kind = reference.kind
+    if kind == "sprites":
+        return SpriteModel(
+            **base,
+            width=_int_value(raw_data.get("width")),
+            height=_int_value(raw_data.get("height")),
+            origin=_int_value(raw_data.get("origin")),
+        ), ()
+    if kind == "sounds":
+        return SoundModel(
+            **base,
+            sound_file=_string_value(raw_data.get("soundFile")),
+            audio_group=_named_reference(raw_data.get("audioGroupId")) or "",
+        ), ()
+    if kind == "fonts":
+        return FontModel(
+            **base,
+            font_name=_string_value(raw_data.get("fontName")),
+            size=_float_value(raw_data.get("size")),
+        ), ()
+    if kind == "objects":
+        return ObjectModel(
+            **base,
+            sprite_name=_named_reference(raw_data.get("spriteId")),
+            parent_object_name=_named_reference(raw_data.get("parentObjectId")),
+            event_count=len(_dict_list(raw_data.get("eventList"))),
+            persistent=bool(raw_data.get("persistent", False)),
+            solid=bool(raw_data.get("solid", False)),
+        ), ()
+    if kind == "rooms":
+        room_settings = _dict_value(raw_data.get("roomSettings"))
+        layers = _parse_room_layers(reference.name, raw_data.get("layers"))
+        return RoomModel(
+            **base,
+            width=_int_value(room_settings.get("Width")),
+            height=_int_value(room_settings.get("Height")),
+            persistent=bool(room_settings.get("persistent", False)),
+            inherit_layers=bool(raw_data.get("inheritLayers", False)),
+            parent_room_name=_named_reference(raw_data.get("parentRoom")),
+            layers=layers,
+        ), ()
+    if kind == "scripts":
+        return ScriptModel(
+            **base,
+            gml_path=_first_existing_neighbor(yy_path, ".gml"),
+        ), ()
+    if kind == "shaders":
+        return ShaderModel(
+            **base,
+            vertex_path=_first_existing_neighbor(yy_path, ".vsh"),
+            fragment_path=_first_existing_neighbor(yy_path, ".fsh"),
+        ), ()
+    if kind == "tilesets":
+        return TileSetModel(
+            **base,
+            sprite_name=_named_reference(raw_data.get("spriteId")),
+            tile_width=_int_value(raw_data.get("tileWidth")),
+            tile_height=_int_value(raw_data.get("tileHeight")),
+        ), ()
+    if kind == "paths":
+        return PathModel(
+            **base,
+            point_count=len(_dict_list(raw_data.get("points"))),
+            closed=bool(raw_data.get("closed", False)),
+        ), ()
+    if kind == "sequences":
+        return SequenceModel(
+            **base,
+            track_count=len(_dict_list(raw_data.get("tracks"))),
+        ), ()
+    if kind == "timelines":
+        return TimelineModel(
+            **base,
+            moment_count=len(_dict_list(raw_data.get("momentList"))),
+        ), ()
+    return ResourceModel(**base), ()
+
+
+def _base_kwargs(
+    reference: ProjectResourceReference,
+    yy_path: str,
+    raw_data: JsonDict,
+) -> JsonDict:
+    return {
+        "name": reference.name,
+        "kind": reference.kind,
+        "resource_type": reference.resource_type,
+        "yy_path": yy_path,
+        "yyp_path": reference.path,
+        "order": reference.order,
+        "subfolder": _subfolder_from_raw_data(raw_data),
+        "raw_data": raw_data,
+    }
+
+
+def _read_lenient_json_file(path: str) -> JsonDict | None:
+    try:
+        with open(path, "r", encoding="utf-8") as file:
+            source = file.read()
+        data = json.loads(re.sub(r",\s*([}\]])", r"\1", source))
+        return cast(JsonDict, data) if isinstance(data, dict) else None
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return None
+
+
+def _subfolder_from_raw_data(raw_data: JsonDict) -> str:
+    parent = raw_data.get("parent")
+    if not isinstance(parent, dict):
+        return ""
+    parent_path = cast(JsonDict, parent).get("path")
+    if not isinstance(parent_path, str):
+        return ""
+    if parent_path.startswith("folders/"):
+        parent_path = parent_path[len("folders/"):]
+    if parent_path.endswith(".yy"):
+        parent_path = parent_path[:-len(".yy")]
+    parts = parent_path.split("/")
+    if len(parts) <= 1:
+        return ""
+    return generated_subfolder_path("/".join(parts[1:]))
+
+
+def _parse_room_layers(room_name: str, raw_layers: object) -> tuple[RoomLayerModel, ...]:
+    layers: list[RoomLayerModel] = []
+    for index, layer in enumerate(_dict_list(raw_layers)):
+        layers.append(
+            RoomLayerModel(
+                room_name=room_name,
+                name=_string_value(layer.get("%Name")) or _string_value(layer.get("name")) or "Layer",
+                resource_type=_layer_resource_type(layer),
+                depth=_optional_int_value(layer.get("depth")),
+                order=index,
+                raw_data=layer,
+            )
+        )
+        layers.extend(_parse_room_layers(room_name, layer.get("layers") or layer.get("children")))
+    return tuple(layers)
+
+
+def _layer_resource_type(layer: JsonDict) -> str:
+    resource_type = layer.get("resourceType")
+    if isinstance(resource_type, str) and resource_type:
+        return resource_type
+    for key in layer:
+        if key.startswith("$GMR"):
+            return key[1:]
+    return "UnknownLayer"
+
+
+def _first_existing_neighbor(yy_path: str, extension: str) -> str | None:
+    directory = os.path.dirname(yy_path)
+    if not os.path.isdir(directory):
+        return None
+    preferred = os.path.splitext(yy_path)[0] + extension
+    if os.path.isfile(preferred):
+        return preferred
+    for name in sorted(os.listdir(directory)):
+        candidate = os.path.join(directory, name)
+        if name.lower().endswith(extension) and os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def _named_reference(value: object) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    name = cast(JsonDict, value).get("name")
+    return name if isinstance(name, str) and name else None
+
+
+def _dict_value(value: object) -> JsonDict:
+    return cast(JsonDict, value) if isinstance(value, dict) else {}
+
+
+def _dict_list(value: object) -> list[JsonDict]:
+    if not isinstance(value, list):
+        return []
+    result: list[JsonDict] = []
+    for item in cast(JsonList, value):
+        if isinstance(item, dict):
+            result.append(cast(JsonDict, item))
+    return result
+
+
+def _string_value(value: object) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _int_value(value: object) -> int:
+    return value if isinstance(value, int) else 0
+
+
+def _optional_int_value(value: object) -> int | None:
+    return value if isinstance(value, int) else None
+
+
+def _float_value(value: object) -> float:
+    if isinstance(value, int | float):
+        return float(value)
+    return 0.0

--- a/tests/test_conversion_architecture.py
+++ b/tests/test_conversion_architecture.py
@@ -1,0 +1,153 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+import os
+import unittest
+
+from src.conversion.conversion_plan import (
+    build_conversion_plan,
+    group_conversion_plan,
+    validate_conversion_step_graph,
+)
+from src.conversion.gml_transpiler_parts.asset_lowering import (
+    asset_argument_indices,
+    first_argument_is_script_asset,
+)
+from src.conversion.gml_transpiler_parts.emitter import _emit_expression
+from src.conversion.gml_transpiler_parts.expression_parser import _parse_gml_expression
+from src.conversion.gml_transpiler_parts.gml_function_dispatch import (
+    get_gml_function_descriptor,
+    validate_gml_function_arity,
+)
+from src.conversion.gml_transpiler_parts.model import _Binary, _ScopeContext
+from src.conversion.resource_models import (
+    parse_gamemaker_resource_models,
+)
+
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+RESOURCE_MATRIX_PATH = os.path.join(
+    PROJECT_ROOT,
+    "tests",
+    "fixtures",
+    "part2",
+    "projects",
+    "resource_matrix",
+)
+MISSING_YY_PATH = os.path.join(
+    PROJECT_ROOT,
+    "tests",
+    "fixtures",
+    "part2",
+    "projects",
+    "missing_yy",
+)
+
+
+class TestConversionPlan(unittest.TestCase):
+    def test_default_graph_validates(self) -> None:
+        self.assertEqual(validate_conversion_step_graph(), ())
+
+    def test_builds_dependency_order_for_enabled_steps(self) -> None:
+        plan = build_conversion_plan([
+            "asset_registry",
+            "rooms",
+            "objects",
+            "scripts",
+            "sprites",
+            "tilesets",
+        ])
+        keys = [step.key for step in plan]
+
+        self.assertLess(keys.index("sprites"), keys.index("objects"))
+        self.assertLess(keys.index("scripts"), keys.index("objects"))
+        self.assertLess(keys.index("objects"), keys.index("rooms"))
+        self.assertLess(keys.index("tilesets"), keys.index("rooms"))
+        self.assertLess(keys.index("rooms"), keys.index("asset_registry"))
+
+    def test_dependencies_order_only_enabled_steps(self) -> None:
+        self.assertEqual(
+            [step.key for step in build_conversion_plan(["objects"])],
+            ["objects"],
+        )
+
+    def test_groups_planned_steps(self) -> None:
+        grouped = group_conversion_plan(build_conversion_plan(["project_settings", "sprites", "shaders"]))
+
+        self.assertEqual([step.key for step in grouped["project"]], ["project_settings"])
+        self.assertEqual([step.key for step in grouped["assets"]], ["sprites"])
+        self.assertEqual([step.key for step in grouped["wip"]], ["shaders"])
+
+
+class TestResourceModels(unittest.TestCase):
+    def test_parse_resource_matrix_without_godot_output_path(self) -> None:
+        self.assertFalse(os.path.exists(os.path.join(RESOURCE_MATRIX_PATH, "gm2godot")))
+
+        models = parse_gamemaker_resource_models(RESOURCE_MATRIX_PATH)
+
+        self.assertEqual(models.project.name, "ResourceMatrix")
+        self.assertEqual(models.project.resource_count, 14)
+        self.assertEqual([sprite.name for sprite in models.sprites], ["spr_checker"])
+        self.assertEqual([sound.name for sound in models.sounds], ["snd_click"])
+        self.assertEqual([font.name for font in models.fonts], ["fnt_ui"])
+        self.assertEqual([tileset.name for tileset in models.tilesets], ["ts_ground"])
+        self.assertEqual([path.name for path in models.paths], ["path_patrol"])
+        self.assertEqual([sequence.name for sequence in models.sequences], ["seq_intro"])
+        self.assertEqual([timeline.name for timeline in models.timelines], ["tl_intro"])
+        self.assertTrue(any(script.gml_path for script in models.scripts))
+        self.assertTrue(any(shader.vertex_path for shader in models.shaders))
+        self.assertTrue(any(shader.fragment_path for shader in models.shaders))
+        self.assertTrue(any(room.inherit_layers for room in models.rooms))
+        self.assertIn("GMRInstanceLayer", {layer.resource_type for layer in models.layers})
+        self.assertIn("GMRTileLayer", {layer.resource_type for layer in models.layers})
+        self.assertIn("GMREffectLayer", {layer.resource_type for layer in models.layers})
+        self.assertEqual(models.diagnostics, ())
+        self.assertFalse(os.path.exists(os.path.join(RESOURCE_MATRIX_PATH, "gm2godot")))
+
+    def test_missing_resource_is_structured_parse_diagnostic(self) -> None:
+        models = parse_gamemaker_resource_models(MISSING_YY_PATH)
+        diagnostics = {(diagnostic.code, diagnostic.resource_name) for diagnostic in models.diagnostics}
+
+        self.assertIn(("GM2GD-RESOURCE-YY-MISSING", "spr_missing"), diagnostics)
+        self.assertEqual(models.project.resource_count, 1)
+        self.assertEqual(models.sprites, ())
+
+
+class TestGMLPipelineBoundaries(unittest.TestCase):
+    def test_architecture_doc_names_phase_boundaries(self) -> None:
+        doc_path = os.path.join(PROJECT_ROOT, "src", "conversion", "conversion_architecture.md")
+        with open(doc_path, "r", encoding="utf-8") as doc_file:
+            content = doc_file.read()
+
+        self.assertIn("ConversionContext", content)
+        self.assertIn("CONVERSION_STEPS", content)
+        self.assertIn("Parser phase", content)
+        self.assertIn("Semantic analysis phase", content)
+        self.assertIn("GDScript emission phase", content)
+        self.assertIn("asset_lowering", content)
+
+    def test_parser_semantic_and_emitter_modules_remain_independent(self) -> None:
+        expression = _parse_gml_expression("1 + score")
+        self.assertIsInstance(expression, _Binary)
+
+        emitted, _precedence = _emit_expression(
+            expression,
+            {"score"},
+            scope_context=_ScopeContext(),
+        )
+        self.assertEqual(emitted, "GMRuntime.gml_add(1, score)")
+
+        descriptor = get_gml_function_descriptor("draw_sprite")
+        self.assertIsNotNone(descriptor)
+        if descriptor is None:
+            self.fail("draw_sprite descriptor is required for semantic arity validation")
+        self.assertIsNotNone(validate_gml_function_arity(descriptor, 1))
+
+    def test_asset_lowering_rules_are_outside_emitter(self) -> None:
+        self.assertEqual(asset_argument_indices("draw_sprite", "draw"), frozenset({0}))
+        self.assertEqual(asset_argument_indices("room_goto", "room"), frozenset({0}))
+        self.assertTrue(first_argument_is_script_asset("script_execute"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/todo-list/07-testing-codebase-improvements.md
+++ b/todo-list/07-testing-codebase-improvements.md
@@ -52,12 +52,12 @@ This file tracks engineering work that will make full transpilation safer to bui
 
 ## P1: Architecture Boundaries
 
-- [ ] Introduce typed `ConversionContext` shared by converters.
-- [ ] Replace hard-coded converter sequence with explicit dependency graph.
-- [ ] Split source discovery/parsing from Godot rendering/writing for resource converters.
-- [ ] Create typed intermediate models for projects, sprites, sounds, fonts, objects, rooms, layers, scripts, shaders, tilesets, paths, sequences, timelines, and diagnostics.
-- [ ] Separate parser AST, semantic analysis, and GDScript emission phases more sharply.
-- [ ] Move asset-specific lowering rules out of the general expression emitter where possible.
+- [x] Introduce typed `ConversionContext` shared by converters.
+- [x] Replace hard-coded converter sequence with explicit dependency graph.
+- [x] Split source discovery/parsing from Godot rendering/writing for resource converters.
+- [x] Create typed intermediate models for projects, sprites, sounds, fonts, objects, rooms, layers, scripts, shaders, tilesets, paths, sequences, timelines, and diagnostics.
+- [x] Separate parser AST, semantic analysis, and GDScript emission phases more sharply.
+- [x] Move asset-specific lowering rules out of the general expression emitter where possible.
 - [ ] Unify arity, lowering kind, manifest status, docs URL, runtime function name, and tests in one source of truth.
 - [ ] Add explicit runtime segment dependency declarations.
 - [ ] Add event mapping manifest with event type, event number, callback, runtime requirements, support status, test path, and issue reference.


### PR DESCRIPTION
Closes #611.

## Summary
- add a typed ConversionContext and replace the converter loop with an explicit dependency-ordered conversion plan
- add parse-only GameMaker resource models for project, asset, room/layer, script, shader, tileset, path, sequence, timeline, and diagnostic metadata
- extract GameMaker asset-argument lowering tables out of the generic GML expression emitter
- document conversion orchestration and parser/semantic/emitter phase boundaries, with tests covering the graph, models, docs, and asset lowering

## Tests
- ./venv/bin/python -m unittest tests.test_conversion_architecture tests.test_converter tests.test_gml_transpiler
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest
- git diff --check