### PR TITLE
Add Godot boot log validation

### DIFF
--- a/.github/workflows/tcc-conversion-test.yml
+++ b/.github/workflows/tcc-conversion-test.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Clone SimpleTopDown test game (shallow)
         run: git clone --depth 1 --no-recurse-submodules https://github.com/Infiland/GM2GodotGameTest_SimpleTopDown.git "${{ runner.temp }}/GM2GodotGameTest_SimpleTopDown"
 
-      - name: Run SimpleTopDown conversion test
+      - name: Run SimpleTopDown conversion and boot-log test
         env:
           SIMPLE_TOPDOWN_PROJECT_PATH: ${{ runner.temp }}/GM2GodotGameTest_SimpleTopDown
         run: python -m unittest tests.test_simple_topdown_conversion -v
@@ -68,7 +68,7 @@ jobs:
       - name: Clone Monophobia (shallow)
         run: git clone --depth 1 --no-recurse-submodules https://github.com/Infiland/Monophobia.git "${{ runner.temp }}/Monophobia"
 
-      - name: Run Monophobia conversion test
+      - name: Run Monophobia conversion and boot-log test
         env:
           MONOPHOBIA_PROJECT_PATH: ${{ runner.temp }}/Monophobia
         run: python -m unittest tests.test_monophobia_conversion -v

--- a/src/cli.py
+++ b/src/cli.py
@@ -77,6 +77,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         diagnostics = _validate_project(
             args.godot_project,
             godot_binary=args.godot_bin,
+            godot_boot_frames=args.godot_boot_frames,
             run_godot_validation=not args.skip_godot_validation,
         )
         if args.report_dir:
@@ -173,6 +174,16 @@ def _build_parser() -> argparse.ArgumentParser:
         "--skip-godot-validation",
         action="store_true",
         help="Skip headless Godot generated resource validation.",
+    )
+    validate_parser.add_argument(
+        "--godot-boot-frames",
+        type=_non_negative_int,
+        default=0,
+        help=(
+            "After generated resource validation passes, boot the Godot project's "
+            "configured main scene headlessly for this many frames and fail on "
+            "warning/error output. Default: 0 (disabled)."
+        ),
     )
     _add_report_args(validate_parser, required=False)
     _add_threshold_args(validate_parser)
@@ -277,6 +288,7 @@ def _validate_project(
     godot_project_path: str,
     *,
     godot_binary: str | None = None,
+    godot_boot_frames: int = 0,
     run_godot_validation: bool = True,
 ) -> DiagnosticCollector:
     diagnostics = DiagnosticCollector()
@@ -320,7 +332,12 @@ def _validate_project(
             source_path=report_path,
         )
     if run_godot_validation:
-        _add_godot_validation_diagnostic(diagnostics, godot_project_path, godot_binary)
+        _add_godot_validation_diagnostic(
+            diagnostics,
+            godot_project_path,
+            godot_binary,
+            boot_frames=godot_boot_frames,
+        )
     return diagnostics
 
 
@@ -340,10 +357,13 @@ def _add_godot_validation_diagnostic(
     diagnostics: DiagnosticCollector,
     godot_project_path: str,
     godot_binary: str | None,
+    *,
+    boot_frames: int = 0,
 ) -> None:
     report = validate_generated_godot_project(
         godot_project_path,
         godot_binary=godot_binary,
+        boot_frames=boot_frames,
     )
     write_godot_validation_report(godot_project_path, report)
     if report.status == "passed":
@@ -370,6 +390,16 @@ def _add_godot_validation_diagnostic(
         source_path=godot_project_path,
         workaround="Open the generated project with the pinned Godot version and fix the first parser/resource error reported in gm2godot/godot_validation_report.json.",
     )
+
+
+def _non_negative_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"Expected a non-negative integer: {value}") from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError(f"Expected a non-negative integer: {value}")
+    return parsed
 
 
 def _import_diagnostics_report(

--- a/src/conversion/gml_runtime_parts/segments/40_arrays_structs_variables.gd
+++ b/src/conversion/gml_runtime_parts/segments/40_arrays_structs_variables.gd
@@ -15,6 +15,10 @@ static func gml_array_set(array_value, index, value):
 	var resolved_index = _to_array_index(index)
 	if resolved_index < 0:
 		return gml_undefined()
+	if typeof(array_value) != TYPE_ARRAY:
+		return gml_unsupported_type_error("GML array set", array_value)
+	if resolved_index >= array_value.size():
+		array_value.resize(resolved_index + 1)
 	array_value[resolved_index] = value
 	return value
 

--- a/src/conversion/gml_transpiler_parts/statements.py
+++ b/src/conversion/gml_transpiler_parts/statements.py
@@ -675,6 +675,7 @@ def _transpile_statement(
                 enum_names=enum_names,
                 scope_context=scope_context,
                 macro_values=macro_values,
+                generated_counter=generated_counter,
             )
             return [*prelude_lines, *increment_lines, *assignment_lines]
         _reject_constant_assignment_target_name(target, macro_values.keys())
@@ -871,6 +872,19 @@ def _transpile_statement(
                 ]
             raise GMLTranspileError("Unsupported alarm assignment operator")
         _record_instance_assignment(target, local_names, instance_variables)
+        array_writeback_lines = _member_backed_array_assignment_lines(
+            target_expr,
+            local_names,
+            instance_variables,
+            scope_context,
+            generated_counter,
+            value,
+            operator,
+            prelude_lines,
+            value_prelude_lines,
+        )
+        if array_writeback_lines is not None:
+            return array_writeback_lines
         target = _emit_expression(target_expr, local_names, scope_context=scope_context)[0]
         if isinstance(target_expr, _Index):
             container = _emit_expression(
@@ -2307,6 +2321,74 @@ def _assignment_target_reader_writer(
     raise GMLTranspileError("Assignment target must be assignable")
 
 
+def _member_backed_array_assignment_lines(
+    target_expr: _Expression,
+    local_names: MutableSet[str],
+    instance_variables: MutableSet[str] | None,
+    scope_context: _ScopeContext,
+    generated_counter: list[int],
+    value: str,
+    operator: str,
+    prelude_lines: list[str],
+    value_prelude_lines: Iterable[str],
+) -> list[str] | None:
+    if not isinstance(target_expr, _Index | _ArrayRefAccess):
+        return None
+    if not isinstance(target_expr.target, (_Member, _StructAccess)):
+        return None
+
+    container_reader, container_writer = _assignment_target_reader_writer(
+        "",
+        target_expr.target,
+        local_names,
+        instance_variables,
+        scope_context,
+        generated_counter,
+        prelude_lines,
+    )
+    index = _emit_expression(
+        target_expr.index,
+        local_names,
+        scope_context=scope_context,
+    )[0]
+    index = _cache_assignment_part(
+        prelude_lines,
+        target_expr.index,
+        index,
+        generated_counter,
+        "_gml_array_index",
+    )
+    container_name = _next_generated_name_from_counter(generated_counter, "_gml_array_target")
+    setup_lines = [
+        *prelude_lines,
+        f"var {container_name} = {container_reader}",
+        f"if GMRuntime.is_undefined({container_name}):",
+        f"\t{container_name} = []",
+    ]
+    writeback_lines = [
+        f"GMRuntime.gml_array_set({container_name}, {index}, {value})",
+        *container_writer(container_name),
+    ]
+    if operator in ("=", ":="):
+        return [*setup_lines, *writeback_lines]
+    if operator == "??=":
+        return _nullish_assignment_lines(
+            setup_lines,
+            f"GMRuntime.gml_array_get({container_name}, {index})",
+            value_prelude_lines,
+            writeback_lines,
+        )
+    if operator in _COMPOUND_RUNTIME_FUNCTIONS:
+        helper = _COMPOUND_RUNTIME_FUNCTIONS[operator]
+        return [
+            *setup_lines,
+            f"GMRuntime.gml_array_set({container_name}, {index}, "
+            f"GMRuntime.{helper}(GMRuntime.gml_array_get({container_name}, {index}), {value}))",
+            *container_writer(container_name),
+        ]
+    raise GMLTranspileError("Unsupported member-backed array assignment operator")
+
+
 def _transpile_assignment_expression_to_temp(
     source: str,
     local_names: MutableSet[str],
@@ -2455,9 +2537,11 @@ def _transpile_assignment_to_emitted_value(
     enum_names: Iterable[str] | None = None,
     scope_context: _ScopeContext | None = None,
     macro_values: Mapping[str, str] | None = None,
+    generated_counter: list[int] | None = None,
 ) -> list[str]:
     scope_context = _normalize_scope_context(scope_context)
     macro_values = macro_values or {}
+    generated_counter = generated_counter if generated_counter is not None else [0]
     _reject_constant_assignment_target_name(target, macro_values.keys())
     target_expr = _parse_gml_expression(
         target,
@@ -2512,6 +2596,19 @@ def _transpile_assignment_to_emitted_value(
         index = _alarm_array_index(target_expr, local_names, scope_context)
         return [_alarm_array_set(scope_context, index, value)]
     _record_instance_assignment(target, local_names, instance_variables)
+    array_writeback_lines = _member_backed_array_assignment_lines(
+        target_expr,
+        local_names,
+        instance_variables,
+        scope_context,
+        generated_counter,
+        value,
+        "=",
+        [],
+        (),
+    )
+    if array_writeback_lines is not None:
+        return array_writeback_lines
     if isinstance(target_expr, _Index):
         container = _emit_expression(
             target_expr.target,

--- a/src/conversion/godot_validation.py
+++ b/src/conversion/godot_validation.py
@@ -64,9 +64,12 @@ class GodotValidationReport:
     resource_paths: tuple[str, ...]
     returncode: int | None = None
     import_returncode: int | None = None
+    boot_returncode: int | None = None
     import_output: str = ""
+    boot_output: str = ""
     output: str = ""
     message: str = ""
+    boot_frames: int = 0
     output_issues: tuple[GodotOutputIssue, ...] = ()
 
     def to_dict(self) -> JsonDict:
@@ -79,8 +82,11 @@ class GodotValidationReport:
             "resource_paths": list(self.resource_paths),
             "returncode": self.returncode,
             "import_returncode": self.import_returncode,
+            "boot_returncode": self.boot_returncode,
             "import_output": self.import_output,
+            "boot_output": self.boot_output,
             "output": self.output,
+            "boot_frames": self.boot_frames,
             "output_issue_count": len(self.output_issues),
             "output_error_count": sum(1 for issue in self.output_issues if issue.severity == "error"),
             "output_warning_count": sum(1 for issue in self.output_issues if issue.severity == "warning"),
@@ -116,7 +122,11 @@ def validate_generated_godot_project(
     godot_binary: str | None = None,
     timeout: int = 60,
     load_resources: bool = True,
+    boot_frames: int = 0,
 ) -> GodotValidationReport:
+    if boot_frames < 0:
+        raise ValueError("boot_frames must be zero or greater.")
+
     resolved_binary = find_godot_binary(godot_binary)
     resource_paths = generated_godot_resource_paths(godot_project_path)
     if resolved_binary is None:
@@ -125,7 +135,8 @@ def validate_generated_godot_project(
             godot_binary="",
             project_path=godot_project_path,
             resource_paths=resource_paths,
-            message="Godot binary not found; set GODOT_BIN or pass --godot-bin to run generated resource validation.",
+            boot_frames=boot_frames,
+            message="Godot binary not found; set GODOT_BIN or pass --godot-bin to run generated resource/runtime validation.",
         )
 
     if not os.path.isfile(os.path.join(godot_project_path, "project.godot")):
@@ -134,6 +145,7 @@ def validate_generated_godot_project(
             godot_binary=resolved_binary,
             project_path=godot_project_path,
             resource_paths=resource_paths,
+            boot_frames=boot_frames,
             message="project.godot is missing; generated resources cannot be loaded through Godot.",
         )
 
@@ -152,16 +164,19 @@ def validate_generated_godot_project(
             output = exc.output.decode("utf-8", errors="replace") if isinstance(exc.output, bytes) else str(exc.output or "")
             output_issues = detect_godot_output_issues(output)
             if not load_resources and not output_issues:
-                return GodotValidationReport(
-                    status="passed",
-                    godot_binary=resolved_binary,
-                    project_path=godot_project_path,
-                    resource_paths=resource_paths,
-                    import_output=output,
-                    output=output,
-                    message=_import_only_timeout_message(timeout, len(importable_asset_paths), len(resource_paths)),
-                    output_issues=(),
-                )
+                if boot_frames == 0:
+                    return GodotValidationReport(
+                        status="passed",
+                        godot_binary=resolved_binary,
+                        project_path=godot_project_path,
+                        resource_paths=resource_paths,
+                        import_output=output,
+                        output=output,
+                        message=_import_only_timeout_message(timeout, len(importable_asset_paths), len(resource_paths)),
+                        boot_frames=boot_frames,
+                        output_issues=(),
+                    )
+                output_issues = detect_godot_output_issues(output)
             return GodotValidationReport(
                 status="failed",
                 godot_binary=resolved_binary,
@@ -170,6 +185,7 @@ def validate_generated_godot_project(
                 import_output=output,
                 output=output,
                 message=f"Headless Godot import timed out after {timeout} seconds.",
+                boot_frames=boot_frames,
                 output_issues=output_issues,
             )
         import_output = import_result.stdout
@@ -186,7 +202,7 @@ def validate_generated_godot_project(
                 fallback_output = exc.output.decode("utf-8", errors="replace") if isinstance(exc.output, bytes) else str(exc.output or "")
                 combined_output = _combine_output(import_output, fallback_output)
                 output_issues = detect_godot_output_issues(combined_output)
-                if not output_issues:
+                if not output_issues and boot_frames == 0:
                     return GodotValidationReport(
                         status="passed",
                         godot_binary=resolved_binary,
@@ -195,6 +211,7 @@ def validate_generated_godot_project(
                         import_output=combined_output,
                         output=combined_output,
                         message=_audio_fallback_timeout_message(timeout, len(importable_asset_paths), len(resource_paths)),
+                        boot_frames=boot_frames,
                         output_issues=(),
                     )
                 return GodotValidationReport(
@@ -205,6 +222,7 @@ def validate_generated_godot_project(
                     import_output=combined_output,
                     output=combined_output,
                     message=f"Headless Godot no-audio import fallback timed out after {timeout} seconds.",
+                    boot_frames=boot_frames,
                     output_issues=output_issues,
                 )
 
@@ -212,6 +230,17 @@ def validate_generated_godot_project(
             combined_output = _combine_output(import_output, fallback_output)
             fallback_output_issues = detect_godot_output_issues(combined_output)
             if fallback_result.returncode == 0 and not fallback_output_issues:
+                if boot_frames > 0:
+                    return _run_godot_boot_validation(
+                        resolved_binary,
+                        godot_project_path,
+                        resource_paths=resource_paths,
+                        import_returncode=fallback_result.returncode,
+                        import_output=combined_output,
+                        previous_output=combined_output,
+                        boot_frames=boot_frames,
+                        timeout=timeout,
+                    )
                 return GodotValidationReport(
                     status="passed",
                     godot_binary=resolved_binary,
@@ -227,6 +256,7 @@ def validate_generated_godot_project(
                         len(importable_asset_paths),
                         (),
                     ),
+                    boot_frames=boot_frames,
                     output_issues=(),
                 )
             else:
@@ -245,6 +275,7 @@ def validate_generated_godot_project(
                         len(importable_asset_paths),
                         fallback_output_issues,
                     ),
+                    boot_frames=boot_frames,
                     output_issues=fallback_output_issues,
                 )
         if import_result.returncode != 0 or import_output_issues:
@@ -258,10 +289,22 @@ def validate_generated_godot_project(
                 import_output=import_output,
                 output=import_output,
                 message=_import_message(import_result.returncode, len(importable_asset_paths), import_output_issues),
+                boot_frames=boot_frames,
                 output_issues=import_output_issues,
             )
 
     if not load_resources:
+        if boot_frames > 0:
+            return _run_godot_boot_validation(
+                resolved_binary,
+                godot_project_path,
+                resource_paths=resource_paths,
+                import_returncode=import_returncode,
+                import_output=import_output,
+                previous_output=import_output,
+                boot_frames=boot_frames,
+                timeout=timeout,
+            )
         return GodotValidationReport(
             status="passed",
             godot_binary=resolved_binary,
@@ -272,6 +315,7 @@ def validate_generated_godot_project(
             import_output=import_output,
             output=import_output,
             message=_import_only_message(import_returncode, len(importable_asset_paths), len(resource_paths)),
+            boot_frames=boot_frames,
             output_issues=(),
         )
 
@@ -297,6 +341,7 @@ def validate_generated_godot_project(
             )
         except subprocess.TimeoutExpired as exc:
             output = exc.output.decode("utf-8", errors="replace") if isinstance(exc.output, bytes) else str(exc.output or "")
+            combined_output = _combine_output(import_output, output)
             return GodotValidationReport(
                 status="failed",
                 godot_binary=resolved_binary,
@@ -304,8 +349,10 @@ def validate_generated_godot_project(
                 resource_paths=resource_paths,
                 import_returncode=import_returncode,
                 import_output=import_output,
-                output=output,
+                output=combined_output,
                 message=f"Headless Godot validation timed out after {timeout} seconds.",
+                boot_frames=boot_frames,
+                output_issues=detect_godot_output_issues(combined_output),
             )
 
     combined_output = _combine_output(import_output, result.stdout)
@@ -314,7 +361,7 @@ def validate_generated_godot_project(
         "passed" if result.returncode == 0 and not output_issues else "failed"
     )
 
-    return GodotValidationReport(
+    resource_report = GodotValidationReport(
         status=status,
         godot_binary=resolved_binary,
         project_path=godot_project_path,
@@ -324,7 +371,21 @@ def validate_generated_godot_project(
         import_output=import_output,
         output=combined_output,
         message=_validation_message(result.returncode, len(resource_paths), output_issues),
+        boot_frames=boot_frames,
         output_issues=output_issues,
+    )
+    if status == "failed" or boot_frames == 0:
+        return resource_report
+
+    return _run_godot_boot_validation(
+        resolved_binary,
+        godot_project_path,
+        resource_paths=resource_paths,
+        import_returncode=import_returncode,
+        import_output=import_output,
+        previous_output=combined_output,
+        boot_frames=boot_frames,
+        timeout=timeout,
     )
 
 
@@ -428,6 +489,92 @@ def _run_godot_import_without_audio(
             validation_project_path,
             timeout=timeout,
         )
+
+
+def _run_godot_boot_validation(
+    resolved_binary: str,
+    godot_project_path: str,
+    *,
+    resource_paths: tuple[str, ...],
+    import_returncode: int | None,
+    import_output: str,
+    previous_output: str,
+    boot_frames: int,
+    timeout: int,
+) -> GodotValidationReport:
+    try:
+        boot_result = _run_godot_boot(
+            resolved_binary,
+            godot_project_path,
+            boot_frames=boot_frames,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        boot_output = exc.output.decode("utf-8", errors="replace") if isinstance(exc.output, bytes) else str(exc.output or "")
+        combined_output = _combine_output(previous_output, boot_output)
+        output_issues = detect_godot_output_issues(combined_output)
+        return GodotValidationReport(
+            status="failed",
+            godot_binary=resolved_binary,
+            project_path=godot_project_path,
+            resource_paths=resource_paths,
+            import_returncode=import_returncode,
+            import_output=import_output,
+            boot_output=boot_output,
+            output=combined_output,
+            message=f"Headless Godot boot timed out after {timeout} seconds.",
+            boot_frames=boot_frames,
+            output_issues=output_issues,
+        )
+
+    boot_output = boot_result.stdout
+    combined_output = _combine_output(previous_output, boot_output)
+    output_issues = detect_godot_output_issues(combined_output)
+    status: GodotValidationStatus = (
+        "passed" if boot_result.returncode == 0 and not output_issues else "failed"
+    )
+    return GodotValidationReport(
+        status=status,
+        godot_binary=resolved_binary,
+        project_path=godot_project_path,
+        resource_paths=resource_paths,
+        returncode=boot_result.returncode,
+        import_returncode=import_returncode,
+        boot_returncode=boot_result.returncode,
+        import_output=import_output,
+        boot_output=boot_output,
+        output=combined_output,
+        message=_boot_message(boot_result.returncode, boot_frames, output_issues),
+        boot_frames=boot_frames,
+        output_issues=output_issues,
+    )
+
+
+def _run_godot_boot(
+    resolved_binary: str,
+    godot_project_path: str,
+    *,
+    boot_frames: int,
+    timeout: int,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            resolved_binary,
+            "--headless",
+            "--disable-vsync",
+            "--fixed-fps",
+            "60",
+            "--path",
+            godot_project_path,
+            "--quit-after",
+            str(boot_frames),
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=timeout,
+    )
 
 
 def _ignore_audio_import_validation_files(_directory: str, names: list[str]) -> set[str]:
@@ -573,4 +720,28 @@ def _validation_script(resource_paths: tuple[str, ...]) -> str:
         "\tfor failure in failures:\n"
         "\t\tpush_error(\"GM2Godot generated resource failed to load: \" + str(failure))\n"
         "\tquit(1)\n"
+    )
+
+
+def _boot_message(
+    returncode: int,
+    boot_frames: int,
+    output_issues: tuple[GodotOutputIssue, ...],
+) -> str:
+    if output_issues:
+        error_count = sum(1 for issue in output_issues if issue.severity == "error")
+        warning_count = sum(1 for issue in output_issues if issue.severity == "warning")
+        return (
+            "Headless Godot boot reported "
+            f"{error_count} error(s) and {warning_count} warning(s) while running "
+            f"the project main scene for {boot_frames} frame(s)."
+        )
+    if returncode == 0:
+        return (
+            "Headless Godot boot ran the project main scene for "
+            f"{boot_frames} frame(s) without warning/error output."
+        )
+    return (
+        "Headless Godot boot exited with code "
+        f"{returncode} while running the project main scene for {boot_frames} frame(s)."
     )

--- a/tests/fixtures/golden/basic_scripts/expected_snapshot.json
+++ b/tests/fixtures/golden/basic_scripts/expected_snapshot.json
@@ -7,7 +7,7 @@
   },
   "fixture": "basic_scripts",
   "hashes": {
-    "gm2godot/gml_runtime.gd": "sha256:0e5e62e5de8be1947cc4814f8d495245c53c0dc00f73a2d658604d964a0e5837",
+    "gm2godot/gml_runtime.gd": "sha256:a788a6dc42d5c19fa6c6cef3d67fa891c9b67edc1e6fdf350444a2ec9785d003",
     "gm2godot/managers/gm_assets.gd": "sha256:4121345bd843a0bb3487fcba4756a3b2f18700685f5858db5f62f8992d96a76f",
     "gm2godot/managers/gm_async.gd": "sha256:d0a73997476f0e889892f85a6c343fc5b44fecdf9fa547e943902632aedf9df3",
     "gm2godot/managers/gm_audio.gd": "sha256:995a1df58e7f8ad03fa8ed7e9a195cdcfcf256643d73ac06a88bb6bbec82fba4",

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -35,9 +35,9 @@ class TestCIWorkflows(unittest.TestCase):
 
         install_index = content.index("- name: Install pinned Godot")
         self.assertIn("GODOT_BIN=$godot_bin", content)
-        self.assertLess(install_index, content.index("- name: Run SimpleTopDown conversion test"))
+        self.assertLess(install_index, content.index("- name: Run SimpleTopDown conversion and boot-log test"))
         self.assertLess(install_index, content.index("- name: Run TCC conversion test"))
-        self.assertLess(install_index, content.index("- name: Run Monophobia conversion test"))
+        self.assertLess(install_index, content.index("- name: Run Monophobia conversion and boot-log test"))
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,7 @@ if PROJECT_ROOT not in sys.path:
 
 from src import cli
 from src.conversion.diagnostics import DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH
+from src.conversion.godot_validation import GodotValidationReport
 
 
 class TestCLIReports(unittest.TestCase):
@@ -179,6 +180,48 @@ class TestCLIReports(unittest.TestCase):
         exit_code = cli.main(["validate", "--godot-project", godot_dir, "--fail-on-unsupported"])
 
         self.assertEqual(exit_code, 2)
+
+    def test_validate_passes_boot_frame_count_to_godot_validation(self) -> None:
+        godot_dir = os.path.join(self.temp_dir, "godot")
+        report_root = os.path.join(godot_dir, "gm2godot")
+        os.makedirs(report_root)
+        with open(os.path.join(godot_dir, "project.godot"), "w", encoding="utf-8") as project_file:
+            project_file.write('[application]\nconfig/name="Demo"\n')
+        with open(os.path.join(godot_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH), "w", encoding="utf-8") as report_file:
+            json.dump(
+                {"summary": {"info": 0, "warning": 0, "error": 0, "total": 0}, "diagnostics": []},
+                report_file,
+            )
+
+        validation_report = GodotValidationReport(
+            status="passed",
+            godot_binary="/tmp/fake-godot",
+            project_path=godot_dir,
+            resource_paths=(),
+            message="Headless Godot boot ran the project main scene for 5 frame(s).",
+            boot_frames=5,
+        )
+        with (
+            patch("src.cli.validate_generated_godot_project", return_value=validation_report) as validate_project,
+            patch("src.cli.write_godot_validation_report") as write_report,
+        ):
+            exit_code = cli.main([
+                "validate",
+                "--godot-project",
+                godot_dir,
+                "--godot-bin",
+                "/tmp/fake-godot",
+                "--godot-boot-frames",
+                "5",
+            ])
+
+        self.assertEqual(exit_code, 0)
+        validate_project.assert_called_once_with(
+            godot_dir,
+            godot_binary="/tmp/fake-godot",
+            boot_frames=5,
+        )
+        write_report.assert_called_once_with(godot_dir, validation_report)
 
     def test_convert_can_write_selected_reports_and_fail_warning_threshold(self) -> None:
         gm_dir = os.path.join(self.temp_dir, "gm")

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -2311,6 +2311,9 @@ class TestGMLRuntimeScript(unittest.TestCase):
         self.assertIn('return gml_error("GML array index out of bounds")', GML_RUNTIME_SCRIPT)
 
     def test_runtime_array_set_mutates_reference_without_copying(self):
+        self.assertIn('return gml_unsupported_type_error("GML array set", array_value)', GML_RUNTIME_SCRIPT)
+        self.assertIn("if resolved_index >= array_value.size():", GML_RUNTIME_SCRIPT)
+        self.assertIn("array_value.resize(resolved_index + 1)", GML_RUNTIME_SCRIPT)
         self.assertIn("array_value[resolved_index] = value", GML_RUNTIME_SCRIPT)
         self.assertIn("return value", GML_RUNTIME_SCRIPT)
         self.assertNotIn("array_value.duplicate", GML_RUNTIME_SCRIPT)

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -3049,6 +3049,22 @@ class TestGMLStatementTranspiler(unittest.TestCase):
             "GMRuntime.gml_array_set(items, _gml_array_index_0, "
             "GMRuntime.gml_add(GMRuntime.gml_array_get(items, _gml_array_index_0), value))",
         )
+        self.assertEqual(
+            transpile_gml_code('global.telephonenumber[3] = "";', indent=""),
+            'var _gml_array_target_0 = GMRuntime.gml_selector_get(GMRuntime.gml_global_scope(), "telephonenumber")\n'
+            "if GMRuntime.is_undefined(_gml_array_target_0):\n"
+            "\t_gml_array_target_0 = []\n"
+            'GMRuntime.gml_array_set(_gml_array_target_0, 3, "")\n'
+            'GMRuntime.gml_selector_set(GMRuntime.gml_global_scope(), "telephonenumber", _gml_array_target_0)',
+        )
+        self.assertEqual(
+            transpile_gml_code("player.inventory[slot] = item;", indent=""),
+            'var _gml_array_target_0 = GMRuntime.gml_selector_get(player, "inventory")\n'
+            "if GMRuntime.is_undefined(_gml_array_target_0):\n"
+            "\t_gml_array_target_0 = []\n"
+            "GMRuntime.gml_array_set(_gml_array_target_0, slot, item)\n"
+            'GMRuntime.gml_selector_set(player, "inventory", _gml_array_target_0)',
+        )
 
     def test_transpiles_multidimensional_array_assignments(self):
         self.assertEqual(

--- a/tests/test_godot_validation.py
+++ b/tests/test_godot_validation.py
@@ -317,6 +317,109 @@ class TestGodotValidation(unittest.TestCase):
         self.assertEqual(len(report.output_issues), 1)
         self.assertEqual(report.output_issues[0].severity, "error")
 
+    def test_boot_validation_runs_main_scene_for_requested_frames(self) -> None:
+        project_dir = self._write_project()
+        args_file = self.temp_dir / "boot-args.txt"
+        fake_godot = self.temp_dir / "fake-godot"
+        fake_godot.write_text(
+            "#!/bin/sh\n"
+            "is_boot=0\n"
+            "is_script=0\n"
+            "for arg in \"$@\"; do\n"
+            "  if [ \"$arg\" = \"--quit-after\" ]; then is_boot=1; fi\n"
+            "  if [ \"$arg\" = \"--script\" ]; then is_script=1; fi\n"
+            "done\n"
+            "if [ \"$is_boot\" = \"1\" ]; then\n"
+            f"  printf '%s\\n' \"$@\" > '{args_file}'\n"
+            "  printf '%s\\n' 'GM2GODOT_BOOT_OK'\n"
+            "  exit 0\n"
+            "fi\n"
+            "if [ \"$is_script\" = \"1\" ]; then\n"
+            "  printf '%s\\n' 'GM2GODOT_VALIDATION_OK 2'\n"
+            "  exit 0\n"
+            "fi\n"
+            "printf '%s\\n' 'unexpected Godot invocation'\n"
+            "exit 8\n",
+            encoding="utf-8",
+        )
+        fake_godot.chmod(0o755)
+
+        report = validate_generated_godot_project(
+            str(project_dir),
+            godot_binary=str(fake_godot),
+            boot_frames=4,
+        )
+
+        self.assertEqual(report.status, "passed", report.output)
+        self.assertEqual(report.boot_frames, 4)
+        self.assertEqual(report.boot_returncode, 0)
+        self.assertIn("GM2GODOT_VALIDATION_OK 2", report.output)
+        self.assertIn("GM2GODOT_BOOT_OK", report.boot_output)
+        boot_args = args_file.read_text(encoding="utf-8").splitlines()
+        self.assertIn("--headless", boot_args)
+        self.assertIn("--fixed-fps", boot_args)
+        self.assertIn("--path", boot_args)
+        self.assertIn("--quit-after", boot_args)
+        self.assertIn("4", boot_args)
+        self.assertNotIn("--script", boot_args)
+
+    def test_boot_validation_fails_on_runtime_warning_with_zero_exit(self) -> None:
+        project_dir = self._write_project()
+        fake_godot = self.temp_dir / "fake-godot"
+        fake_godot.write_text(
+            "#!/bin/sh\n"
+            "for arg in \"$@\"; do\n"
+            "  if [ \"$arg\" = \"--quit-after\" ]; then\n"
+            "    printf '%s\\n' 'WARNING: Runtime warning from main scene.'\n"
+            "    exit 0\n"
+            "  fi\n"
+            "done\n"
+            "printf '%s\\n' 'GM2GODOT_VALIDATION_OK 2'\n"
+            "exit 0\n",
+            encoding="utf-8",
+        )
+        fake_godot.chmod(0o755)
+
+        report = validate_generated_godot_project(
+            str(project_dir),
+            godot_binary=str(fake_godot),
+            boot_frames=2,
+        )
+
+        self.assertEqual(report.status, "failed")
+        self.assertEqual(report.boot_returncode, 0)
+        self.assertEqual(len(report.output_issues), 1)
+        self.assertEqual(report.output_issues[0].severity, "warning")
+        self.assertIn("boot reported 0 error(s) and 1 warning(s)", report.message)
+
+    def test_boot_validation_fails_on_runtime_nonzero_exit(self) -> None:
+        project_dir = self._write_project()
+        fake_godot = self.temp_dir / "fake-godot"
+        fake_godot.write_text(
+            "#!/bin/sh\n"
+            "for arg in \"$@\"; do\n"
+            "  if [ \"$arg\" = \"--quit-after\" ]; then\n"
+            "    printf '%s\\n' 'Runtime exited without warning lines.'\n"
+            "    exit 13\n"
+            "  fi\n"
+            "done\n"
+            "printf '%s\\n' 'GM2GODOT_VALIDATION_OK 2'\n"
+            "exit 0\n",
+            encoding="utf-8",
+        )
+        fake_godot.chmod(0o755)
+
+        report = validate_generated_godot_project(
+            str(project_dir),
+            godot_binary=str(fake_godot),
+            boot_frames=2,
+        )
+
+        self.assertEqual(report.status, "failed")
+        self.assertEqual(report.boot_returncode, 13)
+        self.assertEqual(report.output_issues, ())
+        self.assertIn("boot exited with code 13", report.message)
+
     @unittest.skipIf(find_godot_binary() is None, "Godot binary not available")
     def test_headless_godot_validation_loads_generated_resources(self) -> None:
         project_dir = self._write_project()
@@ -340,6 +443,18 @@ class TestGodotValidation(unittest.TestCase):
         self.assertIn("GM2GODOT_VALIDATION_OK", report.output)
 
     @unittest.skipIf(find_godot_binary() is None, "Godot binary not available")
+    def test_headless_godot_boots_main_scene_without_warnings(self) -> None:
+        project_dir = self._write_project()
+
+        report = validate_generated_godot_project(str(project_dir), boot_frames=2)
+
+        self.assertEqual(report.status, "passed", report.output)
+        self.assertEqual(report.boot_frames, 2)
+        self.assertEqual(report.boot_returncode, 0, report.boot_output)
+        self.assertEqual(report.output_issues, (), report.output)
+        self.assertIn("main scene", report.message)
+
+    @unittest.skipIf(find_godot_binary() is None, "Godot binary not available")
     def test_cli_validate_writes_godot_validation_report(self) -> None:
         project_dir = self._write_project()
         (project_dir / "gm2godot").mkdir()
@@ -356,6 +471,7 @@ class TestGodotValidation(unittest.TestCase):
         report = json.loads(report_path.read_text(encoding="utf-8"))
         self.assertEqual(report["status"], "passed")
         self.assertEqual(report["resource_count"], 2)
+        self.assertEqual(report["boot_frames"], 0)
         self.assertEqual(report["output_issue_count"], 0)
 
 

--- a/tests/test_monophobia_conversion.py
+++ b/tests/test_monophobia_conversion.py
@@ -156,9 +156,10 @@ class TestMonophobiaConversion(unittest.TestCase):
             find_godot_binary(),
             "Godot binary is required for Monophobia strict validation.",
         )
-        report = validate_generated_godot_project(self.godot_dir, timeout=180)
+        report = validate_generated_godot_project(self.godot_dir, timeout=180, boot_frames=2)
 
         self.assertEqual(report.status, "passed", report.message + "\n" + report.output)
+        self.assertEqual(report.boot_returncode, 0, report.boot_output)
         self.assertEqual(report.output_issues, (), report.message + "\n" + report.output)
 
 

--- a/tests/test_simple_topdown_conversion.py
+++ b/tests/test_simple_topdown_conversion.py
@@ -163,9 +163,10 @@ class TestSimpleTopDownConversion(unittest.TestCase):
 
     @unittest.skipIf(find_godot_binary() is None, "Godot binary not available")
     def test_generated_project_has_no_godot_warnings_or_errors(self) -> None:
-        report = validate_generated_godot_project(self.godot_dir)
+        report = validate_generated_godot_project(self.godot_dir, boot_frames=2)
 
         self.assertEqual(report.status, "passed", report.output)
+        self.assertEqual(report.boot_returncode, 0, report.boot_output)
         self.assertEqual(report.output_issues, (), report.output)
 
 


### PR DESCRIPTION
## Summary
- add opt-in Godot main-scene boot validation with boot-specific report fields and CLI `--godot-boot-frames`
- enforce boot-log-clean checks for SimpleTopDown and Monophobia in the external fixture workflow
- fix Monophobia startup by materializing member-backed arrays and resizing arrays on indexed writes

Fixes #672.

## Verification
- `./venv/bin/pyright --warnings`
- `./venv/bin/ruff check .`
- `git diff --check`
- `./venv/bin/python -m unittest`
- `SIMPLE_TOPDOWN_PROJECT_PATH=/Users/infi/Documents/Github/GM2GodotGameTest_SimpleTopDown GODOT_BIN=/tmp/godot-4.4.1-macos/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_simple_topdown_conversion -v`
- `MONOPHOBIA_PROJECT_PATH=/Users/infi/Documents/Github/Monophobia GODOT_BIN=/tmp/godot-4.4.1-macos/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_monophobia_conversion -v`
- `TCC_PROJECT_PATH=/Users/infi/Documents/Github/TheColorfulCreature GODOT_BIN=/tmp/godot-4.4.1-macos/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_tcc_conversion -v`
