### PR TITLE
Fail Godot validation on warning output

### DIFF
--- a/src/conversion/godot_validation.py
+++ b/src/conversion/godot_validation.py
@@ -14,7 +14,22 @@ GODOT_VALIDATION_REPORT_RELATIVE_PATH = os.path.join(
     "gm2godot", "godot_validation_report.json"
 )
 GodotValidationStatus: TypeAlias = Literal["passed", "failed", "skipped"]
+GodotOutputIssueSeverity: TypeAlias = Literal["warning", "error"]
 _LOADABLE_EXTENSIONS = (".gd", ".gdshader", ".tscn", ".tres")
+_GODOT_ERROR_PREFIXES = ("ERROR:", "SCRIPT ERROR:", "SHADER ERROR:")
+_GODOT_WARNING_PREFIXES = ("WARNING:", "SCRIPT WARNING:", "SHADER WARNING:")
+
+
+@dataclass(frozen=True)
+class GodotOutputIssue:
+    severity: GodotOutputIssueSeverity
+    line: str
+
+    def to_dict(self) -> JsonDict:
+        return {
+            "severity": self.severity,
+            "line": self.line,
+        }
 
 
 @dataclass(frozen=True)
@@ -26,6 +41,7 @@ class GodotValidationReport:
     returncode: int | None = None
     output: str = ""
     message: str = ""
+    output_issues: tuple[GodotOutputIssue, ...] = ()
 
     def to_dict(self) -> JsonDict:
         return {
@@ -37,6 +53,10 @@ class GodotValidationReport:
             "resource_paths": list(self.resource_paths),
             "returncode": self.returncode,
             "output": self.output,
+            "output_issue_count": len(self.output_issues),
+            "output_error_count": sum(1 for issue in self.output_issues if issue.severity == "error"),
+            "output_warning_count": sum(1 for issue in self.output_issues if issue.severity == "warning"),
+            "output_issues": [issue.to_dict() for issue in self.output_issues],
             "message": self.message,
         }
 
@@ -120,18 +140,20 @@ def validate_generated_godot_project(
                 message=f"Headless Godot validation timed out after {timeout} seconds.",
             )
 
+    output_issues = detect_godot_output_issues(result.stdout)
+    status: GodotValidationStatus = (
+        "passed" if result.returncode == 0 and not output_issues else "failed"
+    )
+
     return GodotValidationReport(
-        status="passed" if result.returncode == 0 else "failed",
+        status=status,
         godot_binary=resolved_binary,
         project_path=godot_project_path,
         resource_paths=resource_paths,
         returncode=result.returncode,
         output=result.stdout,
-        message=(
-            f"Headless Godot validation loaded {len(resource_paths)} generated resources."
-            if result.returncode == 0
-            else "Headless Godot validation failed while loading generated scripts/scenes/resources."
-        ),
+        message=_validation_message(result.returncode, len(resource_paths), output_issues),
+        output_issues=output_issues,
     )
 
 
@@ -160,6 +182,37 @@ def generated_godot_resource_paths(godot_project_path: str) -> tuple[str, ...]:
             relative_path = os.path.relpath(full_path, godot_project_path).replace(os.sep, "/")
             resource_paths.append("res://" + relative_path)
     return tuple(sorted(resource_paths))
+
+
+def detect_godot_output_issues(output: str) -> tuple[GodotOutputIssue, ...]:
+    issues: list[GodotOutputIssue] = []
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith(_GODOT_ERROR_PREFIXES):
+            issues.append(GodotOutputIssue(severity="error", line=stripped))
+        elif stripped.startswith(_GODOT_WARNING_PREFIXES):
+            issues.append(GodotOutputIssue(severity="warning", line=stripped))
+    return tuple(issues)
+
+
+def _validation_message(
+    returncode: int,
+    resource_count: int,
+    output_issues: tuple[GodotOutputIssue, ...],
+) -> str:
+    if output_issues:
+        error_count = sum(1 for issue in output_issues if issue.severity == "error")
+        warning_count = sum(1 for issue in output_issues if issue.severity == "warning")
+        return (
+            "Headless Godot validation reported "
+            f"{error_count} error(s) and {warning_count} warning(s) "
+            "while loading generated scripts/scenes/resources."
+        )
+    if returncode == 0:
+        return f"Headless Godot validation loaded {resource_count} generated resources."
+    return "Headless Godot validation failed while loading generated scripts/scenes/resources."
 
 
 def _validation_script(resource_paths: tuple[str, ...]) -> str:

--- a/tests/test_godot_validation.py
+++ b/tests/test_godot_validation.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from src import cli
 from src.conversion.godot_validation import (
     GODOT_VALIDATION_REPORT_RELATIVE_PATH,
+    detect_godot_output_issues,
     find_godot_binary,
     generated_godot_resource_paths,
     validate_generated_godot_project,
@@ -57,6 +58,47 @@ class TestGodotValidation(unittest.TestCase):
             ("res://main.gd", "res://main.tscn"),
         )
 
+    def test_detects_godot_warning_and_error_output(self) -> None:
+        issues = detect_godot_output_issues(
+            "\n".join(
+                [
+                    "Godot Engine v4.6.3.stable.official",
+                    "SCRIPT ERROR: Parse Error: Identifier not declared.",
+                    "          at: GDScript::reload (res://bad.gd:4)",
+                    "WARNING: Some generated resource warning.",
+                    "GM2GODOT_VALIDATION_OK 1",
+                ]
+            )
+        )
+
+        self.assertEqual(len(issues), 2)
+        self.assertEqual(issues[0].severity, "error")
+        self.assertEqual(issues[0].line, "SCRIPT ERROR: Parse Error: Identifier not declared.")
+        self.assertEqual(issues[1].severity, "warning")
+
+    def test_validation_fails_when_godot_outputs_error_with_zero_exit(self) -> None:
+        project_dir = self._write_project()
+        fake_godot = self.temp_dir / "fake-godot"
+        fake_godot.write_text(
+            "#!/bin/sh\n"
+            "printf '%s\\n' 'Godot Engine v4.6.3.stable.official'\n"
+            "printf '%s\\n' 'SCRIPT ERROR: Parse Error: Identifier not declared.'\n"
+            "printf '%s\\n' 'GM2GODOT_VALIDATION_OK 2'\n"
+            "exit 0\n",
+            encoding="utf-8",
+        )
+        fake_godot.chmod(0o755)
+
+        report = validate_generated_godot_project(
+            str(project_dir),
+            godot_binary=str(fake_godot),
+        )
+
+        self.assertEqual(report.status, "failed")
+        self.assertEqual(report.returncode, 0)
+        self.assertEqual(len(report.output_issues), 1)
+        self.assertEqual(report.output_issues[0].severity, "error")
+
     @unittest.skipIf(find_godot_binary() is None, "Godot binary not available")
     def test_headless_godot_validation_loads_generated_resources(self) -> None:
         project_dir = self._write_project()
@@ -64,6 +106,7 @@ class TestGodotValidation(unittest.TestCase):
         report = validate_generated_godot_project(str(project_dir))
 
         self.assertEqual(report.status, "passed", report.output)
+        self.assertEqual(report.output_issues, (), report.output)
         self.assertIn("GM2GODOT_VALIDATION_OK", report.output)
         self.assertEqual(report.resource_paths, ("res://main.gd", "res://main.tscn"))
 
@@ -84,6 +127,7 @@ class TestGodotValidation(unittest.TestCase):
         report = json.loads(report_path.read_text(encoding="utf-8"))
         self.assertEqual(report["status"], "passed")
         self.assertEqual(report["resource_count"], 2)
+        self.assertEqual(report["output_issue_count"], 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_golden_conversion.py
+++ b/tests/test_golden_conversion.py
@@ -15,6 +15,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from src import cli
+from src.conversion.godot_validation import find_godot_binary, validate_generated_godot_project
 
 
 FIXTURE_ROOT = PROJECT_ROOT / "tests" / "fixtures" / "golden" / "basic_scripts"
@@ -31,6 +32,21 @@ class TestGoldenConversion(unittest.TestCase):
         shutil.rmtree(self.temp_dir)
 
     def test_basic_scripts_conversion_matches_golden_snapshot(self) -> None:
+        godot_dir = self._convert_basic_scripts_fixture()
+        actual = _snapshot_output(godot_dir, FIXTURE_ROOT)
+        expected = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(actual, expected)
+
+    @unittest.skipIf(find_godot_binary() is None, "Godot binary not available")
+    def test_basic_scripts_godot_validation_has_no_warnings_or_errors(self) -> None:
+        godot_dir = self._convert_basic_scripts_fixture()
+
+        report = validate_generated_godot_project(str(godot_dir))
+
+        self.assertEqual(report.status, "passed", report.output)
+        self.assertEqual(report.output_issues, (), report.output)
+
+    def _convert_basic_scripts_fixture(self) -> Path:
         godot_dir = self.temp_dir / "godot"
         report_dir = self.temp_dir / "reports"
         godot_dir.mkdir()
@@ -62,9 +78,7 @@ class TestGoldenConversion(unittest.TestCase):
         )
 
         self.assertEqual(exit_code, 0)
-        actual = _snapshot_output(godot_dir, FIXTURE_ROOT)
-        expected = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
-        self.assertEqual(actual, expected)
+        return godot_dir
 
 
 def _snapshot_output(godot_dir: Path, gm_project_dir: Path) -> dict[str, object]:

--- a/tests/test_simple_topdown_conversion.py
+++ b/tests/test_simple_topdown_conversion.py
@@ -14,6 +14,7 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from src.conversion.converter import CONVERSION_CATEGORIES, Converter
+from src.conversion.godot_validation import find_godot_binary, validate_generated_godot_project
 from src.gui.setting_value import SettingValue
 
 
@@ -159,6 +160,13 @@ class TestSimpleTopDownConversion(unittest.TestCase):
         joined = "\n".join(str(msg) for msg in self.logs)
         self.assertNotIn("Traceback", joined, "Conversion produced a Python traceback")
         self.assertNotIn("Could not transpile GameMaker event code", joined)
+
+    @unittest.skipIf(find_godot_binary() is None, "Godot binary not available")
+    def test_generated_project_has_no_godot_warnings_or_errors(self) -> None:
+        report = validate_generated_godot_project(self.godot_dir)
+
+        self.assertEqual(report.status, "passed", report.output)
+        self.assertEqual(report.output_issues, (), report.output)
 
 
 if __name__ == "__main__":

--- a/tests/test_tcc_conversion.py
+++ b/tests/test_tcc_conversion.py
@@ -15,6 +15,7 @@ if PROJECT_ROOT not in sys.path:
 
 from src.conversion.converter import CONVERSION_CATEGORIES, Converter
 from src.conversion.generated_paths import generated_resource_stem
+from src.conversion.godot_validation import find_godot_binary, validate_generated_godot_project
 from src.gui.setting_value import SettingValue
 
 
@@ -205,6 +206,13 @@ class TestTCCConversion(unittest.TestCase):
     def test_no_tracebacks_in_logs(self):
         joined = "\n".join(str(msg) for msg in self.logs)
         self.assertNotIn("Traceback", joined, "Conversion produced a Python traceback")
+
+    @unittest.skipIf(find_godot_binary() is None, "Godot binary not available")
+    def test_generated_project_has_no_godot_warnings_or_errors(self) -> None:
+        report = validate_generated_godot_project(self.godot_dir)
+
+        self.assertEqual(report.status, "passed", report.output)
+        self.assertEqual(report.output_issues, (), report.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fail generated Godot validation when stdout contains Godot warning/error lines, even if Godot exits 0.
- Add structured `output_issues` and warning/error counts to the validation report.
- Add strict Godot validation checks to golden, SimpleTopDown, and TCC conversion test paths when `GODOT_BIN` is available.

Closes #662.

## Verification
- `GODOT_BIN=/Applications/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_godot_validation tests.test_golden_conversion -v`
- `./venv/bin/pyright --warnings`
- `GODOT_BIN=/Applications/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_simple_topdown_conversion tests.test_tcc_conversion -v`
- `./venv/bin/python -m ruff check src/conversion/godot_validation.py tests/test_godot_validation.py tests/test_golden_conversion.py tests/test_simple_topdown_conversion.py tests/test_tcc_conversion.py`
