### PR TITLE
Preserve caller scope for script calls

### DIFF
--- a/src/conversion/gml_runtime_parts/segments/20_methods_and_exceptions.gd
+++ b/src/conversion/gml_runtime_parts/segments/20_methods_and_exceptions.gd
@@ -15,33 +15,40 @@ static func gml_method_call(method, array_args = null, offset = 0, num_args = nu
 	return method.gml_callv(call_args) if method is GMLMethod else method.callv(call_args)
 
 
-static func gml_script_execute(script, args = []):
+static func gml_script_execute(script, args = [], caller_self = null, caller_other = null):
 	var descriptor: Variant = _gml_script_resolve(script)
 	if descriptor == null:
 		return gml_unsupported_type_error("GML script_execute", script)
-	return gml_script_call(descriptor, args)
+	return gml_script_call(descriptor, args, caller_self, caller_other)
 
 
-static func gml_script_call(script_or_callable, args = []):
+static func gml_script_call(script_or_callable, args = [], caller_self = null, caller_other = null):
 	var call_args = args if typeof(args) == TYPE_ARRAY else [args]
 	var callable = script_or_callable
 	var use_legacy_arguments = false
+	var has_caller_scope = caller_self != null and not is_undefined(caller_self)
 	if typeof(script_or_callable) == TYPE_DICTIONARY and script_or_callable.has("callable"):
-		callable = script_or_callable["callable"]
+		if has_caller_scope and script_or_callable.has("scoped_callable"):
+			callable = script_or_callable["scoped_callable"]
+		else:
+			callable = script_or_callable["callable"]
 		use_legacy_arguments = bool(script_or_callable.get("legacy_arguments", false))
 	if not is_method(callable):
 		return gml_unsupported_type_error("GML script callable", callable)
 	_gml_script_push_arguments(call_args)
+	var runtime_args = []
+	if has_caller_scope and typeof(script_or_callable) == TYPE_DICTIONARY and script_or_callable.has("scoped_callable"):
+		runtime_args.append(caller_self)
+		runtime_args.append(caller_other if caller_other != null and not is_undefined(caller_other) else caller_self)
+	if not use_legacy_arguments:
+		runtime_args.append_array(call_args)
 	var result = null
-	if use_legacy_arguments:
-		result = callable.gml_callv([]) if callable is GMLMethod else callable.callv([])
-	else:
-		result = callable.gml_callv(call_args) if callable is GMLMethod else callable.callv(call_args)
+	result = callable.gml_callv(runtime_args) if callable is GMLMethod else callable.callv(runtime_args)
 	_gml_script_pop_arguments()
 	return result
 
 
-static func gml_script_register(script, callable, legacy_arguments = false):
+static func gml_script_register(script, callable, legacy_arguments = false, scoped_callable = null):
 	if not is_method(callable):
 		return false
 	var key = _gml_script_key(script)
@@ -50,6 +57,7 @@ static func gml_script_register(script, callable, legacy_arguments = false):
 	var name = _gml_script_name(script)
 	_gml_script_registry[key] = {
 		"callable": callable,
+		"scoped_callable": scoped_callable if is_method(scoped_callable) else callable,
 		"name": name,
 		"legacy_arguments": gml_bool(legacy_arguments)
 	}
@@ -67,7 +75,12 @@ static func gml_script_registry_set(entries):
 		if typeof(entry) != TYPE_DICTIONARY or not entry.has("callable"):
 			continue
 		var script = entry["id"] if entry.has("id") else entry.get("name", "")
-		gml_script_register(script, entry["callable"], bool(entry.get("legacy_arguments", false)))
+		gml_script_register(
+			script,
+			entry["callable"],
+			bool(entry.get("legacy_arguments", false)),
+			entry.get("scoped_callable", null)
+		)
 	return null
 
 
@@ -80,6 +93,7 @@ static func gml_script_registry_entries():
 			"id": int(key) if is_numeric(key) else key,
 			"name": str(entry.get("name", key)),
 			"callable": entry["callable"],
+			"scoped_callable": entry.get("scoped_callable", entry["callable"]),
 			"legacy_arguments": bool(entry.get("legacy_arguments", false))
 		})
 	return entries

--- a/src/conversion/gml_transpiler_parts/emitter.py
+++ b/src/conversion/gml_transpiler_parts/emitter.py
@@ -248,6 +248,21 @@ def _emit_expression(
         builtin_call = _emit_builtin_call(expr, local_names, scope_context=scope_context)
         if builtin_call is not None:
             return builtin_call, _POSTFIX_PRECEDENCE
+        if (
+            isinstance(expr.callee, _Name)
+            and expr.callee.value not in local_names
+            and expr.callee.value in scope_context.asset_names
+        ):
+            args = ", ".join(
+                _emit_expression(arg, local_names, scope_context=scope_context)[0]
+                for arg in expr.args
+            )
+            return (
+                "GMRuntime.gml_script_call("
+                f"GMRuntime.gml_asset_get_index({json.dumps(expr.callee.value)}), "
+                f"[{args}], {scope_context.self_expression}, {scope_context.other_expression})",
+                _POSTFIX_PRECEDENCE,
+            )
         if isinstance(expr.callee, _Name):
             callee = _emit_name(
                 expr.callee.value,
@@ -608,6 +623,12 @@ def _emit_descriptor_call(
             _emit_expression(arg, local_names, scope_context=scope_context)[0]
             for arg in args[1:]
         )
+        if descriptor.name == "script_execute":
+            return (
+                f"GMRuntime.{descriptor.lowering_target}("
+                f"{emitted_first}, [{emitted_rest}], "
+                f"{scope_context.self_expression}, {scope_context.other_expression})"
+            )
         return f"GMRuntime.{descriptor.lowering_target}({emitted_first}, [{emitted_rest}])"
 
     if descriptor.lowering_kind == "runtime_variadic_all":

--- a/src/conversion/scripts.py
+++ b/src/conversion/scripts.py
@@ -31,6 +31,7 @@ from src.conversion.gml_transpiler_parts.identifiers import (
     _sanitize_gdscript_identifier,
     _validate_gml_identifier,
 )
+from src.conversion.gml_transpiler_parts.model import _ScopeContext
 from src.conversion.gml_transpiler_parts.utils import (
     _split_assignment,
     _split_top_level,
@@ -41,6 +42,8 @@ from src.conversion.type_defs import ConversionRunning, LogCallback, ProgressCal
 
 SCRIPT_REGISTRY_RELATIVE_PATH = os.path.join("gm2godot", "gml_script_registry.gd")
 SCRIPT_REGISTRY_RESOURCE_PATH = "res://gm2godot/gml_script_registry.gd"
+_SCRIPT_SELF_PARAMETER = "_gml_script_self"
+_SCRIPT_OTHER_PARAMETER = "_gml_script_other"
 
 
 @dataclass(frozen=True)
@@ -64,6 +67,38 @@ class _ScriptFunctionDeclaration:
     body: str
 
 
+def _script_scope_context() -> _ScopeContext:
+    return _ScopeContext(
+        self_expression=_SCRIPT_SELF_PARAMETER,
+        other_expression=_SCRIPT_OTHER_PARAMETER,
+        instance_target=_SCRIPT_SELF_PARAMETER,
+    )
+
+
+def _script_scope_lines() -> list[str]:
+    return [
+        (
+            f"\tif {_SCRIPT_SELF_PARAMETER} == null "
+            f"or GMRuntime.is_undefined({_SCRIPT_SELF_PARAMETER}): "
+            f"{_SCRIPT_SELF_PARAMETER} = self"
+        ),
+        (
+            f"\tif {_SCRIPT_OTHER_PARAMETER} == null "
+            f"or GMRuntime.is_undefined({_SCRIPT_OTHER_PARAMETER}): "
+            f"{_SCRIPT_OTHER_PARAMETER} = {_SCRIPT_SELF_PARAMETER}"
+        ),
+    ]
+
+
+def _script_forward_call(*, declaration: _ScriptFunctionDeclaration) -> str:
+    args = [
+        "self",
+        "self",
+        *(_sanitize_gdscript_identifier(parameter.name) for parameter in declaration.parameters),
+    ]
+    return f"\treturn _gm_script_call_scoped({', '.join(args)})\n"
+
+
 def render_script_registry_script(entries: Iterable[ScriptRegistryEntry]) -> str:
     lines = [
         "extends RefCounted\n\n",
@@ -77,6 +112,7 @@ def render_script_registry_script(entries: Iterable[ScriptRegistryEntry]) -> str
                 f"\t\t\t\"id\": {entry.id},\n",
                 f"\t\t\t\"name\": {json.dumps(entry.name)},\n",
                 f"\t\t\t\"callable\": preload({json.dumps(entry.resource_path)}).new().gm2godot_callable(),\n",
+                f"\t\t\t\"scoped_callable\": preload({json.dumps(entry.resource_path)}).new().gm2godot_scoped_callable(),\n",
                 f"\t\t\t\"legacy_arguments\": {str(entry.legacy_arguments).lower()},\n",
                 "\t\t},\n",
             ]
@@ -115,7 +151,7 @@ class ScriptConverter(BaseConverter):
         self.godot_scripts_path = os.path.join(self.godot_project_path, "scripts")
         self.macro_configuration = macro_configuration
 
-    def _asset_entries(self) -> tuple[AssetRegistryEntry, ...]:
+    def _registry_entries(self) -> tuple[AssetRegistryEntry, ...]:
         registry_converter = AssetRegistryConverter(
             self.gm_project_path,
             self.godot_project_path,
@@ -123,11 +159,10 @@ class ScriptConverter(BaseConverter):
             progress_callback=lambda _value: None,
             conversion_running=self.conversion_running,
         )
-        return tuple(
-            entry
-            for entry in registry_converter.build_entries()
-            if entry.asset_type == "script"
-        )
+        return tuple(registry_converter.build_entries())
+
+    def _asset_entries(self) -> tuple[AssetRegistryEntry, ...]:
+        return tuple(entry for entry in self._registry_entries() if entry.asset_type == "script")
 
     def _source_gml_path(self, entry: AssetRegistryEntry) -> str | None:
         yy_path = os.path.join(self.gm_project_path, entry.source_path)
@@ -240,7 +275,8 @@ class ScriptConverter(BaseConverter):
         generated_line_offset: int = 0,
     ) -> tuple[str, GMLSourceMap]:
         local_names = {parameter.name for parameter in declaration.parameters}
-        lines: list[str] = []
+        script_scope = _script_scope_context()
+        lines: list[str] = _script_scope_lines()
         for parameter in declaration.parameters:
             parameter_name = _sanitize_gdscript_identifier(parameter.name)
             if parameter.default is None:
@@ -250,6 +286,7 @@ class ScriptConverter(BaseConverter):
                 parameter.default,
                 local_names=local_names,
                 asset_names=asset_names,
+                scope_context=script_scope,
                 extension_functions=extension_functions,
                 extension_function_mappings=extension_function_mappings,
             )
@@ -262,6 +299,9 @@ class ScriptConverter(BaseConverter):
             return_depth=1,
             asset_names=asset_names,
             static_scope_prefix=static_scope_prefix,
+            self_expression=script_scope.self_expression,
+            other_expression=script_scope.other_expression,
+            instance_target=script_scope.instance_target,
             local_names=local_names,
             extension_functions=extension_functions,
             extension_function_mappings=extension_function_mappings,
@@ -295,11 +335,20 @@ class ScriptConverter(BaseConverter):
                 f"{_sanitize_gdscript_identifier(parameter.name)} = null"
                 for parameter in modern_declaration.parameters
             )
+            scoped_params = ", ".join(
+                [
+                    f"{_SCRIPT_SELF_PARAMETER} = null",
+                    f"{_SCRIPT_OTHER_PARAMETER} = null",
+                    *(f"{_sanitize_gdscript_identifier(parameter.name)} = null" for parameter in modern_declaration.parameters),
+                ]
+            )
             prefix = (
                 "extends RefCounted\n\n"
                 f"{header}"
                 'const GMRuntime = preload("res://gm2godot/gml_runtime.gd")\n\n'
                 f"func _gm_script_call({params}):\n"
+                f"{_script_forward_call(declaration=modern_declaration)}\n"
+                f"func _gm_script_call_scoped({scoped_params}):\n"
             )
             body, source_map = self._modern_function_body(
                 modern_declaration,
@@ -315,7 +364,9 @@ class ScriptConverter(BaseConverter):
                 + f"{body}\n"
                 + "\treturn GMRuntime.gml_undefined()\n\n"
                 + "func gm2godot_callable():\n"
-                + '\treturn GMRuntime.gml_method(self, Callable(self, "_gm_script_call"))\n',
+                + '\treturn GMRuntime.gml_method(self, Callable(self, "_gm_script_call"))\n\n'
+                + "func gm2godot_scoped_callable():\n"
+                + '\treturn GMRuntime.gml_method(self, Callable(self, "_gm_script_call_scoped"))\n',
                 False,
                 source_map,
             )
@@ -325,26 +376,36 @@ class ScriptConverter(BaseConverter):
             f"{header}"
             'const GMRuntime = preload("res://gm2godot/gml_runtime.gd")\n\n'
             "func _gm_script_call():\n"
+            "\treturn _gm_script_call_scoped(self, self)\n\n"
+            f"func _gm_script_call_scoped({_SCRIPT_SELF_PARAMETER} = null, {_SCRIPT_OTHER_PARAMETER} = null):\n"
         )
+        script_scope = _script_scope_context()
         result = transpile_gml_code_with_source_map(
             source,
             return_depth=1,
             asset_names=asset_names,
             static_scope_prefix=f"{entry.name}.script",
+            self_expression=script_scope.self_expression,
+            other_expression=script_scope.other_expression,
+            instance_target=script_scope.instance_target,
             extension_functions=extension_functions,
             extension_function_mappings=extension_function_mappings,
             macro_configuration=self.macro_configuration,
             source_path=source_path,
             event=f"script:{entry.name}",
             preserve_source_comments=True,
-            generated_line_offset=prefix.count("\n"),
+            generated_line_offset=prefix.count("\n") + len(_script_scope_lines()),
         )
         return (
             prefix
+            + "\n".join(_script_scope_lines())
+            + "\n"
             + f"{result.code}\n"
             + "\treturn GMRuntime.gml_undefined()\n\n"
             + "func gm2godot_callable():\n"
-            + '\treturn GMRuntime.gml_method(self, Callable(self, "_gm_script_call"))\n',
+            + '\treturn GMRuntime.gml_method(self, Callable(self, "_gm_script_call"))\n\n'
+            + "func gm2godot_scoped_callable():\n"
+            + '\treturn GMRuntime.gml_method(self, Callable(self, "_gm_script_call_scoped"))\n',
             True,
             result.source_map,
         )
@@ -475,14 +536,15 @@ class ScriptConverter(BaseConverter):
         if not self.conversion_running():
             return None
 
-        entries = self._asset_entries()
+        all_entries = self._registry_entries()
+        entries = tuple(entry for entry in all_entries if entry.asset_type == "script")
         if not entries:
             self.log_callback(get_localized("Console_Convertor_Scripts_Complete"))
             return None
 
         write_gml_runtime(self.godot_project_path)
         os.makedirs(self.godot_scripts_path, exist_ok=True)
-        asset_names = {entry.name for entry in entries}
+        asset_names = {entry.name for entry in all_entries}
         extension_functions = self._extension_functions()
         extension_function_mappings = self._extension_function_mappings()
         registry_entries: list[ScriptRegistryEntry] = []

--- a/tests/fixtures/golden/basic_scripts/expected_snapshot.json
+++ b/tests/fixtures/golden/basic_scripts/expected_snapshot.json
@@ -1,13 +1,13 @@
 {
   "files": {
-    "gm2godot/gml_script_registry.gd": "extends RefCounted\n\nstatic func gml_script_registry_entries():\n\treturn [\n\t\t{\n\t\t\t\"id\": 179646376,\n\t\t\t\"name\": \"scr_add\",\n\t\t\t\"callable\": preload(\"res://scripts/game/scr_add.gd\").new().gm2godot_callable(),\n\t\t\t\"legacy_arguments\": true,\n\t\t},\n\t\t{\n\t\t\t\"id\": 950140064,\n\t\t\t\"name\": \"scr_stats\",\n\t\t\t\"callable\": preload(\"res://scripts/game/scr_stats.gd\").new().gm2godot_callable(),\n\t\t\t\"legacy_arguments\": false,\n\t\t},\n\t]\n",
+    "gm2godot/gml_script_registry.gd": "extends RefCounted\n\nstatic func gml_script_registry_entries():\n\treturn [\n\t\t{\n\t\t\t\"id\": 179646376,\n\t\t\t\"name\": \"scr_add\",\n\t\t\t\"callable\": preload(\"res://scripts/game/scr_add.gd\").new().gm2godot_callable(),\n\t\t\t\"scoped_callable\": preload(\"res://scripts/game/scr_add.gd\").new().gm2godot_scoped_callable(),\n\t\t\t\"legacy_arguments\": true,\n\t\t},\n\t\t{\n\t\t\t\"id\": 950140064,\n\t\t\t\"name\": \"scr_stats\",\n\t\t\t\"callable\": preload(\"res://scripts/game/scr_stats.gd\").new().gm2godot_callable(),\n\t\t\t\"scoped_callable\": preload(\"res://scripts/game/scr_stats.gd\").new().gm2godot_scoped_callable(),\n\t\t\t\"legacy_arguments\": false,\n\t\t},\n\t]\n",
     "project.godot": "[application]\nconfig/name=\"Golden Fixture\"\n\n[autoload]\nGMRuntime=\"*res://gm2godot/managers/gm_runtime_manager.gd\"\nGMAssets=\"*res://gm2godot/managers/gm_assets.gd\"\nGMRooms=\"*res://gm2godot/managers/gm_rooms.gd\"\nGMInstances=\"*res://gm2godot/managers/gm_instances.gd\"\nGMEvents=\"*res://gm2godot/managers/gm_events.gd\"\nGMDraw=\"*res://gm2godot/managers/gm_draw.gd\"\nGMInput=\"*res://gm2godot/managers/gm_input.gd\"\nGMAudio=\"*res://gm2godot/managers/gm_audio.gd\"\nGMAsync=\"*res://gm2godot/managers/gm_async.gd\"\nGMPlatform=\"*res://gm2godot/managers/gm_platform.gd\"\n",
-    "scripts/game/scr_add.gd": "extends RefCounted\n\n# GM2Godot source: <GM_PROJECT>/scripts/scr_add/scr_add.gml\n# GM2Godot event: script:scr_add\n\nconst GMRuntime = preload(\"res://gm2godot/gml_runtime.gd\")\n\nfunc _gm_script_call():\n\treturn GMRuntime.gml_add(GMRuntime.gml_argument(0), GMRuntime.gml_argument(1))\n\treturn GMRuntime.gml_undefined()\n\nfunc gm2godot_callable():\n\treturn GMRuntime.gml_method(self, Callable(self, \"_gm_script_call\"))\n",
-    "scripts/game/scr_stats.gd": "extends RefCounted\n\n# GM2Godot source: <GM_PROJECT>/scripts/scr_stats/scr_stats.gml\n# GM2Godot event: script:scr_stats\n\nconst GMRuntime = preload(\"res://gm2godot/gml_runtime.gd\")\n\nfunc _gm_script_call(a = null, b = null):\n\tif a == null: a = GMRuntime.gml_undefined()\n\tif b == null or GMRuntime.is_undefined(b): b = 4\n\tvar values = [a]\n\tGMRuntime.gml_array_push(values, [GMRuntime.gml_min([4, 1, 2]), GMRuntime.gml_max([4, 1, 2]), GMRuntime.gml_choose([7, 8, 9])])\n\treturn GMRuntime.gml_add(GMRuntime.gml_add(GMRuntime.gml_add(GMRuntime.gml_array_get(values, 0), GMRuntime.gml_array_get(values, 1)), GMRuntime.gml_array_get(values, 2)), b)\n\treturn GMRuntime.gml_undefined()\n\nfunc gm2godot_callable():\n\treturn GMRuntime.gml_method(self, Callable(self, \"_gm_script_call\"))\n"
+    "scripts/game/scr_add.gd": "extends RefCounted\n\n# GM2Godot source: <GM_PROJECT>/scripts/scr_add/scr_add.gml\n# GM2Godot event: script:scr_add\n\nconst GMRuntime = preload(\"res://gm2godot/gml_runtime.gd\")\n\nfunc _gm_script_call():\n\treturn _gm_script_call_scoped(self, self)\n\nfunc _gm_script_call_scoped(_gml_script_self = null, _gml_script_other = null):\n\tif _gml_script_self == null or GMRuntime.is_undefined(_gml_script_self): _gml_script_self = self\n\tif _gml_script_other == null or GMRuntime.is_undefined(_gml_script_other): _gml_script_other = _gml_script_self\n\treturn GMRuntime.gml_add(GMRuntime.gml_argument(0), GMRuntime.gml_argument(1))\n\treturn GMRuntime.gml_undefined()\n\nfunc gm2godot_callable():\n\treturn GMRuntime.gml_method(self, Callable(self, \"_gm_script_call\"))\n\nfunc gm2godot_scoped_callable():\n\treturn GMRuntime.gml_method(self, Callable(self, \"_gm_script_call_scoped\"))\n",
+    "scripts/game/scr_stats.gd": "extends RefCounted\n\n# GM2Godot source: <GM_PROJECT>/scripts/scr_stats/scr_stats.gml\n# GM2Godot event: script:scr_stats\n\nconst GMRuntime = preload(\"res://gm2godot/gml_runtime.gd\")\n\nfunc _gm_script_call(a = null, b = null):\n\treturn _gm_script_call_scoped(self, self, a, b)\n\nfunc _gm_script_call_scoped(_gml_script_self = null, _gml_script_other = null, a = null, b = null):\n\tif _gml_script_self == null or GMRuntime.is_undefined(_gml_script_self): _gml_script_self = self\n\tif _gml_script_other == null or GMRuntime.is_undefined(_gml_script_other): _gml_script_other = _gml_script_self\n\tif a == null: a = GMRuntime.gml_undefined()\n\tif b == null or GMRuntime.is_undefined(b): b = 4\n\tvar values = [a]\n\tGMRuntime.gml_array_push(values, [GMRuntime.gml_min([4, 1, 2]), GMRuntime.gml_max([4, 1, 2]), GMRuntime.gml_choose([7, 8, 9])])\n\treturn GMRuntime.gml_add(GMRuntime.gml_add(GMRuntime.gml_add(GMRuntime.gml_array_get(values, 0), GMRuntime.gml_array_get(values, 1)), GMRuntime.gml_array_get(values, 2)), b)\n\treturn GMRuntime.gml_undefined()\n\nfunc gm2godot_callable():\n\treturn GMRuntime.gml_method(self, Callable(self, \"_gm_script_call\"))\n\nfunc gm2godot_scoped_callable():\n\treturn GMRuntime.gml_method(self, Callable(self, \"_gm_script_call_scoped\"))\n"
   },
   "fixture": "basic_scripts",
   "hashes": {
-    "gm2godot/gml_runtime.gd": "sha256:b617b26cbefdb24656d08ec577a2dd835a8692d0edf1f640f428b897b099a154",
+    "gm2godot/gml_runtime.gd": "sha256:f7926b4ec9389c06d73299a9571d693f90b8885884267fa8dab37248ef43dcf1",
     "gm2godot/managers/gm_assets.gd": "sha256:4121345bd843a0bb3487fcba4756a3b2f18700685f5858db5f62f8992d96a76f",
     "gm2godot/managers/gm_async.gd": "sha256:d0a73997476f0e889892f85a6c343fc5b44fecdf9fa547e943902632aedf9df3",
     "gm2godot/managers/gm_audio.gd": "sha256:995a1df58e7f8ad03fa8ed7e9a195cdcfcf256643d73ac06a88bb6bbec82fba4",
@@ -367,7 +367,7 @@
       "entries": [
         {
           "event": "script:scr_add",
-          "generated_line": 9,
+          "generated_line": 14,
           "generated_text": "return GMRuntime.gml_add(GMRuntime.gml_argument(0), GMRuntime.gml_argument(1))",
           "source_column": 1,
           "source_line": 1,
@@ -383,7 +383,7 @@
       "entries": [
         {
           "event": "script:scr_stats",
-          "generated_line": 11,
+          "generated_line": 16,
           "generated_text": "var values = [a]",
           "source_column": 5,
           "source_line": 2,
@@ -392,7 +392,7 @@
         },
         {
           "event": "script:scr_stats",
-          "generated_line": 12,
+          "generated_line": 17,
           "generated_text": "GMRuntime.gml_array_push(values, [GMRuntime.gml_min([4, 1, 2]), GMRuntime.gml_max([4, 1, 2]), GMRuntime.gml_choose([7, 8, 9])])",
           "source_column": 5,
           "source_line": 3,
@@ -401,7 +401,7 @@
         },
         {
           "event": "script:scr_stats",
-          "generated_line": 13,
+          "generated_line": 18,
           "generated_text": "return GMRuntime.gml_add(GMRuntime.gml_add(GMRuntime.gml_add(GMRuntime.gml_array_get(values, 0), GMRuntime.gml_array_get(values, 1)), GMRuntime.gml_array_get(values, 2)), b)",
           "source_column": 5,
           "source_line": 4,

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -433,7 +433,7 @@ RUNTIME_VALUE_PARITY_CASES: tuple[RuntimeValueParityCase, ...] = (
     RuntimeValueParityCase("physics_joint_delete(joint)", "GMRuntime.gml_physics_joint_delete(joint)"),
     RuntimeValueParityCase(
         "script_execute(scr_add, 1, 2)",
-        'GMRuntime.gml_script_execute(GMRuntime.gml_asset_get_index("scr_add"), [1, 2])',
+        'GMRuntime.gml_script_execute(GMRuntime.gml_asset_get_index("scr_add"), [1, 2], self, other)',
     ),
     RuntimeValueParityCase("script_exists(scr_add)", 'GMRuntime.gml_script_exists(GMRuntime.gml_asset_get_index("scr_add"))'),
     RuntimeValueParityCase("script_get_name(scr_add)", 'GMRuntime.gml_script_get_name(GMRuntime.gml_asset_get_index("scr_add"))'),

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -2497,7 +2497,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
         )
         self.assertEqual(
             transpile_gml_expression("scr_add(1)", asset_names={"scr_add"}),
-            "scr_add(1)",
+            'GMRuntime.gml_script_call(GMRuntime.gml_asset_get_index("scr_add"), [1], self, other)',
         )
         with self.assertRaisesRegex(GMLTranspileError, "collides with a global and asset name"):
             transpile_gml_expression("shared_name", global_names={"shared_name"}, asset_names={"shared_name"})
@@ -4088,7 +4088,7 @@ class TestGMLStatementTranspiler(unittest.TestCase):
                 indent="",
                 asset_names={"scr_add"},
             ),
-            "result = GMRuntime.gml_script_execute(GMRuntime.gml_asset_get_index(\"scr_add\"), [1, 2])\n"
+            "result = GMRuntime.gml_script_execute(GMRuntime.gml_asset_get_index(\"scr_add\"), [1, 2], self, other)\n"
             "ok = GMRuntime.gml_script_exists(GMRuntime.gml_asset_get_index(\"scr_add\"))\n"
             "name = GMRuntime.gml_script_get_name(GMRuntime.gml_asset_get_index(\"scr_add\"))\n"
             "fn = GMRuntime.gml_global_function('scr_add')\n"

--- a/tests/test_script_runtime_godot.py
+++ b/tests/test_script_runtime_godot.py
@@ -55,12 +55,13 @@ def _write_gm_project(gm_dir: Path) -> None:
             "resources": [
                 _resource_entry("scripts", "scr_add"),
                 _resource_entry("scripts", "scr_modern"),
+                _resource_entry("scripts", "scr_context"),
             ],
             "RoomOrderNodes": [],
             "resourceType": "GMProject",
         },
     )
-    for script_name in ("scr_add", "scr_modern"):
+    for script_name in ("scr_add", "scr_modern", "scr_context"):
         _write_json(
             gm_dir / "scripts" / script_name / f"{script_name}.yy",
             {
@@ -74,6 +75,10 @@ def _write_gm_project(gm_dir: Path) -> None:
     _write_text(
         gm_dir / "scripts" / "scr_modern" / "scr_modern.gml",
         "function scr_modern(a, b = 4) { return a + b; }",
+    )
+    _write_text(
+        gm_dir / "scripts" / "scr_context" / "scr_context.gml",
+        "function scr_context(delta) { score += delta; return score; }",
     )
 
 
@@ -114,6 +119,7 @@ class TestScriptRuntimeGodotSmoke(unittest.TestCase):
             func _run():
             \tvar legacy_id = GMRuntime.gml_asset_get_index("scr_add")
             \tvar modern_id = GMRuntime.gml_asset_get_index("scr_modern")
+            \tvar context_id = GMRuntime.gml_asset_get_index("scr_context")
 
             \tif not _check(GMRuntime.gml_script_exists(legacy_id), "script_exists failed"):
             \t\treturn
@@ -132,6 +138,11 @@ class TestScriptRuntimeGodotSmoke(unittest.TestCase):
             \tif not _check(method_result == 10, "callable lookup did not remain method-callable: " + str(method_result)):
             \t\treturn
             \tif not _check(GMRuntime.gml_script_execute(modern_id, [5]) == 9, "optional default argument failed"):
+            \t\treturn
+            \tGMRuntime.gml_variable_instance_set(self, "score", 10)
+            \tif not _check(GMRuntime.gml_script_execute(context_id, [5], self, self) == 15, "caller-scoped script result failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_variable_instance_get(self, "score") == 15, "caller-scoped script mutation failed"):
             \t\treturn
 
             \tvar method_a = GMRuntime.gml_method(self, Callable(self, "_identity"))

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -118,6 +118,7 @@ class TestScriptConverter(unittest.TestCase):
         registry = (self.godot_dir / SCRIPT_REGISTRY_RELATIVE_PATH).read_text(encoding="utf-8")
 
         self.assertIn("func _gm_script_call():", legacy_script)
+        self.assertIn("func _gm_script_call_scoped(_gml_script_self = null, _gml_script_other = null):", legacy_script)
         self.assertIn("# GM2Godot source:", legacy_script)
         self.assertIn("GMRuntime.gml_argument(0)", legacy_script)
         self.assertIn("GMRuntime.gml_argument(1)", legacy_script)
@@ -129,12 +130,47 @@ class TestScriptConverter(unittest.TestCase):
         )
         self.assertEqual(legacy_source_map["entries"][0]["source_line"], 1)
         self.assertIn("func gm2godot_callable():", modern_script)
+        self.assertIn("func gm2godot_scoped_callable():", modern_script)
         self.assertIn("func _gm_script_call(a = null, b = null):", modern_script)
+        self.assertIn(
+            "func _gm_script_call_scoped(_gml_script_self = null, _gml_script_other = null, a = null, b = null):",
+            modern_script,
+        )
         self.assertIn("if b == null or GMRuntime.is_undefined(b): b = 4", modern_script)
         self.assertIn('preload("res://scripts/game/scr_add.gd").new().gm2godot_callable()', registry)
+        self.assertIn('preload("res://scripts/game/scr_add.gd").new().gm2godot_scoped_callable()', registry)
         self.assertIn('"legacy_arguments": true', registry)
         self.assertIn('preload("res://scripts/game/scr_modern.gd").new().gm2godot_callable()', registry)
+        self.assertIn('preload("res://scripts/game/scr_modern.gd").new().gm2godot_scoped_callable()', registry)
         self.assertIn('"legacy_arguments": false', registry)
+
+    def test_script_body_uses_caller_instance_scope(self) -> None:
+        self._write_project()
+        project_path = self.gm_dir / "ScriptTest.yyp"
+        project = json.loads(project_path.read_text(encoding="utf-8"))
+        resources = cast(list[object], project["resources"])
+        resources.append(_resource_entry("scripts", "scr_move"))
+        _write_json(project_path, project)
+        _write_json(
+            self.gm_dir / "scripts" / "scr_move" / "scr_move.yy",
+            {
+                "%Name": "scr_move",
+                "name": "scr_move",
+                "parent": {"name": "Game", "path": "folders/Scripts/Game.yy"},
+                "resourceType": "GMScript",
+            },
+        )
+        _write_text(
+            self.gm_dir / "scripts" / "scr_move" / "scr_move.gml",
+            "function scr_move(amount) { x += amount; return x; }",
+        )
+
+        self._converter().convert_all()
+
+        script = (self.godot_dir / "scripts" / "game" / "scr_move.gd").read_text(encoding="utf-8")
+        self.assertIn('GMRuntime.gml_variable_instance_get(_gml_script_self, "x")', script)
+        self.assertIn('GMRuntime.gml_variable_instance_set(_gml_script_self, "x"', script)
+        self.assertNotIn("position.x", script)
 
     def test_converts_scripts_with_mapped_extension_calls(self) -> None:
         self._write_project()


### PR DESCRIPTION
Closes #663

## Summary
- add scoped script callables so script bodies can read and mutate the caller instance rather than the RefCounted wrapper
- lower direct script asset calls and script_execute through GMRuntime with caller self/other context
- update runtime registration and golden/script smoke tests for the scoped ABI

## Validation
- GODOT_BIN=/Applications/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_golden_conversion -v
- ./venv/bin/python -m ruff check src/conversion/scripts.py src/conversion/gml_transpiler_parts/emitter.py tests/test_gml_runtime.py tests/test_gml_transpiler.py tests/test_scripts.py tests/test_script_runtime_godot.py
- ./venv/bin/pyright --warnings
- GODOT_BIN=/Applications/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest
- Monophobia probe: strict validation no longer reports scr_collision/scr_moving/key_right/playerspeed caller-scope parse errors; remaining failures are inherited object redeclarations, PNG import resource loading, alarm/runtime API gaps, and multi-function ending.gml support tracked separately.