### PR TITLE
Load named collision event sources

### DIFF
--- a/src/conversion/events/base.py
+++ b/src/conversion/events/base.py
@@ -19,8 +19,11 @@ class EventMapping:
         params: Function parameter string (e.g. "", "delta", "event").
         sort_key: Canonical ordering in the generated .gd file.
         gml_filename: Expected GML source filename (e.g. "Create_0.gml").
+        fallback_gml_filenames: Additional source filenames to try when the
+            preferred GameMaker event source file is not present.
     """
     godot_func: str
     params: str
     sort_key: int
     gml_filename: str
+    fallback_gml_filenames: tuple[str, ...] = ()

--- a/src/conversion/events/mappings/core.py
+++ b/src/conversion/events/mappings/core.py
@@ -44,7 +44,15 @@ def map_collision_event(event: JsonDict, gml_filename: str) -> EventMapping:
     if collision_obj and isinstance(collision_obj, dict):
         collision_data = cast(JsonDict, collision_obj)
         obj_name = cast(str, collision_data.get('name', 'unknown'))
-        return EventMapping(f"_on_collision_{obj_name}", "", 13, gml_filename)
+        named_filename = f"Collision_{obj_name}.gml"
+        fallback_filenames = () if named_filename == gml_filename else (gml_filename,)
+        return EventMapping(
+            f"_on_collision_{obj_name}",
+            "",
+            13,
+            named_filename,
+            fallback_filenames,
+        )
     return EventMapping("_on_collision", "", 13, gml_filename)
 
 

--- a/src/conversion/objects.py
+++ b/src/conversion/objects.py
@@ -111,6 +111,14 @@ class ObjectEventSource(TypedDict):
     inherited_event_call: str | None
 
 
+def _event_source_filenames(mapping: EventMapping) -> tuple[str, ...]:
+    filenames: list[str] = []
+    for filename in (mapping.gml_filename, *mapping.fallback_gml_filenames):
+        if filename and filename not in filenames:
+            filenames.append(filename)
+    return tuple(filenames)
+
+
 def _line_offset_for_block(script_content: str, block: str) -> int:
     script_lines = script_content.splitlines()
     block_lines = block.splitlines()
@@ -529,8 +537,9 @@ class ObjectConverter(BaseConverter):
             if mapping is None or not mapping.gml_filename:
                 continue
 
-            source_path = os.path.join(object_dir, mapping.gml_filename)
-            if not os.path.isfile(source_path):
+            source_path = self._event_source_path(object_dir, mapping)
+            if source_path is None:
+                self._record_missing_event_source(object_name, object_dir, mapping)
                 continue
 
             try:
@@ -622,6 +631,40 @@ class ObjectConverter(BaseConverter):
                 self._safe_log(message)
 
         return code_bodies, instance_variables, source_maps
+
+    def _event_source_path(self, object_dir: str, mapping: EventMapping) -> str | None:
+        for filename in _event_source_filenames(mapping):
+            source_path = os.path.join(object_dir, filename)
+            if os.path.isfile(source_path):
+                return source_path
+        return None
+
+    def _record_missing_event_source(
+        self,
+        object_name: str,
+        object_dir: str,
+        mapping: EventMapping,
+    ) -> None:
+        if not mapping.gml_filename.startswith("Collision_"):
+            return
+        filenames = _event_source_filenames(mapping)
+        message = (
+            "Warning: Missing GameMaker collision event code file for "
+            f"{object_name}/{mapping.godot_func}; looked for {', '.join(filenames)}"
+        )
+        if self.diagnostics is not None:
+            self.diagnostics.add(
+                "warning",
+                "GM2GD-OBJECT-MISSING-COLLISION-EVENT-SOURCE",
+                message,
+                source_path=os.path.join(object_dir, filenames[0]) if filenames else object_dir,
+                resource=object_name,
+                resource_type="object",
+                event=mapping.godot_func,
+                workaround="Add the missing GameMaker collision event GML file or remove the stale event metadata.",
+            )
+        with self._lock:
+            self.log_callback(message)
 
     def _record_event_source_diagnostics(
         self,

--- a/tests/conversion/events/test_collision_events.py
+++ b/tests/conversion/events/test_collision_events.py
@@ -22,7 +22,8 @@ class TestCollisionEvents(unittest.TestCase):
         self.assertEqual(mapping.godot_func, "_on_collision_o_enemy")
         self.assertEqual(mapping.params, "")
         self.assertEqual(mapping.sort_key, 13)
-        self.assertEqual(mapping.gml_filename, "Collision_0.gml")
+        self.assertEqual(mapping.gml_filename, "Collision_o_enemy.gml")
+        self.assertEqual(mapping.fallback_gml_filenames, ("Collision_0.gml",))
 
     def test_maps_collision_without_target_object(self):
         mapping = map_event({"eventType": 4, "eventNum": 0})
@@ -32,6 +33,7 @@ class TestCollisionEvents(unittest.TestCase):
         self.assertEqual(mapping.params, "")
         self.assertEqual(mapping.sort_key, 13)
         self.assertEqual(mapping.gml_filename, "Collision_0.gml")
+        self.assertEqual(mapping.fallback_gml_filenames, ())
 
     def test_generates_collision_stubs(self):
         content = generate_script_content([

--- a/tests/test_event_mapping.py
+++ b/tests/test_event_mapping.py
@@ -164,7 +164,8 @@ class TestMapEventDynamic(unittest.TestCase):
         })
         self.assertEqual(m.godot_func, "_on_collision_o_bullet")
         self.assertEqual(m.sort_key, 13)
-        self.assertEqual(m.gml_filename, "Collision_0.gml")
+        self.assertEqual(m.gml_filename, "Collision_o_bullet.gml")
+        self.assertEqual(m.fallback_gml_filenames, ("Collision_0.gml",))
 
     def test_collision_without_object(self):
         m = map_event({"eventType": 4, "eventNum": 0})

--- a/tests/test_monophobia_conversion.py
+++ b/tests/test_monophobia_conversion.py
@@ -151,6 +151,18 @@ class TestMonophobiaConversion(unittest.TestCase):
 
         self.assertEqual(player_background_failures, [])
 
+    def test_named_collision_event_files_are_transpiled(self) -> None:
+        player = self._read_generated_file("objects", "o_player", "o_player.gd")
+        bullet = self._read_generated_file("objects", "o_bullet", "o_bullet.gd")
+
+        self.assertIn('{"target_object": "o_enemyroad", "method": "_on_collision_o_enemyroad"}', player)
+        self.assertIn("func _on_collision_o_enemyroad():", player)
+        self.assertIn('GMRuntime.gml_audio_play_sound(GMRuntime.gml_asset_get_index("snd_carstop"), 0, 0)', player)
+        self.assertIn("func _on_collision_o_murderer():", player)
+        self.assertIn('GMRuntime.gml_selector_set(GMRuntime.gml_global_scope(), "gas", 0)', player)
+        self.assertIn('{"target_object": "o_girl", "method": "_on_collision_o_girl"}', bullet)
+        self.assertIn("func _on_collision_o_girl():\n\tGMRuntime.gml_instance_destroy(self)", bullet)
+
     def test_generated_project_has_no_godot_warnings_or_errors(self) -> None:
         self.assertIsNotNone(
             find_godot_binary(),

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1149,6 +1149,74 @@ class TestScriptGeneration(unittest.TestCase):
         self.assertIn('{"target_object": "o_bullet", "method": "_on_collision_o_bullet"}', content)
         self.assertIn("func _on_collision_o_bullet():", content)
 
+    def test_named_collision_event_source_file_transpiles_body(self):
+        self._setup_object("o_test", event_list=[
+            {"eventType": 4, "eventNum": 0, "collisionObjectId": {"name": "o_bullet"}}
+        ])
+        with open(
+            os.path.join(self.gm_dir, "objects", "o_test", "Collision_o_bullet.gml"),
+            "w",
+            encoding="utf-8",
+        ) as f:
+            f.write("collision_seen = true;")
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        gd_path = os.path.join(self.godot_dir, "objects", "o_test", "o_test.gd")
+        with open(gd_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        self.assertIn("func _on_collision_o_bullet():", content)
+        self.assertIn("\tcollision_seen = true", content)
+
+    def test_collision_event_source_falls_back_to_numeric_filename(self):
+        self._setup_object("o_test", event_list=[
+            {"eventType": 4, "eventNum": 0, "collisionObjectId": {"name": "o_bullet"}}
+        ])
+        with open(
+            os.path.join(self.gm_dir, "objects", "o_test", "Collision_0.gml"),
+            "w",
+            encoding="utf-8",
+        ) as f:
+            f.write("legacy_collision_seen = true;")
+
+        converter = self._make_converter()
+        converter.convert_all()
+
+        gd_path = os.path.join(self.godot_dir, "objects", "o_test", "o_test.gd")
+        with open(gd_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        self.assertIn("func _on_collision_o_bullet():", content)
+        self.assertIn("\tlegacy_collision_seen = true", content)
+
+    def test_missing_collision_event_source_records_diagnostic(self):
+        self._setup_object("o_test", event_list=[
+            {"eventType": 4, "eventNum": 0, "collisionObjectId": {"name": "o_bullet"}}
+        ])
+        diagnostics = DiagnosticCollector()
+        converter = ObjectConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=lambda msg: self.logs.append(msg),
+            progress_callback=lambda v: None,
+            conversion_running=lambda: True,
+            diagnostics=diagnostics,
+        )
+        converter.convert_all()
+
+        missing_diagnostics = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-OBJECT-MISSING-COLLISION-EVENT-SOURCE"
+        ]
+        self.assertEqual(len(missing_diagnostics), 1)
+        self.assertEqual(missing_diagnostics[0].resource, "o_test")
+        self.assertEqual(missing_diagnostics[0].event, "_on_collision_o_bullet")
+        self.assertIn("Collision_o_bullet.gml", missing_diagnostics[0].message)
+        self.assertIn("Collision_0.gml", missing_diagnostics[0].message)
+
     def test_script_with_multiple_events(self):
         """Multiple events should produce multiple function stubs."""
         self._setup_object("o_test", event_list=[


### PR DESCRIPTION
## Summary
- prefer GameMaker collision event source files named after their target object, such as `Collision_o_enemy.gml`
- preserve legacy numeric fallback loading via `Collision_0.gml`
- add a structured missing-source diagnostic when collision metadata has no matching event source
- assert Monophobia named collision handlers are transpiled into generated object scripts

Fixes #670.

## Verification
- `./venv/bin/pyright --warnings`
- `./venv/bin/ruff check .`
- `git diff --check`
- `./venv/bin/python -m unittest tests.test_event_mapping tests.conversion.events.test_collision_events tests.test_objects -v`
- `./venv/bin/python -m unittest`
- `MONOPHOBIA_PROJECT_PATH=/Users/infi/Documents/Github/Monophobia GODOT_BIN=/tmp/godot-4.4.1-macos/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_monophobia_conversion -v`
