### PR TITLE
Support multi-function GameMaker scripts

### DIFF
--- a/src/conversion/asset_registry.py
+++ b/src/conversion/asset_registry.py
@@ -18,6 +18,7 @@ from src.conversion.generated_paths import (
     generated_path_segment,
     generated_resource_stem,
 )
+from src.conversion.script_functions import modern_script_function_names
 from src.conversion.type_defs import (
     ConversionRunning,
     JsonDict,
@@ -239,6 +240,28 @@ class AssetRegistryConverter(BaseConverter):
                 metadata=self._metadata(resource, room_order_indices),
             )
             entries.append(entry)
+            if resource.kind == "scripts":
+                for function_name in self._script_function_names(resource):
+                    if function_name == resource.name:
+                        continue
+                    entries.append(
+                        AssetRegistryEntry(
+                            id=self._stable_asset_id(asset_type, function_name, used_ids),
+                            name=function_name,
+                            kind=resource.kind,
+                            asset_type=asset_type,
+                            type_name=self.TYPE_NAME_BY_KIND[resource.kind],
+                            source_path=resource.source_path,
+                            godot_path=entry.godot_path,
+                            legacy_id=f"{self._legacy_id(resource)}#function:{function_name}",
+                            tags=self._extract_tags(resource.raw_data),
+                            metadata={
+                                "script_function": True,
+                                "script_asset": resource.name,
+                                "script_source_path": resource.source_path,
+                            },
+                        )
+                    )
 
         return tuple(entries)
 
@@ -381,6 +404,31 @@ class AssetRegistryConverter(BaseConverter):
                     )
                 )
         return tuple(resources)
+
+    def _script_source_gml_path(self, resource: _ProjectResource) -> str | None:
+        script_dir = os.path.dirname(resource.yy_path)
+        preferred_path = os.path.join(script_dir, resource.name + ".gml")
+        if os.path.isfile(preferred_path):
+            return preferred_path
+        if not os.path.isdir(script_dir):
+            return None
+        try:
+            for filename in sorted(os.listdir(script_dir)):
+                if filename.endswith(".gml"):
+                    return os.path.join(script_dir, filename)
+        except OSError:
+            return None
+        return None
+
+    def _script_function_names(self, resource: _ProjectResource) -> tuple[str, ...]:
+        source_path = self._script_source_gml_path(resource)
+        if source_path is None:
+            return ()
+        try:
+            with open(source_path, "r", encoding="utf-8") as source_file:
+                return modern_script_function_names(source_file.read())
+        except OSError:
+            return ()
 
     def _included_files_from_disk(self) -> tuple[_ProjectResource, ...]:
         datafiles_dir = os.path.join(self.gm_project_path, "datafiles")

--- a/src/conversion/objects.py
+++ b/src/conversion/objects.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import TypedDict, cast
 
 from src.localization import get_localized
+from src.conversion.asset_registry import AssetRegistryConverter
 from src.conversion.base_converter import BaseConverter
 from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.events.base import EventMapping
@@ -72,6 +73,7 @@ class ObjectConverter(BaseConverter):
                          diagnostics=diagnostics)
         self.godot_objects_path = os.path.join(self.godot_project_path, 'objects')
         self.macro_configuration = macro_configuration
+        self._project_asset_names_cache: set[str] | None = None
 
     def _get_valid_object_names(self) -> dict[str, str] | None:
         """Parse the .yyp project file and return a dict of object name -> subfolder.
@@ -107,6 +109,23 @@ class ObjectConverter(BaseConverter):
 
     def _get_project_asset_names(self) -> set[str]:
         """Return GameMaker resource names that can collide with unscoped GML identifiers."""
+        if self._project_asset_names_cache is not None:
+            return set(self._project_asset_names_cache)
+
+        try:
+            registry_converter = AssetRegistryConverter(
+                self.gm_project_path,
+                self.godot_project_path,
+                log_callback=lambda _message: None,
+                progress_callback=lambda _value: None,
+                conversion_running=self.conversion_running,
+            )
+            asset_names = {entry.name for entry in registry_converter.build_entries()}
+            self._project_asset_names_cache = asset_names
+            return set(asset_names)
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+            pass
+
         try:
             yyp_files = [f for f in os.listdir(self.gm_project_path) if f.endswith('.yyp')]
             if yyp_files:
@@ -123,7 +142,8 @@ class ObjectConverter(BaseConverter):
                     name = res_id.get('name')
                     if isinstance(name, str) and name:
                         asset_names.add(name)
-                return asset_names
+                self._project_asset_names_cache = asset_names
+                return set(asset_names)
         except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
             pass
 
@@ -140,7 +160,8 @@ class ObjectConverter(BaseConverter):
                 )
             except OSError:
                 continue
-        return asset_names
+        self._project_asset_names_cache = asset_names
+        return set(asset_names)
 
     def _parse_object_yy(self, object_name: str) -> ParsedObject | None:
         """Parse an object .yy file and extract the sprite reference and event list.

--- a/src/conversion/rooms.py
+++ b/src/conversion/rooms.py
@@ -6,6 +6,7 @@ import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TypedDict, cast
 
+from src.conversion.asset_registry import AssetRegistryConverter
 from src.conversion.base_converter import BaseConverter
 from src.conversion.architecture_policy import (
     ROOM_ROOT_POLICY_ID,
@@ -131,6 +132,7 @@ class RoomConverter(BaseConverter):
                          max_workers=max_workers, diagnostics=diagnostics)
         self.godot_rooms_path = os.path.join(self.godot_project_path, "rooms")
         self.resource_index = resource_index
+        self._asset_names_cache: set[str] | None = None
 
     def _build_resource_index(self) -> GameMakerResourceIndex:
         if self.resource_index is not None:
@@ -425,12 +427,31 @@ class RoomConverter(BaseConverter):
         return f"{base}_{count + 1}"
 
     def _asset_names(self, resource_index: GameMakerResourceIndex | None) -> set[str]:
+        if self._asset_names_cache is not None:
+            return set(self._asset_names_cache)
+
+        try:
+            registry_converter = AssetRegistryConverter(
+                self.gm_project_path,
+                self.godot_project_path,
+                log_callback=lambda _message: None,
+                progress_callback=lambda _value: None,
+                conversion_running=self.conversion_running,
+            )
+            asset_names = {entry.name for entry in registry_converter.build_entries()}
+            self._asset_names_cache = asset_names
+            return set(asset_names)
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+            pass
+
         if resource_index is None:
+            self._asset_names_cache = set()
             return set()
         names = set(resource_index.rooms.keys())
         for resources in resource_index.resources.values():
             names.update(resources.keys())
-        return names
+        self._asset_names_cache = names
+        return set(names)
 
     def _process_room(
         self, room: IndexedRoom, resource_index: GameMakerResourceIndex | None = None

--- a/src/conversion/script_functions.py
+++ b/src/conversion/script_functions.py
@@ -1,0 +1,142 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from src.conversion.gml_transpiler import GMLTranspileError
+from src.conversion.gml_transpiler_parts.identifiers import _validate_gml_identifier
+from src.conversion.gml_transpiler_parts.utils import (
+    _split_assignment,
+    _split_top_level,
+    _strip_comments,
+)
+
+
+@dataclass(frozen=True)
+class ScriptFunctionParameter:
+    name: str
+    default: str | None
+
+
+@dataclass(frozen=True)
+class ScriptFunctionDeclaration:
+    name: str
+    parameters: tuple[ScriptFunctionParameter, ...]
+    body: str
+
+
+def find_matching_delimiter(source: str, start: int, opener: str, closer: str) -> int | None:
+    if start < 0 or start >= len(source) or source[start] != opener:
+        return None
+    depth = 0
+    index = start
+    quote: str | None = None
+    while index < len(source):
+        char = source[index]
+        if quote is not None:
+            if char == "\\":
+                index += 2
+                continue
+            if char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in ("'", '"'):
+            quote = char
+        elif char == opener:
+            depth += 1
+        elif char == closer:
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+    return None
+
+
+def parse_script_function_parameters(params_text: str) -> tuple[ScriptFunctionParameter, ...]:
+    if not params_text.strip():
+        return ()
+    parameters: list[ScriptFunctionParameter] = []
+    for raw_param in _split_top_level(params_text, ","):
+        raw_param = raw_param.strip()
+        if not raw_param:
+            continue
+        assignment = _split_assignment(raw_param)
+        if assignment is None:
+            name = raw_param
+            default = None
+        else:
+            name, operator, default = assignment
+            if operator != "=":
+                raise GMLTranspileError("Script function parameters only support simple defaults")
+        name = name.strip()
+        _validate_gml_identifier(name)
+        parameters.append(
+            ScriptFunctionParameter(
+                name=name,
+                default=default.strip() if default is not None else None,
+            )
+        )
+    return tuple(parameters)
+
+
+def modern_script_function_declarations(source: str) -> tuple[ScriptFunctionDeclaration, ...] | None:
+    candidate = _strip_comments(source).strip()
+    if not candidate:
+        return None
+
+    declarations: list[ScriptFunctionDeclaration] = []
+    index = 0
+    while index < len(candidate):
+        while index < len(candidate) and (candidate[index].isspace() or candidate[index] == ";"):
+            index += 1
+        if index >= len(candidate):
+            break
+
+        match = re.match(r"function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(", candidate[index:])
+        if match is None:
+            return None
+        name = match.group(1)
+        declaration_start = index + match.start()
+        params_start = candidate.find("(", declaration_start)
+        params_end = find_matching_delimiter(candidate, params_start, "(", ")")
+        if params_end is None:
+            return None
+        body_start = candidate.find("{", params_end + 1)
+        if body_start == -1 or candidate[params_end + 1:body_start].strip():
+            return None
+        body_end = find_matching_delimiter(candidate, body_start, "{", "}")
+        if body_end is None:
+            return None
+        try:
+            parameters = parse_script_function_parameters(candidate[params_start + 1:params_end])
+        except GMLTranspileError:
+            return None
+        declarations.append(
+            ScriptFunctionDeclaration(
+                name=name,
+                parameters=parameters,
+                body=candidate[body_start + 1:body_end],
+            )
+        )
+        index = body_end + 1
+
+    return tuple(declarations) if declarations else None
+
+
+def modern_script_function_names(source: str) -> tuple[str, ...]:
+    declarations = modern_script_function_declarations(source)
+    if declarations is None:
+        return ()
+    return tuple(declaration.name for declaration in declarations)
+
+
+__all__ = [
+    "ScriptFunctionDeclaration",
+    "ScriptFunctionParameter",
+    "find_matching_delimiter",
+    "modern_script_function_declarations",
+    "modern_script_function_names",
+    "parse_script_function_parameters",
+]

--- a/src/conversion/scripts.py
+++ b/src/conversion/scripts.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 from dataclasses import dataclass
 from typing import Iterable
 
@@ -27,16 +26,14 @@ from src.conversion.gml_transpiler import (
     write_gml_source_map,
 )
 from src.conversion.resource_index import GameMakerResourceIndex
+from src.conversion.script_functions import (
+    ScriptFunctionDeclaration,
+    modern_script_function_declarations,
+)
 from src.conversion.gml_transpiler_parts.identifiers import (
     _sanitize_gdscript_identifier,
-    _validate_gml_identifier,
 )
 from src.conversion.gml_transpiler_parts.model import _ScopeContext
-from src.conversion.gml_transpiler_parts.utils import (
-    _split_assignment,
-    _split_top_level,
-    _strip_comments,
-)
 from src.conversion.type_defs import ConversionRunning, LogCallback, ProgressCallback, StrPath
 
 
@@ -48,23 +45,20 @@ _SCRIPT_OTHER_PARAMETER = "_gml_script_other"
 
 @dataclass(frozen=True)
 class ScriptRegistryEntry:
-    id: int
+    id: int | str
     name: str
     resource_path: str
     legacy_arguments: bool
+    callable_method: str = "gm2godot_callable"
+    scoped_callable_method: str = "gm2godot_scoped_callable"
 
 
 @dataclass(frozen=True)
-class _ScriptFunctionParameter:
-    name: str
-    default: str | None
-
-
-@dataclass(frozen=True)
-class _ScriptFunctionDeclaration:
-    name: str
-    parameters: tuple[_ScriptFunctionParameter, ...]
-    body: str
+class _ScriptCallableNames:
+    call_method: str
+    scoped_call_method: str
+    callable_accessor: str
+    scoped_callable_accessor: str
 
 
 def _script_scope_context() -> _ScopeContext:
@@ -90,13 +84,35 @@ def _script_scope_lines() -> list[str]:
     ]
 
 
-def _script_forward_call(*, declaration: _ScriptFunctionDeclaration) -> str:
+def _script_forward_call(*, declaration: ScriptFunctionDeclaration, scoped_call_method: str) -> str:
     args = [
         "self",
         "self",
         *(_sanitize_gdscript_identifier(parameter.name) for parameter in declaration.parameters),
     ]
-    return f"\treturn _gm_script_call_scoped({', '.join(args)})\n"
+    return f"\treturn {scoped_call_method}({', '.join(args)})\n"
+
+
+def _script_callable_names(declaration_name: str, *, use_default_names: bool) -> _ScriptCallableNames:
+    if use_default_names:
+        return _ScriptCallableNames(
+            call_method="_gm_script_call",
+            scoped_call_method="_gm_script_call_scoped",
+            callable_accessor="gm2godot_callable",
+            scoped_callable_accessor="gm2godot_scoped_callable",
+        )
+    suffix = _sanitize_gdscript_identifier(declaration_name)
+    return _ScriptCallableNames(
+        call_method=f"_gm_script_call_{suffix}",
+        scoped_call_method=f"_gm_script_call_scoped_{suffix}",
+        callable_accessor=f"gm2godot_callable_{suffix}",
+        scoped_callable_accessor=f"gm2godot_scoped_callable_{suffix}",
+    )
+
+
+def _is_script_function_entry(entry: AssetRegistryEntry) -> bool:
+    metadata = entry.metadata or {}
+    return bool(metadata.get("script_function"))
 
 
 def render_script_registry_script(entries: Iterable[ScriptRegistryEntry]) -> str:
@@ -109,10 +125,10 @@ def render_script_registry_script(entries: Iterable[ScriptRegistryEntry]) -> str
         lines.extend(
             [
                 "\t\t{\n",
-                f"\t\t\t\"id\": {entry.id},\n",
+                f"\t\t\t\"id\": {json.dumps(entry.id)},\n",
                 f"\t\t\t\"name\": {json.dumps(entry.name)},\n",
-                f"\t\t\t\"callable\": preload({json.dumps(entry.resource_path)}).new().gm2godot_callable(),\n",
-                f"\t\t\t\"scoped_callable\": preload({json.dumps(entry.resource_path)}).new().gm2godot_scoped_callable(),\n",
+                f"\t\t\t\"callable\": preload({json.dumps(entry.resource_path)}).new().{entry.callable_method}(),\n",
+                f"\t\t\t\"scoped_callable\": preload({json.dumps(entry.resource_path)}).new().{entry.scoped_callable_method}(),\n",
                 f"\t\t\t\"legacy_arguments\": {str(entry.legacy_arguments).lower()},\n",
                 "\t\t},\n",
             ]
@@ -183,89 +199,9 @@ class ScriptConverter(BaseConverter):
         relative_path = entry.godot_path[len("res://"):].replace("/", os.sep)
         return os.path.join(self.godot_project_path, relative_path)
 
-    def _modern_function_declaration(self, source: str) -> _ScriptFunctionDeclaration | None:
-        candidate = _strip_comments(source).strip()
-        while candidate.endswith(";"):
-            candidate = candidate[:-1].rstrip()
-        match = re.match(r"^function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(", candidate)
-        if match is None:
-            return None
-        params_start = candidate.find("(", match.start())
-        params_end = self._find_matching(candidate, params_start, "(", ")")
-        if params_end is None:
-            return None
-        body_start = candidate.find("{", params_end + 1)
-        if body_start == -1 or candidate[params_end + 1:body_start].strip():
-            return None
-        body_end = self._find_matching(candidate, body_start, "{", "}")
-        if body_end is None or candidate[body_end + 1:].strip():
-            return None
-        try:
-            parameters = self._parse_function_parameters(candidate[params_start + 1:params_end])
-        except GMLTranspileError:
-            return None
-        return _ScriptFunctionDeclaration(
-            name=match.group(1),
-            parameters=parameters,
-            body=candidate[body_start + 1:body_end],
-        )
-
-    def _find_matching(self, source: str, start: int, opener: str, closer: str) -> int | None:
-        if start < 0 or start >= len(source) or source[start] != opener:
-            return None
-        depth = 0
-        index = start
-        quote: str | None = None
-        while index < len(source):
-            char = source[index]
-            if quote is not None:
-                if char == "\\":
-                    index += 2
-                    continue
-                if char == quote:
-                    quote = None
-                index += 1
-                continue
-            if char in ("'", '"'):
-                quote = char
-            elif char == opener:
-                depth += 1
-            elif char == closer:
-                depth -= 1
-                if depth == 0:
-                    return index
-            index += 1
-        return None
-
-    def _parse_function_parameters(self, params_text: str) -> tuple[_ScriptFunctionParameter, ...]:
-        if not params_text.strip():
-            return ()
-        parameters: list[_ScriptFunctionParameter] = []
-        for raw_param in _split_top_level(params_text, ","):
-            raw_param = raw_param.strip()
-            if not raw_param:
-                continue
-            assignment = _split_assignment(raw_param)
-            if assignment is None:
-                name = raw_param
-                default = None
-            else:
-                name, operator, default = assignment
-                if operator != "=":
-                    raise GMLTranspileError("Script function parameters only support simple defaults")
-            name = name.strip()
-            _validate_gml_identifier(name)
-            parameters.append(
-                _ScriptFunctionParameter(
-                    name=name,
-                    default=default.strip() if default is not None else None,
-                )
-            )
-        return tuple(parameters)
-
     def _modern_function_body(
         self,
-        declaration: _ScriptFunctionDeclaration,
+        declaration: ScriptFunctionDeclaration,
         *,
         source_path: str,
         asset_names: set[str],
@@ -321,55 +257,79 @@ class ScriptConverter(BaseConverter):
         *,
         source_path: str,
         asset_names: set[str],
+        script_entries_by_name: dict[str, AssetRegistryEntry],
         extension_functions: dict[str, GMLExtensionFunction],
         extension_function_mappings: dict[str, GMLExtensionFunctionMapping],
-    ) -> tuple[str, bool, GMLSourceMap]:
+    ) -> tuple[str, tuple[ScriptRegistryEntry, ...], tuple[GMLSourceMap, ...]]:
         header = render_gml_source_header(
             source_path=source_path,
             event=f"script:{entry.name}",
             source=source,
         )
-        modern_declaration = self._modern_function_declaration(source)
-        if modern_declaration is not None:
-            params = ", ".join(
-                f"{_sanitize_gdscript_identifier(parameter.name)} = null"
-                for parameter in modern_declaration.parameters
-            )
-            scoped_params = ", ".join(
-                [
-                    f"{_SCRIPT_SELF_PARAMETER} = null",
-                    f"{_SCRIPT_OTHER_PARAMETER} = null",
-                    *(f"{_sanitize_gdscript_identifier(parameter.name)} = null" for parameter in modern_declaration.parameters),
-                ]
-            )
-            prefix = (
-                "extends RefCounted\n\n"
-                f"{header}"
-                'const GMRuntime = preload("res://gm2godot/gml_runtime.gd")\n\n'
-                f"func _gm_script_call({params}):\n"
-                f"{_script_forward_call(declaration=modern_declaration)}\n"
-                f"func _gm_script_call_scoped({scoped_params}):\n"
-            )
-            body, source_map = self._modern_function_body(
-                modern_declaration,
-                source_path=source_path,
-                asset_names=asset_names,
-                static_scope_prefix=f"{entry.name}.{modern_declaration.name}",
-                extension_functions=extension_functions,
-                extension_function_mappings=extension_function_mappings,
-                generated_line_offset=prefix.count("\n"),
-            )
-            return (
-                prefix
-                + f"{body}\n"
-                + "\treturn GMRuntime.gml_undefined()\n\n"
-                + "func gm2godot_callable():\n"
-                + '\treturn GMRuntime.gml_method(self, Callable(self, "_gm_script_call"))\n\n'
-                + "func gm2godot_scoped_callable():\n"
-                + '\treturn GMRuntime.gml_method(self, Callable(self, "_gm_script_call_scoped"))\n',
-                False,
-                source_map,
-            )
+        modern_declarations = modern_script_function_declarations(source)
+        if modern_declarations is not None:
+            chunks = [
+                "extends RefCounted\n\n",
+                f"{header}",
+                'const GMRuntime = preload("res://gm2godot/gml_runtime.gd")\n\n',
+            ]
+            registry_entries: list[ScriptRegistryEntry] = []
+            source_maps: list[GMLSourceMap] = []
+            for declaration in modern_declarations:
+                callable_names = _script_callable_names(
+                    declaration.name,
+                    use_default_names=declaration.name == entry.name,
+                )
+                params = ", ".join(
+                    f"{_sanitize_gdscript_identifier(parameter.name)} = null"
+                    for parameter in declaration.parameters
+                )
+                scoped_params = ", ".join(
+                    [
+                        f"{_SCRIPT_SELF_PARAMETER} = null",
+                        f"{_SCRIPT_OTHER_PARAMETER} = null",
+                        *(
+                            f"{_sanitize_gdscript_identifier(parameter.name)} = null"
+                            for parameter in declaration.parameters
+                        ),
+                    ]
+                )
+                function_prefix = (
+                    f"func {callable_names.call_method}({params}):\n"
+                    f"{_script_forward_call(declaration=declaration, scoped_call_method=callable_names.scoped_call_method)}\n"
+                    f"func {callable_names.scoped_call_method}({scoped_params}):\n"
+                )
+                body, source_map = self._modern_function_body(
+                    declaration,
+                    source_path=source_path,
+                    asset_names=asset_names,
+                    static_scope_prefix=f"{entry.name}.{declaration.name}",
+                    extension_functions=extension_functions,
+                    extension_function_mappings=extension_function_mappings,
+                    generated_line_offset=("".join(chunks) + function_prefix).count("\n"),
+                )
+                chunks.append(
+                    function_prefix
+                    + f"{body}\n"
+                    + "\treturn GMRuntime.gml_undefined()\n\n"
+                    + f"func {callable_names.callable_accessor}():\n"
+                    + f'\treturn GMRuntime.gml_method(self, Callable(self, "{callable_names.call_method}"))\n\n'
+                    + f"func {callable_names.scoped_callable_accessor}():\n"
+                    + f'\treturn GMRuntime.gml_method(self, Callable(self, "{callable_names.scoped_call_method}"))\n\n'
+                )
+                script_entry = script_entries_by_name.get(declaration.name)
+                registry_entries.append(
+                    ScriptRegistryEntry(
+                        id=script_entry.id if script_entry is not None else f"{entry.name}:{declaration.name}",
+                        name=declaration.name,
+                        resource_path=entry.godot_path,
+                        legacy_arguments=False,
+                        callable_method=callable_names.callable_accessor,
+                        scoped_callable_method=callable_names.scoped_callable_accessor,
+                    )
+                )
+                source_maps.append(source_map)
+            return "".join(chunks).rstrip("\n") + "\n", tuple(registry_entries), tuple(source_maps)
 
         prefix = (
             "extends RefCounted\n\n"
@@ -406,8 +366,15 @@ class ScriptConverter(BaseConverter):
             + '\treturn GMRuntime.gml_method(self, Callable(self, "_gm_script_call"))\n\n'
             + "func gm2godot_scoped_callable():\n"
             + '\treturn GMRuntime.gml_method(self, Callable(self, "_gm_script_call_scoped"))\n',
-            True,
-            result.source_map,
+            (
+                ScriptRegistryEntry(
+                    id=entry.id,
+                    name=entry.name,
+                    resource_path=entry.godot_path,
+                    legacy_arguments=True,
+                ),
+            ),
+            (result.source_map,),
         )
 
     def _record_source_diagnostics(
@@ -441,22 +408,24 @@ class ScriptConverter(BaseConverter):
         entry: AssetRegistryEntry,
         *,
         asset_names: set[str],
+        script_entries_by_name: dict[str, AssetRegistryEntry],
         extension_functions: dict[str, GMLExtensionFunction],
         extension_function_mappings: dict[str, GMLExtensionFunctionMapping],
-    ) -> ScriptRegistryEntry | None:
+    ) -> tuple[ScriptRegistryEntry, ...]:
         source_path = self._source_gml_path(entry)
         output_path = self._output_path(entry)
         if source_path is None or output_path is None:
-            return None
+            return ()
         try:
             with open(source_path, "r", encoding="utf-8") as source_file:
                 source = source_file.read()
             self._record_source_diagnostics(source, source_path, entry)
-            script_content, legacy_arguments, source_map = self._render_script(
+            script_content, registry_entries, source_maps = self._render_script(
                 entry,
                 source,
                 source_path=source_path,
                 asset_names=asset_names,
+                script_entries_by_name=script_entries_by_name,
                 extension_functions=extension_functions,
                 extension_function_mappings=extension_function_mappings,
             )
@@ -486,21 +455,16 @@ class ScriptConverter(BaseConverter):
                         resource_type="script",
                     )
             self._safe_log(message)
-            return None
+            return ()
 
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
         with open(output_path, "w", encoding="utf-8") as output_file:
             output_file.write(script_content)
         write_gml_source_map(
             output_path,
-            merge_gml_source_maps([source_map], source_path=source_path, event=f"script:{entry.name}"),
+            merge_gml_source_maps(source_maps, source_path=source_path, event=f"script:{entry.name}"),
         )
-        return ScriptRegistryEntry(
-            id=entry.id,
-            name=entry.name,
-            resource_path=entry.godot_path,
-            legacy_arguments=legacy_arguments,
-        )
+        return registry_entries
 
     def _extension_functions(self) -> dict[str, GMLExtensionFunction]:
         index = GameMakerResourceIndex(
@@ -537,7 +501,11 @@ class ScriptConverter(BaseConverter):
             return None
 
         all_entries = self._registry_entries()
-        entries = tuple(entry for entry in all_entries if entry.asset_type == "script")
+        entries = tuple(
+            entry
+            for entry in all_entries
+            if entry.asset_type == "script" and not _is_script_function_entry(entry)
+        )
         if not entries:
             self.log_callback(get_localized("Console_Convertor_Scripts_Complete"))
             return None
@@ -545,6 +513,11 @@ class ScriptConverter(BaseConverter):
         write_gml_runtime(self.godot_project_path)
         os.makedirs(self.godot_scripts_path, exist_ok=True)
         asset_names = {entry.name for entry in all_entries}
+        script_entries_by_name = {
+            entry.name: entry
+            for entry in all_entries
+            if entry.asset_type == "script"
+        }
         extension_functions = self._extension_functions()
         extension_function_mappings = self._extension_function_mappings()
         registry_entries: list[ScriptRegistryEntry] = []
@@ -554,14 +527,15 @@ class ScriptConverter(BaseConverter):
             if not self.conversion_running():
                 self.log_callback(get_localized("Console_Convertor_Scripts_Stopped"))
                 return None
-            registry_entry = self._write_script(
+            converted_registry_entries = self._write_script(
                 entry,
                 asset_names=asset_names,
+                script_entries_by_name=script_entries_by_name,
                 extension_functions=extension_functions,
                 extension_function_mappings=extension_function_mappings,
             )
-            if registry_entry is not None:
-                registry_entries.append(registry_entry)
+            if converted_registry_entries:
+                registry_entries.extend(converted_registry_entries)
                 self._safe_log(
                     get_localized("Console_Convertor_Scripts_Converted").format(script_name=entry.name)
                 )

--- a/tests/test_asset_registry.py
+++ b/tests/test_asset_registry.py
@@ -307,6 +307,38 @@ class TestAssetRegistryConverter(unittest.TestCase):
 
         self.assertEqual(first_ids, second_ids)
 
+    def test_build_entries_includes_modern_script_function_assets(self) -> None:
+        _write_yyp(self.gm_dir, [("scripts", "ending")])
+        self._write_resource("scripts", "ending", "GMScript", "folders/Scripts/Game.yy")
+        _write_file(
+            os.path.join(self.gm_dir, "scripts", "ending", "ending.gml"),
+            "function loadending() { return 1; }\n"
+            "function saveending() { loadending(); }\n",
+        )
+
+        entries = self._converter().build_entries()
+        by_name = {entry.name: entry for entry in entries}
+
+        self.assertIn("ending", by_name)
+        self.assertIn("loadending", by_name)
+        self.assertIn("saveending", by_name)
+        self.assertEqual(by_name["ending"].godot_path, "res://scripts/game/ending.gd")
+        self.assertEqual(by_name["loadending"].asset_type, "script")
+        self.assertEqual(by_name["loadending"].godot_path, by_name["ending"].godot_path)
+        self.assertNotEqual(by_name["loadending"].id, by_name["ending"].id)
+        self.assertEqual(
+            by_name["loadending"].legacy_id,
+            "scripts/ending/ending.yy#function:loadending",
+        )
+        self.assertEqual(
+            by_name["loadending"].metadata,
+            {
+                "script_function": True,
+                "script_asset": "ending",
+                "script_source_path": "scripts/ending/ending.yy",
+            },
+        )
+
     def test_convert_all_writes_runtime_registry_script(self) -> None:
         _write_yyp(
             self.gm_dir,

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -647,6 +647,39 @@ class TestScriptGeneration(unittest.TestCase):
         self.assertEqual(source_map["entries"][0]["event"], "_ready")
         self.assertEqual(source_map["entries"][0]["source_line"], 1)
 
+    def test_script_transpiles_calls_to_modern_script_function_assets(self):
+        self._setup_object("o_test", event_list=[{"eventType": 0, "eventNum": 0}])
+        script_dir = os.path.join(self.gm_dir, "scripts", "ending")
+        os.makedirs(script_dir)
+        with open(os.path.join(script_dir, "ending.yy"), "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "%Name": "ending",
+                    "name": "ending",
+                    "parent": {"name": "Game", "path": "folders/Scripts/Game.yy"},
+                    "resourceType": "GMScript",
+                },
+                f,
+            )
+        with open(os.path.join(script_dir, "ending.gml"), "w", encoding="utf-8") as f:
+            f.write("function loadending() { return 1; }\nfunction saveending() { loadending(); }\n")
+        source_path = os.path.join(self.gm_dir, "objects", "o_test", "Create_0.gml")
+        with open(source_path, "w", encoding="utf-8") as f:
+            f.write("loadending();")
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        gd_path = os.path.join(self.godot_dir, "objects", "o_test", "o_test.gd")
+        with open(gd_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        self.assertIn(
+            'GMRuntime.gml_script_call(GMRuntime.gml_asset_get_index("loadending"), [], self, other)',
+            content,
+        )
+        self.assertNotIn("\tloadending()", content)
+
     def test_script_transpiles_infinity_runtime_support(self):
         """Infinity-sensitive GML should use the shared runtime support layer."""
         self._setup_object("o_test", event_list=[{"eventType": 0, "eventNum": 0}])

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -219,25 +219,30 @@ class TestScriptConverter(unittest.TestCase):
         self.assertIn("return 11", modern_script)
         self.assertNotIn("return 22", modern_script)
 
-    def test_records_migration_diagnostic_for_unsupported_multi_function_script_assets(self) -> None:
+    def test_converts_multi_function_script_assets_and_declared_registry_names(self) -> None:
         self._write_project()
         project_path = self.gm_dir / "ScriptTest.yyp"
         project = json.loads(project_path.read_text(encoding="utf-8"))
         resources = cast(list[object], project["resources"])
-        resources.append(_resource_entry("scripts", "scr_multi"))
+        resources.append(_resource_entry("scripts", "ending"))
         _write_json(project_path, project)
         _write_json(
-            self.gm_dir / "scripts" / "scr_multi" / "scr_multi.yy",
+            self.gm_dir / "scripts" / "ending" / "ending.yy",
             {
-                "%Name": "scr_multi",
-                "name": "scr_multi",
+                "%Name": "ending",
+                "name": "ending",
                 "parent": {"name": "Game", "path": "folders/Scripts/Game.yy"},
                 "resourceType": "GMScript",
             },
         )
         _write_text(
-            self.gm_dir / "scripts" / "scr_multi" / "scr_multi.gml",
-            "function helper(a) { return a; } function scr_multi(a) { return helper(a); }",
+            self.gm_dir / "scripts" / "ending" / "ending.gml",
+            "function loadending() {\n"
+            "    for (var i = 1; i <= 7; i++) { global.endingnum[i] = i; }\n"
+            "}\n"
+            "function saveending() {\n"
+            "    for (var i = 1; i <= 7; i++) { loadending(); }\n"
+            "}\n",
         )
         diagnostics = DiagnosticCollector()
 
@@ -251,18 +256,33 @@ class TestScriptConverter(unittest.TestCase):
         ).convert_all()
 
         self.assertEqual(registry_path, str(self.godot_dir / SCRIPT_REGISTRY_RELATIVE_PATH))
-        recorded = diagnostics.diagnostics()
-        self.assertEqual(len(recorded), 1)
-        diagnostic = recorded[0]
-        self.assertEqual(diagnostic.code, "GM2GD-GML-TRANSPILE")
-        self.assertEqual(diagnostic.resource, "scr_multi")
-        self.assertEqual(diagnostic.resource_type, "script")
-        self.assertIn("Unexpected token: function", diagnostic.message)
-        self.assertIn("Split or rewrite unsupported GML", diagnostic.workaround or "")
+        self.assertEqual(diagnostics.diagnostics(), ())
+        ending_script = (self.godot_dir / "scripts" / "game" / "ending.gd").read_text(encoding="utf-8")
+        self.assertIn("func _gm_script_call_loadending():", ending_script)
+        self.assertIn(
+            "func _gm_script_call_scoped_loadending(_gml_script_self = null, _gml_script_other = null):",
+            ending_script,
+        )
+        self.assertIn("func _gm_script_call_saveending():", ending_script)
+        self.assertIn(
+            "GMRuntime.gml_script_call(GMRuntime.gml_asset_get_index(\"loadending\"), [], "
+            "_gml_script_self, _gml_script_other)",
+            ending_script,
+        )
         registry = (self.godot_dir / SCRIPT_REGISTRY_RELATIVE_PATH).read_text(encoding="utf-8")
         self.assertIn('"name": "scr_add"', registry)
         self.assertIn('"name": "scr_modern"', registry)
-        self.assertNotIn('"name": "scr_multi"', registry)
+        self.assertIn('"name": "loadending"', registry)
+        self.assertIn('"name": "saveending"', registry)
+        self.assertNotIn('"name": "ending"', registry)
+        self.assertIn(
+            'preload("res://scripts/game/ending.gd").new().gm2godot_callable_loadending()',
+            registry,
+        )
+        self.assertIn(
+            'preload("res://scripts/game/ending.gd").new().gm2godot_scoped_callable_saveending()',
+            registry,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Parse modern GameMaker script files that contain multiple top-level function declarations.
- Register each declared function by its GameMaker function name while preserving legacy/same-name script behavior.
- Expand asset-name discovery for script functions so object, room, and timeline code can resolve calls like loadending().

## Validation
- ./venv/bin/pyright --warnings
- ./venv/bin/ruff check .
- ./venv/bin/python -m unittest
- Monophobia probe: converted /Users/infi/Documents/Github/Monophobia into an initialized Godot project and validate_generated_godot_project returned status=passed with 0 output issues.

Closes #664