### PR TITLE
Add CLI version and converter discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.1 - 2026-05-28
+
+- Added CLI version output, converter inventory discovery, JSON inventory output for automation, and direct `python -m src.cli` execution.
+- Documented the new CLI commands and incremented the source version for issue #660.
+
 ## 0.6.0 - 2026-05-28
 
 Milestone 7: GML Transpiler Part 2.
@@ -8,4 +13,3 @@ Milestone 7: GML Transpiler Part 2.
 - Added broad Part 2 transpiler/runtime coverage for value semantics, dynamic variables, accessors, constructors, control flow, macros, project metadata, rooms, layers, paths, tilesets, timelines, sequences, particles, async queues, draw phases, input events, collisions, data structures, files, buffers, networking, audio, cameras, display/window APIs, movement, physics, platform services, and runtime managers.
 - Added pinned Godot smoke validation, external project conversion gates, golden conversion snapshots, Ruff code-health checks, fixture corpus coverage, architecture policy reports, and contributor/runtime documentation.
 - Milestone audit: implementation issues #575 through #612 plus #642, #643, and #644 are closed and merged with green checks. The release PR closes the Milestone 7 master tracker (#574) and release issue (#613).
-

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.6.0`.
+Current source version: `0.6.1`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 
@@ -116,17 +116,23 @@ python main.py
 The same entrypoint can run headless conversion, analysis, validation, and report generation:
 
 ```bash
+python main.py --version
+python main.py list-converters
+python main.py list-converters --format json
 python main.py report --report-dir reports
 python main.py analyze --gm-project path/to/GameMakerProject --report-dir reports --target-platform windows
 python main.py convert --gm-project path/to/GameMakerProject --godot-project path/to/GodotProject --groups assets,project --report-dir reports --target-platform windows
 python main.py validate --godot-project path/to/GodotProject --fail-on-unsupported
 ```
 
+You can also invoke the same headless interface directly with `python -m src.cli`.
+
 CLI reports are written under `gm2godot/` inside the selected report or Godot project directory. The diagnostic outputs are `conversion_diagnostics.json` and `conversion_diagnostics.md`; static compatibility outputs include `gml_manual_scope.md` and `gml_api_compatibility.md`.
 
 Useful conversion and validation filters:
 - `--groups assets,project,wip` selects conversion groups.
 - `--only asset_registry,scripts,objects` runs specific converter keys instead of groups.
+- `list-converters --format json` prints the exact converter keys accepted by `--only`.
 - `--fail-on-unsupported`, `--max-warnings`, `--max-errors`, and `--max-unsupported` turn diagnostics into non-zero exit codes for CI.
 - `--godot-bin` points validation at a specific Godot executable when `GODOT_BIN` is not set.
 
@@ -173,6 +179,8 @@ Run the application using:
 python main.py
 
 Headless verification examples:
+python main.py --version
+python main.py list-converters --format json
 python main.py report --report-dir reports
 python main.py analyze --gm-project path/to/GameMakerProject --report-dir reports --target-platform windows
 python main.py validate --godot-project path/to/GodotProject --fail-on-unsupported

--- a/main.py
+++ b/main.py
@@ -1,10 +1,11 @@
 import sys
 
-CLI_COMMANDS = {"analyze", "convert", "report", "validate"}
+CLI_COMMANDS = {"analyze", "convert", "list-converters", "report", "validate"}
+CLI_GLOBAL_FLAGS = {"--help", "-h", "--version"}
 
 
 def main() -> None:
-    if len(sys.argv) > 1 and sys.argv[1] in CLI_COMMANDS:
+    if len(sys.argv) > 1 and (sys.argv[1] in CLI_COMMANDS or sys.argv[1] in CLI_GLOBAL_FLAGS):
         from src.cli import main as cli_main
 
         sys.exit(cli_main(sys.argv[1:]))

--- a/src/cli.py
+++ b/src/cli.py
@@ -6,7 +6,7 @@ import os
 import sys
 import threading
 from dataclasses import dataclass
-from typing import Sequence, cast
+from typing import Sequence, TypedDict, cast
 
 from src.conversion.converter import CONVERSION_CATEGORIES, Converter
 from src.conversion.diagnostics import (
@@ -26,6 +26,16 @@ from src.conversion.platform_capabilities import (
     generate_platform_capability_report,
     render_platform_capability_markdown,
 )
+from src.version import get_version
+
+
+DEFAULT_CONVERSION_GROUPS = ("assets", "project", "wip")
+
+
+class ConverterInventory(TypedDict):
+    default_groups: list[str]
+    groups: dict[str, list[str]]
+    converter_keys: list[str]
 
 
 @dataclass(frozen=True)
@@ -39,6 +49,14 @@ class CLISetting:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.version:
+        print(f"GM2Godot {get_version()}")
+        return 0
+
+    if args.command == "list-converters":
+        _print_converter_inventory(args.output_format)
+        return 0
 
     if args.command == "report":
         diagnostics = DiagnosticCollector()
@@ -75,7 +93,24 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="GM2Godot",
         description="Headless GM2Godot conversion, analysis, validation, and reporting.",
     )
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Print the GM2Godot version and exit.",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    list_parser = subparsers.add_parser(
+        "list-converters",
+        help="List available conversion groups and converter keys.",
+    )
+    list_parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        dest="output_format",
+        help="Output format for converter inventory.",
+    )
 
     report_parser = subparsers.add_parser("report", help="Write static compatibility reports.")
     _add_report_args(report_parser)
@@ -410,6 +445,33 @@ def _settings_for_args(args: argparse.Namespace) -> dict[str, CLISetting]:
     return settings
 
 
+def _converter_inventory() -> ConverterInventory:
+    groups = {group: list(keys) for group, keys in CONVERSION_CATEGORIES.items()}
+    converter_keys = sorted({key for keys in groups.values() for key in keys})
+    return {
+        "default_groups": list(DEFAULT_CONVERSION_GROUPS),
+        "groups": groups,
+        "converter_keys": converter_keys,
+    }
+
+
+def _print_converter_inventory(output_format: str) -> None:
+    inventory = _converter_inventory()
+    if output_format == "json":
+        print(json.dumps(inventory, indent=2, sort_keys=True))
+        return
+
+    print("Default groups: " + ", ".join(inventory["default_groups"]))
+    print("")
+    print("Conversion groups:")
+    for group, keys in inventory["groups"].items():
+        print(f"  {group}: {', '.join(keys)}")
+    print("")
+    print("Converter keys:")
+    for key in inventory["converter_keys"]:
+        print(f"  {key}")
+
+
 def _write_static_reports(report_dir: str, target_platform: str | None = None) -> None:
     report_root = os.path.join(report_dir, "gm2godot")
     os.makedirs(report_root, exist_ok=True)
@@ -501,3 +563,7 @@ def _default_platform() -> str:
     if sys.platform.startswith("linux"):
         return "linux"
     return "windows"
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,5 @@
-VERSION = "0.6.0"
+VERSION = "0.6.1"
+
 
 def get_version():
     return VERSION

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import importlib
+import io
 import json
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
@@ -52,6 +57,67 @@ class TestCLIReports(unittest.TestCase):
                 for check in capability_report["checks"]
             )
         )
+
+    def test_version_flag_prints_current_version(self) -> None:
+        output = io.StringIO()
+
+        with redirect_stdout(output):
+            exit_code = cli.main(["--version"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(output.getvalue().strip(), "GM2Godot 0.6.1")
+
+    def test_list_converters_writes_text_inventory(self) -> None:
+        output = io.StringIO()
+
+        with redirect_stdout(output):
+            exit_code = cli.main(["list-converters"])
+
+        inventory = output.getvalue()
+        self.assertEqual(exit_code, 0)
+        self.assertIn("Default groups: assets, project, wip", inventory)
+        self.assertIn("Conversion groups:", inventory)
+        self.assertIn("Converter keys:", inventory)
+        self.assertIn("  assets: sprites, fonts, sounds", inventory)
+        self.assertIn("  asset_registry", inventory)
+
+    def test_list_converters_writes_json_inventory(self) -> None:
+        output = io.StringIO()
+
+        with redirect_stdout(output):
+            exit_code = cli.main(["list-converters", "--format", "json"])
+
+        inventory = json.loads(output.getvalue())
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(inventory["default_groups"], ["assets", "project", "wip"])
+        self.assertIn("sprites", inventory["groups"]["assets"])
+        self.assertIn("project_settings", inventory["groups"]["project"])
+        self.assertIn("sound_group_folders", inventory["converter_keys"])
+
+    def test_module_entrypoint_prints_version(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "-m", "src.cli", "--version"],
+            capture_output=True,
+            text=True,
+            cwd=PROJECT_ROOT,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "GM2Godot 0.6.1")
+
+    def test_app_entrypoint_routes_global_cli_flags(self) -> None:
+        app_entrypoint = importlib.import_module("main")
+
+        with (
+            patch.object(sys, "argv", ["main.py", "--version"]),
+            patch("src.cli.main", return_value=0) as cli_main,
+            self.assertRaises(SystemExit) as context,
+        ):
+            app_entrypoint.main()
+
+        self.assertEqual(context.exception.code, 0)
+        cli_main.assert_called_once_with(["--version"])
 
     def test_analyze_only_writes_platform_diagnostic_without_conversion_output(self) -> None:
         gm_dir = os.path.join(self.temp_dir, "gm")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,18 +10,19 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_6_0(self) -> None:
-        self.assertEqual(get_version(), "0.6.0")
+    def test_release_version_is_0_6_1(self) -> None:
+        self.assertEqual(get_version(), "0.6.1")
 
-    def test_release_docs_reference_0_6_0(self) -> None:
+    def test_release_docs_reference_0_6_1(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
         readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
 
+        self.assertIn("## 0.6.1 - 2026-05-28", changelog)
+        self.assertIn("Current source version: `0.6.1`.", readme)
+        self.assertIn("converter inventory discovery", changelog)
         self.assertIn("## 0.6.0 - 2026-05-28", changelog)
-        self.assertIn("Current source version: `0.6.0`.", readme)
         self.assertIn("Milestone audit", changelog)
 
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Summary
- add a global CLI version flag that routes through `main.py` without launching the GUI
- add `list-converters` with text and JSON output for automation
- support direct `python -m src.cli` execution
- bump the source version to 0.6.1 and document the CLI commands

Closes #660

## Verification
- `./venv/bin/pyright --warnings`
- `./venv/bin/python -m unittest tests.test_cli tests.test_version`
- `./venv/bin/python -m unittest`
- `./venv/bin/ruff check .`
- `git diff --check`