### PR TITLE
Downgrade non-actionable conversion diagnostics

### DIFF
--- a/Languages/de.json
+++ b/Languages/de.json
@@ -86,8 +86,8 @@
 "Console_Convertor_Fonts_Stopped" : "Schriftarten-Konvertierung gestoppt.",
 "Console_Convertor_Fonts_SizeNote" : "  Hinweis: {name} Groesse {size}px muss auf der Node-/Theme-Ebene in Godot gesetzt werden.",
 "Console_Convertor_Fonts_ParseError" : "Warnung: {yy_path} konnte nicht gelesen werden, Schriftart wird uebersprungen.",
-"Console_Convertor_Fonts_TTFMissing" : "Warnung: {name} hat includeTTF=true, aber TTF-Datei '{ttf_name}' nicht gefunden. Fallback auf SystemFont.",
-"Console_Convertor_Fonts_SystemFontFallback" : "Warnung: Schriftart '{font_name}' fuer {name} nicht auf dem System gefunden. SystemFont-Referenz erstellt. Installieren Sie die Schriftart und fuehren Sie erneut aus, oder fuegen Sie die Schriftartdatei manuell zu fonts/ hinzu.",
+"Console_Convertor_Fonts_TTFMissing" : "Info: {name} hat includeTTF=true, aber TTF-Datei '{ttf_name}' nicht gefunden. Fallback auf SystemFont.",
+"Console_Convertor_Fonts_SystemFontFallback" : "Info: Schriftart '{font_name}' fuer {name} nicht auf dem System gefunden. SystemFont-Referenz erstellt. Installieren Sie die Schriftart und fuehren Sie erneut aus, oder fuegen Sie die Schriftartdatei manuell zu fonts/ hinzu.",
 
 "Console_Convertor_Tilesets" : "Tilesets werden konvertiert...",
 "Console_Convertor_Tilesets_Complete" : "Tileset-Konvertierung abgeschlossen.",

--- a/Languages/eng.json
+++ b/Languages/eng.json
@@ -86,8 +86,8 @@
 "Console_Convertor_Fonts_Stopped" : "Font conversion stopped.",
 "Console_Convertor_Fonts_SizeNote" : "  Note: {name} size {size}px must be set at the node/theme level in Godot.",
 "Console_Convertor_Fonts_ParseError" : "Warning: Could not parse {yy_path}, skipping font.",
-"Console_Convertor_Fonts_TTFMissing" : "Warning: {name} has includeTTF=true but TTF file '{ttf_name}' not found. Falling back to SystemFont.",
-"Console_Convertor_Fonts_SystemFontFallback" : "Warning: Font '{font_name}' for {name} not found on system. Created SystemFont reference. Install the font and re-run, or manually add the font file to fonts/.",
+"Console_Convertor_Fonts_TTFMissing" : "Info: {name} has includeTTF=true but TTF file '{ttf_name}' not found. Falling back to SystemFont.",
+"Console_Convertor_Fonts_SystemFontFallback" : "Info: Font '{font_name}' for {name} not found on system. Created SystemFont reference. Install the font and re-run, or manually add the font file to fonts/.",
 
 "Console_Convertor_Tilesets" : "Converting tilesets...",
 "Console_Convertor_Tilesets_Complete" : "Tileset conversion completed.",

--- a/src/conversion/diagnostics.py
+++ b/src/conversion/diagnostics.py
@@ -241,6 +241,8 @@ def _escape_markdown_table(value: str) -> str:
 
 def _severity_from_log_message(message: str) -> DiagnosticSeverity | None:
     normalized = message.lower()
+    if normalized.startswith("info:"):
+        return "info"
     if normalized.startswith("warning:"):
         return "warning"
     if normalized.startswith("error:"):

--- a/src/conversion/project_manifest.py
+++ b/src/conversion/project_manifest.py
@@ -9,7 +9,7 @@ from typing import Callable, Iterable, Literal, Mapping, cast
 from src.conversion.type_defs import JsonDict, JsonList
 
 
-ProjectManifestSeverity = Literal["warning", "error"]
+ProjectManifestSeverity = Literal["info", "warning", "error"]
 
 _RESOURCE_TYPE_KIND = {
     "GMAnimationCurve": "animcurves",
@@ -270,7 +270,7 @@ def unsupported_project_option_diagnostics(
             continue
         diagnostics.append(
             ProjectManifestDiagnostic(
-                severity="warning",
+                severity="info",
                 code="GM2GD-PROJECT-OPTION-UNSUPPORTED",
                 message=(
                     "Unsupported GameMaker project option "

--- a/src/conversion/project_settings.py
+++ b/src/conversion/project_settings.py
@@ -156,7 +156,7 @@ class ProjectSettingsConverter(BaseConverter):
                 target_platform=self.gm_platform,
                 supported_keys=self._supported_project_option_keys(),
             ):
-                self._safe_log(f"Warning: {diagnostic.message}")
+                self._safe_log(f"{diagnostic.severity.title()}: {diagnostic.message}")
 
             with open(project_godot_path, 'w', encoding='utf-8') as file:
                 file.write(content)

--- a/src/conversion/resource_models.py
+++ b/src/conversion/resource_models.py
@@ -11,7 +11,7 @@ from src.conversion.project_manifest import GameMakerProjectManifest, ProjectRes
 from src.conversion.type_defs import JsonDict, JsonList
 
 
-ResourceModelSeverity = Literal["warning", "error"]
+ResourceModelSeverity = Literal["info", "warning", "error"]
 
 
 def _empty_json_dict() -> JsonDict:

--- a/src/conversion/room_creation_code.py
+++ b/src/conversion/room_creation_code.py
@@ -64,7 +64,7 @@ def resolve_room_creation_code(
 
     if metadata.has_code and not metadata.exists and warn_callback is not None:
         warn_callback(
-            "Warning: Missing GameMaker room creation code file for room {room}: {path}".format(
+            "Info: Missing GameMaker room creation code file for room {room}: {path}".format(
                 room=room.name,
                 path=metadata.source_path,
             )
@@ -100,7 +100,7 @@ def resolve_instance_creation_code(
 
     if metadata.has_code and not metadata.exists and warn_callback is not None:
         warn_callback(
-            "Warning: Missing GameMaker instance creation code file for room {room}, "
+            "Info: Missing GameMaker instance creation code file for room {room}, "
             "instance {instance}: {path}".format(
                 room=room.name,
                 instance=instance_name,

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -36,6 +36,17 @@ class TestDiagnosticCollector(unittest.TestCase):
         self.assertEqual(recorded[0].severity, "warning")
         self.assertEqual(recorded[0].code, "GM2GD-WARNING")
 
+    def test_info_log_wrapper_records_informational_diagnostic(self):
+        diagnostics = DiagnosticCollector()
+        wrapped_log = diagnostics.wrap_log_callback(lambda message: None)
+
+        wrapped_log("Info: Missing optional GameMaker metadata file; fallback metadata preserved.")
+
+        recorded = diagnostics.diagnostics()
+        self.assertEqual(len(recorded), 1)
+        self.assertEqual(recorded[0].severity, "info")
+        self.assertEqual(recorded[0].code, "GM2GD-WARNING")
+
     def test_transpile_failure_extracts_api_and_issue_metadata(self):
         diagnostics = DiagnosticCollector()
 

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -109,12 +109,14 @@ class TestFontConverterSystemFont(unittest.TestCase):
         self.assertIn("font_weight = 400", content)
         self.assertIn("antialiasing = 1", content)
 
-    def test_logs_warning_for_missing_font(self):
+    def test_logs_info_for_missing_font(self):
         converter = self._make_converter()
         converter.convert_all()
-        warnings = [l for l in self.logs if "Warning:" in l or "warning:" in l.lower()]
-        self.assertTrue(len(warnings) > 0,
-                        "Expected a warning when font is not found on system")
+        info_logs = [l for l in self.logs if l.startswith("Info:")]
+        warnings = [l for l in self.logs if l.startswith("Warning:")]
+        self.assertTrue(info_logs,
+                        "Expected an informational fallback log when font is not found on system")
+        self.assertEqual(warnings, [])
 
 
 class TestFontConverterBold(unittest.TestCase):
@@ -222,6 +224,10 @@ class TestFontConverterTTFMissing(unittest.TestCase):
         with open(tres_path, "r", encoding="utf-8") as f:
             content = f.read()
         self.assertIn('PackedStringArray("NonExistentTestFont99999")', content)
+        fallback_logs = [l for l in self.logs if l.startswith("Info:")]
+        warning_logs = [l for l in self.logs if l.startswith("Warning:")]
+        self.assertTrue(fallback_logs)
+        self.assertEqual(warning_logs, [])
 
 
 class TestFontConverterSystemFontLookup(unittest.TestCase):

--- a/tests/test_monophobia_conversion.py
+++ b/tests/test_monophobia_conversion.py
@@ -89,6 +89,23 @@ class TestMonophobiaConversion(unittest.TestCase):
         with open(os.path.join(self.godot_dir, *parts), "r", encoding="utf-8") as f:
             return f.read()
 
+    def _conversion_diagnostics(self) -> dict[str, Any]:
+        return cast(
+            dict[str, Any],
+            json.loads(self._read_generated_file("gm2godot", "conversion_diagnostics.json")),
+        )
+
+    @staticmethod
+    def _is_expected_room_behavior_warning(message: str) -> bool:
+        normalized = message.lower()
+        return (
+            "gamemaker background layer" in normalized
+            and "scrolling/tiling" in normalized
+        ) or (
+            "gamemaker view in room" in normalized
+            and "follows object" in normalized
+        )
+
     def test_ending_script_functions_are_registered(self) -> None:
         registry = self._read_generated_file("gm2godot", "gml_script_registry.gd")
         ending_script = self._read_generated_file("scripts", "ending.gd")
@@ -125,9 +142,7 @@ class TestMonophobiaConversion(unittest.TestCase):
         self.assertNotIn("\tsaveending()", ending_picture)
 
     def test_ending_script_has_no_transpile_failure_diagnostic(self) -> None:
-        diagnostics = json.loads(
-            self._read_generated_file("gm2godot", "conversion_diagnostics.json")
-        )
+        diagnostics = self._conversion_diagnostics()
         ending_failures = [
             diagnostic
             for diagnostic in diagnostics.get("diagnostics", [])
@@ -138,9 +153,7 @@ class TestMonophobiaConversion(unittest.TestCase):
         self.assertEqual(ending_failures, [])
 
     def test_player_background_layer_calls_have_no_transpile_failure_diagnostic(self) -> None:
-        diagnostics = json.loads(
-            self._read_generated_file("gm2godot", "conversion_diagnostics.json")
-        )
+        diagnostics = self._conversion_diagnostics()
         player_background_failures = [
             diagnostic
             for diagnostic in diagnostics.get("diagnostics", [])
@@ -150,6 +163,29 @@ class TestMonophobiaConversion(unittest.TestCase):
         ]
 
         self.assertEqual(player_background_failures, [])
+
+    def test_conversion_warnings_are_actionable_room_behavior_gaps(self) -> None:
+        diagnostics = self._conversion_diagnostics()
+        diagnostic_entries = cast(list[dict[str, Any]], diagnostics.get("diagnostics", []))
+        warning_messages = [
+            str(diagnostic.get("message", ""))
+            for diagnostic in diagnostic_entries
+            if diagnostic.get("severity") == "warning"
+        ]
+        unexpected_warnings = [
+            message
+            for message in warning_messages
+            if not self._is_expected_room_behavior_warning(message)
+        ]
+        info_messages = [
+            str(diagnostic.get("message", ""))
+            for diagnostic in diagnostic_entries
+            if diagnostic.get("severity") == "info"
+        ]
+
+        self.assertEqual(unexpected_warnings, [])
+        self.assertTrue(any("Unsupported GameMaker project option" in message for message in info_messages))
+        self.assertTrue(any("Missing GameMaker" in message for message in info_messages))
 
     def test_named_collision_event_files_are_transpiled(self) -> None:
         player = self._read_generated_file("objects", "o_player", "o_player.gd")

--- a/tests/test_project_manifest.py
+++ b/tests/test_project_manifest.py
@@ -8,7 +8,10 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
-from src.conversion.project_manifest import load_gamemaker_project_manifest
+from src.conversion.project_manifest import (
+    load_gamemaker_project_manifest,
+    unsupported_project_option_diagnostics,
+)
 
 
 def _write_file(path: str, content: str) -> None:
@@ -98,6 +101,14 @@ class TestGameMakerProjectManifest(unittest.TestCase):
         self.assertTrue(
             any(diagnostic.code == "GM2GD-PROJECT-UNKNOWN-FIELD" for diagnostic in manifest.diagnostics)
         )
+
+        unsupported = unsupported_project_option_diagnostics(
+            manifest,
+            target_platform="windows",
+            supported_keys={"option_game_speed", "option_windows_resize_window"},
+        )
+        self.assertTrue(unsupported)
+        self.assertTrue(all(diagnostic.severity == "info" for diagnostic in unsupported))
 
     def test_reports_duplicate_resource_conflicts_without_rejecting_manifest(self) -> None:
         _write_file(

--- a/tests/test_project_settings.py
+++ b/tests/test_project_settings.py
@@ -211,7 +211,11 @@ class TestUpdateProjectSettingsFromManifest(unittest.TestCase):
         self.assertIn("window/size/borderless=false", content)
         self.assertIn("textures/canvas_textures/default_texture_filter=1", content)
         self.assertIn("window/size/mode=3", content)
-        self.assertTrue(any("option_windows_custom_future" in log for log in self.logs))
+        unsupported_logs = [
+            log for log in self.logs if "option_windows_custom_future" in log
+        ]
+        self.assertTrue(unsupported_logs)
+        self.assertTrue(all(log.startswith("Info:") for log in unsupported_logs))
 
 
 class TestConvertIconFallback(unittest.TestCase):

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -1135,7 +1135,7 @@ class TestRoomConverter(unittest.TestCase):
         self.assertIn('extends "res://gm2godot/gml_room_node.gd"', script)
         self.assertIn("func _gm2godot_room_creation_code():", script)
 
-    def test_room_creation_code_missing_warns_and_marks_missing(self):
+    def test_room_creation_code_missing_logs_info_and_marks_missing(self):
         self._write_yyp(["r_missing_code"])
         missing_path = os.path.join(
             self.gm_dir, "rooms", "r_missing_code", "MissingCreationCode.gml"
@@ -1153,12 +1153,17 @@ class TestRoomConverter(unittest.TestCase):
             content,
         )
         self.assertIn('metadata/gamemaker_creation_code_file_exists = false', content)
-        self.assertTrue(any(
+        missing_logs = [
+            log
+            for log in self.logs
+            if (
             "Missing GameMaker room creation code file" in log
             and "r_missing_code" in log
             and missing_path in log
-            for log in self.logs
-        ))
+            )
+        ]
+        self.assertTrue(missing_logs)
+        self.assertTrue(all(log.startswith("Info:") for log in missing_logs))
 
     def test_instance_emits_creation_code_metadata(self):
         self._write_yyp(["r_instance_code"], extra_resources=[("objects", "o_player")])
@@ -1269,7 +1274,7 @@ class TestRoomConverter(unittest.TestCase):
             script,
         )
 
-    def test_instance_creation_code_missing_warns_and_marks_missing(self):
+    def test_instance_creation_code_missing_logs_info_and_marks_missing(self):
         self._write_yyp(["r_missing_instance_code"], extra_resources=[("objects", "o_player")])
         self._write_object("o_player")
         self._write_object_scene("o_player")
@@ -1301,13 +1306,18 @@ class TestRoomConverter(unittest.TestCase):
             content,
         )
         self.assertIn('metadata/gamemaker_creation_code_file_exists = false', content)
-        self.assertTrue(any(
+        missing_logs = [
+            log
+            for log in self.logs
+            if (
             "Missing GameMaker instance creation code file" in log
             and "inst_player" in log
             and "r_missing_instance_code" in log
             and missing_path in log
-            for log in self.logs
-        ))
+            )
+        ]
+        self.assertTrue(missing_logs)
+        self.assertTrue(all(log.startswith("Info:") for log in missing_logs))
 
     def test_execution_metadata_preserves_lifecycle_order(self):
         self._write_yyp(["r_lifecycle"], extra_resources=[("objects", "o_enemy")])


### PR DESCRIPTION
## Summary
- classify unsupported GameMaker project options as informational diagnostics
- log font SystemFont fallback and missing optional room/instance creation-code files as info instead of warnings
- add Monophobia coverage that allows warnings only for the remaining room runtime behavior gaps

Fixes #668

## Verification
- ./venv/bin/python -m unittest tests.test_diagnostics tests.test_project_settings tests.test_project_manifest tests.test_fonts tests.test_rooms -v
- MONOPHOBIA_PROJECT_PATH=/Users/infi/Documents/Github/Monophobia GODOT_BIN=/tmp/godot-4.4.1-macos/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_monophobia_conversion -v
- ./venv/bin/pyright --warnings
- ./venv/bin/ruff check .
- git diff --check
- ./venv/bin/python -m unittest