### PR TITLE
Use sanitized sprite stems in texture references

### DIFF
--- a/src/conversion/sprites.py
+++ b/src/conversion/sprites.py
@@ -301,9 +301,10 @@ class SpriteConverter(BaseConverter):
         has_collision = collision_sub is not None
         load_steps = 2 if has_collision else 1
         res_prefix = self._sprite_res_path(subfolder, sprite_name)
+        sprite_stem = generated_resource_stem(sprite_name)
 
         parts: list[str] = [f'[gd_scene format=3 load_steps={load_steps}]\n']
-        parts.append(f'\n[ext_resource type="Texture2D" path="{res_prefix}/{sprite_name}.png" id="1"]\n')
+        parts.append(f'\n[ext_resource type="Texture2D" path="{res_prefix}/{sprite_stem}.png" id="1"]\n')
 
         if has_collision:
             parts.append(f'\n{collision_sub}')
@@ -318,7 +319,6 @@ class SpriteConverter(BaseConverter):
 
         tscn_content = ''.join(parts)
 
-        sprite_stem = generated_resource_stem(sprite_name)
         tscn_dir = generated_resource_directory(self.godot_sprites_path, subfolder, sprite_name)
         os.makedirs(tscn_dir, exist_ok=True)
         tscn_path = os.path.join(tscn_dir, f"{sprite_stem}.tscn")
@@ -336,12 +336,13 @@ class SpriteConverter(BaseConverter):
         # ext_resources (one per frame) + SpriteFrames sub_resource + optional collision sub_resource
         load_steps = frame_count + 1 + (1 if has_collision else 0)
         res_prefix = self._sprite_res_path(subfolder, sprite_name)
+        sprite_stem = generated_resource_stem(sprite_name)
 
         parts = [f'[gd_scene format=3 load_steps={load_steps}]\n']
 
         # One ext_resource per frame
         for i in range(1, frame_count + 1):
-            parts.append(f'\n[ext_resource type="Texture2D" path="{res_prefix}/{sprite_name}_{i}.png" id="{i}"]\n')
+            parts.append(f'\n[ext_resource type="Texture2D" path="{res_prefix}/{sprite_stem}_{i}.png" id="{i}"]\n')
 
         # Build frame entries for the SpriteFrames animation array
         durations = animation_data.get("frame_durations", [])
@@ -375,7 +376,6 @@ class SpriteConverter(BaseConverter):
 
         tscn_content = ''.join(parts)
 
-        sprite_stem = generated_resource_stem(sprite_name)
         tscn_dir = generated_resource_directory(self.godot_sprites_path, subfolder, sprite_name)
         os.makedirs(tscn_dir, exist_ok=True)
         tscn_path = os.path.join(tscn_dir, f"{sprite_stem}.tscn")

--- a/tests/test_sprites.py
+++ b/tests/test_sprites.py
@@ -883,6 +883,16 @@ class TestGenerateSpriteScene(unittest.TestCase):
         self.assertIn('type="CollisionShape2D"', content)
         self.assertIn('res://sprites/spr_rect/spr_rect.png', content)
 
+    def test_static_scene_uses_sanitized_texture_filename(self):
+        self.converter._generate_sprite_scene("sLogo", None, 1, subfolder="logo")
+
+        tscn_path = os.path.join(self.godot_dir, "sprites", "logo", "s_logo", "s_logo.tscn")
+        with open(tscn_path, "r") as f:
+            content = f.read()
+
+        self.assertIn('res://sprites/logo/s_logo/s_logo.png', content)
+        self.assertNotIn("sLogo.png", content)
+
     def test_rectangle_with_origin_offset(self):
         # Middle center origin on 32x32 sprite, full bbox
         data = self._make_collision_data(collision_kind=1, origin=4, width=32, height=32,
@@ -910,6 +920,24 @@ class TestGenerateSpriteScene(unittest.TestCase):
             content = f.read()
 
         self.assertIn("spr_anim_1.png", content)
+
+    def test_animated_scene_uses_sanitized_texture_filenames(self):
+        anim_data: AnimationData = {
+            "playbackSpeed": 30.0,
+            "playbackSpeedType": 0,
+            "loop": True,
+            "frame_durations": [1.0, 1.0],
+        }
+        self.converter._generate_sprite_scene("sLogo", None, 2, anim_data, subfolder="logo")
+
+        tscn_path = os.path.join(self.godot_dir, "sprites", "logo", "s_logo", "s_logo.tscn")
+        with open(tscn_path, "r") as f:
+            content = f.read()
+
+        self.assertIn('res://sprites/logo/s_logo/s_logo_1.png', content)
+        self.assertIn('res://sprites/logo/s_logo/s_logo_2.png', content)
+        self.assertNotIn("sLogo_1.png", content)
+        self.assertNotIn("sLogo_2.png", content)
 
     def test_ellipse_circle_shape(self):
         # Square bbox -> CircleShape2D


### PR DESCRIPTION
Closes #677

## Summary
- make static and animated sprite `.tscn` files reference the sanitized texture filenames written by sprite conversion
- add static and animated regression coverage for `sLogo`-style names that normalize to `s_logo`

## Validation
- GODOT_BIN=/Applications/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_sprites -v
- ./venv/bin/python -m ruff check src/conversion/sprites.py tests/test_sprites.py
- ./venv/bin/pyright --warnings
- GODOT_BIN=/Applications/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest
- Monophobia probe after #676: strict validation dropped from 12 output issues to 10; `sLogo`/`s_logo` missing texture resource failures are gone. Remaining failures are undeclared `alarm` script errors in generated object code.