### PR TITLE
Release GM2Godot 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.6.0 - 2026-05-28
+
+Milestone 7: GML Transpiler Part 2.
+
+- Expanded current GMS2+ GML compatibility indexing, diagnostics, CLI reporting, source maps, runtime segment validation, and generated-output manifests.
+- Added broad Part 2 transpiler/runtime coverage for value semantics, dynamic variables, accessors, constructors, control flow, macros, project metadata, rooms, layers, paths, tilesets, timelines, sequences, particles, async queues, draw phases, input events, collisions, data structures, files, buffers, networking, audio, cameras, display/window APIs, movement, physics, platform services, and runtime managers.
+- Added pinned Godot smoke validation, external project conversion gates, golden conversion snapshots, Ruff code-health checks, fixture corpus coverage, architecture policy reports, and contributor/runtime documentation.
+- Milestone audit: implementation issues #575 through #612 plus #642, #643, and #644 are closed and merged with green checks. The release PR closes the Milestone 7 master tracker (#574) and release issue (#613).
+

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
+Current source version: `0.6.0`.
+
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 
 To build a local macOS distributable (`.app` + `.dmg`), run `bash build_macos.sh` from the project root.

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.5.4"
+VERSION = "0.6.0"
 
 def get_version():
     return VERSION

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+from src.version import get_version
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestVersion(unittest.TestCase):
+    def test_release_version_is_0_6_0(self) -> None:
+        self.assertEqual(get_version(), "0.6.0")
+
+    def test_release_docs_reference_0_6_0(self) -> None:
+        changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+        readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
+
+        self.assertIn("## 0.6.0 - 2026-05-28", changelog)
+        self.assertIn("Current source version: `0.6.0`.", readme)
+        self.assertIn("Milestone audit", changelog)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
Closes #613.
Closes #574.

## Milestone 7 audit
- all implementation issues in Milestone 7 are closed and merged: #575-#612 plus #642, #643, and #644
- only the master tracker (#574) and release issue (#613) remained open before this release PR
- latest main after #612 had green Code Health, Pyright, Tests, Godot Headless Smoke, and TCC Conversion Test checks
- local audit on main passed Ruff, Pyright, and the full unit suite before this branch was created

## Summary
- bump `src/version.py` from 0.5.4 to 0.6.0
- add 0.6.0 changelog notes with the Milestone 7 audit summary
- add release-version tests and note the current source version in README

## Tests
- ./venv/bin/python -m unittest tests.test_version tests.test_documentation_health
- ./venv/bin/python -m ruff check .
- ./venv/bin/pyright --warnings
- ./venv/bin/python -m unittest
- git diff --check