### PR TITLE
Support alarm array access

### DIFF
--- a/src/conversion/gml_transpiler_parts/emitter.py
+++ b/src/conversion/gml_transpiler_parts/emitter.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import json
-from typing import Iterable
+from typing import Iterable, TypeGuard
 
 from .asset_lowering import asset_argument_indices, first_argument_is_script_asset
 from .constants import (
@@ -183,6 +183,19 @@ def _legacy_argument_replacement(name: str) -> str | None:
     return f"GMRuntime.gml_argument({index})"
 
 
+def _is_alarm_array_access(
+    expr: _Expression,
+    local_names: Iterable[str] | None,
+) -> TypeGuard[_Index]:
+    local_name_set = _normalize_local_names(local_names)
+    return (
+        isinstance(expr, _Index)
+        and isinstance(expr.target, _Name)
+        and expr.target.value == "alarm"
+        and expr.target.value not in local_name_set
+    )
+
+
 def _emit_expression(
     expr: _Expression,
     local_names: Iterable[str] | None = None,
@@ -329,6 +342,12 @@ def _emit_expression(
         )
         return f"GMRuntime.gml_struct({{{fields}}})", _POSTFIX_PRECEDENCE
     if isinstance(expr, _Index):
+        if _is_alarm_array_access(expr, local_names):
+            index = _emit_expression(expr.index, local_names, scope_context=scope_context)[0]
+            return (
+                f"GMRuntime.gml_alarm_get({scope_context.self_expression}, {index})",
+                _POSTFIX_PRECEDENCE,
+            )
         target = _emit_expression(expr.target, local_names, scope_context=scope_context)[0]
         index = _emit_expression(expr.index, local_names, scope_context=scope_context)[0]
         return f"GMRuntime.gml_array_get({target}, {index})", _POSTFIX_PRECEDENCE

--- a/src/conversion/gml_transpiler_parts/statements.py
+++ b/src/conversion/gml_transpiler_parts/statements.py
@@ -13,6 +13,7 @@ from .constants import (
     _GML_LITERAL_IDENTIFIERS,
 )
 from .emitter import (
+    _is_alarm_array_access,
     _emit_expression,
     _emit_instance_keyword_argument,
     _name_resolves_to_global,
@@ -61,6 +62,26 @@ from .utils import (
 )
 
 _MOTION_SYNCHRONIZED_BUILTINS = frozenset({"direction", "hspeed", "speed", "vspeed"})
+
+
+def _alarm_array_index(
+    target_expr: _Index,
+    local_names: Iterable[str],
+    scope_context: _ScopeContext,
+) -> str:
+    return _emit_expression(
+        target_expr.index,
+        local_names,
+        scope_context=scope_context,
+    )[0]
+
+
+def _alarm_array_get(scope_context: _ScopeContext, index: str) -> str:
+    return f"GMRuntime.gml_alarm_get({scope_context.self_expression}, {index})"
+
+
+def _alarm_array_set(scope_context: _ScopeContext, index: str, value: str) -> str:
+    return f"GMRuntime.gml_alarm_set({scope_context.self_expression}, {index}, {value})"
 
 
 @dataclass(frozen=True)
@@ -312,6 +333,25 @@ def _transpile_statement(
                 "GMRuntime.gml_variable_instance_set("
                 f"{instance_target}, {member_name}, "
                 f"GMRuntime.{helper}({current_value}, 1))"
+            ]
+        if _is_alarm_array_access(target_expr, local_names):
+            index = _alarm_array_index(target_expr, local_names, scope_context)
+            prelude_lines: list[str] = []
+            index = _cache_assignment_part(
+                prelude_lines,
+                target_expr.index,
+                index,
+                generated_counter,
+                "_gml_alarm_index",
+            )
+            current_value = _alarm_array_get(scope_context, index)
+            return [
+                *prelude_lines,
+                _alarm_array_set(
+                    scope_context,
+                    index,
+                    f"GMRuntime.{helper}({current_value}, 1)",
+                ),
             ]
         selector_target = _selector_assignment_parts(
             target_expr,
@@ -737,6 +777,36 @@ def _transpile_statement(
                     f"GMRuntime.{helper}({current_value}, {value}))"
                 ]
             raise GMLTranspileError("Unsupported scoped instance assignment operator")
+        if _is_alarm_array_access(target_expr, local_names):
+            index = _alarm_array_index(target_expr, local_names, scope_context)
+            if operator in ("=", ":="):
+                return [*prelude_lines, _alarm_array_set(scope_context, index, value)]
+            index = _cache_assignment_part(
+                prelude_lines,
+                target_expr.index,
+                index,
+                generated_counter,
+                "_gml_alarm_index",
+            )
+            current_value = _alarm_array_get(scope_context, index)
+            if operator == "??=":
+                return _nullish_assignment_lines(
+                    prelude_lines,
+                    current_value,
+                    value_prelude_lines,
+                    [_alarm_array_set(scope_context, index, value)],
+                )
+            if operator in _COMPOUND_RUNTIME_FUNCTIONS:
+                helper = _COMPOUND_RUNTIME_FUNCTIONS[operator]
+                return [
+                    *prelude_lines,
+                    _alarm_array_set(
+                        scope_context,
+                        index,
+                        f"GMRuntime.{helper}({current_value}, {value})",
+                    ),
+                ]
+            raise GMLTranspileError("Unsupported alarm assignment operator")
         _record_instance_assignment(target, local_names, instance_variables)
         target = _emit_expression(target_expr, local_names, scope_context=scope_context)[0]
         if isinstance(target_expr, _Index):
@@ -1908,6 +1978,20 @@ def _assignment_target_reader_writer(
             ],
         )
 
+    if _is_alarm_array_access(target_expr, local_names):
+        index = _alarm_array_index(target_expr, local_names, scope_context)
+        index = _cache_assignment_part(
+            prelude_lines,
+            target_expr.index,
+            index,
+            generated_counter,
+            "_gml_alarm_index",
+        )
+        return (
+            _alarm_array_get(scope_context, index),
+            lambda value: [_alarm_array_set(scope_context, index, value)],
+        )
+
     _record_instance_assignment(target_source, local_names, instance_variables)
     if isinstance(target_expr, _Index | _ArrayRefAccess):
         container = _emit_expression(
@@ -2288,6 +2372,9 @@ def _transpile_assignment_to_emitted_value(
             "GMRuntime.gml_variable_instance_set("
             f"{instance_target}, {member_name}, {value})"
         ]
+    if _is_alarm_array_access(target_expr, local_names):
+        index = _alarm_array_index(target_expr, local_names, scope_context)
+        return [_alarm_array_set(scope_context, index, value)]
     _record_instance_assignment(target, local_names, instance_variables)
     if isinstance(target_expr, _Index):
         container = _emit_expression(

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -1700,6 +1700,28 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
             "var view_xview = [1]\nvalue = GMRuntime.gml_array_get(view_xview, 0)",
         )
 
+    def test_transpiles_alarm_array_through_instance_runtime(self):
+        self.assertEqual(
+            transpile_gml_expression("alarm[0]"),
+            "GMRuntime.gml_alarm_get(self, 0)",
+        )
+        self.assertEqual(
+            transpile_gml_code("alarm[0] = 30;", indent=""),
+            "GMRuntime.gml_alarm_set(self, 0, 30)",
+        )
+        self.assertEqual(
+            transpile_gml_code("alarm[next_alarm()] += 1;", indent=""),
+            "var _gml_alarm_index_0 = next_alarm()\n"
+            "GMRuntime.gml_alarm_set(self, _gml_alarm_index_0, "
+            "GMRuntime.gml_add(GMRuntime.gml_alarm_get(self, _gml_alarm_index_0), 1))",
+        )
+        self.assertEqual(
+            transpile_gml_code("var alarm = [1]; value = alarm[0]; alarm[0] = 2;", indent=""),
+            "var alarm = [1]\n"
+            "value = GMRuntime.gml_array_get(alarm, 0)\n"
+            "GMRuntime.gml_array_set(alarm, 0, 2)",
+        )
+
     def test_transpiles_builtin_room_and_global_variables_through_runtime(self):
         cases = (
             ("room", 'GMRuntime.gml_builtin_global("room")'),
@@ -3196,6 +3218,12 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             transpile_gml_code("foo(items[i]++);", indent=""),
             "var _gm2gd_mutation_value_0 = GMRuntime.gml_array_get(items, i)\n"
             "GMRuntime.gml_array_set(items, i, GMRuntime.gml_add(_gm2gd_mutation_value_0, 1))\n"
+            "foo(_gm2gd_mutation_value_0)",
+        )
+        self.assertEqual(
+            transpile_gml_code("foo(alarm[i]++);", indent=""),
+            "var _gm2gd_mutation_value_0 = GMRuntime.gml_alarm_get(self, i)\n"
+            "GMRuntime.gml_alarm_set(self, i, GMRuntime.gml_add(_gm2gd_mutation_value_0, 1))\n"
             "foo(_gm2gd_mutation_value_0)",
         )
         self.assertEqual(

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -948,6 +948,25 @@ class TestScriptGeneration(unittest.TestCase):
             content = f.read()
         self.assertIn("func _on_alarm_3():", content)
 
+    def test_event_source_uses_runtime_alarm_array_access(self):
+        self._setup_object("o_test", event_list=[{"eventType": 0, "eventNum": 0}])
+        with open(
+            os.path.join(self.gm_dir, "objects", "o_test", "Create_0.gml"),
+            "w",
+            encoding="utf-8",
+        ) as f:
+            f.write("alarm[0] = 3;\nnext_alarm = alarm[0];")
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        gd_path = os.path.join(self.godot_dir, "objects", "o_test", "o_test.gd")
+        with open(gd_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        self.assertIn("GMRuntime.gml_alarm_set(self, 0, 3)", content)
+        self.assertIn("next_alarm = GMRuntime.gml_alarm_get(self, 0)", content)
+        self.assertNotIn("alarm[", content)
+
     def test_script_with_collision_event(self):
         """eventType 4 with collisionObjectId should produce func _on_collision_NAME()."""
         self._setup_object("o_test", event_list=[


### PR DESCRIPTION
## Summary
- lower GameMaker `alarm[index]` reads to `GMRuntime.gml_alarm_get(self, index)`
- lower direct, compound, nullish, chained, and mutation writes to `GMRuntime.gml_alarm_set(...)`
- preserve local variables named `alarm` as normal arrays

Fixes #679.

## Validation
- `./venv/bin/pyright --warnings`
- `./venv/bin/ruff check .`
- `./venv/bin/python -m unittest` (1022 tests, 24 skipped)
- Monophobia probe: converted `/Users/infi/Documents/Github/Monophobia` into `/tmp/gm2godot-monophobia-679-XOniRF` and strict Godot validation no longer reports `Identifier "alarm" not declared`; remaining 36 errors are separate unresolved helper/multi-function-script issues (`distance_to_object`, `matrix_build_*`, `saveending/loadending`, draw helpers).
