### PR TITLE
Avoid inherited object member redeclarations

### DIFF
--- a/src/conversion/script_generator.py
+++ b/src/conversion/script_generator.py
@@ -88,6 +88,43 @@ _SPRITE_RUNTIME_RESERVED_NAMES = _SCRIPT_BUILTIN_VARIABLES | frozenset({
     "_gm_sprite_visual_node",
     "Vector2",
 })
+_NATIVE_NODE2D_MEMBER_VARIABLES = frozenset({
+    "editor_description",
+    "global_position",
+    "global_rotation",
+    "global_rotation_degrees",
+    "global_scale",
+    "global_transform",
+    "light_mask",
+    "material",
+    "modulate",
+    "multiplayer",
+    "name",
+    "owner",
+    "position",
+    "process_mode",
+    "process_physics_priority",
+    "process_priority",
+    "process_thread_group",
+    "rotation",
+    "rotation_degrees",
+    "scale",
+    "scene_file_path",
+    "self_modulate",
+    "show_behind_parent",
+    "skew",
+    "texture_filter",
+    "texture_repeat",
+    "top_level",
+    "transform",
+    "unique_name_in_owner",
+    "use_parent_material",
+    "visible",
+    "visibility_layer",
+    "y_sort_enabled",
+    "z_as_relative",
+    "z_index",
+})
 _GDSCRIPT_RESERVED_WORDS = frozenset({
     "and",
     "as",
@@ -193,6 +230,7 @@ def _valid_instance_variables(instance_variables: Iterable[str] | None) -> list[
     return sorted(
         name for name in instance_variables
         if _IDENTIFIER_RE.match(name) and name not in _SCRIPT_BUILTIN_VARIABLES
+        and name not in _NATIVE_NODE2D_MEMBER_VARIABLES
     )
 
 
@@ -218,7 +256,15 @@ def _extends_line(base_script_path: str | None = None) -> str:
     return f"extends {_gd_string(base_script_path)}\n"
 
 
-def _emit_sprite_runtime_prelude(lines: list[str], sprite_runtime: SpriteRuntimeConfig) -> None:
+def _emit_sprite_runtime_prelude(
+    lines: list[str],
+    sprite_runtime: SpriteRuntimeConfig,
+    *,
+    declare_members: bool,
+) -> None:
+    if not declare_members:
+        return
+
     sprite_scene_paths = dict(sprite_runtime.sprite_scene_paths or {})
     sprite_constants = [
         sprite_name for sprite_name in sorted(sprite_scene_paths)
@@ -395,8 +441,17 @@ def _emit_sprite_runtime_prelude(lines: list[str], sprite_runtime: SpriteRuntime
     )
 
 
-def _prepend_sprite_runtime_ready_body(body: str) -> str:
-    init_body = "\t_gm_initialize_sprite_runtime()"
+def _prepend_sprite_runtime_ready_body(
+    body: str,
+    sprite_runtime: SpriteRuntimeConfig,
+    *,
+    inherited_runtime: bool,
+) -> str:
+    init_lines: list[str] = []
+    if inherited_runtime and sprite_runtime.initial_sprite_name is not None:
+        init_lines.append(f"\tsprite_index = {_gd_string(sprite_runtime.initial_sprite_name)}")
+    init_lines.append("\t_gm_initialize_sprite_runtime()")
+    init_body = "\n".join(init_lines)
     if body.strip() == "pass":
         return init_body
     return f"{init_body}\n{body}"
@@ -477,12 +532,16 @@ def _emit_motion_runtime_prelude(lines: list[str], *, declare_members: bool) -> 
 
 def _wrap_object_runtime_ready_body(body: str, object_runtime: ObjectRuntimeConfig) -> str:
     init_lines = ["\t_gm_register_instance()", "\t_gm_initialize_motion_runtime()"]
-    if object_runtime.inherit_ready and body.strip() == "pass":
+    should_call_parent_ready = object_runtime.inherit_ready
+    if should_call_parent_ready and body.strip() == "pass":
         init_lines.append("\tsuper._ready()")
         return "\n".join(init_lines)
     if body.strip() == "pass":
         return "\n".join(init_lines)
-    return "\n".join(init_lines) + "\n" + body
+    wrapped_body = "\n".join(init_lines) + "\n" + body
+    if should_call_parent_ready:
+        wrapped_body += "\n\tsuper._ready()"
+    return wrapped_body
 
 
 def _wrap_object_runtime_exit_tree_body(body: str, object_runtime: ObjectRuntimeConfig) -> str:
@@ -661,8 +720,13 @@ def generate_script_content(
         emit_prelude = cast(_EmitPrelude | None, getattr(feature, "emit_prelude", None))
         if emit_prelude is not None:
             emit_prelude(lines, function_names)
+    inherited_sprite_runtime = base_script_path is not None
     if uses_sprite_runtime and sprite_runtime is not None:
-        _emit_sprite_runtime_prelude(lines, sprite_runtime)
+        _emit_sprite_runtime_prelude(
+            lines,
+            sprite_runtime,
+            declare_members=not inherited_sprite_runtime,
+        )
     if uses_object_runtime and object_runtime is not None:
         _emit_object_runtime_prelude(
             lines,
@@ -683,8 +747,12 @@ def generate_script_content(
             wrap_body = cast(_WrapBody | None, getattr(feature, "wrap_body", None))
             if wrap_body is not None:
                 body = wrap_body(func, body, function_names)
-        if uses_sprite_runtime and func.godot_func == "_ready":
-            body = _prepend_sprite_runtime_ready_body(body)
+        if uses_sprite_runtime and sprite_runtime is not None and func.godot_func == "_ready":
+            body = _prepend_sprite_runtime_ready_body(
+                body,
+                sprite_runtime,
+                inherited_runtime=inherited_sprite_runtime,
+            )
         if uses_object_runtime and object_runtime is not None and func.godot_func == "_ready":
             body = _wrap_object_runtime_ready_body(body, object_runtime)
         if uses_object_runtime and object_runtime is not None and func.godot_func == "_exit_tree":

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -556,6 +556,34 @@ class TestScriptGeneration(unittest.TestCase):
             content,
         )
 
+    def test_child_object_reuses_inherited_sprite_runtime_members(self):
+        self._setup_object(
+            "o_parent",
+            sprite_name="s_parent",
+            event_list=[{"eventType": 0, "eventNum": 0}],
+        )
+        self._setup_object(
+            "o_child",
+            sprite_name="s_child",
+            event_list=[],
+            parent_object_name="o_parent",
+        )
+        converter = self._make_converter()
+        converter.convert_all()
+
+        gd_path = os.path.join(self.godot_dir, "objects", "o_child", "o_child.gd")
+        with open(gd_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        self.assertTrue(content.startswith('extends "res://objects/o_parent/o_parent.gd"'))
+        self.assertNotIn('const s_child = "s_child"', content)
+        self.assertNotIn("const _GM_SPRITE_SCENES", content)
+        self.assertNotIn("\nvar sprite_index =", content)
+        self.assertNotIn("\nvar image_index =", content)
+        self.assertNotIn("func _gm_apply_sprite_index():", content)
+        self.assertIn("\tsprite_index = \"s_child\"\n\t_gm_initialize_sprite_runtime()", content)
+        self.assertIn("\tsuper._ready()", content)
+
     def test_script_event_sources_use_selected_macro_configuration(self):
         self._setup_object("o_test", event_list=[{"eventType": 0, "eventNum": 0}])
         with open(

--- a/tests/test_script_generator.py
+++ b/tests/test_script_generator.py
@@ -85,6 +85,41 @@ class TestScriptGeneratorBasic(unittest.TestCase):
         )
         self.assertIn("func _exit_tree():\n\tsuper._exit_tree()\n\t_gm_unregister_instance()", content)
 
+    def test_inherited_sprite_runtime_reuses_parent_members(self):
+        content = generate_script_content(
+            [],
+            sprite_runtime=SpriteRuntimeConfig(
+                initial_sprite_name="s_child",
+                sprite_scene_paths={
+                    "s_child": "res://sprites/s_child/s_child.tscn",
+                    "s_parent": "res://sprites/s_parent/s_parent.tscn",
+                },
+            ),
+            object_runtime=ObjectRuntimeConfig(
+                object_name="o_child",
+                parent_object_names=("o_parent",),
+                inherit_ready=True,
+                inherit_exit_tree=True,
+            ),
+            base_script_path="res://objects/o_parent/o_parent.gd",
+        )
+
+        self.assertTrue(content.startswith('extends "res://objects/o_parent/o_parent.gd"'))
+        self.assertNotIn('const s_child = "s_child"', content)
+        self.assertNotIn("const _GM_SPRITE_SCENES", content)
+        self.assertNotIn("\nvar sprite_index =", content)
+        self.assertNotIn("\nvar image_index =", content)
+        self.assertNotIn("func _gm_apply_sprite_index():", content)
+        self.assertIn(
+            "func _ready():\n"
+            "\t_gm_register_instance()\n"
+            "\t_gm_initialize_motion_runtime()\n"
+            "\tsprite_index = \"s_child\"\n"
+            "\t_gm_initialize_sprite_runtime()\n"
+            "\tsuper._ready()",
+            content,
+        )
+
     def test_object_runtime_records_solid_metadata_for_motion_contact(self):
         content = generate_script_content(
             [],
@@ -466,6 +501,17 @@ class TestScriptGeneratorSpriteRuntime(unittest.TestCase):
         self.assertIn("\n\nvar score\n", content)
         self.assertNotIn("\n\nvar image_index\n", content)
         self.assertNotIn("\n\nvar sprite_index\n", content)
+
+    def test_native_node2d_members_are_not_redeclared(self):
+        content = generate_script_content(
+            [{"eventType": 0, "eventNum": 0}],
+            code_bodies={"_ready": "\trotation = 0\n\tscore = 1"},
+            instance_variables={"rotation", "score"},
+        )
+
+        self.assertIn("\trotation = 0", content)
+        self.assertIn("\n\nvar score\n", content)
+        self.assertNotIn("\n\nvar rotation\n", content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #671

## Summary
- reuse inherited sprite runtime members/functions in child object scripts instead of re-emitting constants, sprite maps, image variables, and helpers
- keep child object registration overrides so inherited lifecycle code registers the concrete child object
- set the child initial sprite before inherited sprite initialization and preserve parent _ready calls for inherited Create events
- avoid declaring generated member vars that collide with native Node2D properties such as rotation

## Validation
- GODOT_BIN=/Applications/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_script_generator tests.test_objects -v
- ./venv/bin/python -m ruff check src/conversion/script_generator.py tests/test_script_generator.py tests/test_objects.py
- ./venv/bin/pyright --warnings
- GODOT_BIN=/Applications/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest
- Monophobia probe: inherited member redeclaration script errors dropped from 642 to 0; native rotation redeclaration dropped from 1 to 0. Remaining strict validation failures are PNG import/resource loading, alarm variable support, missing distance/draw/matrix helpers, and multi-function ending.gml.