### PR TITLE
Pin GameMaker LTS 2026 fixtures in Godot 4.7.1 CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.0, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.1, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/.github/workflows/tcc-conversion-test.yml
+++ b/.github/workflows/tcc-conversion-test.yml
@@ -14,6 +14,8 @@ env:
   SIMPLE_TOPDOWN_REF: 2413d7714b0dbd5d548058ea4c74f591f0d4e1e3
   TCC_REF: 4b6e942caca4d58af49dc006a037404d2f2a348c
   MONOPHOBIA_REF: b79cc26f2d3d01823d7e6359ee116322840f97a2
+  SNAP_REF: b4191e195c7c84359f995d568d8906c452b83e50
+  ADDING_REF: 1bf032618be258242f78505de7cd151242452776
 
 jobs:
   tcc-conversion:
@@ -98,3 +100,96 @@ jobs:
         env:
           MONOPHOBIA_PROJECT_PATH: ${{ runner.temp }}/Monophobia
         run: python -m unittest tests.test_monophobia_conversion -v
+
+  lts-2026-conversion:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install test dependencies
+        run: pip install Pillow
+
+      - name: Cache pinned Godot
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/gm2godot/godot-${{ env.GODOT_VERSION }}
+          key: godot-${{ runner.os }}-${{ env.GODOT_VERSION }}-${{ env.GODOT_ARCHIVE_SHA256 }}
+
+      - name: Install pinned Godot
+        run: |
+          set -euo pipefail
+          godot_dir="$HOME/.cache/gm2godot/godot-${GODOT_VERSION}"
+          godot_bin="${godot_dir}/${GODOT_BINARY}"
+          if [ ! -x "$godot_bin" ]; then
+            mkdir -p "$godot_dir"
+            curl --fail --location --retry 3 \
+              "https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}/${GODOT_ARCHIVE}" \
+              --output "${RUNNER_TEMP}/${GODOT_ARCHIVE}"
+            echo "${GODOT_ARCHIVE_SHA256}  ${RUNNER_TEMP}/${GODOT_ARCHIVE}" | sha256sum --check --strict
+            unzip -q "${RUNNER_TEMP}/${GODOT_ARCHIVE}" -d "$godot_dir"
+            chmod +x "$godot_bin"
+          fi
+          echo "GODOT_BIN=$godot_bin" >> "$GITHUB_ENV"
+          godot_build="$("$godot_bin" --version)"
+          test "$godot_build" = "4.7.1.stable.official.a13da4feb"
+
+      - name: Checkout pinned SNAP
+        run: |
+          set -euo pipefail
+          repo_dir="${{ runner.temp }}/SNAP"
+          git init --quiet "$repo_dir"
+          git -C "$repo_dir" remote add origin https://github.com/JujuAdams/SNAP.git
+          git -C "$repo_dir" fetch --quiet --depth 1 --no-tags origin "${SNAP_REF}"
+          git -C "$repo_dir" checkout --quiet --detach FETCH_HEAD
+          test "$(git -C "$repo_dir" rev-parse HEAD)" = "${SNAP_REF}"
+          test -f "$repo_dir/snap.yyp"
+
+      - name: Checkout pinned Adding
+        run: |
+          set -euo pipefail
+          repo_dir="${{ runner.temp }}/Adding"
+          git init --quiet "$repo_dir"
+          git -C "$repo_dir" remote add origin https://github.com/WuffMakesGames/Adding.git
+          git -C "$repo_dir" fetch --quiet --depth 1 --no-tags origin "${ADDING_REF}"
+          git -C "$repo_dir" checkout --quiet --detach FETCH_HEAD
+          test "$(git -C "$repo_dir" rev-parse HEAD)" = "${ADDING_REF}"
+          test -f "$repo_dir/Adding.yyp"
+
+      - name: Prepare bounded report directory
+        run: |
+          output_root="${RUNNER_TEMP}/gm2godot-lts-2026-output"
+          mkdir -p "$output_root"
+          echo "LTS_FIXTURE_OUTPUT_ROOT=$output_root" >> "$GITHUB_ENV"
+
+      - name: Run current-LTS conversion, validation, and boot tests
+        timeout-minutes: 15
+        env:
+          SNAP_PROJECT_PATH: ${{ runner.temp }}/SNAP
+          ADDING_PROJECT_PATH: ${{ runner.temp }}/Adding
+          GM2GODOT_REQUIRE_LTS_FIXTURES: '1'
+        run: |
+          set -o pipefail
+          python -m unittest tests.test_lts_2026_conversion -v 2>&1 \
+            | tee "$LTS_FIXTURE_OUTPUT_ROOT/unittest.log"
+
+      - name: Upload bounded current-LTS failure reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lts-2026-fixture-reports
+          path: |
+            ${{ runner.temp }}/gm2godot-lts-2026-output/lts_fixture_report.json
+            ${{ runner.temp }}/gm2godot-lts-2026-output/unittest.log
+            ${{ runner.temp }}/gm2godot-lts-2026-output/*/gm2godot/conversion_diagnostics.json
+            ${{ runner.temp }}/gm2godot-lts-2026-output/*/gm2godot/conversion_diagnostics.md
+            ${{ runner.temp }}/gm2godot-lts-2026-output/*/gm2godot/conversion_manifest.json
+            ${{ runner.temp }}/gm2godot-lts-2026-output/*/gm2godot/godot_validation_report.json
+          if-no-files-found: ignore
+          retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1 - 2026-07-17
+
+- Added immutable GameMaker LTS 2026 SNAP and Adding fixtures to CI with exact Godot 4.7.1 conversion, generated-resource validation, short runtime boot checks, and bounded failure reports.
+
 ## 0.7.0 - 2026-07-17
 
 - Retargeted generated projects and CI to GameMaker LTS 2026 and exact Godot 4.7.1 compatibility, with locally pinned SNAP and Adding fixture conversions and runtime boots used as release evidence.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.0`.
+Current source version: `0.7.1`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.0"
+VERSION = "0.7.1"
 
 
 def get_version():

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -22,10 +22,12 @@ EXTERNAL_CONVERSION_MODULES = (
     "tests.test_simple_topdown_conversion",
     "tests.test_tcc_conversion",
     "tests.test_monophobia_conversion",
+    "tests.test_lts_2026_conversion",
 )
 CONVERSION_BOOT_MODULES = (
     "tests.test_simple_topdown_conversion",
     "tests.test_monophobia_conversion",
+    "tests.test_lts_2026_conversion",
 )
 EXTERNAL_FIXTURE_REPOSITORIES = (
     (
@@ -39,6 +41,14 @@ EXTERNAL_FIXTURE_REPOSITORIES = (
     (
         "MONOPHOBIA_REF",
         "https://github.com/Infiland/Monophobia.git",
+    ),
+    (
+        "SNAP_REF",
+        "https://github.com/JujuAdams/SNAP.git",
+    ),
+    (
+        "ADDING_REF",
+        "https://github.com/WuffMakesGames/Adding.git",
     ),
 )
 
@@ -128,6 +138,10 @@ class TestCIWorkflows(unittest.TestCase):
         self.assertLess(install_index, content.index("- name: Run SimpleTopDown conversion and boot-log test"))
         self.assertLess(install_index, content.index("- name: Run TCC conversion test"))
         self.assertLess(install_index, content.index("- name: Run Monophobia conversion and boot-log test"))
+        self.assertLess(
+            install_index,
+            content.index("- name: Run current-LTS conversion, validation, and boot tests"),
+        )
         for module in EXTERNAL_CONVERSION_MODULES:
             with self.subTest(module=module):
                 self.assertIn(f"python -m unittest {module} -v", content)
@@ -174,6 +188,79 @@ class TestCIWorkflows(unittest.TestCase):
                     f'rev-parse HEAD)" = "${{{ref_name}}}"',
                     content,
                 )
+
+    def test_current_lts_job_verifies_exact_godot_build_and_fixture_projects(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "tcc-conversion-test.yml"
+        content = workflow.read_text(encoding="utf-8")
+        job_index = content.index("  lts-2026-conversion:")
+        lts_job = content[job_index:]
+        checksum_command = (
+            'echo "${GODOT_ARCHIVE_SHA256}  '
+            '${RUNNER_TEMP}/${GODOT_ARCHIVE}" | sha256sum --check --strict'
+        )
+
+        self.assertIn('test "$godot_build" = "4.7.1.stable.official.a13da4feb"', lts_job)
+        self.assertIn(checksum_command, lts_job)
+        self.assertLess(lts_job.index(checksum_command), lts_job.index("unzip -q"))
+        self.assertIn('test -f "$repo_dir/snap.yyp"', lts_job)
+        self.assertIn('test -f "$repo_dir/Adding.yyp"', lts_job)
+        self.assertIn("GM2GODOT_REQUIRE_LTS_FIXTURES: '1'", lts_job)
+        self.assertIn("SNAP_PROJECT_PATH: ${{ runner.temp }}/SNAP", lts_job)
+        self.assertIn("ADDING_PROJECT_PATH: ${{ runner.temp }}/Adding", lts_job)
+        self.assertIn(
+            "python -m unittest tests.test_lts_2026_conversion -v",
+            lts_job,
+        )
+        test_step_index = lts_job.index(
+            "- name: Run current-LTS conversion, validation, and boot tests"
+        )
+        upload_step_index = lts_job.index(
+            "- name: Upload bounded current-LTS failure reports"
+        )
+        test_step = lts_job[test_step_index:upload_step_index]
+        job_timeout_match = re.search(
+            r"(?m)^    timeout-minutes: ([0-9]+)$",
+            lts_job,
+        )
+        step_timeout_match = re.search(
+            r"(?m)^        timeout-minutes: ([0-9]+)$",
+            test_step,
+        )
+        self.assertIsNotNone(job_timeout_match)
+        self.assertIsNotNone(step_timeout_match)
+        assert job_timeout_match is not None
+        assert step_timeout_match is not None
+        self.assertLess(
+            int(step_timeout_match.group(1)),
+            int(job_timeout_match.group(1)),
+        )
+        self.assertLess(
+            lts_job.index("- name: Install pinned Godot"),
+            test_step_index,
+        )
+
+    def test_current_lts_job_uploads_only_bounded_failure_reports(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "tcc-conversion-test.yml"
+        content = workflow.read_text(encoding="utf-8")
+        upload_index = content.index("- name: Upload bounded current-LTS failure reports")
+        upload_step = content[upload_index:]
+
+        self.assertIn("if: failure()", upload_step)
+        self.assertIn("uses: actions/upload-artifact@v4", upload_step)
+        self.assertIn("if-no-files-found: ignore", upload_step)
+        self.assertIn("retention-days: 7", upload_step)
+        for report_name in (
+            "lts_fixture_report.json",
+            "unittest.log",
+            "conversion_diagnostics.json",
+            "conversion_diagnostics.md",
+            "conversion_manifest.json",
+            "godot_validation_report.json",
+        ):
+            with self.subTest(report=report_name):
+                self.assertIn(report_name, upload_step)
+        self.assertNotIn("gm2godot-lts-2026-output/*/**", upload_step)
+        self.assertNotRegex(upload_step, r"(?m)^\s+path:\s+.*gm2godot-lts-2026-output/?\s*$")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,7 @@ class TestCLIReports(unittest.TestCase):
             exit_code = cli.main(["--version"])
 
         self.assertEqual(exit_code, 0)
-        self.assertEqual(output.getvalue().strip(), "GM2Godot 0.7.0")
+        self.assertEqual(output.getvalue().strip(), "GM2Godot 0.7.1")
 
     def test_list_converters_writes_text_inventory(self) -> None:
         output = io.StringIO()
@@ -108,7 +108,7 @@ class TestCLIReports(unittest.TestCase):
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.strip(), "GM2Godot 0.7.0")
+        self.assertEqual(result.stdout.strip(), "GM2Godot 0.7.1")
 
     def test_app_entrypoint_routes_global_cli_flags(self) -> None:
         app_entrypoint = importlib.import_module("main")

--- a/tests/test_lts_2026_conversion.py
+++ b/tests/test_lts_2026_conversion.py
@@ -1,0 +1,426 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+import unittest
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ClassVar, cast
+
+from src.conversion.converter import CONVERSION_CATEGORIES, Converter
+from src.conversion.diagnostics import DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH
+from src.conversion.godot_validation import (
+    GodotValidationReport,
+    generated_godot_importable_asset_paths,
+    validate_generated_godot_project,
+    write_godot_validation_report,
+)
+from src.gui.setting_value import SettingValue
+
+
+REQUIRE_FIXTURES_ENV = "GM2GODOT_REQUIRE_LTS_FIXTURES"
+OUTPUT_ROOT_ENV = "LTS_FIXTURE_OUTPUT_ROOT"
+SNAP_PROJECT_ENV = "SNAP_PROJECT_PATH"
+ADDING_PROJECT_ENV = "ADDING_PROJECT_PATH"
+
+HISTORICAL_SNAP_SCRIPT_BLOCKERS = frozenset(
+    {
+        "SnapBufferReadGML",
+        "SnapBufferReadYAML",
+        "SnapBufferReadTilemapNew",
+        "TestGlobalConstructor",
+    }
+)
+# All four historical blockers convert on 0.7.0. Keeping the active set empty
+# makes any regression fail rather than silently restoring an old exception.
+ACTIVE_SNAP_SCRIPT_BLOCKERS: frozenset[str] = frozenset()
+SNAP_CASE_COLLISION_MESSAGE = (
+    "GML identifiers differ only by case in a Godot/GDScript output context: "
+    "INDENT, indent"
+)
+EXPECTED_SNAP_WARNINGS = (
+    (
+        "warning",
+        "GM2GD-GML-CASE-COLLISION",
+        "SnapBufferReadYAML",
+        "script",
+        19,
+        5,
+        SNAP_CASE_COLLISION_MESSAGE,
+    ),
+    (
+        "warning",
+        "GM2GD-GML-CASE-COLLISION",
+        "SnapBufferReadYAML",
+        "script",
+        315,
+        5,
+        SNAP_CASE_COLLISION_MESSAGE,
+    ),
+)
+EXPECTED_ADDING_OPERATIONS = (
+    "Equals (=)",
+    "Inequal (≠)",
+    "Approximately Equal (≈)",
+    "Strict Inequality (>)",
+    "Strict Inequality (<)",
+    "Inequality (≥)",
+    "Inequality (≤)",
+    "Plus (+)",
+    "Minus (-)",
+    "Plus - Minus (±)",
+    "Minus - Plus (±)",
+    "Multiply (*)",
+    "Times (×)",
+    "Division (÷)",
+    "Fraction (/)",
+    "Modulo (%)",
+    "Power (^)",
+    "Square Root (√)",
+    "Percent (%)",
+    "Per-Mille (‰)",
+)
+GODOT_LOADABLE_EXTENSIONS = frozenset({".gd", ".gdshader", ".tscn", ".tres"})
+
+
+@dataclass(frozen=True)
+class FixtureSpec:
+    name: str
+    project_env: str
+    project_filename: str
+    expected_ide_version: str
+    expected_script_count: int
+    expected_resource_type_counts: tuple[tuple[str, int], ...]
+
+
+@dataclass(frozen=True)
+class FixtureResult:
+    spec: FixtureSpec
+    source_path: Path
+    godot_path: Path
+    source_script_names: frozenset[str]
+    manifest: dict[str, Any]
+    diagnostics: dict[str, Any]
+    primary_script_entries: tuple[dict[str, Any], ...]
+    validation: GodotValidationReport
+    logs: tuple[str, ...]
+
+    def summary(self) -> dict[str, object]:
+        diagnostic_summary = cast(dict[str, Any], self.diagnostics["summary"])
+        source_project = cast(dict[str, Any], self.manifest["source_project"])
+        return {
+            "fixture": self.spec.name,
+            "ide_version": source_project["ide_version"],
+            "source_script_count": len(self.source_script_names),
+            "generated_script_count": len(self.primary_script_entries),
+            "conversion_warning_count": diagnostic_summary["warning"],
+            "conversion_error_count": diagnostic_summary["error"],
+            "godot_status": self.validation.status,
+            "godot_resource_count": len(self.validation.resource_paths),
+            "godot_import_returncode": self.validation.import_returncode,
+            "godot_validation_returncode": self.validation.returncode,
+            "godot_boot_returncode": self.validation.boot_returncode,
+            "godot_output_issue_count": len(self.validation.output_issues),
+        }
+
+
+FIXTURE_SPECS = (
+    FixtureSpec(
+        name="snap",
+        project_env=SNAP_PROJECT_ENV,
+        project_filename="snap.yyp",
+        expected_ide_version="2026.0.0.15",
+        expected_script_count=76,
+        expected_resource_type_counts=(
+            ("included_file", 1),
+            ("object", 19),
+            ("room", 1),
+            ("script", 123),
+            ("sprite", 1),
+        ),
+    ),
+    FixtureSpec(
+        name="adding",
+        project_env=ADDING_PROJECT_ENV,
+        project_filename="Adding.yyp",
+        expected_ide_version="2026.0.0.16",
+        expected_script_count=4,
+        expected_resource_type_counts=(
+            ("object", 1),
+            ("room", 1),
+            ("script", 4),
+        ),
+    ),
+)
+
+
+def _resolve_fixture_path(spec: FixtureSpec) -> Path | None:
+    raw_path = os.environ.get(spec.project_env)
+    if raw_path:
+        path = Path(raw_path).resolve()
+        if path.is_dir() and (path / spec.project_filename).is_file():
+            return path
+    if os.environ.get(REQUIRE_FIXTURES_ENV) == "1":
+        raise RuntimeError(
+            f"{spec.project_env} must name a directory containing "
+            f"{spec.project_filename} when {REQUIRE_FIXTURES_ENV}=1."
+        )
+    return None
+
+
+RESOLVED_FIXTURES = {
+    spec.name: resolved_path
+    for spec in FIXTURE_SPECS
+    if (resolved_path := _resolve_fixture_path(spec)) is not None
+}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
+
+
+def _primary_script_entries(manifest: dict[str, Any]) -> tuple[dict[str, Any], ...]:
+    resources = cast(list[dict[str, Any]], manifest["resources"])
+    entries: list[dict[str, Any]] = []
+    for entry in resources:
+        metadata = cast(dict[str, Any], entry.get("metadata", {}))
+        if entry.get("type") == "script" and not metadata.get("script_function", False):
+            entries.append(entry)
+    return tuple(sorted(entries, key=lambda entry: str(entry["name"])))
+
+
+def _convert_fixture(
+    spec: FixtureSpec,
+    source_path: Path,
+    output_root: Path,
+) -> FixtureResult:
+    godot_path = output_root / spec.name
+    godot_path.mkdir(parents=True, exist_ok=False)
+    (godot_path / "project.godot").write_text(
+        '[application]\nconfig/name="GM2Godot LTS 2026 CI Probe"\n',
+        encoding="utf-8",
+    )
+
+    all_keys = (
+        CONVERSION_CATEGORIES["assets"]
+        + CONVERSION_CATEGORIES["project"]
+        + CONVERSION_CATEGORIES["wip"]
+    )
+    settings = {key: SettingValue(True) for key in all_keys}
+    logs: list[str] = []
+    conversion_running = threading.Event()
+    conversion_running.set()
+
+    def log_message(message: object) -> None:
+        logs.append(str(message))
+
+    def ignore_progress(_value: object) -> None:
+        return None
+
+    def ignore_status(_message: object) -> None:
+        return None
+
+    converter = cast(Any, Converter)(
+        log_callback=log_message,
+        progress_callback=ignore_progress,
+        status_callback=ignore_status,
+        conversion_running=conversion_running,
+        compact_logging=True,
+    )
+    converter.convert(str(source_path), "windows", str(godot_path), settings)
+
+    manifest = _load_json(godot_path / "gm2godot" / "conversion_manifest.json")
+    diagnostics = _load_json(godot_path / DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
+    validation = validate_generated_godot_project(
+        str(godot_path),
+        timeout=180,
+        load_resources=True,
+        boot_frames=2,
+    )
+    write_godot_validation_report(str(godot_path), validation)
+    source_script_names = frozenset(
+        path.stem for path in (source_path / "scripts").rglob("*.gml")
+    )
+    return FixtureResult(
+        spec=spec,
+        source_path=source_path,
+        godot_path=godot_path,
+        source_script_names=source_script_names,
+        manifest=manifest,
+        diagnostics=diagnostics,
+        primary_script_entries=_primary_script_entries(manifest),
+        validation=validation,
+        logs=tuple(logs),
+    )
+
+
+class TestLTS2026Policy(unittest.TestCase):
+    def test_snap_blocker_allowlist_can_only_shrink(self) -> None:
+        self.assertLessEqual(
+            ACTIVE_SNAP_SCRIPT_BLOCKERS,
+            HISTORICAL_SNAP_SCRIPT_BLOCKERS,
+        )
+        self.assertEqual(ACTIVE_SNAP_SCRIPT_BLOCKERS, frozenset())
+
+
+@unittest.skipUnless(
+    len(RESOLVED_FIXTURES) == len(FIXTURE_SPECS),
+    "SNAP_PROJECT_PATH and ADDING_PROJECT_PATH are not both available.",
+)
+class TestLTS2026Conversion(unittest.TestCase):
+    results: ClassVar[dict[str, FixtureResult]]
+    output_root: ClassVar[Path]
+    temporary_output: ClassVar[tempfile.TemporaryDirectory[str] | None]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        configured_output_root = os.environ.get(OUTPUT_ROOT_ENV)
+        if configured_output_root:
+            cls.temporary_output = None
+            cls.output_root = Path(configured_output_root).resolve()
+            cls.output_root.mkdir(parents=True, exist_ok=True)
+        else:
+            cls.temporary_output = tempfile.TemporaryDirectory(
+                prefix="gm2godot_lts_2026_"
+            )
+            cls.output_root = Path(cls.temporary_output.name)
+
+        cls.results = {}
+        try:
+            for spec in FIXTURE_SPECS:
+                source_path = RESOLVED_FIXTURES[spec.name]
+                cls.results[spec.name] = _convert_fixture(
+                    spec,
+                    source_path,
+                    cls.output_root,
+                )
+        finally:
+            summary_path = cls.output_root / "lts_fixture_report.json"
+            summary_path.write_text(
+                json.dumps(
+                    {
+                        "format_version": 1,
+                        "fixtures": [
+                            cls.results[name].summary()
+                            for name in sorted(cls.results)
+                        ],
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.temporary_output is not None:
+            cls.temporary_output.cleanup()
+
+    def _assert_common_fixture_contract(self, result: FixtureResult) -> None:
+        spec = result.spec
+        source_project = cast(dict[str, Any], result.manifest["source_project"])
+        resources = cast(list[dict[str, Any]], result.manifest["resources"])
+        self.assertEqual(source_project["ide_version"], spec.expected_ide_version)
+        self.assertEqual(len(result.source_script_names), spec.expected_script_count)
+        self.assertEqual(len(result.primary_script_entries), spec.expected_script_count)
+        self.assertEqual(
+            {str(entry["name"]) for entry in result.primary_script_entries},
+            set(result.source_script_names),
+        )
+
+        generated_paths = [
+            str(entry["godot_path"])
+            for entry in result.primary_script_entries
+        ]
+        self.assertEqual(len(generated_paths), len(set(generated_paths)))
+        resource_type_counts = Counter(str(entry["type"]) for entry in resources)
+        self.assertEqual(
+            dict(resource_type_counts),
+            dict(spec.expected_resource_type_counts),
+        )
+        validation_paths = set(result.validation.resource_paths)
+        for resource in resources:
+            generated_path = str(resource["godot_path"])
+            with self.subTest(
+                fixture=spec.name,
+                resource=resource["name"],
+                generated_path=generated_path,
+            ):
+                self.assertTrue(generated_path.startswith("res://"))
+                relative_path = generated_path.removeprefix("res://")
+                self.assertTrue((result.godot_path / relative_path).is_file())
+                if Path(relative_path).suffix.lower() in GODOT_LOADABLE_EXTENSIONS:
+                    self.assertIn(generated_path, validation_paths)
+
+        diagnostic_summary = cast(dict[str, Any], result.diagnostics["summary"])
+        self.assertEqual(diagnostic_summary["error"], 0)
+        self.assertNotIn("Traceback", "\n".join(result.logs))
+
+        validation = result.validation
+        self.assertEqual(validation.status, "passed", validation.message + "\n" + validation.output)
+        importable_assets = generated_godot_importable_asset_paths(str(result.godot_path))
+        if importable_assets:
+            self.assertEqual(validation.import_returncode, 0, validation.import_output)
+        else:
+            self.assertIsNone(validation.import_returncode, validation.import_output)
+        self.assertEqual(validation.returncode, 0, validation.output)
+        self.assertEqual(validation.boot_returncode, 0, validation.boot_output)
+        self.assertEqual(validation.boot_frames, 2)
+        self.assertEqual(validation.output_issues, (), validation.output)
+
+    def test_adding_converts_all_scripts_without_diagnostics(self) -> None:
+        result = self.results["adding"]
+        self._assert_common_fixture_contract(result)
+        diagnostic_summary = cast(dict[str, Any], result.diagnostics["summary"])
+
+        self.assertEqual(diagnostic_summary["warning"], 0)
+        operation_names = [
+            line.partition("Adding: Performed ")[2].partition(" on ")[0]
+            for line in result.validation.boot_output.splitlines()
+            if "Adding: Performed " in line
+        ]
+        self.assertCountEqual(
+            operation_names,
+            EXPECTED_ADDING_OPERATIONS,
+            result.validation.boot_output,
+        )
+
+    def test_snap_converts_all_scripts_with_only_known_case_collisions(self) -> None:
+        result = self.results["snap"]
+        self._assert_common_fixture_contract(result)
+        diagnostics = cast(list[dict[str, Any]], result.diagnostics["diagnostics"])
+        warnings = [
+            diagnostic
+            for diagnostic in diagnostics
+            if diagnostic.get("severity") == "warning"
+        ]
+        warning_tuples = tuple(
+            (
+                diagnostic.get("severity"),
+                diagnostic.get("code"),
+                diagnostic.get("resource"),
+                diagnostic.get("resource_type"),
+                diagnostic.get("line"),
+                diagnostic.get("column"),
+                diagnostic.get("message"),
+            )
+            for diagnostic in warnings
+        )
+        observed_blockers = frozenset(
+            str(diagnostic["resource"])
+            for diagnostic in diagnostics
+            if diagnostic.get("code") == "GM2GD-GML-TRANSPILE"
+            and diagnostic.get("resource_type") == "script"
+            and diagnostic.get("resource")
+        )
+
+        self.assertEqual(observed_blockers, ACTIVE_SNAP_SCRIPT_BLOCKERS)
+        self.assertCountEqual(warning_tuples, EXPECTED_SNAP_WARNINGS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,15 +10,21 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_0(self) -> None:
-        self.assertEqual(get_version(), "0.7.0")
+    def test_release_version_is_0_7_1(self) -> None:
+        self.assertEqual(get_version(), "0.7.1")
 
-    def test_release_docs_reference_0_7_0(self) -> None:
+    def test_release_docs_reference_0_7_1(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
         readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
+        issue_template = (
+            PROJECT_ROOT / ".github" / "ISSUE_TEMPLATE" / "unsupported_gml_api.yml"
+        ).read_text(encoding="utf-8")
 
+        self.assertIn("## 0.7.1 - 2026-07-17", changelog)
+        self.assertIn("Current source version: `0.7.1`.", readme)
+        self.assertIn("GM2Godot 0.7.1, GameMaker LTS 2026", issue_template)
+        self.assertIn("immutable GameMaker LTS 2026 SNAP and Adding fixtures", changelog)
         self.assertIn("## 0.7.0 - 2026-07-17", changelog)
-        self.assertIn("Current source version: `0.7.0`.", readme)
         self.assertIn("GameMaker LTS 2026", changelog)
         self.assertIn("## 0.6.1 - 2026-05-28", changelog)
         self.assertIn("converter inventory discovery", changelog)


### PR DESCRIPTION
## Summary

- Pin SNAP and Adding at immutable GameMaker LTS 2026 commits in a dedicated CI job using checksum-verified Godot 4.7.1.
- Require complete script and manifest-resource conversion, zero Adding diagnostics, and an empty active SNAP blocker set while retaining the historical four-name ceiling.
- Load every generated Godot resource, boot both main scenes, verify the exact Adding operator set, and upload only bounded reports on failure.
- Bump GM2Godot to 0.7.1.

## Validation

- `./venv/bin/pyright --warnings`
- `./venv/bin/ruff check src/version.py tests/test_ci_workflows.py tests/test_lts_2026_conversion.py tests/test_version.py tests/test_cli.py`
- `./venv/bin/python -m unittest` (1,264 tests; 37 skipped)
- Fresh SNAP and Adding conversion under `4.7.1.stable.official.a13da4feb`

Closes #698