### PR TITLE
Support room camera follow and scrolling backgrounds

### DIFF
--- a/src/conversion/gml_runtime_parts/manifest.py
+++ b/src/conversion/gml_runtime_parts/manifest.py
@@ -176,7 +176,13 @@ RUNTIME_SEGMENTS: tuple[RuntimeSegmentDefinition, ...] = (
     _segment(
         "55_room_game_flow.gd",
         "Room order, game flow, transitions, and restart/end behavior.",
-        depends_on=("00_prelude.gd", "10_handles_and_instances.gd", "11_layers.gd", "15_asset_registry.gd"),
+        depends_on=(
+            "00_prelude.gd",
+            "10_handles_and_instances.gd",
+            "11_layers.gd",
+            "15_asset_registry.gd",
+            "52_cameras_display.gd",
+        ),
         tests=("tests/test_room_game_flow_godot.py",),
     ),
     _segment(

--- a/src/conversion/gml_runtime_parts/segments/52_cameras_display.gd
+++ b/src/conversion/gml_runtime_parts/segments/52_cameras_display.gd
@@ -418,6 +418,18 @@ static func gml_view_backend_diagnostics():
 	return _gml_clone_value(_gml_view_backend_diagnostics, 8)
 
 
+static func _gml_view_register_scene(scene):
+	if not (scene is Node):
+		return false
+	var camera_nodes = []
+	_gml_find_camera_nodes_recursive(scene, camera_nodes)
+	for camera_node in camera_nodes:
+		var view_index = int(camera_node.get_meta("gamemaker_view_index"))
+		_gml_view_camera_handle_for_node(view_index, camera_node)
+	_gml_view_sync_backend()
+	return true
+
+
 static func gml_display_get_gui_width():
 	return _gml_display_gui_dimensions().x
 
@@ -818,9 +830,22 @@ static func _gml_view_default_value(name, index):
 
 static func _gml_view_camera_handle(index):
 	var view_index = int(index)
-	if _gml_camera_entries_by_index.has(view_index):
-		return _gml_camera_entries_by_index[view_index]["handle"]
 	var camera_node = _gml_view_find_camera_node(view_index)
+	return _gml_view_camera_handle_for_node(view_index, camera_node)
+
+
+static func _gml_view_camera_handle_for_node(view_index, camera_node):
+	if _gml_camera_entries_by_index.has(view_index):
+		var existing = _gml_camera_entries_by_index[view_index]
+		if existing.has("handle") and gml_handle_is_valid(existing["handle"]):
+			var existing_handle = existing["handle"]
+			var existing_camera = existing_handle.reference
+			if typeof(existing_camera) == TYPE_DICTIONARY and camera_node is Camera2D and is_instance_valid(camera_node):
+				existing_camera["node"] = camera_node
+				_gml_view_sync_port_arrays_from_node(view_index, camera_node)
+				_gml_camera_sync_from_node(existing_camera, camera_node)
+				_gml_camera_apply_state(existing_camera)
+			return existing_handle
 	var camera = _gml_camera_make(
 		_to_real(_gml_array_get_default("view_xview", view_index, 0)),
 		_to_real(_gml_array_get_default("view_yview", view_index, 0)),
@@ -974,11 +999,21 @@ static func _gml_camera_apply_state(camera):
 
 
 static func _gml_camera_update_visible_views():
-	if not _gml_builtin_arrays.has("view_camera"):
-		return null
-	var values = _gml_builtin_arrays["view_camera"]
-	for view_index in range(min(values.size(), GML_BUILTIN_ARRAY_SIZE)):
-		var handle = gml_handle_from_value(GML_CAMERA_HANDLE_KIND, values[view_index])
+	var view_indices = []
+	if _gml_builtin_arrays.has("view_camera"):
+		var values = _gml_builtin_arrays["view_camera"]
+		for view_index in range(min(values.size(), GML_BUILTIN_ARRAY_SIZE)):
+			view_indices.append(view_index)
+	else:
+		for view_index in _gml_camera_entries_by_index.keys():
+			view_indices.append(int(view_index))
+	view_indices.sort()
+	for view_index in view_indices:
+		var handle = null
+		if _gml_builtin_arrays.has("view_camera"):
+			handle = gml_handle_from_value(GML_CAMERA_HANDLE_KIND, _gml_builtin_arrays["view_camera"][view_index])
+		elif _gml_camera_entries_by_index.has(view_index):
+			handle = _gml_camera_entries_by_index[view_index]["handle"]
 		if not gml_handle_is_valid(handle) or typeof(handle.reference) != TYPE_DICTIONARY:
 			continue
 		var camera = handle.reference
@@ -1097,6 +1132,15 @@ static func _gml_find_camera_node_recursive(node, view_index):
 		if result != null:
 			return result
 	return null
+
+
+static func _gml_find_camera_nodes_recursive(node, results):
+	if node is Camera2D and node.has_meta("gamemaker_view_index"):
+		results.append(node)
+	if not (node is Node):
+		return
+	for child in node.get_children():
+		_gml_find_camera_nodes_recursive(child, results)
 
 
 static func _gml_view_get_port_value(view_port, name, fallback):

--- a/src/conversion/gml_runtime_parts/segments/55_room_game_flow.gd
+++ b/src/conversion/gml_runtime_parts/segments/55_room_game_flow.gd
@@ -20,6 +20,7 @@ static func gml_room_enter_scene(scene, force = false):
 		return false
 	_gml_room_pending_entry = null
 	gml_layer_register_scene(scene)
+	_gml_view_register_scene(scene)
 	_gml_room_update_current(entry, scene)
 	_gml_room_warn_persistent_room(scene)
 	_gml_room_run_instance_creation_code(scene)
@@ -130,6 +131,14 @@ static func gml_room_transition_log():
 	return _gml_room_transition_log
 
 
+static func _gml_room_process_scene(scene, delta):
+	if not (scene is Node):
+		return false
+	_gml_camera_update_visible_views()
+	_gml_room_update_background_layers(scene, delta)
+	return true
+
+
 static func _gml_room_change_to_entry(entry, restarting):
 	var tree = _gml_room_tree()
 	if tree == null:
@@ -178,6 +187,48 @@ static func _gml_room_update_current(entry, scene):
 		height = int(scene.get_meta("gamemaker_room_height"))
 	_gml_builtin_globals["room_width"] = width
 	_gml_builtin_globals["room_height"] = height
+
+
+static func _gml_room_update_background_layers(scene, delta):
+	if not (scene is Node):
+		return
+	var step_scale = _gml_room_step_scale(delta)
+	for node in _gml_layer_tree_nodes(scene):
+		if node == scene:
+			continue
+		if node is Object and node.has_meta("gamemaker_background_visual"):
+			_gml_room_update_background_node(node, step_scale)
+
+
+static func _gml_room_update_background_node(node, step_scale):
+	var hspeed = _gml_room_background_speed(node, "h")
+	var vspeed = _gml_room_background_speed(node, "v")
+	if abs(hspeed) < 0.0001 and abs(vspeed) < 0.0001:
+		return
+	var motion = Vector2(hspeed * step_scale, vspeed * step_scale)
+	if node is Parallax2D:
+		node.scroll_offset += motion
+	elif node is Node2D:
+		node.position += motion
+
+
+static func _gml_room_background_speed(node, axis):
+	var background_key = "gamemaker_background_hspeed" if axis == "h" else "gamemaker_background_vspeed"
+	var layer_key = "gamemaker_layer_hspeed" if axis == "h" else "gamemaker_layer_vspeed"
+	if node is Object and node.has_meta(background_key):
+		return _to_real(node.get_meta(background_key))
+	if node is Object and node.has_meta(layer_key):
+		return _to_real(node.get_meta(layer_key))
+	return 0.0
+
+
+static func _gml_room_step_scale(delta):
+	var room_speed = _to_real(_gml_builtin_globals.get("room_speed", 0))
+	if room_speed <= 0.0:
+		room_speed = float(Engine.max_fps)
+	if room_speed <= 0.0:
+		room_speed = 60.0
+	return max(_to_real(delta), 0.0) * room_speed
 
 
 static func _gml_room_dispatch_lifecycle(root_node, method_name):

--- a/src/conversion/room_layers.py
+++ b/src/conversion/room_layers.py
@@ -816,15 +816,6 @@ def _camera_node_lines(context: RoomLayerSerializationContext) -> list[str]:
         object_id = _dict_value(view.get("objectId"))
         object_name = object_id.get("name") if isinstance(object_id.get("name"), str) else None
 
-        if object_name:
-            context.warn(
-                "Warning: GameMaker view in room {room_name} follows object {object_name}; "
-                "follow behavior is preserved as Camera2D metadata for runtime support.".format(
-                    room_name=context.room.name,
-                    object_name=object_name,
-                )
-            )
-
         lines.extend([
             f'[node name={godot_string(node_name)} type="Camera2D" parent="."]',
             "position = Vector2({x}, {y})".format(
@@ -896,6 +887,23 @@ def _background_color_lines(
     layer: JsonDict, parent_path: str, context: RoomLayerSerializationContext
 ) -> list[str]:
     width, height = _room_size(context)
+    if _background_needs_runtime(layer):
+        node_name = "BackgroundVisual"
+        child_path = f"{parent_path}/{node_name}"
+        lines = _background_parallax_lines(layer, parent_path, node_name, "color", context)
+        lines.extend([
+            f'[node name="BackgroundColor" type="ColorRect" parent={godot_string(child_path)}]',
+            "visible = true",
+            "position = Vector2(0, 0)",
+            "size = Vector2({width}, {height})".format(
+                width=_format_number(width),
+                height=_format_number(height),
+            ),
+            "color = {color}".format(color=_godot_color(layer.get("colour", 4278190080))),
+            "",
+        ])
+        return lines
+
     lines = [
         f'[node name="BackgroundVisual" type="ColorRect" parent={godot_string(parent_path)}]',
         f"visible = {godot_value(bool(layer.get('visible', True)))}",
@@ -907,7 +915,6 @@ def _background_color_lines(
         "color = {color}".format(color=_godot_color(layer.get("colour", 4278190080))),
     ]
     lines.extend(_background_metadata_lines(layer, "color"))
-    _warn_background_runtime_requirements(layer, context)
     lines.append("")
     return lines
 
@@ -920,6 +927,23 @@ def _background_sprite_lines(
     context: RoomLayerSerializationContext,
 ) -> list[str]:
     node_name = _sanitize_node_name(sprite_name) or "BackgroundSprite"
+    if _background_needs_runtime(layer):
+        child_path = f"{parent_path}/{node_name}"
+        visual_name = _sanitize_node_name(sprite_name + "Visual") or "BackgroundSpriteVisual"
+        lines = _background_parallax_lines(layer, parent_path, node_name, "sprite", context)
+        lines.extend([
+            '[node name={name} parent={parent} instance=ExtResource("{resource_id}")]'.format(
+                name=godot_string(visual_name),
+                parent=godot_string(child_path),
+                resource_id=ext_resource_id,
+            ),
+            "visible = true",
+            "position = Vector2(0, 0)",
+            "modulate = {color}".format(color=_godot_color(layer.get("colour", 4294967295))),
+            "",
+        ])
+        return lines
+
     lines = [
         '[node name={name} parent={parent} instance=ExtResource("{resource_id}")]'.format(
             name=godot_string(node_name),
@@ -931,7 +955,6 @@ def _background_sprite_lines(
         "modulate = {color}".format(color=_godot_color(layer.get("colour", 4294967295))),
     ]
     lines.extend(_background_metadata_lines(layer, "sprite"))
-    _warn_background_runtime_requirements(layer, context)
     lines.append("")
     return lines
 
@@ -962,18 +985,50 @@ def _background_metadata_lines(layer: JsonDict, visual_type: str) -> list[str]:
     return lines
 
 
-def _warn_background_runtime_requirements(
+def _background_parallax_lines(
+    layer: JsonDict,
+    parent_path: str,
+    node_name: str,
+    visual_type: str,
+    context: RoomLayerSerializationContext,
+) -> list[str]:
+    repeat_x, repeat_y = _background_repeat_size(layer, context)
+    lines = [
+        f'[node name={godot_string(node_name)} type="Parallax2D" parent={godot_string(parent_path)}]',
+        f"visible = {godot_value(bool(layer.get('visible', True)))}",
+        "position = Vector2({x}, {y})".format(
+            x=_format_number(layer.get("x", 0)),
+            y=_format_number(layer.get("y", 0)),
+        ),
+        "repeat_size = Vector2({x}, {y})".format(
+            x=_format_number(repeat_x),
+            y=_format_number(repeat_y),
+        ),
+        "repeat_times = 3",
+        "scroll_offset = Vector2(0, 0)",
+    ]
+    lines.extend(_background_metadata_lines(layer, visual_type))
+    lines.append("metadata/gamemaker_background_runtime_support = true")
+    lines.append("")
+    return lines
+
+
+def _background_needs_runtime(layer: JsonDict) -> bool:
+    return (
+        _truthy(layer.get("htiled"))
+        or _truthy(layer.get("vtiled"))
+        or _nonzero(layer.get("hspeed"))
+        or _nonzero(layer.get("vspeed"))
+    )
+
+
+def _background_repeat_size(
     layer: JsonDict, context: RoomLayerSerializationContext
-) -> None:
-    if not (_truthy(layer.get("htiled")) or _truthy(layer.get("vtiled"))
-            or _nonzero(layer.get("hspeed")) or _nonzero(layer.get("vspeed"))):
-        return
-    context.warn(
-        "Warning: GameMaker background layer {layer_name} in room {room_name} uses "
-        "scrolling/tiling; runtime support is required for hspeed/vspeed/htiled/vtiled.".format(
-            layer_name=_layer_name(layer),
-            room_name=context.room.name,
-        )
+) -> tuple[JsonValue, JsonValue]:
+    width, height = _room_size(context)
+    return (
+        width if _truthy(layer.get("htiled")) else 0,
+        height if _truthy(layer.get("vtiled")) else 0,
     )
 
 

--- a/src/conversion/rooms.py
+++ b/src/conversion/rooms.py
@@ -39,6 +39,9 @@ def render_room_runtime_script() -> str:
         f'const GM2GODOT_ROOM_ROOT_POLICY = "{ROOM_ROOT_POLICY_ID}"\n\n'
         "func _ready():\n"
         "\tGMRuntime.gml_room_enter_scene(self)\n"
+        "\n\n"
+        "func _process(delta):\n"
+        "\tGMRuntime._gml_room_process_scene(self, delta)\n"
     )
 
 

--- a/tests/fixtures/golden/basic_scripts/expected_snapshot.json
+++ b/tests/fixtures/golden/basic_scripts/expected_snapshot.json
@@ -7,7 +7,7 @@
   },
   "fixture": "basic_scripts",
   "hashes": {
-    "gm2godot/gml_runtime.gd": "sha256:a788a6dc42d5c19fa6c6cef3d67fa891c9b67edc1e6fdf350444a2ec9785d003",
+    "gm2godot/gml_runtime.gd": "sha256:72399bf7b8b5c555b8d02d806aaec45a076358e3eab44270e09531a157ab90ce",
     "gm2godot/managers/gm_assets.gd": "sha256:4121345bd843a0bb3487fcba4756a3b2f18700685f5858db5f62f8992d96a76f",
     "gm2godot/managers/gm_async.gd": "sha256:d0a73997476f0e889892f85a6c343fc5b44fecdf9fa547e943902632aedf9df3",
     "gm2godot/managers/gm_audio.gd": "sha256:995a1df58e7f8ad03fa8ed7e9a195cdcfcf256643d73ac06a88bb6bbec82fba4",

--- a/tests/test_monophobia_conversion.py
+++ b/tests/test_monophobia_conversion.py
@@ -95,17 +95,6 @@ class TestMonophobiaConversion(unittest.TestCase):
             json.loads(self._read_generated_file("gm2godot", "conversion_diagnostics.json")),
         )
 
-    @staticmethod
-    def _is_expected_room_behavior_warning(message: str) -> bool:
-        normalized = message.lower()
-        return (
-            "gamemaker background layer" in normalized
-            and "scrolling/tiling" in normalized
-        ) or (
-            "gamemaker view in room" in normalized
-            and "follows object" in normalized
-        )
-
     def test_ending_script_functions_are_registered(self) -> None:
         registry = self._read_generated_file("gm2godot", "gml_script_registry.gd")
         ending_script = self._read_generated_file("scripts", "ending.gd")
@@ -164,18 +153,13 @@ class TestMonophobiaConversion(unittest.TestCase):
 
         self.assertEqual(player_background_failures, [])
 
-    def test_conversion_warnings_are_actionable_room_behavior_gaps(self) -> None:
+    def test_conversion_diagnostics_have_no_warnings(self) -> None:
         diagnostics = self._conversion_diagnostics()
         diagnostic_entries = cast(list[dict[str, Any]], diagnostics.get("diagnostics", []))
-        warning_messages = [
-            str(diagnostic.get("message", ""))
+        warnings = [
+            diagnostic
             for diagnostic in diagnostic_entries
             if diagnostic.get("severity") == "warning"
-        ]
-        unexpected_warnings = [
-            message
-            for message in warning_messages
-            if not self._is_expected_room_behavior_warning(message)
         ]
         info_messages = [
             str(diagnostic.get("message", ""))
@@ -183,7 +167,7 @@ class TestMonophobiaConversion(unittest.TestCase):
             if diagnostic.get("severity") == "info"
         ]
 
-        self.assertEqual(unexpected_warnings, [])
+        self.assertEqual(warnings, [])
         self.assertTrue(any("Unsupported GameMaker project option" in message for message in info_messages))
         self.assertTrue(any("Missing GameMaker" in message for message in info_messages))
 

--- a/tests/test_room_game_flow_godot.py
+++ b/tests/test_room_game_flow_godot.py
@@ -192,6 +192,156 @@ def _write_scripts(project_dir: Path) -> None:
 
 
 class TestRoomGameFlowGodotSmoke(unittest.TestCase):
+    def test_room_runtime_updates_view_follow_and_scrolling_background(self) -> None:
+        godot_binary = _find_godot_binary()
+        if godot_binary is None:
+            self.skipTest("Godot binary not available")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir)
+            _write_text(
+                project_dir / "project.godot",
+                '[application]\nconfig/name="RoomRuntimeBehaviorSmoke"\nrun/main_scene="res://rooms/r_one/r_one.tscn"\n',
+            )
+            write_gml_runtime(str(project_dir))
+            _write_text(project_dir / "gm2godot" / "gml_room_node.gd", render_room_runtime_script())
+            _write_registry(project_dir)
+            _write_text(
+                project_dir / "target.gd",
+                textwrap.dedent(
+                    """\
+                    extends Node2D
+
+                    const GMRuntime = preload("res://gm2godot/gml_runtime.gd")
+
+                    var _gm_handle = GMRuntime.gml_instance_noone()
+
+                    func _ready():
+                    \tposition = Vector2(300, 20)
+                    \t_gm_handle = GMRuntime.gml_instance_register(self, "o_player", [])
+
+                    func _exit_tree():
+                    \tGMRuntime.gml_instance_unregister(_gm_handle)
+                    """
+                ),
+            )
+            _write_text(
+                project_dir / "controller.gd",
+                textwrap.dedent(
+                    """\
+                    extends Node
+
+                    func _ready():
+                    \tcall_deferred("_run")
+
+                    func _check(condition, message):
+                    \tif not condition:
+                    \t\tpush_error(str(message))
+                    \t\tget_tree().quit(1)
+                    \t\treturn false
+                    \treturn true
+
+                    func _run():
+                    \tawait get_tree().process_frame
+                    \tawait get_tree().process_frame
+                    \tvar room = get_parent()
+                    \tvar camera = room.get_node("ViewCamera")
+                    \tvar background = room.get_node("Backgrounds/BackgroundVisual")
+                    \tif not _check(abs(camera.position.x - 260.0) < 0.01, "Camera2D did not follow target on x"):
+                    \t\treturn
+                    \tif not _check(background.scroll_offset.x > 0.0, "Background Parallax2D did not scroll"):
+                    \t\treturn
+                    \tprint("ROOM_RUNTIME_BEHAVIOR_SMOKE_OK")
+                    \tget_tree().quit(0)
+                    """
+                ),
+            )
+            _write_text(
+                project_dir / "rooms" / "r_one" / "r_one.tscn",
+                textwrap.dedent(
+                    """\
+                    [gd_scene load_steps=4 format=3]
+
+                    [ext_resource type="Script" path="res://gm2godot/gml_room_node.gd" id="gm_room_runtime"]
+                    [ext_resource type="Script" path="res://controller.gd" id="controller"]
+                    [ext_resource type="Script" path="res://target.gd" id="target"]
+
+                    [node name="r_one" type="Node2D"]
+                    script = ExtResource("gm_room_runtime")
+                    metadata/gamemaker_room_width = 320
+                    metadata/gamemaker_room_height = 180
+                    metadata/gamemaker_room_persistent = false
+
+                    [node name="ViewCamera" type="Camera2D" parent="."]
+                    position = Vector2(50, 50)
+                    enabled = true
+                    metadata/gamemaker_view_camera = true
+                    metadata/gamemaker_view_enabled_camera = true
+                    metadata/gamemaker_view_visible = true
+                    metadata/gamemaker_view_index = 0
+                    metadata/gamemaker_view_xview = 0
+                    metadata/gamemaker_view_yview = 0
+                    metadata/gamemaker_view_wview = 100
+                    metadata/gamemaker_view_hview = 100
+                    metadata/gamemaker_view_xport = 0
+                    metadata/gamemaker_view_yport = 0
+                    metadata/gamemaker_view_wport = 100
+                    metadata/gamemaker_view_hport = 100
+                    metadata/gamemaker_view_object_name = "o_player"
+                    metadata/gamemaker_view_hborder = 10
+                    metadata/gamemaker_view_vborder = 10
+                    metadata/gamemaker_view_hspeed = -1
+                    metadata/gamemaker_view_vspeed = -1
+
+                    [node name="Backgrounds" type="Node2D" parent="."]
+                    metadata/gamemaker_layer_name = "Backgrounds"
+                    metadata/gamemaker_layer_type = "GMRBackgroundLayer"
+
+                    [node name="BackgroundVisual" type="Parallax2D" parent="Backgrounds"]
+                    repeat_size = Vector2(320, 0)
+                    repeat_times = 3
+                    scroll_offset = Vector2(0, 0)
+                    metadata/gamemaker_layer_element_type = "background"
+                    metadata/gamemaker_background_visual = true
+                    metadata/gamemaker_background_hspeed = 2
+                    metadata/gamemaker_background_vspeed = 0
+                    metadata/gamemaker_background_runtime_support = true
+
+                    [node name="Target" type="Node2D" parent="."]
+                    script = ExtResource("target")
+
+                    [node name="Controller" type="Node" parent="."]
+                    script = ExtResource("controller")
+                    """
+                ),
+            )
+
+            godot_env = dict(os.environ)
+            godot_env["HOME"] = str(project_dir)
+            result = subprocess.run(
+                [
+                    godot_binary,
+                    "--headless",
+                    "--log-file",
+                    str(project_dir / "godot.log"),
+                    "--path",
+                    str(project_dir),
+                    "--scene",
+                    "res://rooms/r_one/r_one.tscn",
+                    "--quit-after",
+                    "10",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=20,
+                check=False,
+                env=godot_env,
+            )
+            output = result.stdout + result.stderr
+
+        self.assertEqual(result.returncode, 0, output)
+        self.assertIn("ROOM_RUNTIME_BEHAVIOR_SMOKE_OK", output)
+
     def test_room_creation_code_lifecycle_trace_order(self) -> None:
         godot_binary = _find_godot_binary()
         if godot_binary is None:

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -509,7 +509,36 @@ class TestRoomConverter(unittest.TestCase):
         self.assertIn('modulate = Color(1, 1, 1, 1)', content)
         self.assertIn('metadata/gamemaker_background_visual_type = "sprite"', content)
 
-    def test_background_layer_preserves_scrolling_tiling_metadata_and_warns(self):
+    def test_sprite_background_layer_with_scrolling_uses_parallax_runtime(self):
+        self._write_yyp(["r_background"], extra_resources=[("sprites", "s_background")])
+        self._write_sprite("s_background")
+        self._write_sprite_scene("s_background")
+        self._write_room("r_background", layers=[
+            {
+                "%Name": "Backgrounds",
+                "resourceType": "GMRBackgroundLayer",
+                "spriteId": {"name": "s_background", "path": "sprites/s_background/s_background.yy"},
+                "htiled": True,
+                "vtiled": True,
+                "hspeed": 1,
+                "vspeed": -2,
+            },
+        ])
+
+        self._make_converter().convert_all()
+        content = self._read_scene("r_background")
+
+        self.assertIn('[node name="s_background" type="Parallax2D" parent="Backgrounds"]', content)
+        self.assertIn('repeat_size = Vector2(1024, 768)', content)
+        self.assertIn('scroll_offset = Vector2(0, 0)', content)
+        self.assertIn('metadata/gamemaker_background_runtime_support = true', content)
+        self.assertIn(
+            '[node name="s_backgroundVisual" parent="Backgrounds/s_background" instance=ExtResource("1")]',
+            content,
+        )
+        self.assertFalse(any("scrolling/tiling" in log for log in self.logs))
+
+    def test_background_layer_preserves_scrolling_tiling_runtime_metadata(self):
         self._write_yyp(["r_background"])
         self._write_room("r_background", layers=[
             {
@@ -536,10 +565,12 @@ class TestRoomConverter(unittest.TestCase):
         self.assertIn('metadata/gamemaker_layer_vspeed = 0', content)
         self.assertIn('metadata/gamemaker_background_stretch = true', content)
         self.assertIn('metadata/gamemaker_background_animation_fps = 12', content)
-        self.assertTrue(any(
-            "scrolling/tiling" in log and "MovingBackground" in log
-            for log in self.logs
-        ))
+        self.assertIn('[node name="BackgroundVisual" type="Parallax2D" parent="MovingBackground"]', content)
+        self.assertIn('repeat_size = Vector2(1024, 0)', content)
+        self.assertIn('repeat_times = 3', content)
+        self.assertIn('metadata/gamemaker_background_runtime_support = true', content)
+        self.assertIn('[node name="BackgroundColor" type="ColorRect" parent="MovingBackground/BackgroundVisual"]', content)
+        self.assertFalse(any("scrolling/tiling" in log for log in self.logs))
 
     def test_layer_depth_maps_to_inverse_z_index(self):
         self._write_yyp(["r_depths"])
@@ -1410,7 +1441,7 @@ class TestRoomConverter(unittest.TestCase):
         self.assertIn('limit_bottom = 560', content)
         self.assertIn('zoom = Vector2(2, 2)', content)
         self.assertIn('metadata/gamemaker_view_object_name = "o_player"', content)
-        self.assertTrue(any("follows object o_player" in log for log in self.logs))
+        self.assertFalse(any("follows object o_player" in log for log in self.logs))
 
     def test_multiple_visible_views_disable_additional_cameras_and_warn(self):
         self._write_yyp(["r_cameras"])


### PR DESCRIPTION
## Summary
- register generated room Camera2D nodes with the runtime and update follow cameras each room frame
- emit Parallax2D wrappers for scrolling/tiled GameMaker background layers and advance background scroll offsets at runtime
- remove Monophobia follow/background conversion warnings and require zero Monophobia conversion warnings

Fixes #667

## Verification
- GODOT_BIN=/tmp/godot-4.4.1-macos/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_rooms tests.test_room_game_flow_godot -v
- MONOPHOBIA_PROJECT_PATH=/Users/infi/Documents/Github/Monophobia GODOT_BIN=/tmp/godot-4.4.1-macos/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_monophobia_conversion -v
- ./venv/bin/pyright --warnings
- ./venv/bin/ruff check .
- git diff --check
- ./venv/bin/python -m unittest
- SIMPLE_TOPDOWN_PROJECT_PATH=/Users/infi/Documents/Github/GM2GodotGameTest_SimpleTopDown GODOT_BIN=/tmp/godot-4.4.1-macos/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_simple_topdown_conversion -v
- TCC_PROJECT_PATH=/Users/infi/Documents/Github/TheColorfulCreature GODOT_BIN=/tmp/godot-4.4.1-macos/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest tests.test_tcc_conversion -v