### PR TITLE
Improve code health docs and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/fixture_contribution.yml
+++ b/.github/ISSUE_TEMPLATE/fixture_contribution.yml
@@ -1,0 +1,43 @@
+name: Fixture Contribution
+description: Propose or contribute a minimal GameMaker fixture for regression coverage.
+title: "Fixture contribution: "
+labels: ["documentation"]
+body:
+  - type: input
+    id: coverage-target
+    attributes:
+      label: Coverage target
+      description: Name the API, resource type, event, runtime behavior, or malformed project case covered by this fixture.
+      placeholder: "Async HTTP event ordering"
+    validations:
+      required: true
+  - type: textarea
+    id: fixture-contents
+    attributes:
+      label: Fixture contents
+      description: List the `.yyp`, `.yy`, `.gml`, assets, and generated expectations included.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-result
+    attributes:
+      label: Expected conversion result
+      description: Describe expected diagnostics, generated files, snapshots, or Godot validation behavior.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Fixture checklist
+      options:
+        - label: The fixture is minimal and does not include unrelated project assets.
+        - label: Any third-party assets are removed or clearly licensed for repository use.
+        - label: Expected warnings or unsupported features are documented.
+        - label: Tests or corpus metadata are included or described.
+  - type: input
+    id: versions
+    attributes:
+      label: Versions
+      description: GameMaker version, Godot version, and target platform used to create or verify the fixture.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/invalid_generated_gdscript.yml
+++ b/.github/ISSUE_TEMPLATE/invalid_generated_gdscript.yml
@@ -1,0 +1,44 @@
+name: Invalid Generated GDScript
+description: Report GDScript emitted by GM2Godot that Godot cannot parse or load.
+title: "Invalid generated GDScript: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: source
+    attributes:
+      label: Original GameMaker source
+      description: Include the smallest source file, script, event, or room code that generates invalid GDScript.
+      render: gml
+    validations:
+      required: true
+  - type: textarea
+    id: generated
+    attributes:
+      label: Generated GDScript
+      description: Paste the generated GDScript around the failing line.
+      render: gdscript
+    validations:
+      required: true
+  - type: textarea
+    id: godot-error
+    attributes:
+      label: Godot error
+      description: Paste the Godot parse, load, or validation error.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: GM2Godot diagnostics
+      description: Paste relevant `conversion_diagnostics.json` or `godot_validation_report.json` entries.
+      render: json
+    validations:
+      required: false
+  - type: input
+    id: versions
+    attributes:
+      label: Versions
+      description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/resource_conversion_mismatch.yml
+++ b/.github/ISSUE_TEMPLATE/resource_conversion_mismatch.yml
@@ -1,0 +1,58 @@
+name: Resource Conversion Mismatch
+description: Report a converted sprite, sound, room, object, tilemap, shader, or other resource that differs from GameMaker.
+title: "Resource conversion mismatch: "
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: resource-kind
+    attributes:
+      label: Resource kind
+      options:
+        - Sprite
+        - Sound or audio group
+        - Font
+        - Script
+        - Object or event
+        - Room or layer
+        - Tileset or tilemap
+        - Shader or material
+        - Path, sequence, or timeline
+        - Included file, extension, option, or platform setting
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: resource-name
+    attributes:
+      label: Resource name
+      placeholder: "obj_player"
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected GameMaker behavior or metadata
+      description: Describe what the original project contains or does.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Godot output
+      description: Describe the generated file, scene, resource, or runtime behavior that is wrong.
+    validations:
+      required: true
+  - type: textarea
+    id: attachments
+    attributes:
+      label: Minimal fixture or screenshots
+      description: Attach a minimal `.yyp/.yy` fixture, generated output, screenshots, or logs if possible.
+    validations:
+      required: false
+  - type: input
+    id: versions
+    attributes:
+      label: Versions
+      description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -1,0 +1,44 @@
+name: Unsupported GML API
+description: Report a GameMaker API that GM2Godot does not transpile or emulate yet.
+title: "Unsupported GML API: "
+labels: ["feature"]
+body:
+  - type: input
+    id: api-name
+    attributes:
+      label: GML API name
+      description: Name of the missing function, variable, constant, or language feature.
+      placeholder: "audio_play_sound"
+    validations:
+      required: true
+  - type: textarea
+    id: source
+    attributes:
+      label: Minimal GameMaker source
+      description: Include the smallest GML snippet that reproduces the unsupported API.
+      render: gml
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostic
+    attributes:
+      label: GM2Godot diagnostic or output
+      description: Paste the relevant log line, diagnostic JSON entry, or generated GDScript.
+      render: text
+    validations:
+      required: false
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Describe the GameMaker behavior that should be represented in Godot.
+    validations:
+      required: true
+  - type: input
+    id: versions
+    attributes:
+      label: Versions
+      description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
+      placeholder: "GM2Godot 0.6.0, GameMaker 2024.14.2, Godot 4.6.2, Windows"
+    validations:
+      required: true

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -1,0 +1,25 @@
+name: Code Health
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Ruff
+        run: pip install ruff
+
+      - name: Run Ruff
+        run: ruff check .
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,14 +13,16 @@ Thank you for your interest in contributing to GM2Godot! We aim to make GameMake
      ```
 
 2. **Set Up Development Environment**
-   - Install Python 3.9.0 or later
+   - Install Python 3.12 or later
    - Install required packages:
      ```bash
-     pip install Pillow markdown2 tkhtmlview
+     python3 -m venv venv
+     source venv/bin/activate
+     pip install -r requirements.txt
      ```
-   - For Linux users, install additional dependencies:
+   - Install optional local tooling when changing Python code:
      ```bash
-     sudo apt-get install python3-tk python3-pil python3-pil.imagetk python3-markdown2
+     pip install pyright ruff
      ```
 
 ## Development Guidelines
@@ -32,6 +34,7 @@ Thank you for your interest in contributing to GM2Godot! We aim to make GameMake
 - Keep functions focused and concise
 - Use type hints where appropriate
 - Keep linting and type checking clean for code changes. Run `./venv/bin/pyright --warnings` before submitting Python or generated-code logic changes and fix every reported error or warning.
+- Run `ruff check .` before submitting Python code. The project currently enables fatal/static Ruff checks in CI; broader style rules should be introduced separately from feature work.
 
 ### UI Development
 - Maintain consistency with the existing dark theme
@@ -46,6 +49,47 @@ When adding new asset conversion features:
 3. Add appropriate error handling
 4. Include progress reporting
 5. Add the new feature to the settings UI
+
+### Conversion Architecture
+New conversion work should fit the current staged architecture:
+- Add orchestration metadata to `src/conversion/conversion_plan.py` when a converter needs a stable execution slot or dependency.
+- Use `src/conversion/conversion_context.py` for shared conversion-run state instead of adding parallel callback/path arguments in the orchestrator.
+- Keep parse-only GameMaker metadata in `src/conversion/resource_models.py` or a resource-specific model helper so parsing can be tested without writing Godot files.
+- Keep generated output deterministic; update golden or manifest tests only when output changes intentionally.
+
+### GML API Support
+When adding or improving a GML API:
+- Update the manifest entry in `src/conversion/gml_transpiler_parts/gml_api_manifest.py`.
+- Add or update dispatch metadata in `gml_function_dispatch.py` and keep asset-argument rules in `asset_lowering.py`.
+- Implement runtime behavior in the owning `src/conversion/gml_runtime_parts/segments/*.gd` segment and declare ownership in `gml_runtime_parts/manifest.py`.
+- Add focused Python and, when behavior depends on Godot, `*_godot.py` coverage.
+- Update compatibility docs or reports when support status changes.
+
+### Runtime Segments
+When adding a runtime segment or moving runtime helpers:
+- Declare the segment, dependencies, description, and tests in `src/conversion/gml_runtime_parts/manifest.py`.
+- Keep public `gml_*` helper names unique; `tests/test_gml_runtime_segments.py` validates duplicate symbols and API-to-segment ownership.
+- Prefer segment-local state buckets or generated managers for mutable runtime state.
+- Document user-visible semantic differences in `src/conversion/runtime_managers.md` or `src/conversion/godot_architecture_policy.md`.
+
+### Resource Converters
+When adding a converter for a GameMaker resource type:
+- Add parse fixtures under `tests/fixtures/part2/` when possible.
+- Add parse-only model coverage before renderer/writer coverage.
+- Route warnings through diagnostics where they can become reports.
+- Add converter tests that check deterministic paths and generated Godot resources.
+
+### Event Mappings
+When adding object event support:
+- Add event metadata in `src/conversion/events/mappings/` and registry coverage in `tests/conversion/events/`.
+- Document event-order differences when GameMaker and Godot callback order cannot match exactly.
+- Add runtime scheduler tests for events that depend on frame ordering, input, alarms, async queues, draw phases, or collisions.
+
+### Fixtures
+Fixture contributions should include:
+- A minimal `.yyp` plus committed `.yy` resources.
+- A short note in `tests/fixtures/part2/fixtures.json` or `corpus.json` explaining the coverage target.
+- Tests that prove conversion continues when the fixture is malformed, unsupported, or expected to warn.
 
 ## Making Changes
 

--- a/README.md
+++ b/README.md
@@ -2,43 +2,44 @@
 
 <img width="802" height="632" alt="screen" src="https://github.com/user-attachments/assets/cedf47f5-6668-44ab-8cf6-959a21afd7fa" />
 
-GM2Godot is a modern, user-friendly tool designed to convert GameMaker (2024.14.2) projects to Godot (4.6.2) projects. It features a sleek dark-themed interface and intuitive controls for a seamless conversion experience.
+GM2Godot converts GameMaker (2024.14.2) projects into Godot (4.6.2) projects. It includes a GUI, a headless CLI, a growing GMS2+ GML-to-GDScript transpiler, generated Godot runtime helpers, deterministic asset registries, diagnostics, compatibility reports, and fixture-backed regression tests.
 
 ## Features
 
-- **Modern Dark Theme UI**: Clean, intuitive interface with modern design elements
-- **Asset Conversion**: Converts various GameMaker assets to Godot format:
-  - Sprites and Images
-  - Sound Effects and Music
-  - Fonts
-  - Project Settings
-  - Game Icons
-  - Audio Bus Layout
-  - Notes and Documentation
+- **Modern Dark Theme UI**: Clean project selection, settings, progress, and logs
+- **Headless CLI**: Convert, analyze, validate, and generate compatibility reports for CI workflows
+- **GML Transpilation**: Converts supported GMS2+ expressions, scripts, object events, room creation code, macros, extension stubs, and source-map metadata into GDScript
+- **Generated Runtime**: Emits `gm2godot/gml_runtime.gd`, runtime managers, asset registries, room/runtime metadata, and compatibility helpers for supported GameMaker APIs
+- **Asset Conversion**: Converts GameMaker project resources to Godot format:
+  - Sprites, collision masks, animation metadata, and generated scenes
+  - Sound effects, audio groups, bus layouts, and runtime playback metadata
+  - Fonts, notes, included files, scripts, objects, rooms, tilesets, shaders, paths, timelines, sequences, particles, extensions, texture groups, and options metadata where supported
+  - Project settings, game icons, platform options, and validation reports
 - **Platform Support**: Converts settings for multiple platforms:
   - Windows
   - macOS
   - Linux
-- **Real-time Progress**: Visual feedback with progress bar and time tracking
-- **Customizable Conversion**: Choose exactly which assets to convert
+- **Diagnostics and Reports**: Writes structured warnings/errors, compatibility Markdown/JSON, conversion manifests, architecture-policy reports, and optional headless Godot validation reports
+- **Customizable Conversion**: Choose conversion groups or specific converter keys
 - **Compatibility Roadmap**: Tracks current and missing GameMaker-to-Godot coverage in [`todo-list/`](todo-list/README.md)
 
 ## What GM2Godot Is and Isn't
 
 **GM2Godot is:**
-- A modern asset conversion tool from GameMaker to Godot
-- A growing GMS2+ GML-to-GDScript transpiler and Godot runtime compatibility layer
+- A modern project conversion tool from GameMaker to Godot
+- A growing GMS2+ GML-to-GDScript transpiler and Godot runtime compatibility layer with tests and reports
 - A time-saver for starting Godot projects from GameMaker
 - A tool for developers who want to migrate their projects
 
 **GM2Godot isn't:**
 - A perfect 1:1 conversion tool
 - A complete implementation of every current GameMaker GML Code and GML Reference page yet
+- A guarantee that converted gameplay semantics match GameMaker without manual review, especially for unsupported platform services, precise collision masks, shaders, and target-specific runtime APIs
 - A tool for converting compiled GM projects (use [UndertaleToolMod](https://github.com/UnderminersTeam/UndertaleModTool) instead)
 
 ## Compatibility Todo List
 
-The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It tracks checked current coverage, missing features, GMS2+ GML Code coverage, GML Reference/runtime API coverage, events, project import work, Godot architecture, and testing/codebase improvements.
+The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It tracks checked current coverage, missing features, GMS2+ GML Code coverage, GML Reference/runtime API coverage, events, project import work, Godot architecture, and testing/codebase improvements. Generated report commands can also write current compatibility artifacts under `gm2godot/`.
 
 ## Releases
 
@@ -50,7 +51,7 @@ To build a local macOS distributable (`.app` + `.dmg`), run `bash build_macos.sh
 
 ### Prerequisites
 
-- Python 3.9 or later
+- Python 3.12 or later
 
 ### Setup
 
@@ -121,10 +122,11 @@ python main.py validate --godot-project path/to/GodotProject --fail-on-unsupport
 
 CLI reports are written under `gm2godot/` inside the selected report or Godot project directory. The diagnostic outputs are `conversion_diagnostics.json` and `conversion_diagnostics.md`; static compatibility outputs include `gml_manual_scope.md` and `gml_api_compatibility.md`.
 
-Useful conversion filters:
+Useful conversion and validation filters:
 - `--groups assets,project,wip` selects conversion groups.
 - `--only asset_registry,scripts,objects` runs specific converter keys instead of groups.
 - `--fail-on-unsupported`, `--max-warnings`, `--max-errors`, and `--max-unsupported` turn diagnostics into non-zero exit codes for CI.
+- `--godot-bin` points validation at a specific Godot executable when `GODOT_BIN` is not set.
 
 ## Contributing
 
@@ -150,7 +152,7 @@ To contribute:
 ```text
 You are setting up the GM2Godot project.
 
-Ensure Python 3.9 or later is installed.
+Ensure Python 3.12 or later is installed.
 
 Create and activate a virtual environment:
 python3 -m venv venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+extend-exclude = [
+  "build",
+  "dist",
+  "release",
+  "venv",
+]
+
+[tool.ruff.lint]
+select = [
+  "E9",
+  "F63",
+  "F7",
+  "F82",
+]

--- a/src/conversion/gml_runtime_parts/README.md
+++ b/src/conversion/gml_runtime_parts/README.md
@@ -8,3 +8,34 @@ Segment rules:
 - Add at least one focused test module in `test_modules`.
 - Split a segment when it starts owning a separate GameMaker manual area, needs independent Godot smoke tests, or exposes a lifecycle/state registry that can be validated on its own.
 - Do not add duplicate `class`, `const`, `static var`, or `static func` providers across segments; `tests/test_gml_runtime_segments.py` fails on duplicates.
+
+## Ownership
+
+Each segment owns one GameMaker runtime domain and should keep public `gml_*`
+helpers close to the state they mutate. The manifest description is the public
+owner note for that segment. If a helper crosses domains, keep the call-site
+facade in the API's owner segment and call a smaller helper in the dependency
+segment rather than duplicating state.
+
+Runtime segment ownership is indexed by:
+- `runtime_segment_names()` for stable concatenation order.
+- `runtime_symbol_index()` for public symbol-to-segment lookup.
+- `runtime_api_index()` for manifest API entries linked to runtime symbols,
+  test modules, docs URLs, and issue numbers.
+
+## Adding Runtime API Coverage
+
+1. Add or update the GML API manifest entry.
+2. Add dispatch metadata in the transpiler when the API can be lowered from GML.
+3. Implement the `gml_*` helper in the owning segment.
+4. Declare or update the segment's dependency and test metadata in `manifest.py`.
+5. Add a focused unit test and a Godot smoke test when behavior depends on
+   Godot nodes, resources, input, draw order, audio, networking, or physics.
+
+## Runtime State
+
+Prefer segment-owned dictionaries, typed handle records, or generated manager
+state buckets for mutable state. Keep `GMRuntime.gml_*` names stable because
+generated scripts call them directly. When state needs to outlive a room, record
+the persistence rule in `src/conversion/runtime_managers.md` and add tests that
+cover room transitions or restart behavior.

--- a/src/conversion/runtime_managers.md
+++ b/src/conversion/runtime_managers.md
@@ -32,3 +32,37 @@ Collision events are dispatched by the central scheduler after motion/path updat
 The manager layer is enabled by default when `write_gml_runtime()` runs and `project.godot` exists. Existing generated scripts remain compatible because they still preload and call `res://gm2godot/gml_runtime.gd`.
 
 Projects can remove or override the generated `GM*` autoloads while keeping the static compatibility facade for tests or incremental migrations. New runtime code should prefer manager `state_bucket()` ownership for persistent domain state and keep `GMRuntime.gml_*` helpers as stable call-site facades.
+
+## Event Order And Deviations
+
+GameMaker event order is coordinated through `GMEvents` and generated object
+methods rather than relying on individual Godot node callback order. The runtime
+dispatches Create/room-enter behavior during room scene setup, then uses the
+frame pump for Begin Step, Step, End Step, alarm processing, collision dispatch,
+timelines/sequences, input edge clearing, draw phases, GUI phases, and queued
+async delivery. Tests that depend on these phases should assert the generated
+method names or manager queues rather than incidental node order.
+
+Known semantic differences must be documented where they are introduced. Current
+examples include precise pixel collision masks falling back to Godot collision
+shape bounds, shader-language differences between GLSL ES and Godot shaders,
+platform-service calls routed through `GMPlatform`, and target permissions that
+cannot be inferred from GameMaker options alone.
+
+## State, Globals, And Persistence
+
+Runtime state has three ownership levels:
+
+- Static compatibility state in `gml_runtime.gd` for helper functions that are
+  still called directly by generated scripts.
+- Autoload manager state buckets for generated projects, exposed through stable
+  manager names such as `GMAssets`, `GMRooms`, `GMInstances`, `GMEvents`,
+  `GMDraw`, `GMInput`, `GMAudio`, `GMAsync`, and `GMPlatform`.
+- Scene-local room/object state for generated room scenes and object instances.
+
+Global variables, asset ids, handles, room order, persistent instances, async
+queues, and audio handles must survive the same transitions that GameMaker keeps
+alive. Room-local layers, transient draw state, one-frame input edges, collision
+pairs, and non-persistent instances should be reset at the documented frame or
+room boundary. Add regression tests whenever a runtime change moves state between
+these levels.

--- a/tests/test_documentation_health.py
+++ b/tests/test_documentation_health.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestDocumentationHealth(unittest.TestCase):
+    def test_readme_describes_transpiler_runtime_reports_and_limits(self) -> None:
+        readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
+
+        required_phrases = (
+            "GML-to-GDScript transpiler",
+            "Generated Runtime",
+            "Diagnostics and Reports",
+            "compatibility reports",
+            "A perfect 1:1 conversion tool",
+            "--fail-on-unsupported",
+        )
+        for phrase in required_phrases:
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, readme)
+
+    def test_contributing_documents_extension_points(self) -> None:
+        contributing = (PROJECT_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+
+        required_headings = (
+            "### Conversion Architecture",
+            "### GML API Support",
+            "### Runtime Segments",
+            "### Resource Converters",
+            "### Event Mappings",
+            "### Fixtures",
+        )
+        for heading in required_headings:
+            with self.subTest(heading=heading):
+                self.assertIn(heading, contributing)
+
+    def test_runtime_docs_cover_ownership_event_order_and_state(self) -> None:
+        segment_readme = (PROJECT_ROOT / "src" / "conversion" / "gml_runtime_parts" / "README.md").read_text(
+            encoding="utf-8"
+        )
+        managers_doc = (PROJECT_ROOT / "src" / "conversion" / "runtime_managers.md").read_text(encoding="utf-8")
+
+        self.assertIn("## Ownership", segment_readme)
+        self.assertIn("runtime_api_index()", segment_readme)
+        self.assertIn("## Runtime State", segment_readme)
+        self.assertIn("## Event Order And Deviations", managers_doc)
+        self.assertIn("## State, Globals, And Persistence", managers_doc)
+
+    def test_required_issue_templates_exist(self) -> None:
+        template_dir = PROJECT_ROOT / ".github" / "ISSUE_TEMPLATE"
+        expected_templates = {
+            "unsupported_gml_api.yml": ("Unsupported GML API", "Minimal GameMaker source"),
+            "invalid_generated_gdscript.yml": ("Invalid Generated GDScript", "Godot error"),
+            "resource_conversion_mismatch.yml": ("Resource Conversion Mismatch", "Resource kind"),
+            "fixture_contribution.yml": ("Fixture Contribution", "Fixture checklist"),
+        }
+
+        for filename, phrases in expected_templates.items():
+            with self.subTest(template=filename):
+                content = (template_dir / filename).read_text(encoding="utf-8")
+                for phrase in phrases:
+                    self.assertIn(phrase, content)
+
+    def test_code_health_workflow_runs_ruff(self) -> None:
+        workflow = (PROJECT_ROOT / ".github" / "workflows" / "code-health.yml").read_text(encoding="utf-8")
+        pyproject = (PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+
+        self.assertIn("ruff check .", workflow)
+        self.assertIn("[tool.ruff.lint]", pyproject)
+        self.assertIn('"F82"', pyproject)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/todo-list/00-priority-index.md
+++ b/todo-list/00-priority-index.md
@@ -89,7 +89,7 @@ This file is the high-level roadmap for reaching full GameMaker-to-Godot transpi
 - [ ] Add CLI modes: analyze-only, convert, validate, report, fail-on-unsupported, and target-platform filter.
 - [ ] Generate compatibility reports grouped by manual category, asset type, event, function, source file, and severity.
 - [ ] Add source-linked warnings for unsupported GML APIs, unsupported resources, skipped event source, shader failures, invalid generated code, and platform gaps.
-- [ ] Update README product positioning because the project now contains a real transpiler and runtime.
+- [x] Update README product positioning because the project now contains a real transpiler and runtime.
 - [ ] Add documentation for adding a new GML API, runtime segment, resource converter, event mapping, fixture, and Godot smoke test.
 
 ## P1: Expand Correctness And Coverage

--- a/todo-list/07-testing-codebase-improvements.md
+++ b/todo-list/07-testing-codebase-improvements.md
@@ -115,13 +115,13 @@ This file tracks engineering work that will make full transpilation safer to bui
 ## P2: Pyright, Lint, And Code Health
 
 - [ ] Reduce broad file-level Pyright suppressions over time.
-- [ ] Add Ruff or equivalent linting.
+- [x] Add Ruff or equivalent linting.
 - [ ] Add complexity checks for parser/emitter/runtime generation modules.
 - [ ] Add import sorting.
 - [ ] Add unused code checks.
 - [ ] Add broad exception checks.
 - [ ] Add unreachable branch checks.
-- [ ] Add typed `.yy` dataclasses or `TypedDict` models instead of repeated casts.
+- [x] Add typed `.yy` dataclasses or `TypedDict` models instead of repeated casts.
 - [ ] Add local pre-commit hooks or documented equivalent commands.
 - [ ] Make tests import source through package configuration rather than repeated `sys.path` mutation.
 - [ ] Add shared test utility for Godot binary discovery.
@@ -130,33 +130,33 @@ This file tracks engineering work that will make full transpilation safer to bui
 
 ## P2: Runtime Maintainability
 
-- [ ] Add per-segment ownership docs.
-- [ ] Add public runtime function indexes.
+- [x] Add per-segment ownership docs.
+- [x] Add public runtime function indexes.
 - [ ] Split runtime segments when they accumulate unrelated concerns.
 - [ ] Add concatenation tests for segment ordering.
 - [ ] Add tests for duplicate runtime function names.
 - [ ] Add tests for duplicate runtime constants.
 - [ ] Add event mapping conflict tests across modules.
-- [ ] Add docs for event execution order and deviations from GameMaker semantics.
-- [ ] Add docs for runtime state, global state, and persistence behavior.
+- [x] Add docs for event execution order and deviations from GameMaker semantics.
+- [x] Add docs for runtime state, global state, and persistence behavior.
 
 ## P2: Documentation And UX
 
-- [ ] Update README to reflect that the project now includes substantial GML transpilation and runtime work.
-- [ ] Update setup docs to match current dependencies.
+- [x] Update README to reflect that the project now includes substantial GML transpilation and runtime work.
+- [x] Update setup docs to match current dependencies.
 - [ ] Add compatibility report document generated from the manifest.
 - [ ] Add `What failed and what to do next` conversion report UX.
-- [ ] Add issue template for unsupported GML API reports.
-- [ ] Add issue template for invalid generated GDScript.
-- [ ] Add issue template for resource conversion mismatches.
-- [ ] Add issue template for fixture contributions.
-- [ ] Add CLI docs.
-- [ ] Add docs for adding a new GML API.
-- [ ] Add docs for adding a new runtime segment.
-- [ ] Add docs for adding a new resource converter.
-- [ ] Add docs for adding a new event mapping.
-- [ ] Add docs for adding a new fixture.
-- [ ] Add docs for known GameMaker/Godot semantic differences.
+- [x] Add issue template for unsupported GML API reports.
+- [x] Add issue template for invalid generated GDScript.
+- [x] Add issue template for resource conversion mismatches.
+- [x] Add issue template for fixture contributions.
+- [x] Add CLI docs.
+- [x] Add docs for adding a new GML API.
+- [x] Add docs for adding a new runtime segment.
+- [x] Add docs for adding a new resource converter.
+- [x] Add docs for adding a new event mapping.
+- [x] Add docs for adding a new fixture.
+- [x] Add docs for known GameMaker/Godot semantic differences.
 
 ## Current Design Risks To Track
 
@@ -166,5 +166,5 @@ This file tracks engineering work that will make full transpilation safer to bui
 - [ ] Public transpiler facade exports private internals, making refactors risky.
 - [ ] Runtime segment concatenation order is manual.
 - [ ] String-based generated-code tests can miss invalid GDScript.
-- [ ] README and CONTRIBUTING docs may lag implementation maturity.
+- [x] README and CONTRIBUTING docs may lag implementation maturity.
 - [ ] External project CI can become non-reproducible if third-party repos are not pinned.


### PR DESCRIPTION
Closes #612.

## Summary
- add a Ruff code-health configuration and CI workflow for fatal/static lint checks
- update README and setup docs to reflect the current GML transpiler, generated runtime, CLI reports, diagnostics, compatibility limits, and Python baseline
- expand contributor and runtime docs with conversion architecture, extension points, runtime ownership, event-order, state, globals, and persistence guidance
- add issue forms for unsupported GML APIs, invalid generated GDScript, resource conversion mismatches, and fixture contributions
- add documentation-health tests that guard the README, contributor docs, runtime docs, issue templates, and Ruff workflow

## Tests
- ./venv/bin/python -m ruff check .
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest tests.test_documentation_health
- ./venv/bin/python -m unittest
- git diff --check