### PR TITLE
Implement Monophobia background layer APIs

### DIFF
--- a/src/conversion/gml_runtime_parts/segments/11_layers.gd
+++ b/src/conversion/gml_runtime_parts/segments/11_layers.gd
@@ -277,6 +277,48 @@ static func gml_layer_get_element_type(element):
 	return "undefined"
 
 
+static func gml_layer_background_get_id(layer):
+	var layer_node = _gml_layer_resolve_node(layer)
+	if layer_node == null:
+		return gml_handle_invalid(GML_LAYER_ELEMENT_HANDLE_KIND)
+	if _gml_layer_node_is_background(layer_node):
+		return _gml_layer_element_register(layer_node)
+	if not (layer_node is Node):
+		return gml_handle_invalid(GML_LAYER_ELEMENT_HANDLE_KIND)
+	for child in layer_node.get_children():
+		if _gml_layer_node_is_background(child):
+			return _gml_layer_element_register(child)
+	return gml_handle_invalid(GML_LAYER_ELEMENT_HANDLE_KIND)
+
+
+static func gml_layer_background_alpha(background, alpha):
+	var node = _gml_layer_background_resolve_node(background)
+	if node == null:
+		return false
+	var resolved_alpha = clamp(_to_real(alpha), 0.0, 1.0)
+	if node is CanvasItem:
+		var color = node.modulate
+		color.a = resolved_alpha
+		node.modulate = color
+	node.set_meta("gamemaker_background_alpha", resolved_alpha)
+	return true
+
+
+static func gml_layer_background_blend(background, color):
+	var node = _gml_layer_background_resolve_node(background)
+	if node == null:
+		return false
+	var resolved_color = _gml_layer_background_color(color)
+	if node is CanvasItem:
+		var modulate = node.modulate
+		modulate.r = resolved_color.r
+		modulate.g = resolved_color.g
+		modulate.b = resolved_color.b
+		node.modulate = modulate
+	node.set_meta("gamemaker_background_blend", int(_to_real(color)))
+	return true
+
+
 static func _gml_layer_register_current_scene():
 	var scene = _gml_layer_current_scene()
 	if scene != null:
@@ -566,6 +608,8 @@ static func _gml_layer_element_register(node):
 
 
 static func _gml_layer_element_name(node):
+	if node is Object and node.has_meta("gamemaker_background_visual"):
+		return str(node.get_meta("gamemaker_layer_name", str(node.name)))
 	if node is Object and node.has_meta("gamemaker_instance_name"):
 		return str(node.get_meta("gamemaker_instance_name"))
 	if node is Object and node.has_meta("gamemaker_asset_name"):
@@ -610,3 +654,26 @@ static func _gml_layer_element_unregister_handle(handle, invalidate = true):
 		_gml_layer_element_handles_by_node_id.erase(node.get_instance_id())
 	if invalidate:
 		gml_handle_invalidate(handle)
+
+
+static func _gml_layer_node_is_background(node):
+	return node is Object and node.has_meta("gamemaker_background_visual")
+
+
+static func _gml_layer_background_resolve_node(background):
+	var node = _gml_layer_element_resolve_node(background)
+	if _gml_layer_node_is_background(node):
+		return node
+	return null
+
+
+static func _gml_layer_background_color(color):
+	if color is Color:
+		return color
+	var value = int(_to_real(color))
+	return Color(
+		float(value & 0xff) / 255.0,
+		float((value >> 8) & 0xff) / 255.0,
+		float((value >> 16) & 0xff) / 255.0,
+		1.0
+	)

--- a/src/conversion/gml_transpiler_parts/constants.py
+++ b/src/conversion/gml_transpiler_parts/constants.py
@@ -1343,6 +1343,9 @@ _LAYER_RUNTIME_FUNCTIONS = {
     "layer_get_element_type": "gml_layer_get_element_type",
     "layer_set_visible": "gml_layer_set_visible",
     "layer_get_visible": "gml_layer_get_visible",
+    "layer_background_get_id": "gml_layer_background_get_id",
+    "layer_background_alpha": "gml_layer_background_alpha",
+    "layer_background_blend": "gml_layer_background_blend",
 }
 
 _SEQUENCE_TIMELINE_RUNTIME_FUNCTIONS = {

--- a/src/conversion/gml_transpiler_parts/gml_api_manifest.py
+++ b/src/conversion/gml_transpiler_parts/gml_api_manifest.py
@@ -157,6 +157,9 @@ _LAYER_IMPLEMENTED_APIS = frozenset(
         "layer_get_element_type",
         "layer_set_visible",
         "layer_get_visible",
+        "layer_background_get_id",
+        "layer_background_alpha",
+        "layer_background_blend",
     }
 )
 _LAYER_UNSUPPORTED_ELEMENT_APIS = (
@@ -167,10 +170,6 @@ _LAYER_UNSUPPORTED_ELEMENT_APIS = (
     (
         "layer_tilemap_create",
         "Runtime tilemap element creation needs the texture/tilemap compatibility surface tracked by #568.",
-    ),
-    (
-        "layer_background_get_id",
-        "Background layer element mutation needs dedicated background asset compatibility; converted backgrounds remain static metadata.",
     ),
     (
         "layer_background_create",
@@ -214,6 +213,9 @@ def _layer_entries() -> tuple[GMLAPIEntry, ...]:
                 "layer_add_instance",
                 "layer_get_all_elements",
                 "layer_get_element_type",
+                "layer_background_get_id",
+                "layer_background_alpha",
+                "layer_background_blend",
             }
             else "no",
             _LAYER_DOCS_PATH,

--- a/src/conversion/gml_transpiler_parts/gml_function_dispatch.py
+++ b/src/conversion/gml_transpiler_parts/gml_function_dispatch.py
@@ -728,6 +728,9 @@ _LAYER_ARITY: dict[str, tuple[int, int | None]] = {
     "layer_get_element_type": (1, 1),
     "layer_set_visible": (2, 2),
     "layer_get_visible": (1, 1),
+    "layer_background_get_id": (1, 1),
+    "layer_background_alpha": (2, 2),
+    "layer_background_blend": (2, 2),
 }
 
 _SEQUENCE_TIMELINE_ARITY: dict[str, tuple[int, int | None]] = {

--- a/src/conversion/gml_transpiler_parts/statement_parser.py
+++ b/src/conversion/gml_transpiler_parts/statement_parser.py
@@ -42,6 +42,7 @@ class _StatementParser:
         self,
         tokens: list[_Token],
         local_names: Iterable[str] | None = None,
+        declared_local_names: MutableSet[str] | None = None,
         instance_variables: MutableSet[str] | None = None,
         loop_depth: int = 0,
         continue_depth: int = 0,
@@ -66,6 +67,9 @@ class _StatementParser:
         self.tokens = tokens
         self.position = 0
         self.local_names = set(local_names or [])
+        self.declared_local_names: MutableSet[str] = (
+            declared_local_names if declared_local_names is not None else set[str]()
+        )
         self.instance_variables = instance_variables
         self.loop_depth = loop_depth
         self.continue_depth = continue_depth
@@ -141,6 +145,7 @@ class _StatementParser:
         return _transpile_statement(
             _tokens_to_source(statement_tokens),
             self.local_names,
+            self.declared_local_names,
             self.instance_variables,
             loop_depth=self.loop_depth,
             continue_depth=self.continue_depth,
@@ -392,6 +397,7 @@ class _StatementParser:
                 _transpile_statement(
                     initializer,
                     self.local_names,
+                    self.declared_local_names,
                     self.instance_variables,
                     loop_depth=self.loop_depth,
                     continue_depth=self.continue_depth,
@@ -422,6 +428,7 @@ class _StatementParser:
             _transpile_statement(
                 operation,
                 self.local_names,
+                self.declared_local_names,
                 self.instance_variables,
                 loop_depth=self.loop_depth,
                 continue_depth=self.continue_depth,
@@ -623,6 +630,7 @@ class _StatementParser:
         parser = _StatementParser(
             body_tokens,
             local_names=self.local_names,
+            declared_local_names=set[str](),
             instance_variables=self.instance_variables,
             loop_depth=self.loop_depth + 1,
             continue_depth=self.continue_depth,
@@ -766,9 +774,7 @@ class _StatementParser:
 
     def _parse_do_until_body(self) -> list[str]:
         if self._match("{"):
-            lines = self.parse(terminator="}")
-            self._consume("}")
-            return lines
+            return self._parse_nested_braced_body()
 
         statement_tokens = self._read_do_until_statement_tokens()
         if not statement_tokens:
@@ -776,6 +782,7 @@ class _StatementParser:
         return _transpile_statement(
             _tokens_to_source(statement_tokens),
             self.local_names,
+            self.declared_local_names,
             self.instance_variables,
             loop_depth=self.loop_depth,
             continue_depth=self.continue_depth,
@@ -791,12 +798,28 @@ class _StatementParser:
 
     def _parse_body(self) -> list[str]:
         if self._match("{"):
+            return self._parse_nested_braced_body()
+        if self._at_end() or self._check("}"):
+            return []
+        return self._parse_nested_single_statement_body()
+
+    def _parse_nested_braced_body(self) -> list[str]:
+        outer_declared_local_names = self.declared_local_names
+        self.declared_local_names = set[str]()
+        try:
             lines = self.parse(terminator="}")
             self._consume("}")
             return lines
-        if self._at_end() or self._check("}"):
-            return []
-        return self._parse_statement()
+        finally:
+            self.declared_local_names = outer_declared_local_names
+
+    def _parse_nested_single_statement_body(self) -> list[str]:
+        outer_declared_local_names = self.declared_local_names
+        self.declared_local_names = set[str]()
+        try:
+            return self._parse_statement()
+        finally:
+            self.declared_local_names = outer_declared_local_names
 
     def _read_condition_tokens(self) -> list[_Token]:
         if self._match("("):

--- a/src/conversion/gml_transpiler_parts/statements.py
+++ b/src/conversion/gml_transpiler_parts/statements.py
@@ -99,6 +99,7 @@ class _ControlFlowCapture:
 def _transpile_statement(
     statement: str,
     local_names: MutableSet[str] | None = None,
+    declared_local_names: MutableSet[str] | None = None,
     instance_variables: MutableSet[str] | None = None,
     loop_depth: int = 0,
     continue_depth: int = 0,
@@ -117,6 +118,8 @@ def _transpile_statement(
 
     if local_names is None:
         local_names = set()
+    if declared_local_names is None:
+        declared_local_names = set()
     scope_context = _normalize_scope_context(scope_context)
     macro_values = macro_values or {}
     generated_counter = generated_counter if generated_counter is not None else [0]
@@ -267,6 +270,7 @@ def _transpile_statement(
         return _transpile_var_statement(
             statement[4:].strip(),
             local_names,
+            declared_local_names,
             instance_variables,
             enum_values,
             enum_names,
@@ -624,6 +628,7 @@ def _transpile_statement(
             increment_lines = _transpile_statement(
                 f"{increment_target}{suffix}",
                 local_names,
+                declared_local_names,
                 instance_variables,
                 loop_depth=loop_depth,
                 continue_depth=continue_depth,
@@ -1552,6 +1557,7 @@ def _record_instance_assignment(
 def _transpile_var_statement(
     statement: str,
     local_names: MutableSet[str] | None = None,
+    declared_local_names: MutableSet[str] | None = None,
     instance_variables: MutableSet[str] | None = None,
     enum_values: MutableMapping[str, dict[str, int]] | None = None,
     enum_names: Iterable[str] | None = None,
@@ -1562,6 +1568,8 @@ def _transpile_var_statement(
     lines: list[str] = []
     if local_names is None:
         local_names = set()
+    if declared_local_names is None:
+        declared_local_names = set()
     scope_context = _normalize_scope_context(scope_context)
     enum_name_set = frozenset(enum_names or [])
     macro_values = macro_values or {}
@@ -1578,8 +1586,10 @@ def _transpile_var_statement(
             _reject_constant_declaration_name(name, macro_values.keys())
             if name in enum_name_set:
                 raise GMLTranspileError("Cannot redeclare enum")
-            lines.append(f"var {_sanitize_gdscript_identifier(name)} = GMRuntime.gml_undefined()")
+            declaration_prefix = "" if name in declared_local_names else "var "
+            lines.append(f"{declaration_prefix}{_sanitize_gdscript_identifier(name)} = GMRuntime.gml_undefined()")
             local_names.add(name)
+            declared_local_names.add(name)
             continue
         name, operator, value = assignment
         if operator not in ("=", ":="):
@@ -1623,8 +1633,10 @@ def _transpile_var_statement(
                 macro_values=macro_values,
             )
             lines.extend(prelude_lines)
-        lines.append(f"var {_sanitize_gdscript_identifier(name)} = {initial_value}")
+        declaration_prefix = "" if name in declared_local_names else "var "
+        lines.append(f"{declaration_prefix}{_sanitize_gdscript_identifier(name)} = {initial_value}")
         local_names.add(name)
+        declared_local_names.add(name)
     return lines
 
 def _parse_increment_statement(statement: str) -> tuple[str, _IncrementDelta] | None:

--- a/tests/fixtures/golden/basic_scripts/expected_snapshot.json
+++ b/tests/fixtures/golden/basic_scripts/expected_snapshot.json
@@ -7,7 +7,7 @@
   },
   "fixture": "basic_scripts",
   "hashes": {
-    "gm2godot/gml_runtime.gd": "sha256:ac6e2eb5f9a78ac2244d3795b74a62f1cd8a68ef58a8158ec68d5d3d803dc2d6",
+    "gm2godot/gml_runtime.gd": "sha256:fd375397667b40dacfe23aa17ae2c7a046f7c668d95013def502b5b68db48198",
     "gm2godot/managers/gm_assets.gd": "sha256:4121345bd843a0bb3487fcba4756a3b2f18700685f5858db5f62f8992d96a76f",
     "gm2godot/managers/gm_async.gd": "sha256:d0a73997476f0e889892f85a6c343fc5b44fecdf9fa547e943902632aedf9df3",
     "gm2godot/managers/gm_audio.gd": "sha256:995a1df58e7f8ad03fa8ed7e9a195cdcfcf256643d73ac06a88bb6bbec82fba4",

--- a/tests/test_gml_api_manifest.py
+++ b/tests/test_gml_api_manifest.py
@@ -302,6 +302,11 @@ class TestGMLAPIManifest(unittest.TestCase):
         assert layer_get_id is not None
         self.assertEqual(layer_get_id.status, "implemented")
         self.assertEqual(layer_get_id.issue_number, 566)
+        layer_background_get_id = get_gml_api_entry("layer_background_get_id")
+        self.assertIsNotNone(layer_background_get_id)
+        assert layer_background_get_id is not None
+        self.assertEqual(layer_background_get_id.status, "implemented")
+        self.assertEqual(layer_background_get_id.issue_number, 566)
         layer_sequence_create = get_gml_api_entry("layer_sequence_create")
         self.assertIsNotNone(layer_sequence_create)
         assert layer_sequence_create is not None
@@ -610,6 +615,9 @@ class TestGMLAPIManifest(unittest.TestCase):
             "layer_add_instance",
             "layer_get_all_elements",
             "layer_get_element_type",
+            "layer_background_get_id",
+            "layer_background_alpha",
+            "layer_background_blend",
             "timeline_exists",
             "timeline_moment_add_script",
             "sequence_get",

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -479,6 +479,9 @@ RUNTIME_VALUE_PARITY_CASES: tuple[RuntimeValueParityCase, ...] = (
     RuntimeValueParityCase("layer_add_instance(layer_id, id)", "GMRuntime.gml_layer_add_instance(layer_id, id)"),
     RuntimeValueParityCase("layer_get_all_elements(layer_id)", "GMRuntime.gml_layer_get_all_elements(layer_id)"),
     RuntimeValueParityCase("layer_get_element_type(element)", "GMRuntime.gml_layer_get_element_type(element)"),
+    RuntimeValueParityCase("layer_background_get_id(layer_id)", "GMRuntime.gml_layer_background_get_id(layer_id)"),
+    RuntimeValueParityCase("layer_background_alpha(bg, 0.25)", "GMRuntime.gml_layer_background_alpha(bg, 0.25)"),
+    RuntimeValueParityCase("layer_background_blend(bg, 255)", "GMRuntime.gml_layer_background_blend(bg, 255)"),
     RuntimeValueParityCase("layer_destroy(layer_id)", "GMRuntime.gml_layer_destroy(layer_id)"),
     RuntimeValueParityCase("timeline_exists(tl_intro)", 'GMRuntime.gml_timeline_exists(GMRuntime.gml_asset_get_index("tl_intro"))'),
     RuntimeValueParityCase("timeline_get_name(tl_intro)", 'GMRuntime.gml_timeline_get_name(GMRuntime.gml_asset_get_index("tl_intro"))'),
@@ -1344,6 +1347,9 @@ class TestGMLRuntimeScript(unittest.TestCase):
             "gml_layer_add_instance",
             "gml_layer_get_all_elements",
             "gml_layer_get_element_type",
+            "gml_layer_background_get_id",
+            "gml_layer_background_alpha",
+            "gml_layer_background_blend",
             "gml_timeline_exists",
             "gml_timeline_get_name",
             "gml_timeline_moment_add_script",
@@ -2574,6 +2580,9 @@ class TestGMLRuntimeScript(unittest.TestCase):
         self.assertIn("static func gml_layer_add_instance(layer, instance):", GML_RUNTIME_SCRIPT)
         self.assertIn("static func gml_layer_get_all_elements(layer):", GML_RUNTIME_SCRIPT)
         self.assertIn("static func gml_layer_get_element_type(element):", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_layer_background_get_id(layer):", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_layer_background_alpha(background, alpha):", GML_RUNTIME_SCRIPT)
+        self.assertIn("static func gml_layer_background_blend(background, color):", GML_RUNTIME_SCRIPT)
         self.assertIn("gml_layer_register_scene(scene)", GML_RUNTIME_SCRIPT)
         self.assertIn("var resolved_layer = _gml_layer_resolve_node(layer)", GML_RUNTIME_SCRIPT)
 

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -2396,6 +2396,21 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             "var _str = GMRuntime.gml_undefined()",
         )
 
+    def test_redeclared_local_vars_lower_to_assignments(self):
+        self.assertEqual(
+            transpile_gml_code(
+                "var x = 1; var x = 2; if ready { var x = 3; var x; } if retry { var x = 4; }",
+                indent="",
+            ),
+            "var x = 1\n"
+            "x = 2\n"
+            "if GMRuntime.gml_bool(ready):\n"
+            "\tvar x = 3\n"
+            "\tx = GMRuntime.gml_undefined()\n"
+            "if GMRuntime.gml_bool(retry):\n"
+            "\tvar x = 4",
+        )
+
     def test_unknown_reads_remain_runtime_or_compile_errors(self):
         self.assertEqual(
             transpile_gml_expression("missing_value"),
@@ -3541,6 +3556,9 @@ class TestGMLStatementTranspiler(unittest.TestCase):
                 "kind = layer_get_element_type(elements[0]);"
                 "layer_set_visible(fx, false);"
                 "visible = layer_get_visible(fx);"
+                "bg = layer_background_get_id(layer_id);"
+                "layer_background_alpha(bg, 0.25);"
+                "layer_background_blend(bg, 255);"
                 "layer_destroy(fx);",
                 indent="",
             ),
@@ -3566,6 +3584,9 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             "kind = GMRuntime.gml_layer_get_element_type(GMRuntime.gml_array_get(elements, 0))\n"
             "GMRuntime.gml_layer_set_visible(fx, false)\n"
             "visible = GMRuntime.gml_layer_get_visible(fx)\n"
+            "bg = GMRuntime.gml_layer_background_get_id(layer_id)\n"
+            "GMRuntime.gml_layer_background_alpha(bg, 0.25)\n"
+            "GMRuntime.gml_layer_background_blend(bg, 255)\n"
             "GMRuntime.gml_layer_destroy(fx)",
         )
 

--- a/tests/test_layers_runtime_godot.py
+++ b/tests/test_layers_runtime_godot.py
@@ -100,7 +100,15 @@ def _write_smoke_scene(project_dir: Path) -> None:
 
         func _ready():
         \tvar instances = _layer("Instances", 100)
-        \t_layer("Background", 200)
+        \tvar background_layer = _layer("Background", 200)
+        \tvar background_visual = ColorRect.new()
+        \tbackground_visual.name = "BackgroundVisual"
+        \tbackground_visual.color = Color(1, 1, 1, 1)
+        \tbackground_visual.modulate = Color(1, 1, 1, 1)
+        \tbackground_visual.set_meta("gamemaker_layer_element_type", "background")
+        \tbackground_visual.set_meta("gamemaker_background_visual", true)
+        \tbackground_visual.set_meta("gamemaker_background_visual_type", "color")
+        \tbackground_layer.add_child(background_visual)
         \tGMRuntime.gml_layer_register_scene(self)
 
         \tvar layer_id = GMRuntime.gml_layer_get_id("Instances")
@@ -130,6 +138,19 @@ def _write_smoke_scene(project_dir: Path) -> None:
         \t\treturn
         \tGMRuntime.gml_layer_set_visible(layer_id, true)
         \tif not _check(GMRuntime.gml_layer_get_id_at_depth(50).index == layer_id.index, "layer_get_id_at_depth mismatch"):
+        \t\treturn
+        \tvar background_id = GMRuntime.gml_layer_background_get_id("Background")
+        \tif not _check(GMRuntime.gml_handle_is_valid(background_id), "background get id invalid"):
+        \t\treturn
+        \tif not _check(GMRuntime.gml_layer_get_element_type(background_id) == "background", "background element type mismatch"):
+        \t\treturn
+        \tif not _check(GMRuntime.gml_layer_background_alpha(background_id, 0.25), "background alpha returned false"):
+        \t\treturn
+        \tif not _check(is_equal_approx(background_visual.modulate.a, 0.25), "background alpha mismatch"):
+        \t\treturn
+        \tif not _check(GMRuntime.gml_layer_background_blend(background_id, 255), "background blend returned false"):
+        \t\treturn
+        \tif not _check(is_equal_approx(background_visual.modulate.r, 1.0) and is_equal_approx(background_visual.modulate.g, 0.0) and is_equal_approx(background_visual.modulate.b, 0.0), "background blend mismatch"):
         \t\treturn
 
         \tvar fx = GMRuntime.gml_layer_create(25, "Effects")

--- a/tests/test_monophobia_conversion.py
+++ b/tests/test_monophobia_conversion.py
@@ -137,6 +137,20 @@ class TestMonophobiaConversion(unittest.TestCase):
 
         self.assertEqual(ending_failures, [])
 
+    def test_player_background_layer_calls_have_no_transpile_failure_diagnostic(self) -> None:
+        diagnostics = json.loads(
+            self._read_generated_file("gm2godot", "conversion_diagnostics.json")
+        )
+        player_background_failures = [
+            diagnostic
+            for diagnostic in diagnostics.get("diagnostics", [])
+            if diagnostic.get("resource") == "o_player"
+            and diagnostic.get("code") == "GM2GD-GML-TRANSPILE"
+            and diagnostic.get("api") == "layer_background_get_id"
+        ]
+
+        self.assertEqual(player_background_failures, [])
+
     def test_generated_project_has_no_godot_warnings_or_errors(self) -> None:
         self.assertIsNotNone(
             find_godot_binary(),


### PR DESCRIPTION
## Summary
- Implement layer_background_get_id, layer_background_alpha, and layer_background_blend through the layer runtime and transpiler manifest.
- Preserve Godot block scoping while lowering repeated GameMaker var declarations to assignments inside the same emitted block.
- Extend unit, Godot smoke, golden snapshot, and Monophobia integration coverage for the background layer calls.

## Validation
- ./venv/bin/pyright --warnings
- ./venv/bin/ruff check .
- MONOPHOBIA_PROJECT_PATH=/Users/infi/Documents/Github/Monophobia GODOT_BIN=/Applications/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_monophobia_conversion -v
- MONOPHOBIA_PROJECT_PATH=/Users/infi/Documents/Github/Monophobia GODOT_BIN=/Applications/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest

Closes #686