### PR TITLE
Confine nested GameMaker source paths

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.1, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.2, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.2 - 2026-07-17
+
+- Confined nested GameMaker `.yy` sidecar and fallback-scan paths to the declared project root, rejecting traversal, absolute-path, drive-relative, NUL, and symlink escapes with source-linked diagnostics.
+
 ## 0.7.1 - 2026-07-17
 
 - Added immutable GameMaker LTS 2026 SNAP and Adding fixtures to CI with exact Godot 4.7.1 conversion, generated-resource validation, short runtime boot checks, and bounded failure reports.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.1`.
+Current source version: `0.7.2`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 

--- a/src/conversion/animation_curve_registry.py
+++ b/src/conversion/animation_curve_registry.py
@@ -6,6 +6,10 @@ import re
 from dataclasses import dataclass
 from typing import Iterable, Protocol, cast
 
+from src.conversion.project_source_paths import (
+    ProjectSourcePathError,
+    resolve_project_source_path,
+)
 from src.conversion.type_defs import JsonDict
 
 ANIMATION_CURVE_REGISTRY_RELATIVE_PATH = os.path.join(
@@ -86,8 +90,14 @@ def build_animation_curve_registry_entries(
     for asset_entry in asset_entries:
         if asset_entry.kind != "animcurves":
             continue
-        yy_path = os.path.join(gm_project_path, asset_entry.source_path)
-        data = _read_json_lenient(yy_path)
+        try:
+            resolved_yy = resolve_project_source_path(
+                gm_project_path,
+                asset_entry.source_path,
+            )
+        except ProjectSourcePathError:
+            continue
+        data = _read_json_lenient(resolved_yy.filesystem_path)
         if data is None:
             continue
         entries.append(_animation_curve_entry_from_yy(asset_entry, data))

--- a/src/conversion/architecture_policy.py
+++ b/src/conversion/architecture_policy.py
@@ -8,6 +8,10 @@ from typing import Iterable, cast
 
 from src.conversion.resource_index import GameMakerResourceIndex, IndexedRoom
 from src.conversion.runtime_managers import runtime_manager_definitions
+from src.conversion.project_source_paths import (
+    ProjectSourcePathError,
+    resolve_project_filesystem_source_path,
+)
 from src.conversion.type_defs import JsonDict
 
 ARCHITECTURE_POLICY_RELATIVE_PATH = os.path.join("gm2godot", "architecture_policy.json")
@@ -320,9 +324,17 @@ def _read_gml_sources(gm_project_path: str) -> str:
                 continue
             path = os.path.join(root, filename)
             try:
-                with open(path, "r", encoding="utf-8") as source_file:
+                resolved = resolve_project_filesystem_source_path(
+                    gm_project_path,
+                    path,
+                )
+                with open(
+                    resolved.filesystem_path,
+                    "r",
+                    encoding="utf-8",
+                ) as source_file:
                     chunks.append(source_file.read())
-            except OSError:
+            except (OSError, ProjectSourcePathError):
                 continue
     return "\n".join(chunks)
 

--- a/src/conversion/asset_registry.py
+++ b/src/conversion/asset_registry.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import json
 import os
+import posixpath
 from dataclasses import dataclass, field
 from typing import ClassVar, Iterable, cast
 
 from src.conversion.base_converter import BaseConverter
+from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.project_manifest import (
     GameMakerProjectManifest,
     ProjectTextureGroup,
@@ -14,7 +16,6 @@ from src.conversion.project_manifest import (
 from src.conversion.gml_transpiler import GMLTranspileError, transpile_gml_code
 from src.conversion.fonts import (
     bundled_font_output_filename,
-    resolve_bundled_font_source,
     resolve_system_font_source,
 )
 from src.conversion.generated_paths import (
@@ -25,7 +26,8 @@ from src.conversion.generated_paths import (
 )
 from src.conversion.project_source_paths import (
     ProjectSourcePathError,
-    resolve_project_source_path,
+    is_safe_project_source_component,
+    validate_project_resource_source_path,
 )
 from src.conversion.script_functions import modern_script_function_names
 from src.conversion.type_defs import (
@@ -205,6 +207,7 @@ class AssetRegistryConverter(BaseConverter):
         max_workers: int | None = None,
         organize_sounds_by_audio_group: bool = False,
         macro_configuration: str | None = None,
+        diagnostics: DiagnosticCollector | None = None,
     ) -> None:
         super().__init__(
             gm_project_path,
@@ -215,6 +218,7 @@ class AssetRegistryConverter(BaseConverter):
             update_log_callback,
             compact_logging,
             max_workers=max_workers,
+            diagnostics=diagnostics,
         )
         self.organize_sounds_by_audio_group = bool(organize_sounds_by_audio_group)
         self.macro_configuration = macro_configuration
@@ -297,7 +301,12 @@ class AssetRegistryConverter(BaseConverter):
         self._write_timeline_action_scripts(entries)
         write_path_registry(self.gm_project_path, self.godot_project_path, entries)
         write_animation_curve_registry(self.gm_project_path, self.godot_project_path, entries)
-        write_extension_compatibility_outputs(self.gm_project_path, self.godot_project_path)
+        write_extension_compatibility_outputs(
+            self.gm_project_path,
+            self.godot_project_path,
+            diagnostics=self.diagnostics,
+            log_callback=self.log_callback,
+        )
 
         self.log_callback(
             "Generated GameMaker asset registry: {path} ({count} assets)".format(
@@ -318,39 +327,52 @@ class AssetRegistryConverter(BaseConverter):
         )
 
     def _load_project_resources(self) -> tuple[_ProjectResource, ...]:
-        yyp_path = self._find_yyp_path()
-        if yyp_path is not None:
-            yyp_data = self._read_yy_file(yyp_path)
-            if yyp_data is not None:
-                resources = list(self._resources_from_yyp(yyp_data))
-                resources.extend(self._included_files_from_disk())
-                return tuple(self._dedupe_resources(resources))
+        manifest_rejected_fields = (
+            self._record_project_manifest_source_path_diagnostics(
+                self.project_manifest,
+                include_project_sources=True,
+            )
+        )
+        yyp_path = self.project_manifest.yyp_path
+        manifest_parse_failed = any(
+            diagnostic.code == "GM2GD-PROJECT-YYP-MALFORMED"
+            for diagnostic in self.project_manifest.diagnostics
+        )
+        yyp_source_path = self._diagnostic_source_path(yyp_path)
+        if (
+            yyp_path is not None
+            and yyp_source_path is not None
+            and not manifest_parse_failed
+        ):
+            resources = list(
+                self._resources_from_yyp(
+                    self.project_manifest.raw_data,
+                    yyp_source_path,
+                    manifest_rejected_fields,
+                )
+            )
+            resources.extend(self._included_files_from_disk())
+            return tuple(self._dedupe_resources(resources))
 
+        if yyp_path is not None:
             self._safe_log("Warning: Could not parse GameMaker project .yyp; using disk asset scan.")
 
         resources = list(self._resources_from_disk())
         resources.extend(self._included_files_from_disk())
         return tuple(self._dedupe_resources(resources))
 
-    def _find_yyp_path(self) -> str | None:
-        try:
-            yyp_files = sorted(
-                name for name in os.listdir(self.gm_project_path) if name.endswith(".yyp")
-            )
-        except OSError:
-            return None
-
-        if not yyp_files:
-            return None
-        return os.path.join(self.gm_project_path, yyp_files[0])
-
-    def _resources_from_yyp(self, yyp_data: JsonDict) -> tuple[_ProjectResource, ...]:
+    def _resources_from_yyp(
+        self,
+        yyp_data: JsonDict,
+        yyp_source_path: str,
+        manifest_rejected_fields: frozenset[str],
+    ) -> tuple[_ProjectResource, ...]:
         resource_entries = yyp_data.get("resources")
         if not isinstance(resource_entries, list):
             return ()
 
         resources: list[_ProjectResource] = []
-        for raw_entry in cast(list[object], resource_entries):
+        for index, raw_entry in enumerate(cast(list[object], resource_entries)):
             if not isinstance(raw_entry, dict):
                 continue
             entry = cast(JsonDict, raw_entry)
@@ -358,6 +380,9 @@ class AssetRegistryConverter(BaseConverter):
             if not isinstance(raw_id, dict):
                 continue
             resource_id = cast(JsonDict, raw_id)
+            field = f"resources[{index}].id.path"
+            if field in manifest_rejected_fields:
+                continue
             raw_path = resource_id.get("path")
             if not isinstance(raw_path, str) or not raw_path:
                 continue
@@ -368,20 +393,41 @@ class AssetRegistryConverter(BaseConverter):
                 if isinstance(raw_name, str) and raw_name
                 else self._name_from_path(raw_path.replace("\\", "/"))
             )
-            asset_label = name or "<unnamed>"
+            kind_hint = self._normalize_yyp_kind(raw_path.replace("\\", "/"))
+            resolved_path = self._resolve_project_source(
+                raw_path,
+                owner_source_path=yyp_source_path,
+                resource=name or "<unnamed>",
+                resource_type=self.RESOURCE_TYPE_BY_KIND.get(
+                    kind_hint,
+                    kind_hint or "asset",
+                ),
+                field=field,
+            )
+            if resolved_path is None:
+                continue
+
+            declared_kind = self.FOLDER_BY_KIND.get(kind_hint, kind_hint)
             try:
-                resolved_path = resolve_project_source_path(
-                    self.gm_project_path,
-                    raw_path,
+                validate_project_resource_source_path(
+                    resolved_path,
+                    declared_kind,
                 )
             except ProjectSourcePathError as exc:
-                self._safe_log(
-                    f"Warning: Skipping GameMaker asset {asset_label}: {exc}"
+                self._report_source_path_rejection(
+                    raw_path,
+                    exc,
+                    owner_source_path=yyp_source_path,
+                    resource=name or "<unnamed>",
+                    resource_type=self.RESOURCE_TYPE_BY_KIND.get(
+                        kind_hint,
+                        kind_hint or "asset",
+                    ),
+                    field=field,
                 )
                 continue
-            source_path = resolved_path.source_path
 
-            kind = self._normalize_yyp_kind(source_path)
+            kind = kind_hint
             if kind not in self.RESOURCE_TYPE_BY_KIND or kind == "included_files":
                 continue
 
@@ -389,6 +435,7 @@ class AssetRegistryConverter(BaseConverter):
                 continue
 
             yy_path = resolved_path.filesystem_path
+            source_path = resolved_path.source_path
             if not os.path.isfile(yy_path):
                 self._safe_log(f"Warning: Skipping missing GameMaker asset {name}: {yy_path}")
                 continue
@@ -410,45 +457,166 @@ class AssetRegistryConverter(BaseConverter):
             if kind == "included_files":
                 continue
             folder = self.FOLDER_BY_KIND[kind]
-            kind_dir = os.path.join(self.gm_project_path, folder)
-            if not os.path.isdir(kind_dir):
+            resource_type = self.RESOURCE_TYPE_BY_KIND[kind]
+            kind_source = self._resolve_discovered_project_source(
+                os.path.join(self.gm_project_path, folder),
+                resource_type=resource_type,
+                field="disk fallback kind directory",
+            )
+            if kind_source is None or not os.path.isdir(
+                kind_source.filesystem_path
+            ):
                 continue
 
             try:
-                resource_names = sorted(os.listdir(kind_dir))
+                resource_names = sorted(os.listdir(kind_source.filesystem_path))
             except OSError:
                 continue
 
             for name in resource_names:
-                resource_dir = os.path.join(kind_dir, name)
-                yy_path = os.path.join(resource_dir, name + ".yy")
-                if not os.path.isdir(resource_dir) or not os.path.isfile(yy_path):
+                resource_source = self._resolve_discovered_project_source(
+                    os.path.join(kind_source.filesystem_path, name),
+                    owner_source_path=kind_source.source_path,
+                    resource=name,
+                    resource_type=resource_type,
+                    field="disk fallback resource directory",
+                )
+                if resource_source is None or not os.path.isdir(
+                    resource_source.filesystem_path
+                ):
                     continue
-                source_path = "/".join([folder, name, name + ".yy"])
+                yy_source = self._resolve_discovered_project_source(
+                    os.path.join(
+                        resource_source.filesystem_path,
+                        name + ".yy",
+                    ),
+                    owner_source_path=resource_source.source_path,
+                    resource=name,
+                    resource_type=resource_type,
+                    field="disk fallback resource metadata",
+                )
+                if yy_source is None:
+                    continue
+                try:
+                    validate_project_resource_source_path(
+                        yy_source,
+                        folder,
+                    )
+                except ProjectSourcePathError as exc:
+                    self._report_source_path_rejection(
+                        yy_source.source_path,
+                        exc,
+                        owner_source_path=resource_source.source_path,
+                        resource=name,
+                        resource_type=resource_type,
+                        field="disk fallback resource metadata",
+                    )
+                    continue
+                if not os.path.isfile(yy_source.filesystem_path):
+                    continue
                 resources.append(
                     _ProjectResource(
                         kind=kind,
                         name=name,
-                        yy_path=yy_path,
-                        source_path=source_path,
-                        raw_data=self._read_yy_file(yy_path) or {},
+                        yy_path=yy_source.filesystem_path,
+                        source_path=yy_source.source_path,
+                        raw_data=(
+                            self._read_yy_file(yy_source.filesystem_path) or {}
+                        ),
                     )
                 )
         return tuple(resources)
 
     def _script_source_gml_path(self, resource: _ProjectResource) -> str | None:
-        script_dir = os.path.dirname(resource.yy_path)
-        preferred_path = os.path.join(script_dir, resource.name + ".gml")
-        if os.path.isfile(preferred_path):
-            return preferred_path
-        if not os.path.isdir(script_dir):
+        yy_source = self._resolve_project_source(
+            resource.source_path,
+            resource=resource.name,
+            resource_type="script",
+            field="script .yy",
+        )
+        if yy_source is None or not os.path.isfile(yy_source.filesystem_path):
             return None
+
+        script_directory = self._resolve_discovered_project_source(
+            os.path.dirname(yy_source.filesystem_path),
+            owner_source_path=yy_source.source_path,
+            resource=resource.name,
+            resource_type="script",
+            field="script source directory",
+        )
+        if script_directory is None or not os.path.isdir(
+            script_directory.filesystem_path
+        ):
+            return None
+
+        preferred_filename = resource.name + ".gml"
+        excluded_filenames = {preferred_filename}
+        preferred_source = None
+        if not is_safe_project_source_component(resource.name):
+            normalized_preferred_filename = posixpath.basename(
+                posixpath.normpath(preferred_filename.replace("\\", "/"))
+            )
+            if normalized_preferred_filename:
+                excluded_filenames.add(normalized_preferred_filename)
+            self._report_source_path_rejection(
+                preferred_filename,
+                ProjectSourcePathError(
+                    "GameMaker script resource names used to derive source "
+                    "filenames must identify exactly one path component: "
+                    f"{resource.name!r}"
+                ),
+                owner_source_path=yy_source.source_path,
+                resource=resource.name,
+                resource_type="script",
+                field="preferred script source",
+            )
+        else:
+            preferred_source = self._resolve_project_source(
+                preferred_filename,
+                owner_source_path=yy_source.source_path,
+                resource=resource.name,
+                resource_type="script",
+                field="preferred script source",
+            )
+        if preferred_source is not None:
+            owner_directory = posixpath.dirname(yy_source.source_path)
+            preferred_directory = posixpath.dirname(preferred_source.source_path)
+            if preferred_directory != owner_directory:
+                self._report_source_path_rejection(
+                    preferred_filename,
+                    ProjectSourcePathError(
+                        "GameMaker script source derived from the resource name "
+                        "must be next to its script .yy owner: "
+                        f"{preferred_filename!r}"
+                    ),
+                    owner_source_path=yy_source.source_path,
+                    resource=resource.name,
+                    resource_type="script",
+                    field="preferred script source",
+                )
+                preferred_source = None
+            elif os.path.isfile(preferred_source.filesystem_path):
+                return preferred_source.filesystem_path
+
         try:
-            for filename in sorted(os.listdir(script_dir)):
-                if filename.endswith(".gml"):
-                    return os.path.join(script_dir, filename)
+            filenames = sorted(os.listdir(script_directory.filesystem_path))
         except OSError:
             return None
+        for filename in filenames:
+            if not filename.endswith(".gml") or filename in excluded_filenames:
+                continue
+            discovered_source = self._resolve_discovered_project_source(
+                os.path.join(script_directory.filesystem_path, filename),
+                owner_source_path=yy_source.source_path,
+                resource=resource.name,
+                resource_type="script",
+                field="discovered script source",
+            )
+            if discovered_source is None or not os.path.isfile(
+                discovered_source.filesystem_path
+            ):
+                continue
+            return discovered_source.filesystem_path
         return None
 
     def _script_function_names(self, resource: _ProjectResource) -> tuple[str, ...]:
@@ -465,28 +633,73 @@ class AssetRegistryConverter(BaseConverter):
             return ()
 
     def _included_files_from_disk(self) -> tuple[_ProjectResource, ...]:
-        datafiles_dir = os.path.join(self.gm_project_path, "datafiles")
-        if not os.path.isdir(datafiles_dir):
+        datafiles_source = self._resolve_discovered_project_source(
+            os.path.join(self.gm_project_path, "datafiles"),
+            resource_type="included_file",
+            field="datafiles directory",
+        )
+        if datafiles_source is None or not os.path.isdir(
+            datafiles_source.filesystem_path
+        ):
             return ()
 
         resources: list[_ProjectResource] = []
-        for root, dirs, files in os.walk(datafiles_dir):
-            dirs.sort()
-            for filename in sorted(files):
-                if filename.endswith(".yy"):
+        pending_directories = [
+            (
+                datafiles_source.filesystem_path,
+                datafiles_source.source_path,
+            )
+        ]
+        visited_directories: set[str] = set()
+        while pending_directories:
+            directory_path, directory_source_path = pending_directories.pop()
+            canonical_directory = os.path.normcase(os.path.realpath(directory_path))
+            if canonical_directory in visited_directories:
+                continue
+            visited_directories.add(canonical_directory)
+            try:
+                entry_names = sorted(os.listdir(directory_path), reverse=True)
+            except OSError:
+                continue
+            for entry_name in entry_names:
+                entry_path = os.path.join(directory_path, entry_name)
+                entry_is_symlink = os.path.islink(entry_path)
+                entry_source = self._resolve_discovered_project_source(
+                    entry_path,
+                    owner_source_path=directory_source_path,
+                    resource=entry_name,
+                    resource_type="included_file",
+                    field="discovered datafiles entry",
+                )
+                if entry_source is None:
                     continue
-                file_path = os.path.join(root, filename)
-                rel_path = os.path.relpath(file_path, datafiles_dir).replace(os.sep, "/")
+                if os.path.isdir(entry_source.filesystem_path):
+                    if not entry_is_symlink:
+                        pending_directories.append(
+                            (
+                                entry_source.filesystem_path,
+                                entry_source.source_path,
+                            )
+                        )
+                    continue
+                if entry_name.endswith(".yy") or not os.path.isfile(
+                    entry_source.filesystem_path
+                ):
+                    continue
+                rel_path = posixpath.relpath(
+                    entry_source.source_path,
+                    datafiles_source.source_path,
+                )
                 resources.append(
                     _ProjectResource(
                         kind="included_files",
                         name=rel_path,
                         yy_path="",
-                        source_path="datafiles/" + rel_path,
+                        source_path=entry_source.source_path,
                         raw_data={},
                     )
                 )
-        return tuple(resources)
+        return tuple(sorted(resources, key=lambda resource: resource.source_path))
 
     @staticmethod
     def _dedupe_resources(resources: list[_ProjectResource]) -> tuple[_ProjectResource, ...]:
@@ -555,9 +768,19 @@ class AssetRegistryConverter(BaseConverter):
         return ""
 
     def _sound_godot_path(self, resource: _ProjectResource, *, suffix: str = "") -> str:
-        sound_file = resource.raw_data.get("soundFile")
-        if not isinstance(sound_file, str) or not sound_file:
+        sound_file_reference = resource.raw_data.get("soundFile")
+        if not isinstance(sound_file_reference, str) or not sound_file_reference:
             return ""
+        sound_source = self._resolve_project_source(
+            sound_file_reference,
+            owner_source_path=resource.source_path,
+            resource=resource.name,
+            resource_type="sound",
+            field="soundFile",
+        )
+        if sound_source is None:
+            return ""
+        sound_filename = os.path.basename(sound_source.filesystem_path)
 
         parts = ["sounds"]
         if self.organize_sounds_by_audio_group:
@@ -565,7 +788,7 @@ class AssetRegistryConverter(BaseConverter):
             parts.append(generated_path_segment(audio_group or "audiogroup_default", "audiogroup_default"))
         subfolder = self._get_subfolder_from_resource(resource)
         parts.extend(part for part in subfolder.split("/") if part)
-        parts.extend([generated_resource_stem(resource.name) + suffix, sound_file])
+        parts.extend([generated_resource_stem(resource.name) + suffix, sound_filename])
         return "res://" + "/".join(parts)
 
     def _metadata(
@@ -869,9 +1092,8 @@ class AssetRegistryConverter(BaseConverter):
             if action is not None:
                 actions.append(action)
 
-        source_filename = self._timeline_source_filename(resource, moment, frame)
-        if source_filename:
-            source_path = self._resource_relative_path(resource, source_filename)
+        source_path = self._timeline_source_path(resource, moment, frame)
+        if source_path:
             actions.append({
                 "kind": "gml",
                 "source_path": source_path,
@@ -881,8 +1103,17 @@ class AssetRegistryConverter(BaseConverter):
 
     def _timeline_discovered_source_actions(self, resource: _ProjectResource) -> list[tuple[int, list[JsonDict]]]:
         discovered: list[tuple[int, list[JsonDict]]] = []
+        timeline_directory = self._resolve_discovered_project_source(
+            os.path.dirname(resource.yy_path),
+            owner_source_path=resource.source_path,
+            resource=resource.name,
+            resource_type="timeline",
+            field="timeline source directory",
+        )
+        if timeline_directory is None:
+            return discovered
         try:
-            filenames = sorted(os.listdir(os.path.dirname(resource.yy_path)))
+            filenames = sorted(os.listdir(timeline_directory.filesystem_path))
         except OSError:
             return discovered
 
@@ -892,17 +1123,29 @@ class AssetRegistryConverter(BaseConverter):
             frame = self._timeline_frame_from_filename(filename)
             if frame is None:
                 continue
+            resolved_source = self._resolve_discovered_project_source(
+                os.path.join(timeline_directory.filesystem_path, filename),
+                owner_source_path=resource.source_path,
+                resource=resource.name,
+                resource_type="timeline",
+                field="discovered timeline moment source",
+            )
+            if (
+                resolved_source is None
+                or not os.path.isfile(resolved_source.filesystem_path)
+            ):
+                continue
             discovered.append((
                 frame,
                 [{
                     "kind": "gml",
-                    "source_path": self._resource_relative_path(resource, filename),
+                    "source_path": resolved_source.source_path,
                     "script_path": self._timeline_action_script_resource_path(resource.name, frame),
                 }],
             ))
         return discovered
 
-    def _timeline_source_filename(
+    def _timeline_source_path(
         self,
         resource: _ProjectResource,
         moment: JsonDict,
@@ -911,15 +1154,32 @@ class AssetRegistryConverter(BaseConverter):
         for key in ("gmlFile", "eventFile", "filename", "source", "sourceFile"):
             value = moment.get(key)
             if isinstance(value, str) and value:
-                return value
+                resolved_source = self._resolve_project_source(
+                    value,
+                    owner_source_path=resource.source_path,
+                    resource=resource.name,
+                    resource_type="timeline",
+                    field=key,
+                )
+                return resolved_source.source_path if resolved_source is not None else ""
         for candidate in (
             f"Moment_{frame}.gml",
             f"moment_{frame}.gml",
             f"Timeline_{frame}.gml",
             f"{frame}.gml",
         ):
-            if os.path.isfile(os.path.join(os.path.dirname(resource.yy_path), candidate)):
-                return candidate
+            resolved_source = self._resolve_project_source(
+                candidate,
+                owner_source_path=resource.source_path,
+                resource=resource.name,
+                resource_type="timeline",
+                field="implicit timeline moment source",
+            )
+            if (
+                resolved_source is not None
+                and os.path.isfile(resolved_source.filesystem_path)
+            ):
+                return resolved_source.source_path
         return ""
 
     def _raw_action_items(self, moment: JsonDict) -> list[object]:
@@ -1008,23 +1268,40 @@ class AssetRegistryConverter(BaseConverter):
                     source_path = action.get("source_path")
                     script_path = action.get("script_path")
                     if isinstance(source_path, str) and isinstance(script_path, str):
-                        self._write_timeline_action_script(entry.name, frame, source_path, script_path, asset_names)
+                        self._write_timeline_action_script(
+                            entry.name,
+                            frame,
+                            entry.source_path,
+                            source_path,
+                            script_path,
+                            asset_names,
+                        )
 
     def _write_timeline_action_script(
         self,
         timeline_name: str,
         frame: int,
+        owner_source_path: str,
         source_path: str,
         script_path: str,
         asset_names: set[str],
     ) -> None:
         if not script_path.startswith("res://"):
             return
-        gm_source_path = os.path.join(self.gm_project_path, *source_path.split("/"))
+        resolved_source = self._resolve_project_source(
+            source_path,
+            owner_source_path=owner_source_path,
+            resource=timeline_name,
+            resource_type="timeline",
+            field="timeline action source_path",
+        )
+        if resolved_source is None:
+            return
+        gm_source_path = resolved_source.filesystem_path
         try:
             with open(gm_source_path, "r", encoding="utf-8") as source_file:
                 source = source_file.read()
-        except OSError:
+        except (OSError, ValueError):
             self._safe_log(
                 "Warning: Could not read GameMaker timeline moment code for "
                 f"{timeline_name} frame {frame}: {gm_source_path}"
@@ -1078,12 +1355,6 @@ class AssetRegistryConverter(BaseConverter):
                 ])
             )
 
-    def _resource_relative_path(self, resource: _ProjectResource, filename: str) -> str:
-        return os.path.join(
-            os.path.dirname(resource.source_path),
-            filename,
-        ).replace(os.sep, "/")
-
     @staticmethod
     def _timeline_action_script_resource_path(timeline_name: str, frame: int) -> str:
         safe_name = generated_resource_stem(timeline_name)
@@ -1111,9 +1382,8 @@ class AssetRegistryConverter(BaseConverter):
             return {}
 
         ordered: list[str] = []
-        yyp_path = self._find_yyp_path()
-        yyp_data = self._read_yy_file(yyp_path) if yyp_path is not None else None
-        if yyp_data is not None and "RoomOrderNodes" in yyp_data:
+        yyp_data = self.project_manifest.raw_data
+        if "RoomOrderNodes" in yyp_data:
             for raw_node in cast(list[object], yyp_data.get("RoomOrderNodes", [])):
                 if not isinstance(raw_node, dict):
                     continue
@@ -1139,9 +1409,19 @@ class AssetRegistryConverter(BaseConverter):
         ttf_name = resource.raw_data.get("TTFName")
         include_ttf = bool(resource.raw_data.get("includeTTF", False))
         if include_ttf and isinstance(ttf_name, str) and ttf_name:
-            source_ttf_path = resolve_bundled_font_source(resource.yy_path, ttf_name)
+            source_ttf = self._resolve_project_source(
+                ttf_name,
+                owner_source_path=resource.source_path,
+                resource=resource.name,
+                resource_type="font",
+                field="TTFName",
+            )
             output_filename = bundled_font_output_filename(ttf_name)
-            if source_ttf_path is not None and output_filename is not None:
+            if (
+                source_ttf is not None
+                and output_filename is not None
+                and os.path.isfile(source_ttf.filesystem_path)
+            ):
                 stem, extension = os.path.splitext(output_filename)
                 return self._flat_resource_path(
                     "fonts",

--- a/src/conversion/base_converter.py
+++ b/src/conversion/base_converter.py
@@ -10,6 +10,14 @@ from typing import Any, cast
 from src.localization import get_localized
 from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.generated_paths import generated_subfolder_path
+from src.conversion.project_manifest import GameMakerProjectManifest
+from src.conversion.project_source_paths import (
+    ProjectSourcePathError,
+    ResolvedProjectSourcePath,
+    resolve_project_filesystem_source_path,
+    resolve_project_sidecar_source_path,
+    resolve_project_source_path,
+)
 from src.conversion.type_defs import ConversionRunning, JsonDict, LogCallback, ProgressCallback, StrPath
 
 
@@ -53,6 +61,227 @@ class BaseConverter(ABC):
             if self.progress_callback:
                 self.progress_callback(value)
 
+    def _resolve_project_source(
+        self,
+        source_path: str,
+        *,
+        owner_source_path: StrPath | None = None,
+        resource: str | None = None,
+        resource_type: str | None = None,
+        field: str | None = None,
+    ) -> ResolvedProjectSourcePath | None:
+        """Resolve metadata-owned input and report a structured rejection."""
+        try:
+            if owner_source_path is None:
+                return resolve_project_source_path(
+                    self.gm_project_path,
+                    source_path,
+                )
+            return resolve_project_sidecar_source_path(
+                self.gm_project_path,
+                owner_source_path,
+                source_path,
+            )
+        except ProjectSourcePathError as exc:
+            self._report_source_path_rejection(
+                source_path,
+                exc,
+                owner_source_path=owner_source_path,
+                resource=resource,
+                resource_type=resource_type,
+                field=field,
+            )
+            return None
+
+    def _resolve_discovered_project_source(
+        self,
+        filesystem_path: StrPath,
+        *,
+        owner_source_path: StrPath | None = None,
+        resource: str | None = None,
+        resource_type: str | None = None,
+        field: str | None = None,
+    ) -> ResolvedProjectSourcePath | None:
+        """Revalidate a disk-scan candidate before any source-side access."""
+        try:
+            return resolve_project_filesystem_source_path(
+                self.gm_project_path,
+                filesystem_path,
+            )
+        except ProjectSourcePathError as exc:
+            self._report_source_path_rejection(
+                os.fspath(filesystem_path),
+                exc,
+                owner_source_path=owner_source_path,
+                resource=resource,
+                resource_type=resource_type,
+                field=field,
+            )
+            return None
+
+    def _report_source_path_rejection(
+        self,
+        rejected_path: str,
+        error: ProjectSourcePathError,
+        *,
+        owner_source_path: StrPath | None,
+        resource: str | None,
+        resource_type: str | None,
+        field: str | None,
+    ) -> None:
+        owner_label = (
+            os.fspath(owner_source_path)
+            if owner_source_path is not None
+            else "the selected GameMaker project"
+        )
+        field_label = f" field {field}" if field else ""
+        message = (
+            "Warning: Rejected GameMaker source path "
+            f"{rejected_path!r} from {owner_label}{field_label}: {error}"
+        )
+        diagnostic_owner = self._diagnostic_source_path(owner_source_path)
+        with self._lock:
+            if self.diagnostics is not None:
+                self.diagnostics.add(
+                    "warning",
+                    "GM2GD-SOURCE-PATH-REJECTED",
+                    message,
+                    source_path=diagnostic_owner,
+                    resource=resource,
+                    resource_type=resource_type,
+                    manifest_entry=field,
+                    workaround=(
+                        "Keep GameMaker resource and sidecar files inside the "
+                        "selected project root and reference them with contained "
+                        "project-relative paths."
+                    ),
+                )
+            self.log_callback(message)
+
+    def _record_project_manifest_source_path_diagnostics(
+        self,
+        manifest: GameMakerProjectManifest,
+        *,
+        resource_type: str | None = None,
+        include_project_sources: bool = False,
+    ) -> frozenset[str]:
+        """Forward manifest-level source-path rejections to conversion output."""
+        rejected_fields: set[str] = set()
+        for diagnostic in manifest.diagnostics:
+            if diagnostic.code != "GM2GD-SOURCE-PATH-REJECTED":
+                continue
+            source = diagnostic.source
+            field = (
+                source.field_path
+                if source is not None and source.field_path
+                else None
+            )
+            # Dedicated converters already report their own discovered roots,
+            # options, and YYP candidates. This bridge exists for raw resource
+            # entries that manifest kind inference would otherwise discard.
+            if field is None:
+                continue
+            is_resource_field = field.startswith("resources[")
+            if not is_resource_field and not include_project_sources:
+                continue
+            if (
+                is_resource_field
+                and resource_type is not None
+                and diagnostic.resource_kind is not None
+                and not self._manifest_kind_matches_resource_type(
+                    diagnostic.resource_kind,
+                    resource_type,
+                )
+            ):
+                continue
+            rejected_fields.add(field)
+            source_path = (
+                self._diagnostic_source_path(source.path)
+                if source is not None
+                else None
+            )
+            if self.diagnostics is not None:
+                if any(
+                    existing.code == diagnostic.code
+                    and existing.source_path == source_path
+                    and existing.manifest_entry == field
+                    for existing in self.diagnostics.diagnostics()
+                ):
+                    continue
+                self.diagnostics.add(
+                    diagnostic.severity,
+                    diagnostic.code,
+                    diagnostic.message,
+                    source_path=source_path,
+                    line=source.line if source is not None else None,
+                    resource=diagnostic.resource,
+                    resource_type=(
+                        (
+                            resource_type
+                            if is_resource_field
+                            and diagnostic.resource_kind is not None
+                            else None
+                        )
+                        or diagnostic.resource_type
+                        or "project"
+                    ),
+                    manifest_entry=field,
+                    workaround=(
+                        "Keep GameMaker resource and sidecar files inside the "
+                        "selected project root and reference them with contained "
+                        "project-relative paths."
+                    ),
+                )
+            self.log_callback(diagnostic.message)
+        return frozenset(rejected_fields)
+
+    @staticmethod
+    def _manifest_kind_matches_resource_type(
+        resource_kind: str,
+        resource_type: str,
+    ) -> bool:
+        expected_kind = {
+            "animation_curve": "animcurves",
+            "audio_group": "audiogroups",
+            "font": "fonts",
+            "included_file": "datafiles",
+            "object": "objects",
+            "particle_system": "particlesystems",
+            "path": "paths",
+            "room": "rooms",
+            "script": "scripts",
+            "sequence": "sequences",
+            "shader": "shaders",
+            "sound": "sounds",
+            "sprite": "sprites",
+            "tileset": "tilesets",
+            "timeline": "timelines",
+        }.get(resource_type, resource_type)
+        return resource_kind.casefold() == expected_kind.casefold()
+
+    def _diagnostic_source_path(
+        self,
+        owner_source_path: StrPath | None,
+    ) -> str | None:
+        if owner_source_path is None:
+            return None
+        owner_text = os.fspath(owner_source_path)
+        try:
+            resolved = (
+                resolve_project_filesystem_source_path(
+                    self.gm_project_path,
+                    owner_text,
+                )
+                if os.path.isabs(owner_text)
+                else resolve_project_source_path(
+                    self.gm_project_path,
+                    owner_text,
+                )
+            )
+        except ProjectSourcePathError:
+            return None
+        return resolved.source_path
+
     def _log_progress(self, item_name: str, current: int, total: int) -> None:
         """Log compact progress. First item appends a line; subsequent items update it in place."""
         msg = get_localized("Console_Compact_Progress").format(
@@ -70,12 +299,23 @@ class BaseConverter(ABC):
     def _read_yy_file(self, yy_path: StrPath) -> JsonDict | None:
         """Read and parse a GameMaker .yy file, cleaning trailing commas."""
         try:
-            with open(yy_path, 'r', encoding='utf-8') as f:
+            resolved = resolve_project_filesystem_source_path(
+                self.gm_project_path,
+                yy_path,
+            )
+            with open(resolved.filesystem_path, 'r', encoding='utf-8') as f:
                 content = f.read()
             cleaned = re.sub(r',\s*([}\]])', r'\1', content)
             data = json.loads(cleaned)
             return cast(JsonDict, data) if isinstance(data, dict) else None
-        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        except (
+            OSError,
+            ProjectSourcePathError,
+            json.JSONDecodeError,
+            KeyError,
+            TypeError,
+            ValueError,
+        ):
             return None
 
     def _get_subfolder_from_yy(self, yy_path: StrPath) -> str:

--- a/src/conversion/converter.py
+++ b/src/conversion/converter.py
@@ -148,6 +148,7 @@ class Converter:
                 update_log_callback=context.update_log_callback,
                 compact_logging=context.compact_logging,
                 max_workers=context.max_workers,
+                diagnostics=context.diagnostics,
             ).convert_all(),
             "fonts": lambda: FontConverter(
                 context.gm_project_path,
@@ -158,6 +159,7 @@ class Converter:
                 update_log_callback=context.update_log_callback,
                 compact_logging=context.compact_logging,
                 max_workers=context.max_workers,
+                diagnostics=context.diagnostics,
             ).convert_all(),
             "tilesets": lambda: TileSetConverter(
                 context.gm_project_path,
@@ -168,6 +170,7 @@ class Converter:
                 update_log_callback=context.update_log_callback,
                 compact_logging=context.compact_logging,
                 max_workers=context.max_workers,
+                diagnostics=context.diagnostics,
             ).convert_all(),
             "sounds": lambda: SoundConverter(
                 context.gm_project_path,
@@ -179,6 +182,7 @@ class Converter:
                 compact_logging=context.compact_logging,
                 max_workers=context.max_workers,
                 organize_by_audio_group=context.group_sounds_by_audio_group,
+                diagnostics=context.diagnostics,
             ).convert_all(),
             "notes": lambda: NoteConverter(
                 context.gm_project_path,
@@ -189,6 +193,7 @@ class Converter:
                 update_log_callback=context.update_log_callback,
                 compact_logging=context.compact_logging,
                 max_workers=context.max_workers,
+                diagnostics=context.diagnostics,
             ).convert_all(),
             "shaders": lambda: ShaderConverter(
                 context.gm_project_path,
@@ -199,6 +204,7 @@ class Converter:
                 update_log_callback=context.update_log_callback,
                 compact_logging=context.compact_logging,
                 max_workers=context.max_workers,
+                diagnostics=context.diagnostics,
             ).convert_all(),
             "included_files": lambda: IncludedFilesConverter(
                 context.gm_project_path,
@@ -209,6 +215,7 @@ class Converter:
                 update_log_callback=context.update_log_callback,
                 compact_logging=context.compact_logging,
                 max_workers=context.max_workers,
+                diagnostics=context.diagnostics,
             ).convert_all(),
             "scripts": lambda: ScriptConverter(
                 context.gm_project_path,
@@ -256,5 +263,6 @@ class Converter:
                 max_workers=context.max_workers,
                 organize_sounds_by_audio_group=context.group_sounds_by_audio_group,
                 macro_configuration=context.target_platform,
+                diagnostics=context.diagnostics,
             ).convert_all(),
         }

--- a/src/conversion/diagnostics.py
+++ b/src/conversion/diagnostics.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import threading
 from dataclasses import dataclass
 from typing import Callable, Literal, TypeAlias
 
@@ -55,7 +56,9 @@ class ConversionDiagnostic:
 class DiagnosticCollector:
     def __init__(self) -> None:
         self._diagnostics: list[ConversionDiagnostic] = []
+        self._recorded_diagnostics: set[ConversionDiagnostic] = set()
         self._recorded_messages: set[str] = set()
+        self._lock = threading.RLock()
 
     def add(
         self,
@@ -89,20 +92,25 @@ class DiagnosticCollector:
             issue_number=issue_number,
             workaround=workaround,
         )
-        self._diagnostics.append(diagnostic)
-        self._recorded_messages.add(message)
+        with self._lock:
+            if diagnostic in self._recorded_diagnostics:
+                return diagnostic
+            self._diagnostics.append(diagnostic)
+            self._recorded_diagnostics.add(diagnostic)
+            self._recorded_messages.add(message)
         return diagnostic
 
     def add_from_log_message(
         self, message: str, *, code: str = "GM2GD-WARNING"
     ) -> ConversionDiagnostic | None:
-        if message in self._recorded_messages:
-            return None
         stripped = message.strip()
         severity = _severity_from_log_message(stripped)
         if severity is None:
             return None
-        return self.add(severity, code, stripped)
+        with self._lock:
+            if stripped in self._recorded_messages:
+                return None
+            return self.add(severity, code, stripped)
 
     def add_transpile_failure(
         self,
@@ -144,7 +152,8 @@ class DiagnosticCollector:
         return _wrapped
 
     def diagnostics(self) -> tuple[ConversionDiagnostic, ...]:
-        return tuple(self._diagnostics)
+        with self._lock:
+            return tuple(self._diagnostics)
 
     def summary(self) -> dict[str, int]:
         counts = {"info": 0, "warning": 0, "error": 0}

--- a/src/conversion/extension_registry.py
+++ b/src/conversion/extension_registry.py
@@ -6,11 +6,19 @@ import re
 from dataclasses import dataclass
 from typing import Iterable, cast
 
+from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.gml_transpiler_parts.extension_functions import (
     EXTENSION_FUNCTION_MAPPING_FILENAME,
     load_gml_extension_function_mappings,
 )
-from src.conversion.type_defs import JsonDict
+from src.conversion.project_source_paths import (
+    ProjectSourcePathError,
+    ResolvedProjectSourcePath,
+    resolve_project_filesystem_source_path,
+    resolve_project_source_path,
+    validate_project_resource_source_path,
+)
+from src.conversion.type_defs import JsonDict, LogCallback
 
 EXTENSION_COMPATIBILITY_REPORT_RELATIVE_PATH = os.path.join(
     "gm2godot", "extension_compatibility_report.json"
@@ -86,29 +94,103 @@ class ExtensionEntry:
         }
 
 
-def build_extension_entries(gm_project_path: str) -> tuple[ExtensionEntry, ...]:
-    extensions_dir = os.path.join(gm_project_path, "extensions")
-    if not os.path.isdir(extensions_dir):
+@dataclass(frozen=True)
+class _SourceContext:
+    diagnostics: DiagnosticCollector | None
+    log_callback: LogCallback | None
+    owner_source_path: str
+    resource: str
+    field: str
+
+
+def build_extension_entries(
+    gm_project_path: str,
+    *,
+    diagnostics: DiagnosticCollector | None = None,
+    log_callback: LogCallback | None = None,
+) -> tuple[ExtensionEntry, ...]:
+    extensions_context = _SourceContext(
+        diagnostics, log_callback, "extensions", "extensions", "extensions directory"
+    )
+    extensions_dir = _resolve_source(gm_project_path, "extensions", extensions_context)
+    if extensions_dir is None:
+        return ()
+
+    extension_names = _list_confined_directory(
+        gm_project_path, extensions_dir, extensions_context
+    )
+    if extension_names is None:
         return ()
 
     entries: list[ExtensionEntry] = []
-    for name in sorted(os.listdir(extensions_dir)):
-        yy_path = os.path.join(extensions_dir, name, name + ".yy")
-        if not os.path.isfile(yy_path):
+    for name in extension_names:
+        extension_context = _SourceContext(
+            diagnostics,
+            log_callback,
+            f"extensions/{name}",
+            name,
+            "extension directory",
+        )
+        extension_dir = _resolve_source(
+            gm_project_path,
+            os.path.join(extensions_dir.filesystem_path, name),
+            extension_context,
+            discovered=True,
+        )
+        if extension_dir is None or not os.path.isdir(extension_dir.filesystem_path):
             continue
-        data = _read_json_lenient(yy_path)
+
+        yy_source_path = f"{extension_dir.source_path}/{name}.yy"
+        metadata_context = _SourceContext(
+            diagnostics, log_callback, yy_source_path, name, "extension metadata"
+        )
+        yy_path = _resolve_source(
+            gm_project_path,
+            os.path.join(extension_dir.filesystem_path, name + ".yy"),
+            metadata_context,
+            discovered=True,
+        )
+        if yy_path is None:
+            continue
+        try:
+            validate_project_resource_source_path(yy_path, "extensions")
+        except ProjectSourcePathError as error:
+            _report_source_path_rejection(
+                yy_source_path,
+                error,
+                metadata_context,
+            )
+            continue
+        data = _read_json_lenient(gm_project_path, yy_path, metadata_context)
         if data is None:
             continue
-        entries.append(extension_entry_from_yy(gm_project_path, yy_path, data))
+        entries.append(
+            extension_entry_from_yy(
+                gm_project_path,
+                yy_path.filesystem_path,
+                data,
+            )
+        )
     return tuple(entries)
 
 
 def write_extension_compatibility_outputs(
     gm_project_path: str,
     godot_project_path: str,
+    *,
+    diagnostics: DiagnosticCollector | None = None,
+    log_callback: LogCallback | None = None,
 ) -> str:
-    entries = build_extension_entries(gm_project_path)
-    mappings = _load_extension_mapping_names(gm_project_path)
+    entries = build_extension_entries(
+        gm_project_path,
+        diagnostics=diagnostics,
+        log_callback=log_callback,
+    )
+    mappings = _load_extension_mapping_names(
+        gm_project_path,
+        diagnostics=diagnostics,
+        log_callback=log_callback,
+    )
     report_path = os.path.join(godot_project_path, EXTENSION_COMPATIBILITY_REPORT_RELATIVE_PATH)
     os.makedirs(os.path.dirname(report_path), exist_ok=True)
     with open(report_path, "w", encoding="utf-8") as report_file:
@@ -356,12 +438,34 @@ def _extension_function_metadata(function: ExtensionFunctionEntry) -> JsonDict:
     }
 
 
-def _load_extension_mapping_names(gm_project_path: str) -> set[str]:
-    mapping_path = os.path.join(gm_project_path, EXTENSION_FUNCTION_MAPPING_FILENAME)
-    if not os.path.isfile(mapping_path):
+def _load_extension_mapping_names(
+    gm_project_path: str,
+    *,
+    diagnostics: DiagnosticCollector | None,
+    log_callback: LogCallback | None,
+) -> set[str]:
+    context = _SourceContext(
+        diagnostics,
+        log_callback,
+        EXTENSION_FUNCTION_MAPPING_FILENAME,
+        EXTENSION_FUNCTION_MAPPING_FILENAME,
+        "extension function mapping",
+    )
+    mapping_path = _resolve_source(
+        gm_project_path, EXTENSION_FUNCTION_MAPPING_FILENAME, context
+    )
+    if mapping_path is None:
+        return set()
+    refreshed = _resolve_source(
+        gm_project_path,
+        mapping_path.filesystem_path,
+        context,
+        discovered=True,
+    )
+    if refreshed is None or not os.path.isfile(refreshed.filesystem_path):
         return set()
     try:
-        return set(load_gml_extension_function_mappings(mapping_path))
+        return set(load_gml_extension_function_mappings(refreshed.filesystem_path))
     except (OSError, ValueError, TypeError):
         return set()
 
@@ -459,14 +563,92 @@ def _json_dict_list(value: object) -> list[JsonDict]:
     return items
 
 
-def _read_json_lenient(path: str) -> JsonDict | None:
+def _resolve_source(
+    gm_project_path: str,
+    source_path: str,
+    context: _SourceContext,
+    *,
+    discovered: bool = False,
+) -> ResolvedProjectSourcePath | None:
     try:
-        with open(path, "r", encoding="utf-8") as f:
-            content = f.read()
-    except OSError:
+        return (
+            resolve_project_filesystem_source_path(gm_project_path, source_path)
+            if discovered
+            else resolve_project_source_path(gm_project_path, source_path)
+        )
+    except ProjectSourcePathError as error:
+        _report_source_path_rejection(source_path, error, context)
+        return None
+
+
+def _list_confined_directory(
+    gm_project_path: str,
+    directory: ResolvedProjectSourcePath,
+    context: _SourceContext,
+) -> tuple[str, ...] | None:
+    refreshed = _resolve_source(
+        gm_project_path,
+        directory.filesystem_path,
+        context,
+        discovered=True,
+    )
+    if refreshed is None:
         return None
     try:
+        if not os.path.isdir(refreshed.filesystem_path):
+            return None
+        return tuple(sorted(os.listdir(refreshed.filesystem_path)))
+    except OSError:
+        return None
+
+
+def _read_json_lenient(
+    gm_project_path: str,
+    source: ResolvedProjectSourcePath,
+    context: _SourceContext,
+) -> JsonDict | None:
+    refreshed = _resolve_source(
+        gm_project_path,
+        source.filesystem_path,
+        context,
+        discovered=True,
+    )
+    if refreshed is None:
+        return None
+    try:
+        with open(refreshed.filesystem_path, "r", encoding="utf-8") as source_file:
+            content = source_file.read()
         data = json.loads(re.sub(r",\s*([}\]])", r"\1", content))
+    except OSError:
+        return None
     except json.JSONDecodeError:
         return None
     return cast(JsonDict, data) if isinstance(data, dict) else None
+
+
+def _report_source_path_rejection(
+    rejected_path: str,
+    error: ProjectSourcePathError,
+    context: _SourceContext,
+) -> None:
+    message = (
+        "Warning: Rejected GameMaker source path "
+        f"{rejected_path!r} from {context.owner_source_path} "
+        f"field {context.field}: {error}"
+    )
+    if context.diagnostics is not None:
+        context.diagnostics.add(
+            "warning",
+            "GM2GD-SOURCE-PATH-REJECTED",
+            message,
+            source_path=context.owner_source_path,
+            resource=context.resource,
+            resource_type="extension",
+            manifest_entry=context.field,
+            workaround=(
+                "Keep GameMaker extension metadata and mapping files inside "
+                "the selected project root."
+            ),
+        )
+    if context.log_callback is not None:
+        context.log_callback(message)

--- a/src/conversion/fonts.py
+++ b/src/conversion/fonts.py
@@ -11,6 +11,7 @@ from typing import Literal, TypedDict, cast
 
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
+from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.generated_paths import (
     generated_flat_resource_path,
     generated_resource_stem,
@@ -18,7 +19,7 @@ from src.conversion.generated_paths import (
 from src.conversion.project_manifest import load_gamemaker_project_manifest
 from src.conversion.project_source_paths import (
     ProjectSourcePathError,
-    resolve_project_source_path,
+    validate_project_resource_source_path,
 )
 from src.conversion.type_defs import ConversionRunning, JsonDict, LogCallback, ProgressCallback, StrPath
 
@@ -148,14 +149,20 @@ class FontConverter(BaseConverter):
     def __init__(self, gm_project_path: StrPath, godot_project_path: StrPath, log_callback: LogCallback = print,
                  progress_callback: ProgressCallback | None = None, conversion_running: ConversionRunning | None = None,
                  update_log_callback: LogCallback | None = None, compact_logging: bool = False,
-                 max_workers: int | None = None) -> None:
+                 max_workers: int | None = None,
+                 diagnostics: DiagnosticCollector | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback, progress_callback, conversion_running,
-                         update_log_callback, compact_logging, max_workers=max_workers)
+                         update_log_callback, compact_logging, max_workers=max_workers,
+                         diagnostics=diagnostics)
         self.godot_fonts_path = os.path.join(self.godot_project_path, 'fonts')
         self._font_output_paths: dict[str, str] = {}
 
     def find_font_files(self) -> list[str]:
         manifest = load_gamemaker_project_manifest(self.gm_project_path)
+        self._record_project_manifest_source_path_diagnostics(
+            manifest,
+            resource_type="font",
+        )
         if manifest.yyp_path is not None:
             font_files: list[str] = []
             seen_paths: set[str] = set()
@@ -165,12 +172,34 @@ class FontConverter(BaseConverter):
                 source_path = resource.path.casefold()
                 if not source_path.endswith(".yy") or source_path.endswith(".old.yy"):
                     continue
+                manifest_field = (
+                    f"{resource.source.field_path}.id.path"
+                    if resource.source is not None and resource.source.field_path
+                    else "resources[].id.path"
+                )
+                resolved = self._resolve_project_source(
+                    resource.path,
+                    owner_source_path=manifest.yyp_path,
+                    resource=resource.name,
+                    resource_type="font",
+                    field=manifest_field,
+                )
+                if resolved is None:
+                    continue
                 try:
-                    resolved = resolve_project_source_path(
-                        self.gm_project_path,
-                        resource.path,
+                    validate_project_resource_source_path(
+                        resolved,
+                        "fonts",
                     )
-                except ProjectSourcePathError:
+                except ProjectSourcePathError as exc:
+                    self._report_source_path_rejection(
+                        resource.path,
+                        exc,
+                        owner_source_path=manifest.yyp_path,
+                        resource=resource.name,
+                        resource_type="font",
+                        field=manifest_field,
+                    )
                     continue
                 if not os.path.isfile(resolved.filesystem_path):
                     continue
@@ -183,15 +212,114 @@ class FontConverter(BaseConverter):
                 font_files.append(resolved.filesystem_path)
             return font_files
 
-        font_folder = os.path.join(self.gm_project_path, 'fonts')
+        font_folder = self._resolve_discovered_project_source(
+            os.path.join(self.gm_project_path, 'fonts'),
+            resource_type="font",
+            field="fonts directory",
+        )
+        if font_folder is None or not os.path.isdir(font_folder.filesystem_path):
+            return []
+
         font_files: list[str] = []
-        for root, dirs, files in os.walk(font_folder):
-            dirs.sort()
-            font_files.extend(
-                os.path.join(root, file)
-                for file in sorted(files)
-                if file.lower().endswith('.yy') and not file.lower().endswith('.old.yy')
-            )
+        pending_directories = [
+            (font_folder.filesystem_path, font_folder.source_path)
+        ]
+        visited_directories: set[str] = set()
+        while pending_directories:
+            directory_path, directory_source_path = pending_directories.pop()
+            canonical_directory = os.path.normcase(os.path.realpath(directory_path))
+            if canonical_directory in visited_directories:
+                continue
+            visited_directories.add(canonical_directory)
+
+            try:
+                entries = sorted(
+                    os.scandir(directory_path),
+                    key=lambda entry: entry.name,
+                )
+            except OSError:
+                continue
+
+            child_directories: list[tuple[str, str]] = []
+            for entry in entries:
+                filename = entry.name
+                lower_filename = filename.casefold()
+                is_font_yy = (
+                    lower_filename.endswith('.yy')
+                    and not lower_filename.endswith('.old.yy')
+                )
+                try:
+                    is_unlinked_directory = entry.is_dir(
+                        follow_symlinks=False
+                    )
+                    is_symlink = entry.is_symlink()
+                except OSError:
+                    continue
+
+                # Bundled font sidecars are validated against their owning .yy
+                # when referenced. They are not discovery inputs by themselves.
+                if (
+                    is_symlink
+                    and not is_font_yy
+                    and lower_filename.endswith(FONT_EXTENSIONS)
+                ):
+                    continue
+                if not is_unlinked_directory and not is_symlink and not is_font_yy:
+                    continue
+
+                resolved_entry = self._resolve_discovered_project_source(
+                    entry.path,
+                    owner_source_path=directory_source_path,
+                    resource=(
+                        os.path.splitext(filename)[0]
+                        if is_font_yy
+                        else filename
+                    ),
+                    resource_type="font",
+                    field=(
+                        "discovered font .yy"
+                        if is_font_yy
+                        else "discovered font directory"
+                    ),
+                )
+                if resolved_entry is None:
+                    continue
+
+                # Resolve containment before following a possible directory
+                # symlink to classify the canonical target.
+                if os.path.isdir(resolved_entry.filesystem_path):
+                    if is_font_yy:
+                        continue
+                    if not is_symlink:
+                        child_directories.append(
+                            (
+                                resolved_entry.filesystem_path,
+                                resolved_entry.source_path,
+                            )
+                        )
+                    continue
+
+                if not is_font_yy:
+                    continue
+                if os.path.isfile(resolved_entry.filesystem_path):
+                    try:
+                        validate_project_resource_source_path(
+                            resolved_entry,
+                            "fonts",
+                        )
+                    except ProjectSourcePathError as exc:
+                        self._report_source_path_rejection(
+                            entry.path,
+                            exc,
+                            owner_source_path=directory_source_path,
+                            resource=os.path.splitext(filename)[0],
+                            resource_type="font",
+                            field="discovered font .yy",
+                        )
+                        continue
+                    font_files.append(resolved_entry.filesystem_path)
+
+            pending_directories.extend(reversed(child_directories))
         return font_files
 
     def _parse_font_yy(self, yy_path: str) -> FontData | None:
@@ -234,7 +362,30 @@ class FontConverter(BaseConverter):
         if not self.conversion_running():
             return None
 
-        font_data = self._parse_font_yy(yy_path)
+        discovered_name = os.path.splitext(os.path.basename(yy_path))[0]
+        resolved_yy = self._resolve_discovered_project_source(
+            yy_path,
+            owner_source_path=os.path.dirname(yy_path),
+            resource=discovered_name,
+            resource_type="font",
+            field="font .yy",
+        )
+        if resolved_yy is None:
+            return False
+        try:
+            validate_project_resource_source_path(resolved_yy, "fonts")
+        except ProjectSourcePathError as exc:
+            self._report_source_path_rejection(
+                yy_path,
+                exc,
+                owner_source_path=os.path.dirname(yy_path),
+                resource=discovered_name,
+                resource_type="font",
+                field="font .yy",
+            )
+            return False
+
+        font_data = self._parse_font_yy(resolved_yy.filesystem_path)
         if font_data is None:
             return False
 
@@ -247,16 +398,40 @@ class FontConverter(BaseConverter):
 
         # 1. Try bundled TTF from GameMaker project
         if font_data['includeTTF'] and font_data['TTFName']:
-            ttf_path = resolve_bundled_font_source(yy_path, font_data['TTFName'])
-            bundled_output_file = bundled_font_output_filename(font_data['TTFName'])
-            if ttf_path is not None and bundled_output_file is not None:
-                font_source_path = ttf_path
+            ttf_name = font_data['TTFName']
+            resolved_ttf = self._resolve_project_source(
+                ttf_name,
+                owner_source_path=resolved_yy.source_path,
+                resource=font_name,
+                resource_type="font",
+                field="TTFName",
+            )
+            bundled_output_file = bundled_font_output_filename(ttf_name)
+            if resolved_ttf is not None and bundled_output_file is None:
+                self._report_source_path_rejection(
+                    ttf_name,
+                    ProjectSourcePathError(
+                        "Bundled font paths must use non-empty relative path "
+                        "segments and a supported font extension: "
+                        f"{ttf_name!r}"
+                    ),
+                    owner_source_path=resolved_yy.source_path,
+                    resource=font_name,
+                    resource_type="font",
+                    field="TTFName",
+                )
+            if (
+                resolved_ttf is not None
+                and bundled_output_file is not None
+                and os.path.isfile(resolved_ttf.filesystem_path)
+            ):
+                font_source_path = os.path.realpath(resolved_ttf.filesystem_path)
                 output_filename = bundled_output_file
                 preserve_metadata = True
                 bundled_font = True
             else:
                 self._safe_log(get_localized("Console_Convertor_Fonts_TTFMissing").format(
-                    name=font_name, ttf_name=font_data['TTFName']))
+                    name=font_name, ttf_name=ttf_name))
 
         # 2. Try finding the font on the system
         if font_source_path is None:
@@ -273,13 +448,36 @@ class FontConverter(BaseConverter):
             output_filename = generated_resource_stem(font_name) + '.tres'
 
         output_path = self._font_output_destination(
-            yy_path,
+            resolved_yy.filesystem_path,
             font_name,
             output_filename,
         )
         output_file = os.path.basename(output_path)
 
         if font_source_path is not None:
+            if bundled_font:
+                refreshed_ttf = self._resolve_project_source(
+                    font_data['TTFName'],
+                    owner_source_path=resolved_yy.source_path,
+                    resource=font_name,
+                    resource_type="font",
+                    field="TTFName",
+                )
+                if refreshed_ttf is None or not os.path.isfile(
+                    refreshed_ttf.filesystem_path
+                ):
+                    self._safe_log(
+                        get_localized(
+                            "Console_Convertor_Fonts_TTFMissing"
+                        ).format(
+                            name=font_name,
+                            ttf_name=font_data['TTFName'],
+                        )
+                    )
+                    return False
+                font_source_path = os.path.realpath(
+                    refreshed_ttf.filesystem_path
+                )
             _copy_font_file_atomically(
                 font_source_path,
                 output_path,
@@ -344,12 +542,6 @@ class FontConverter(BaseConverter):
     def convert_fonts(self) -> None:
         os.makedirs(self.godot_project_path, exist_ok=True)
         os.makedirs(self.godot_fonts_path, exist_ok=True)
-
-        gm_fonts_path = os.path.join(self.gm_project_path, 'fonts')
-
-        if not os.path.exists(gm_fonts_path):
-            self.log_callback(get_localized("Console_Convertor_Fonts_Error_NotFound").format(gm_project_path=self.gm_project_path))
-            return
 
         font_files = self.find_font_files()
 

--- a/src/conversion/included_files.py
+++ b/src/conversion/included_files.py
@@ -1,65 +1,320 @@
 from __future__ import annotations
 
 import os
+import posixpath
+import stat
 import shutil
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import BinaryIO
 
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
+from src.conversion.diagnostics import DiagnosticCollector
+from src.conversion.project_source_paths import (
+    ProjectSourcePathError,
+    ResolvedProjectSourcePath,
+)
 from src.conversion.type_defs import ConversionRunning, LogCallback, ProgressCallback, StrPath
+
+
+@dataclass(frozen=True)
+class _IncludedFileSource:
+    filesystem_path: str
+    relative_path: str
+    owner_source_path: str
 
 
 class IncludedFilesConverter(BaseConverter):
     def __init__(self, gm_project_path: StrPath, godot_project_path: StrPath, log_callback: LogCallback = print,
                  progress_callback: ProgressCallback | None = None, conversion_running: ConversionRunning | None = None,
                  update_log_callback: LogCallback | None = None, compact_logging: bool = False,
-                 max_workers: int | None = None) -> None:
+                 max_workers: int | None = None,
+                 diagnostics: DiagnosticCollector | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback, progress_callback, conversion_running,
-                         update_log_callback, compact_logging, max_workers=max_workers)
+                         update_log_callback, compact_logging, max_workers=max_workers,
+                         diagnostics=diagnostics)
 
-    def _process_file(self, gm_file_path: str, godot_file_path: str, rel_path: str) -> str | None:
+    def _process_file(
+        self,
+        gm_file_path: str,
+        godot_file_path: str,
+        rel_path: str,
+        owner_source_path: str = "datafiles",
+    ) -> tuple[str, bool] | None:
         if not self.conversion_running():
             return None
-        shutil.copy2(gm_file_path, godot_file_path)
-        return rel_path
+
+        opened_source = self._open_confined_source_file(
+            gm_file_path,
+            owner_source_path=owner_source_path,
+            resource=rel_path,
+        )
+        if opened_source is None:
+            return rel_path, False
+
+        source_file, source_stat = opened_source
+        with source_file:
+            with open(godot_file_path, "wb") as target_file:
+                shutil.copyfileobj(source_file, target_file)
+
+        # Preserve the source file's main copy2 metadata without consulting the
+        # source path again after it has been validated and opened. The held
+        # descriptor remains safe if a path component is swapped concurrently.
+        os.chmod(godot_file_path, stat.S_IMODE(source_stat.st_mode))
+        os.utime(
+            godot_file_path,
+            ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns),
+        )
+        return rel_path, True
+
+    def _open_confined_source_file(
+        self,
+        filesystem_path: str,
+        *,
+        owner_source_path: str,
+        resource: str,
+    ) -> tuple[BinaryIO, os.stat_result] | None:
+        """Open a contained regular file and pin it against late path swaps."""
+        resolved = self._resolve_discovered_project_source(
+            filesystem_path,
+            owner_source_path=owner_source_path,
+            resource=resource,
+            resource_type="included_file",
+            field="discovered datafiles file",
+        )
+        if resolved is None:
+            return None
+
+        try:
+            source_file = open(resolved.filesystem_path, "rb")
+        except OSError:
+            return None
+
+        try:
+            opened_stat = os.fstat(source_file.fileno())
+            revalidated = self._resolve_discovered_project_source(
+                resolved.filesystem_path,
+                owner_source_path=owner_source_path,
+                resource=resource,
+                resource_type="included_file",
+                field="discovered datafiles file",
+            )
+            if revalidated is None:
+                source_file.close()
+                return None
+            current_stat = os.stat(revalidated.filesystem_path)
+            if (
+                not stat.S_ISREG(opened_stat.st_mode)
+                or not os.path.samestat(opened_stat, current_stat)
+            ):
+                source_file.close()
+                self._report_source_path_rejection(
+                    filesystem_path,
+                    ProjectSourcePathError(
+                        "Discovered GameMaker source file changed after validation"
+                    ),
+                    owner_source_path=owner_source_path,
+                    resource=resource,
+                    resource_type="included_file",
+                    field="discovered datafiles file",
+                )
+                return None
+        except OSError:
+            source_file.close()
+            return None
+        return source_file, opened_stat
+
+    def _list_confined_directory(
+        self,
+        directory: ResolvedProjectSourcePath,
+    ) -> tuple[str, ...] | None:
+        """List a contained directory without following a late path swap."""
+        revalidated = self._resolve_discovered_project_source(
+            directory.filesystem_path,
+            owner_source_path=directory.source_path,
+            resource=posixpath.basename(directory.source_path),
+            resource_type="included_file",
+            field="discovered datafiles directory",
+        )
+        if revalidated is None:
+            return None
+
+        # On POSIX, list through a validated directory descriptor. If the path
+        # is exchanged after validation, the descriptor remains bound to the
+        # original contained directory. Other platforms get a before/after
+        # identity check around their path-based directory listing.
+        if os.listdir in os.supports_fd and hasattr(os, "O_DIRECTORY"):
+            flags = os.O_RDONLY | os.O_DIRECTORY
+            try:
+                directory_fd = os.open(revalidated.filesystem_path, flags)
+            except OSError:
+                return None
+            try:
+                opened_stat = os.fstat(directory_fd)
+                current = self._resolve_discovered_project_source(
+                    revalidated.filesystem_path,
+                    owner_source_path=directory.source_path,
+                    resource=posixpath.basename(directory.source_path),
+                    resource_type="included_file",
+                    field="discovered datafiles directory",
+                )
+                if current is None:
+                    return None
+                current_stat = os.stat(current.filesystem_path)
+                if (
+                    not stat.S_ISDIR(opened_stat.st_mode)
+                    or not os.path.samestat(opened_stat, current_stat)
+                ):
+                    self._report_directory_swap(directory)
+                    return None
+                return tuple(sorted(os.listdir(directory_fd)))
+            except OSError:
+                return None
+            finally:
+                os.close(directory_fd)
+
+        try:
+            before_stat = os.stat(revalidated.filesystem_path)
+            entries = tuple(sorted(os.listdir(revalidated.filesystem_path)))
+            current = self._resolve_discovered_project_source(
+                revalidated.filesystem_path,
+                owner_source_path=directory.source_path,
+                resource=posixpath.basename(directory.source_path),
+                resource_type="included_file",
+                field="discovered datafiles directory",
+            )
+            if current is None:
+                return None
+            after_stat = os.stat(current.filesystem_path)
+        except OSError:
+            return None
+        if (
+            not stat.S_ISDIR(before_stat.st_mode)
+            or not os.path.samestat(before_stat, after_stat)
+        ):
+            self._report_directory_swap(directory)
+            return None
+        return entries
+
+    def _report_directory_swap(
+        self,
+        directory: ResolvedProjectSourcePath,
+    ) -> None:
+        self._report_source_path_rejection(
+            directory.filesystem_path,
+            ProjectSourcePathError(
+                "Discovered GameMaker source directory changed after validation"
+            ),
+            owner_source_path=directory.source_path,
+            resource=posixpath.basename(directory.source_path),
+            resource_type="included_file",
+            field="discovered datafiles directory",
+        )
+
+    def _collect_included_files(
+        self,
+        datafiles: ResolvedProjectSourcePath,
+    ) -> list[_IncludedFileSource]:
+        included_files: list[_IncludedFileSource] = []
+        pending_directories = [datafiles]
+        visited_directories: set[str] = set()
+
+        while pending_directories:
+            directory = pending_directories.pop()
+            canonical_directory = os.path.normcase(
+                os.path.realpath(directory.filesystem_path)
+            )
+            if canonical_directory in visited_directories:
+                continue
+            visited_directories.add(canonical_directory)
+
+            entry_names = self._list_confined_directory(directory)
+            if entry_names is None:
+                continue
+            for entry_name in entry_names:
+                entry = self._resolve_discovered_project_source(
+                    os.path.join(directory.filesystem_path, entry_name),
+                    owner_source_path=directory.source_path,
+                    resource=entry_name,
+                    resource_type="included_file",
+                    field="discovered datafiles entry",
+                )
+                if entry is None:
+                    continue
+                if os.path.isdir(entry.filesystem_path):
+                    # Match os.walk's historical default: contained directory
+                    # symlinks are not traversed, while the datafiles root itself
+                    # may still be a contained symlink.
+                    if not os.path.islink(entry.filesystem_path):
+                        pending_directories.append(entry)
+                    continue
+                if entry_name.endswith(".yy") or not os.path.isfile(
+                    entry.filesystem_path
+                ):
+                    continue
+                relative_path = posixpath.relpath(
+                    entry.source_path,
+                    datafiles.source_path,
+                )
+                included_files.append(
+                    _IncludedFileSource(
+                        filesystem_path=entry.filesystem_path,
+                        relative_path=relative_path,
+                        owner_source_path=directory.source_path,
+                    )
+                )
+        return sorted(included_files, key=lambda item: item.relative_path)
 
     def convert_included_files(self) -> None:
-        gm_datafiles_path = os.path.join(self.gm_project_path, "datafiles")
         godot_included_path = os.path.join(self.godot_project_path, "included_files")
 
-        if not os.path.exists(gm_datafiles_path):
+        datafiles = self._resolve_discovered_project_source(
+            os.path.join(self.gm_project_path, "datafiles"),
+            resource="datafiles",
+            resource_type="included_file",
+            field="datafiles directory",
+        )
+        if datafiles is None or not os.path.isdir(datafiles.filesystem_path):
             self.log_callback(get_localized("Console_Convertor_IncludedFiles_Error_NotFound"))
             return
 
         os.makedirs(godot_included_path, exist_ok=True)
 
-        # Collect all files, skipping .yy metadata files
-        all_files: list[str] = []
-        for root, _, files in os.walk(gm_datafiles_path):
-            for file in files:
-                if not file.endswith('.yy'):
-                    all_files.append(os.path.join(root, file))
+        all_files = self._collect_included_files(datafiles)
 
         if not all_files:
             self.log_callback(get_localized("Console_Convertor_IncludedFiles_Error_NotFound"))
             return
 
         # Pre-create all directories
-        for gm_file_path in all_files:
-            rel_path = os.path.relpath(gm_file_path, gm_datafiles_path)
-            godot_dir = os.path.dirname(os.path.join(godot_included_path, rel_path))
+        for source in all_files:
+            godot_dir = os.path.dirname(
+                os.path.join(
+                    godot_included_path,
+                    *source.relative_path.split("/"),
+                )
+            )
             os.makedirs(godot_dir, exist_ok=True)
 
         total_files = len(all_files)
         processed_files = 0
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            futures_map: dict[Future[str | None], str] = {}
-            for gm_file_path in all_files:
-                rel_path = os.path.relpath(gm_file_path, gm_datafiles_path)
-                godot_file_path = os.path.join(godot_included_path, rel_path)
-                future = executor.submit(self._process_file, gm_file_path, godot_file_path, rel_path)
-                futures_map[future] = rel_path
+            futures_map: dict[Future[tuple[str, bool] | None], str] = {}
+            for source in all_files:
+                godot_file_path = os.path.join(
+                    godot_included_path,
+                    *source.relative_path.split("/"),
+                )
+                future = executor.submit(
+                    self._process_file,
+                    source.filesystem_path,
+                    godot_file_path,
+                    source.relative_path,
+                    source.owner_source_path,
+                )
+                futures_map[future] = source.relative_path
 
             for future in as_completed(futures_map):
                 result = future.result()
@@ -68,10 +323,12 @@ class IncludedFilesConverter(BaseConverter):
                     return
 
                 processed_files += 1
-                if self.compact_logging:
-                    self._safe_log_progress(os.path.basename(result), processed_files, total_files)
-                else:
-                    self._safe_log(get_localized("Console_Convertor_IncludedFiles_Copied").format(path=result))
+                rel_path, copied = result
+                if copied:
+                    if self.compact_logging:
+                        self._safe_log_progress(os.path.basename(rel_path), processed_files, total_files)
+                    else:
+                        self._safe_log(get_localized("Console_Convertor_IncludedFiles_Copied").format(path=rel_path))
                 self._safe_progress(int((processed_files / total_files) * 100))
 
     def convert_all(self) -> None:

--- a/src/conversion/notes.py
+++ b/src/conversion/notes.py
@@ -3,76 +3,233 @@ from __future__ import annotations
 import os
 import shutil
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
 
-from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
+from src.conversion.diagnostics import DiagnosticCollector
+from src.conversion.project_source_paths import ResolvedProjectSourcePath
 from src.conversion.type_defs import ConversionRunning, LogCallback, ProgressCallback, StrPath
+from src.localization import get_localized
+
+
+@dataclass(frozen=True)
+class _NoteAsset:
+    filesystem_path: str
+    source_path: str
+    owner_source_path: str
+    name: str
+    subfolder: str
+
+
+@dataclass(frozen=True)
+class _NoteCopyResult:
+    name: str
+    copied: bool
 
 
 class NoteConverter(BaseConverter):
     def __init__(self, gm_project_path: StrPath, godot_project_path: StrPath, log_callback: LogCallback = print,
                  progress_callback: ProgressCallback | None = None, conversion_running: ConversionRunning | None = None,
                  update_log_callback: LogCallback | None = None, compact_logging: bool = False,
-                 max_workers: int | None = None) -> None:
+                 max_workers: int | None = None,
+                 diagnostics: DiagnosticCollector | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback, progress_callback, conversion_running,
-                         update_log_callback, compact_logging, max_workers=max_workers)
+                         update_log_callback, compact_logging, max_workers=max_workers,
+                         diagnostics=diagnostics)
 
-    def _process_note(self, src_file: str, dst_file: str, note_name: str) -> str | None:
+    def _process_note(
+        self,
+        src_file: str,
+        dst_file: str,
+        note_name: str,
+        owner_source_path: str,
+    ) -> _NoteCopyResult | None:
         if not self.conversion_running():
             return None
-        shutil.copy2(src_file, dst_file)
-        return note_name
+
+        # The source may have changed after discovery while waiting for a worker.
+        # Revalidate it at the final source boundary before copying any bytes.
+        resolved_source = self._resolve_discovered_project_source(
+            src_file,
+            owner_source_path=owner_source_path,
+            resource=note_name,
+            resource_type="note",
+            field="note text file (pre-copy)",
+        )
+        if resolved_source is None or not os.path.isfile(
+            resolved_source.filesystem_path
+        ):
+            return _NoteCopyResult(name=note_name, copied=False)
+
+        try:
+            shutil.copy2(resolved_source.filesystem_path, dst_file)
+        except OSError:
+            return _NoteCopyResult(name=note_name, copied=False)
+        return _NoteCopyResult(name=note_name, copied=True)
+
+    def _discover_notes(
+        self,
+        notes_root: ResolvedProjectSourcePath,
+    ) -> list[_NoteAsset]:
+        note_assets: list[_NoteAsset] = []
+        pending_directories = [notes_root]
+        visited_directories: set[str] = set()
+        seen_note_files: set[str] = set()
+
+        while pending_directories:
+            directory = pending_directories.pop()
+            resolved_directory = self._resolve_discovered_project_source(
+                directory.filesystem_path,
+                owner_source_path=directory.source_path,
+                resource_type="note",
+                field="discovered note directory",
+            )
+            if resolved_directory is None or not os.path.isdir(
+                resolved_directory.filesystem_path
+            ):
+                continue
+
+            canonical_directory = os.path.normcase(
+                os.path.realpath(resolved_directory.filesystem_path)
+            )
+            if canonical_directory in visited_directories:
+                continue
+            visited_directories.add(canonical_directory)
+
+            try:
+                with os.scandir(resolved_directory.filesystem_path) as entries:
+                    directory_entries = sorted(entries, key=lambda entry: entry.name)
+            except OSError:
+                continue
+
+            resolved_entries: dict[str, ResolvedProjectSourcePath | None] = {}
+            child_directories: list[ResolvedProjectSourcePath] = []
+            text_entries: list[tuple[str, ResolvedProjectSourcePath]] = []
+            for entry in directory_entries:
+                lower_name = entry.name.casefold()
+                try:
+                    is_symlink = entry.is_symlink()
+                except OSError:
+                    continue
+                if lower_name.endswith(".txt"):
+                    field = "note text file"
+                elif lower_name.endswith(".yy"):
+                    field = "note metadata .yy"
+                else:
+                    field = "discovered note entry"
+                resource_name = os.path.splitext(entry.name)[0]
+                resolved_entry = self._resolve_discovered_project_source(
+                    entry.path,
+                    owner_source_path=resolved_directory.source_path,
+                    resource=resource_name,
+                    resource_type="note",
+                    field=field,
+                )
+                resolved_entries[entry.name] = resolved_entry
+                if resolved_entry is None:
+                    continue
+                if os.path.isdir(resolved_entry.filesystem_path):
+                    if not is_symlink:
+                        child_directories.append(resolved_entry)
+                    continue
+                if lower_name.endswith(".txt") and os.path.isfile(
+                    resolved_entry.filesystem_path
+                ):
+                    text_entries.append((entry.name, resolved_entry))
+
+            for filename, resolved_note in text_entries:
+                canonical_note = os.path.normcase(
+                    os.path.realpath(resolved_note.filesystem_path)
+                )
+                if canonical_note in seen_note_files:
+                    continue
+                seen_note_files.add(canonical_note)
+
+                note_name = os.path.splitext(filename)[0]
+                metadata_name = note_name + ".yy"
+                resolved_metadata = resolved_entries.get(metadata_name)
+                subfolder = ""
+                if resolved_metadata is not None and os.path.isfile(
+                    resolved_metadata.filesystem_path
+                ):
+                    # _get_subfolder_from_yy performs one more containment check
+                    # in _read_yy_file immediately before reading the metadata.
+                    subfolder = self._get_subfolder_from_yy(
+                        resolved_metadata.filesystem_path
+                    )
+                note_assets.append(
+                    _NoteAsset(
+                        filesystem_path=resolved_note.filesystem_path,
+                        source_path=resolved_note.source_path,
+                        owner_source_path=resolved_directory.source_path,
+                        name=note_name,
+                        subfolder=subfolder,
+                    )
+                )
+
+            pending_directories.extend(reversed(child_directories))
+
+        return note_assets
 
     def convert_notes(self) -> None:
-        gm_notes_path = os.path.join(self.gm_project_path, "notes")
         godot_notes_path = os.path.join(self.godot_project_path, "notes")
 
-        if not os.path.exists(gm_notes_path):
+        gm_notes_path = self._resolve_project_source(
+            "notes",
+            resource_type="note",
+            field="notes directory",
+        )
+        if gm_notes_path is None or not os.path.isdir(
+            gm_notes_path.filesystem_path
+        ):
             self.log_callback(get_localized("Console_Convertor_Notes_Error_NotFound"))
             return
 
         os.makedirs(godot_notes_path, exist_ok=True)
 
-        # Collect all note files and their subfolders
-        note_files: list[str] = []
-        note_subfolders: dict[str, str] = {}
-        for root, _, files in os.walk(gm_notes_path):
-            for file in files:
-                if file.endswith('.txt'):
-                    src_path = os.path.join(root, file)
-                    note_name = os.path.splitext(file)[0]
-                    note_files.append(src_path)
-                    # Look for corresponding .yy file in the same directory
-                    yy_path = os.path.join(root, note_name + '.yy')
-                    note_subfolders[src_path] = self._get_subfolder_from_yy(yy_path)
-
-        if not note_files:
+        note_assets = self._discover_notes(gm_notes_path)
+        if not note_assets:
             return
 
         # Pre-create all directories
-        for src_file in note_files:
-            note_name = os.path.splitext(os.path.basename(src_file))[0]
-            subfolder = note_subfolders.get(src_file, "")
-            if subfolder:
-                note_dir = os.path.join(godot_notes_path, subfolder, note_name)
+        for asset in note_assets:
+            if asset.subfolder:
+                note_dir = os.path.join(
+                    godot_notes_path,
+                    asset.subfolder,
+                    asset.name,
+                )
             else:
-                note_dir = os.path.join(godot_notes_path, note_name)
+                note_dir = os.path.join(godot_notes_path, asset.name)
             os.makedirs(note_dir, exist_ok=True)
 
-        total_notes = len(note_files)
+        total_notes = len(note_assets)
         processed_notes = 0
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            futures_map: dict[Future[str | None], str] = {}
-            for src_file in note_files:
-                note_name = os.path.splitext(os.path.basename(src_file))[0]
-                subfolder = note_subfolders.get(src_file, "")
-                if subfolder:
-                    dst_file = os.path.join(godot_notes_path, subfolder, note_name, os.path.basename(src_file))
+            futures_map: dict[Future[_NoteCopyResult | None], str] = {}
+            for asset in note_assets:
+                if asset.subfolder:
+                    dst_file = os.path.join(
+                        godot_notes_path,
+                        asset.subfolder,
+                        asset.name,
+                        os.path.basename(asset.filesystem_path),
+                    )
                 else:
-                    dst_file = os.path.join(godot_notes_path, note_name, os.path.basename(src_file))
-                future = executor.submit(self._process_note, src_file, dst_file, note_name)
-                futures_map[future] = note_name
+                    dst_file = os.path.join(
+                        godot_notes_path,
+                        asset.name,
+                        os.path.basename(asset.filesystem_path),
+                    )
+                future = executor.submit(
+                    self._process_note,
+                    asset.filesystem_path,
+                    dst_file,
+                    asset.name,
+                    asset.owner_source_path,
+                )
+                futures_map[future] = asset.name
 
             for future in as_completed(futures_map):
                 result = future.result()
@@ -81,10 +238,19 @@ class NoteConverter(BaseConverter):
                     return
 
                 processed_notes += 1
-                if self.compact_logging:
-                    self._safe_log_progress(result, processed_notes, total_notes)
-                else:
-                    self._safe_log(get_localized("Console_Convertor_Notes_Copied").format(note_name=result))
+                if result.copied:
+                    if self.compact_logging:
+                        self._safe_log_progress(
+                            result.name,
+                            processed_notes,
+                            total_notes,
+                        )
+                    else:
+                        self._safe_log(
+                            get_localized("Console_Convertor_Notes_Copied").format(
+                                note_name=result.name
+                            )
+                        )
                 self._safe_progress(int((processed_notes / total_notes) * 100))
 
     def convert_all(self) -> None:

--- a/src/conversion/objects.py
+++ b/src/conversion/objects.py
@@ -1,5 +1,6 @@
 # pyright: reportPrivateUsage=false
 import os
+import posixpath
 import re
 import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -40,10 +41,14 @@ from src.conversion.gml_transpiler_parts.preprocessor import preprocess_gml_sour
 from src.conversion.gml_transpiler_parts.model import _Token
 from src.conversion.gml_transpiler_parts.tokens import _tokenize
 from src.conversion.project_source_paths import (
+    is_safe_project_source_component,
     ProjectSourcePathError,
+    ResolvedProjectSourcePath,
     project_gml_source_paths,
     resolve_project_source_path,
+    validate_project_resource_source_path,
 )
+from src.conversion.project_manifest import load_gamemaker_project_manifest
 from src.conversion.project_enums import collect_project_enum_values
 from src.conversion.project_macros import collect_project_macro_values
 from src.conversion.script_generator import (
@@ -99,8 +104,11 @@ _SCRIPT_ASSIGNMENT_SKIP_IDENTIFIERS = (
 
 
 class ParsedObject(TypedDict):
+    source_path: str
     sprite_name: str | None
+    sprite_source_path: str | None
     parent_object_name: str | None
+    parent_object_source_path: str | None
     event_list: list[JsonDict]
     solid: bool
     persistent: bool
@@ -286,6 +294,8 @@ class ObjectConverter(BaseConverter):
         self._project_enum_values_cache: dict[str, dict[str, int]] | None = None
         self._project_macro_values_cache: dict[str, str] | None = None
         self._asset_output_paths: dict[str, dict[str, str]] = {}
+        self._object_source_paths: dict[str, str] = {}
+        self._project_resource_names_by_path: dict[tuple[str, str], str] | None = None
 
     def _get_valid_object_names(self) -> dict[str, str] | None:
         """Parse the .yyp project file and return a dict of object name -> subfolder.
@@ -293,23 +303,37 @@ class ObjectConverter(BaseConverter):
         Returns None if the .yyp file cannot be found or parsed, allowing
         the caller to fall back to converting all objects on disk.
         """
+        manifest = load_gamemaker_project_manifest(self.gm_project_path)
+        manifest_rejected_fields = self._record_project_manifest_source_path_diagnostics(
+            manifest,
+            resource_type="object",
+            include_project_sources=True,
+        )
         try:
-            yyp_files = [f for f in os.listdir(self.gm_project_path) if f.endswith('.yyp')]
-            if not yyp_files:
+            if manifest.yyp_path is None:
                 return None
-
-            yyp_path = os.path.join(self.gm_project_path, yyp_files[0])
-            with open(yyp_path, 'r', encoding='utf-8') as f:
-                content = f.read()
-
-            cleaned = re.sub(r',\s*([}\]])', r'\1', content)
-            data = cast(JsonDict, json.loads(cleaned))
+            yyp_source = self._resolve_discovered_project_source(
+                manifest.yyp_path,
+                resource_type="project",
+                field="projectFile",
+            )
+            if yyp_source is None:
+                return None
+            if any(
+                diagnostic.code == "GM2GD-PROJECT-YYP-MALFORMED"
+                for diagnostic in manifest.diagnostics
+            ):
+                raise TypeError("GameMaker project root must be an object")
+            data = manifest.raw_data
 
             valid_objects: dict[str, str] = {}
-            for resource in cast(list[JsonDict], data.get('resources', [])):
+            for index, resource in enumerate(cast(list[JsonDict], data.get('resources', []))):
                 res_id = cast(JsonDict, resource.get('id', {}))
                 raw_path = res_id.get('path', '')
                 if not isinstance(raw_path, str):
+                    continue
+                field = f"resources[{index}].id.path"
+                if field in manifest_rejected_fields:
                     continue
                 path = raw_path.replace('\\', '/')
                 if path.startswith('objects/'):
@@ -321,23 +345,54 @@ class ObjectConverter(BaseConverter):
                     )
                     if not name:
                         continue
-                    try:
-                        resolved_path = resolve_project_source_path(
-                            self.gm_project_path,
-                            path,
-                        )
-                    except ProjectSourcePathError as exc:
-                        self._safe_log(
-                            f"Warning: Skipping GameMaker object {name}: {exc}"
-                        )
+                    resolved_path = self._resolve_project_source(
+                        path,
+                        owner_source_path=yyp_source.source_path,
+                        resource=name,
+                        resource_type="object",
+                        field=field,
+                    )
+                    if resolved_path is None or not self._source_has_resource_kind(
+                        resolved_path,
+                        "objects",
+                        rejected_path=path,
+                        owner_source_path=yyp_source.source_path,
+                        resource=name,
+                        field=field,
+                    ):
                         continue
                     yy_path = resolved_path.filesystem_path
+                    self._object_source_paths[name] = resolved_path.source_path
                     valid_objects[name] = self._get_subfolder_from_yy(yy_path)
 
             return valid_objects
         except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
             self._safe_log(get_localized("Console_Convertor_Objects_YYPFilterWarning"))
             return None
+
+    def _source_has_resource_kind(
+        self,
+        resolved: ResolvedProjectSourcePath,
+        resource_kind: str,
+        *,
+        rejected_path: str,
+        owner_source_path: StrPath,
+        resource: str,
+        field: str,
+    ) -> bool:
+        try:
+            validate_project_resource_source_path(resolved, resource_kind)
+            return True
+        except ProjectSourcePathError as error:
+            self._report_source_path_rejection(
+                rejected_path,
+                error,
+                owner_source_path=owner_source_path,
+                resource=resource,
+                resource_type="object",
+                field=field,
+            )
+            return False
 
     def _get_project_asset_names(self) -> set[str]:
         """Return GameMaker resource names that can collide with unscoped GML identifiers."""
@@ -352,6 +407,7 @@ class ObjectConverter(BaseConverter):
                 progress_callback=lambda _value: None,
                 conversion_running=self.conversion_running,
                 macro_configuration=self.macro_configuration,
+                diagnostics=self.diagnostics,
             )
             asset_names = {entry.name for entry in registry_converter.build_entries()}
             self._project_asset_names_cache = asset_names
@@ -360,10 +416,18 @@ class ObjectConverter(BaseConverter):
             pass
 
         try:
-            yyp_files = [f for f in os.listdir(self.gm_project_path) if f.endswith('.yyp')]
-            if yyp_files:
-                yyp_path = os.path.join(self.gm_project_path, yyp_files[0])
-                with open(yyp_path, 'r', encoding='utf-8') as f:
+            yyp_files = sorted(
+                f for f in os.listdir(self.gm_project_path) if f.endswith('.yyp')
+            )
+            for yyp_filename in yyp_files:
+                yyp_source = self._resolve_discovered_project_source(
+                    os.path.join(self.gm_project_path, yyp_filename),
+                    resource_type="project",
+                    field="project asset-name discovery",
+                )
+                if yyp_source is None or not os.path.isfile(yyp_source.filesystem_path):
+                    continue
+                with open(yyp_source.filesystem_path, 'r', encoding='utf-8') as f:
                     content = f.read()
 
                 cleaned = re.sub(r',\s*([}\]])', r'\1', content)
@@ -382,17 +446,29 @@ class ObjectConverter(BaseConverter):
 
         asset_names = set()
         for resource_dir in ("objects", "sprites", "sounds", "rooms", "scripts"):
-            root = os.path.join(self.gm_project_path, resource_dir)
-            if not os.path.isdir(root):
+            resolved_root = self._resolve_discovered_project_source(
+                os.path.join(self.gm_project_path, resource_dir),
+                resource_type="project_resource",
+                field="asset-name discovery directory",
+            )
+            if resolved_root is None or not os.path.isdir(resolved_root.filesystem_path):
                 continue
             try:
-                asset_names.update(
-                    name
-                    for name in os.listdir(root)
-                    if os.path.isdir(os.path.join(root, name))
-                )
+                names = sorted(os.listdir(resolved_root.filesystem_path))
             except OSError:
                 continue
+            for name in names:
+                resolved_resource = self._resolve_discovered_project_source(
+                    os.path.join(resolved_root.filesystem_path, name),
+                    owner_source_path=resolved_root.source_path,
+                    resource=name,
+                    resource_type="project_resource",
+                    field="asset-name discovery resource",
+                )
+                if resolved_resource is not None and os.path.isdir(
+                    resolved_resource.filesystem_path
+                ):
+                    asset_names.add(name)
         self._project_asset_names_cache = asset_names
         return set(asset_names)
 
@@ -443,57 +519,347 @@ class ObjectConverter(BaseConverter):
             )
         return dict(self._project_macro_values_cache)
 
-    def _parse_object_yy(self, object_name: str) -> ParsedObject | None:
+    def _resolve_object_yy_source(
+        self,
+        object_name: str,
+        source_path: str | None = None,
+    ) -> ResolvedProjectSourcePath | None:
+        if source_path is not None:
+            resolved = self._resolve_project_source(
+                source_path,
+                resource=object_name,
+                resource_type="object",
+                field="object.yy",
+            )
+            owner_source_path: StrPath = os.path.dirname(source_path)
+            rejected_path = source_path
+        else:
+            candidate = os.path.join(
+                self.gm_project_path,
+                "objects",
+                object_name,
+                object_name + ".yy",
+            )
+            resolved = self._resolve_discovered_project_source(
+                candidate,
+                owner_source_path=os.path.dirname(candidate),
+                resource=object_name,
+                resource_type="object",
+                field="object.yy",
+            )
+            owner_source_path = os.path.dirname(candidate)
+            rejected_path = candidate
+        if resolved is None or not self._source_has_resource_kind(
+            resolved,
+            "objects",
+            rejected_path=rejected_path,
+            owner_source_path=owner_source_path,
+            resource=object_name,
+            field="object.yy",
+        ):
+            return None
+        return resolved
+
+    def _resolve_resource_reference(
+        self,
+        value: object,
+        *,
+        owner_source_path: str,
+        owner_name: str,
+        field: str,
+        resource_kind: str,
+    ) -> tuple[str, str] | None:
+        if not isinstance(value, dict):
+            return None
+
+        reference = cast(JsonDict, value)
+        raw_path = reference.get("path")
+        raw_name = reference.get("name")
+        reference_field = f"{field}.path"
+        legacy_name_reference = "path" not in reference
+        if legacy_name_reference:
+            if not isinstance(raw_name, str) or not is_safe_project_source_component(
+                raw_name
+            ):
+                rejected_name = (
+                    raw_name if isinstance(raw_name, str) else repr(raw_name)
+                )
+                self._report_source_path_rejection(
+                    rejected_name,
+                    ProjectSourcePathError(
+                        "Legacy GameMaker resource reference name must be one "
+                        f"safe path component: {raw_name!r}"
+                    ),
+                    owner_source_path=owner_source_path,
+                    resource=owner_name,
+                    resource_type="object",
+                    field=f"{field}.name",
+                )
+                return None
+            raw_path = f"{resource_kind}/{raw_name}/{raw_name}.yy"
+            reference_field = f"{field}.name"
+        elif not isinstance(raw_path, str) or not raw_path:
+            rejected_path = raw_path if isinstance(raw_path, str) else repr(raw_path)
+            self._report_source_path_rejection(
+                rejected_path,
+                ProjectSourcePathError(
+                    "GameMaker resource reference path must be a non-empty "
+                    f"string: {raw_path!r}"
+                ),
+                owner_source_path=owner_source_path,
+                resource=owner_name,
+                resource_type="object",
+                field=reference_field,
+            )
+            return None
+
+        resolved = self._resolve_project_source(
+            raw_path,
+            owner_source_path=owner_source_path,
+            resource=owner_name,
+            resource_type="object",
+            field=reference_field,
+        )
+        if resolved is None or not self._source_has_resource_kind(
+            resolved,
+            resource_kind,
+            rejected_path=raw_path,
+            owner_source_path=owner_source_path,
+            resource=owner_name,
+            field=reference_field,
+        ):
+            return None
+
+        reference_name = (
+            raw_name
+            if legacy_name_reference and isinstance(raw_name, str)
+            else self._logical_resource_name(resource_kind, resolved)
+        )
+        if not reference_name:
+            return None
+        return reference_name, resolved.source_path
+
+    def _logical_resource_name(
+        self,
+        resource_kind: str,
+        resolved: ResolvedProjectSourcePath,
+    ) -> str:
+        if self._project_resource_names_by_path is None:
+            names_by_path: dict[tuple[str, str], str] = {}
+            manifest = load_gamemaker_project_manifest(self.gm_project_path)
+            for resource in manifest.resources:
+                kind = resource.kind.casefold()
+                if kind not in {"sprites", "objects"}:
+                    continue
+                try:
+                    resource_source = resolve_project_source_path(
+                        self.gm_project_path,
+                        resource.path,
+                    )
+                    validate_project_resource_source_path(
+                        resource_source,
+                        kind,
+                    )
+                except ProjectSourcePathError:
+                    continue
+                if is_safe_project_source_component(resource.name):
+                    names_by_path.setdefault(
+                        (kind, resource_source.source_path),
+                        resource.name,
+                    )
+            self._project_resource_names_by_path = names_by_path
+
+        manifest_name = self._project_resource_names_by_path.get(
+            (resource_kind.casefold(), resolved.source_path),
+            "",
+        )
+        if manifest_name:
+            return manifest_name
+
+        referenced_data = self._read_yy_file(resolved.filesystem_path)
+        if referenced_data is not None:
+            for key in ("%Name", "name"):
+                value = referenced_data.get(key)
+                if isinstance(value, str) and is_safe_project_source_component(value):
+                    return value
+
+        fallback_name = posixpath.splitext(
+            posixpath.basename(resolved.source_path)
+        )[0]
+        return (
+            fallback_name
+            if is_safe_project_source_component(fallback_name)
+            else ""
+        )
+
+    def _sanitize_object_events(
+        self,
+        raw_event_list: object,
+        *,
+        owner_source_path: str,
+        object_name: str,
+    ) -> list[JsonDict]:
+        if not isinstance(raw_event_list, list):
+            return []
+
+        events: list[JsonDict] = []
+        for index, raw_event in enumerate(cast(list[object], raw_event_list)):
+            if not isinstance(raw_event, dict):
+                continue
+            event: JsonDict = {
+                key: value
+                for key, value in cast(dict[object, object], raw_event).items()
+                if isinstance(key, str)
+            }
+            if isinstance(event.get("collisionObjectId"), dict):
+                collision_reference = self._resolve_resource_reference(
+                    event["collisionObjectId"],
+                    owner_source_path=owner_source_path,
+                    owner_name=object_name,
+                    field=f"eventList[{index}].collisionObjectId",
+                    resource_kind="objects",
+                )
+                event["collisionObjectId"] = (
+                    {
+                        "name": collision_reference[0],
+                        "path": collision_reference[1],
+                    }
+                    if collision_reference is not None
+                    else None
+                )
+
+            mapping = map_input_event(event) if is_input_event(event) else map_event(event)
+            if mapping is not None and not self._event_mapping_paths_are_contained(
+                owner_source_path,
+                object_name,
+                mapping,
+                field=f"eventList[{index}].sourceFile",
+            ):
+                continue
+            events.append(event)
+        return events
+
+    def _event_mapping_paths_are_contained(
+        self,
+        owner_source_path: str,
+        object_name: str,
+        mapping: EventMapping,
+        *,
+        field: str,
+    ) -> bool:
+        for filename in _event_source_filenames(mapping):
+            if self._resolve_event_source(
+                owner_source_path,
+                object_name,
+                filename,
+                field=field,
+            ) is None:
+                return False
+        return True
+
+    def _resolve_event_source(
+        self,
+        owner_source_path: str,
+        object_name: str,
+        filename: str,
+        *,
+        field: str = "eventList[].sourceFile",
+    ) -> ResolvedProjectSourcePath | None:
+        if not is_safe_project_source_component(filename):
+            self._report_source_path_rejection(
+                filename,
+                ProjectSourcePathError(
+                    "GameMaker object event source must be one safe filename "
+                    f"component: {filename!r}"
+                ),
+                owner_source_path=owner_source_path,
+                resource=object_name,
+                resource_type="object",
+                field=field,
+            )
+            return None
+        resolved = self._resolve_project_source(
+            filename,
+            owner_source_path=owner_source_path,
+            resource=object_name,
+            resource_type="object",
+            field=field,
+        )
+        if resolved is None:
+            return None
+        owner_directory = posixpath.dirname(owner_source_path.replace("\\", "/"))
+        if posixpath.dirname(resolved.source_path) == owner_directory:
+            return resolved
+        self._report_source_path_rejection(
+            filename,
+            ProjectSourcePathError(
+                "GameMaker object event filenames must stay beside their "
+                "declaring object .yy file"
+            ),
+            owner_source_path=owner_source_path,
+            resource=object_name,
+            resource_type="object",
+            field=field,
+        )
+        return None
+
+    def _parse_object_yy(
+        self,
+        object_name: str,
+        object_source_path: str | None = None,
+    ) -> ParsedObject | None:
         """Parse an object .yy file and extract the sprite reference and event list.
 
         Returns a dict with 'sprite_name' (str or None) and 'event_list' (list)
         or None if parsing fails.
         """
-        yy_path = os.path.join(self.gm_project_path, 'objects', object_name, object_name + '.yy')
+        resolved_object = self._resolve_object_yy_source(
+            object_name,
+            object_source_path or self._object_source_paths.get(object_name),
+        )
+        if resolved_object is None:
+            return None
+        yy_path = resolved_object.filesystem_path
         try:
             with open(yy_path, 'r', encoding='utf-8') as f:
                 content = f.read()
             cleaned = re.sub(r',\s*([}\]])', r'\1', content)
             data = cast(JsonDict, json.loads(cleaned))
 
-            sprite_id = data.get('spriteId')
-            sprite_name: str | None = None
-            if isinstance(sprite_id, dict):
-                sprite_data = cast(JsonDict, sprite_id)
-                sprite_name = cast(str | None, sprite_data.get('name', None))
+            sprite_reference = self._resolve_resource_reference(
+                data.get("spriteId"),
+                owner_source_path=resolved_object.source_path,
+                owner_name=object_name,
+                field="spriteId",
+                resource_kind="sprites",
+            )
+            parent_reference = self._resolve_resource_reference(
+                data.get("parentObjectId"),
+                owner_source_path=resolved_object.source_path,
+                owner_name=object_name,
+                field="parentObjectId",
+                resource_kind="objects",
+            )
+            event_list = self._sanitize_object_events(
+                data.get("eventList", []),
+                owner_source_path=resolved_object.source_path,
+                object_name=object_name,
+            )
 
-            event_list = cast(list[JsonDict], data.get('eventList', []))
-            parent_object_name = self._parse_parent_object_name(data.get('parentObjectId'))
-
-            return {
-                "sprite_name": sprite_name,
-                "parent_object_name": parent_object_name,
-                "event_list": event_list,
-                "solid": bool(data.get("solid", False)),
-                "persistent": bool(data.get("persistent", False)),
-            }
+            return ParsedObject(
+                source_path=resolved_object.source_path,
+                sprite_name=sprite_reference[0] if sprite_reference is not None else None,
+                sprite_source_path=sprite_reference[1] if sprite_reference is not None else None,
+                parent_object_name=parent_reference[0] if parent_reference is not None else None,
+                parent_object_source_path=parent_reference[1] if parent_reference is not None else None,
+                event_list=event_list,
+                solid=bool(data.get("solid", False)),
+                persistent=bool(data.get("persistent", False)),
+            )
         except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
             self._safe_log(get_localized("Console_Convertor_Objects_ParseError").format(
                 yy_path=yy_path, object_name=object_name))
             return None
-
-    def _parse_parent_object_name(self, parent_object_id: object) -> str | None:
-        if not isinstance(parent_object_id, dict):
-            return None
-
-        parent_data = cast(JsonDict, parent_object_id)
-        parent_name = parent_data.get("name")
-        if isinstance(parent_name, str) and parent_name:
-            return parent_name
-
-        parent_path = parent_data.get("path")
-        if not isinstance(parent_path, str):
-            return None
-
-        path_parts = parent_path.replace("\\", "/").split("/")
-        if len(path_parts) >= 2 and path_parts[0] == "objects" and path_parts[1]:
-            return path_parts[1]
-        return None
 
     def _object_script_res_path(self, object_name: str, subfolder: str = "") -> str:
         return resource_sibling_path(
@@ -507,14 +873,41 @@ class ObjectConverter(BaseConverter):
             generated_nested_resource_path("objects", subfolder, object_name, ".tscn"),
         )
 
-    def _get_object_subfolder(self, object_name: str) -> str:
-        yy_path = os.path.join(self.gm_project_path, 'objects', object_name, object_name + '.yy')
-        return self._get_subfolder_from_yy(yy_path)
+    def _get_object_subfolder(
+        self,
+        object_name: str,
+        object_source_path: str | None = None,
+    ) -> str:
+        resolved = self._resolve_object_yy_source(
+            object_name,
+            object_source_path or self._object_source_paths.get(object_name),
+        )
+        return (
+            self._get_subfolder_from_yy(resolved.filesystem_path)
+            if resolved is not None
+            else ""
+        )
 
-    def _get_sprite_subfolder(self, sprite_name: str) -> str:
-        """Resolve a sprite's subfolder by reading its .yy file from the GM project."""
-        yy_path = os.path.join(self.gm_project_path, 'sprites', sprite_name, sprite_name + '.yy')
-        return self._get_subfolder_from_yy(yy_path)
+    def _get_sprite_subfolder(
+        self,
+        sprite_source_path: str,
+        *,
+        owner_source_path: str,
+        object_name: str,
+    ) -> str:
+        """Resolve a sprite's subfolder from the object's contained reference."""
+        resolved = self._resolve_project_source(
+            sprite_source_path,
+            owner_source_path=owner_source_path,
+            resource=object_name,
+            resource_type="object",
+            field="spriteId.path",
+        )
+        return (
+            self._get_subfolder_from_yy(resolved.filesystem_path)
+            if resolved is not None
+            else ""
+        )
 
     def _sprite_scene_exists(self, sprite_name: str, sprite_subfolder: str = "") -> bool:
         """Check whether the converted sprite scene exists in the Godot project."""
@@ -601,6 +994,7 @@ class ObjectConverter(BaseConverter):
     def _load_event_code_bodies(
         self,
         object_name: str,
+        object_source_path: str,
         event_list: list[JsonDict],
         inherited_event_functions: set[str] | None = None,
         asset_names: set[str] | None = None,
@@ -615,7 +1009,6 @@ class ObjectConverter(BaseConverter):
         instance_variables: set[str] = set(project_script_instance_variables or set())
         inherited_functions = inherited_event_functions or set()
         source_entries: list[ObjectEventSource] = []
-        object_dir = os.path.join(self.gm_project_path, 'objects', object_name)
         asset_name_set = set(asset_names or set())
 
         for event in event_list or []:
@@ -623,9 +1016,17 @@ class ObjectConverter(BaseConverter):
             if mapping is None or not mapping.gml_filename:
                 continue
 
-            source_path = self._event_source_path(object_dir, mapping)
+            source_path = self._event_source_path(
+                object_source_path,
+                object_name,
+                mapping,
+            )
             if source_path is None:
-                self._record_missing_event_source(object_name, object_dir, mapping)
+                self._record_missing_event_source(
+                    object_name,
+                    object_source_path,
+                    mapping,
+                )
                 continue
 
             try:
@@ -721,22 +1122,32 @@ class ObjectConverter(BaseConverter):
 
         return code_bodies, instance_variables, source_maps
 
-    def _event_source_path(self, object_dir: str, mapping: EventMapping) -> str | None:
+    def _event_source_path(
+        self,
+        object_source_path: str,
+        object_name: str,
+        mapping: EventMapping,
+    ) -> str | None:
         for filename in _event_source_filenames(mapping):
-            source_path = os.path.join(object_dir, filename)
-            if os.path.isfile(source_path):
-                return source_path
+            resolved = self._resolve_event_source(
+                object_source_path,
+                object_name,
+                filename,
+            )
+            if resolved is not None and os.path.isfile(resolved.filesystem_path):
+                return resolved.filesystem_path
         return None
 
     def _record_missing_event_source(
         self,
         object_name: str,
-        object_dir: str,
+        object_source_path: str,
         mapping: EventMapping,
     ) -> None:
         if not mapping.gml_filename.startswith("Collision_"):
             return
         filenames = _event_source_filenames(mapping)
+        owner_directory = os.path.dirname(object_source_path).replace(os.sep, "/")
         message = (
             "Warning: Missing GameMaker collision event code file for "
             f"{object_name}/{mapping.godot_func}; looked for {', '.join(filenames)}"
@@ -746,7 +1157,11 @@ class ObjectConverter(BaseConverter):
                 "warning",
                 "GM2GD-OBJECT-MISSING-COLLISION-EVENT-SOURCE",
                 message,
-                source_path=os.path.join(object_dir, filenames[0]) if filenames else object_dir,
+                source_path=(
+                    f"{owner_directory}/{filenames[0]}"
+                    if filenames
+                    else object_source_path
+                ),
                 resource=object_name,
                 resource_type="object",
                 event=mapping.godot_func,
@@ -791,11 +1206,18 @@ class ObjectConverter(BaseConverter):
             return f"super.{mapping.godot_func}()"
         return f"super.{mapping.godot_func}({mapping.params})"
 
-    def _parent_event_function_names(self, parent_object_name: str | None) -> set[str]:
+    def _parent_event_function_names(
+        self,
+        parent_object_name: str | None,
+        parent_object_source_path: str | None,
+    ) -> set[str]:
         if parent_object_name is None:
             return set()
 
-        parsed_parent = self._parse_object_yy(parent_object_name)
+        parsed_parent = self._parse_object_yy(
+            parent_object_name,
+            parent_object_source_path,
+        )
         if parsed_parent is None:
             return set()
 
@@ -814,20 +1236,38 @@ class ObjectConverter(BaseConverter):
                 function_names.add(mapping.godot_func)
         return function_names
 
-    def _parent_object_chain(self, object_name: str, seen: set[str] | None = None) -> tuple[str, ...]:
+    def _parent_object_chain(
+        self,
+        object_name: str,
+        object_source_path: str | None = None,
+        seen: set[str] | None = None,
+        parsed_object: ParsedObject | None = None,
+    ) -> tuple[str, ...]:
         seen = set(seen or set())
         if object_name in seen:
             return ()
         seen.add(object_name)
 
-        parsed = self._parse_object_yy(object_name)
+        parsed = parsed_object or self._parse_object_yy(object_name, object_source_path)
         if parsed is None or parsed["parent_object_name"] is None:
             return ()
 
         parent_name = parsed["parent_object_name"]
-        return (parent_name, *self._parent_object_chain(parent_name, seen))
+        return (
+            parent_name,
+            *self._parent_object_chain(
+                parent_name,
+                parsed["parent_object_source_path"],
+                seen,
+            ),
+        )
 
-    def _object_inherits_sprite_runtime(self, object_name: str | None, seen: set[str] | None = None) -> bool:
+    def _object_inherits_sprite_runtime(
+        self,
+        object_name: str | None,
+        object_source_path: str | None = None,
+        seen: set[str] | None = None,
+    ) -> bool:
         if object_name is None:
             return False
         seen = set(seen or set())
@@ -835,22 +1275,40 @@ class ObjectConverter(BaseConverter):
             return False
         seen.add(object_name)
 
-        parsed = self._parse_object_yy(object_name)
+        parsed = self._parse_object_yy(object_name, object_source_path)
         if parsed is None:
             return False
         if parsed["sprite_name"] is not None:
             return True
-        if self._object_event_code_uses_sprite_runtime(object_name, parsed["event_list"]):
+        if self._object_event_code_uses_sprite_runtime(
+            object_name,
+            parsed["source_path"],
+            parsed["event_list"],
+        ):
             return True
-        return self._object_inherits_sprite_runtime(parsed["parent_object_name"], seen)
+        return self._object_inherits_sprite_runtime(
+            parsed["parent_object_name"],
+            parsed["parent_object_source_path"],
+            seen,
+        )
 
-    def _object_event_code_uses_sprite_runtime(self, object_name: str, event_list: list[JsonDict]) -> bool:
-        object_dir = os.path.join(self.gm_project_path, 'objects', object_name)
+    def _object_event_code_uses_sprite_runtime(
+        self,
+        object_name: str,
+        object_source_path: str,
+        event_list: list[JsonDict],
+    ) -> bool:
         for event in event_list:
             mapping = map_input_event(event) if is_input_event(event) else map_event(event)
             if mapping is None or not mapping.gml_filename:
                 continue
-            source_path = os.path.join(object_dir, mapping.gml_filename)
+            source_path = self._event_source_path(
+                object_source_path,
+                object_name,
+                mapping,
+            )
+            if source_path is None:
+                continue
             try:
                 with open(source_path, 'r', encoding='utf-8') as f:
                     if _SPRITE_RUNTIME_IDENTIFIER_RE.search(f.read()) is not None:
@@ -868,6 +1326,7 @@ class ObjectConverter(BaseConverter):
         project_script_instance_variables: set[str] | None = None,
         enum_values: Mapping[str, Mapping[str, int]] | None = None,
         macro_values: Mapping[str, str] | None = None,
+        object_source_path: str | None = None,
     ) -> ObjectProcessResult | None:
         """Process a single object: parse .yy, generate scene and script, write files.
 
@@ -876,12 +1335,14 @@ class ObjectConverter(BaseConverter):
         if not self.conversion_running():
             return None
 
-        parsed = self._parse_object_yy(object_name)
+        parsed = self._parse_object_yy(object_name, object_source_path)
         if parsed is None:
             return {"success": False, "name": object_name, "has_sprite": False, "sprite_name": None, "event_count": 0}
 
         sprite_name = parsed["sprite_name"]
+        sprite_source_path = parsed["sprite_source_path"]
         parent_object_name = parsed["parent_object_name"]
+        parent_object_source_path = parsed["parent_object_source_path"]
         event_list = parsed["event_list"]
         solid = bool(parsed.get("solid", False))
         persistent = bool(parsed.get("persistent", False))
@@ -890,16 +1351,29 @@ class ObjectConverter(BaseConverter):
         inherited_event_functions: set[str] = set()
 
         if parent_object_name is not None and parent_object_name != object_name:
-            parent_subfolder = self._get_object_subfolder(parent_object_name)
+            parent_subfolder = self._get_object_subfolder(
+                parent_object_name,
+                parent_object_source_path,
+            )
             parent_script_res_path = self._object_script_res_path(parent_object_name, parent_subfolder)
-            inherited_event_functions = self._parent_event_function_names(parent_object_name)
-        inherited_sprite_runtime = self._object_inherits_sprite_runtime(parent_object_name)
+            inherited_event_functions = self._parent_event_function_names(
+                parent_object_name,
+                parent_object_source_path,
+            )
+        inherited_sprite_runtime = self._object_inherits_sprite_runtime(
+            parent_object_name,
+            parent_object_source_path,
+        )
         local_event_functions = self._event_function_names(event_list)
 
-        if sprite_name is not None:
+        if sprite_name is not None and sprite_source_path is not None:
             sprite_scene_path = (sprite_scene_paths or {}).get(sprite_name)
             if sprite_scene_path is None:
-                sprite_subfolder = self._get_sprite_subfolder(sprite_name)
+                sprite_subfolder = self._get_sprite_subfolder(
+                    sprite_source_path,
+                    owner_source_path=parsed["source_path"],
+                    object_name=object_name,
+                )
                 if self._sprite_scene_exists(sprite_name, sprite_subfolder):
                     sprite_scene_path = self._asset_output_paths.get("sprites", {}).get(
                         sprite_name,
@@ -919,6 +1393,7 @@ class ObjectConverter(BaseConverter):
 
         code_bodies, instance_variables, event_source_maps = self._load_event_code_bodies(
             object_name,
+            parsed["source_path"],
             event_list,
             inherited_event_functions=inherited_event_functions,
             asset_names=asset_names,
@@ -943,7 +1418,11 @@ class ObjectConverter(BaseConverter):
             ),
             object_runtime=ObjectRuntimeConfig(
                 object_name=object_name,
-                parent_object_names=self._parent_object_chain(object_name),
+                parent_object_names=self._parent_object_chain(
+                    object_name,
+                    parsed["source_path"],
+                    parsed_object=parsed,
+                ),
                 solid=solid,
                 persistent=persistent,
                 inherit_ready="_ready" in inherited_event_functions and "_ready" not in local_event_functions,
@@ -992,27 +1471,72 @@ class ObjectConverter(BaseConverter):
         os.makedirs(self.godot_objects_path, exist_ok=True)
 
         gm_objects_path = os.path.join(self.gm_project_path, 'objects')
-        if not os.path.isdir(gm_objects_path):
+        resolved_objects_root = self._resolve_discovered_project_source(
+            gm_objects_path,
+            resource_type="object",
+            field="objectsDirectory",
+        )
+        if (
+            resolved_objects_root is None
+            or not os.path.isdir(resolved_objects_root.filesystem_path)
+        ):
             self.log_callback(get_localized("Console_Convertor_Objects_Error_NotFound"))
             return
 
         write_gml_runtime(self.godot_project_path)
 
-        object_names = [
-            name for name in os.listdir(gm_objects_path)
-            if os.path.isdir(os.path.join(gm_objects_path, name))
-            and os.path.isfile(os.path.join(gm_objects_path, name, name + '.yy'))
-        ]
-
         valid_names = self._get_valid_object_names()
-        object_subfolders = {}
+        object_names: list[str] = []
+        object_subfolders: dict[str, str] = {}
         if valid_names is not None:
-            object_names = [name for name in object_names if name in valid_names]
-            object_subfolders = {name: valid_names[name] for name in object_names}
+            for name, subfolder in valid_names.items():
+                source_path = self._object_source_paths.get(name)
+                resolved = self._resolve_object_yy_source(name, source_path)
+                if resolved is None or not os.path.isfile(resolved.filesystem_path):
+                    continue
+                object_names.append(name)
+                object_subfolders[name] = subfolder
         else:
-            for name in object_names:
-                yy_path = os.path.join(self.gm_project_path, 'objects', name, name + '.yy')
-                object_subfolders[name] = self._get_subfolder_from_yy(yy_path)
+            for name in os.listdir(resolved_objects_root.filesystem_path):
+                object_directory = self._resolve_discovered_project_source(
+                    os.path.join(resolved_objects_root.filesystem_path, name),
+                    resource=name,
+                    resource_type="object",
+                    field="objectDirectory",
+                )
+                if (
+                    object_directory is None
+                    or not os.path.isdir(object_directory.filesystem_path)
+                ):
+                    continue
+                yy_source = self._resolve_discovered_project_source(
+                    os.path.join(object_directory.filesystem_path, name + ".yy"),
+                    owner_source_path=object_directory.source_path,
+                    resource=name,
+                    resource_type="object",
+                    field="object.yy",
+                )
+                if (
+                    yy_source is None
+                    or not self._source_has_resource_kind(
+                        yy_source,
+                        "objects",
+                        rejected_path=os.path.join(
+                            object_directory.filesystem_path,
+                            name + ".yy",
+                        ),
+                        owner_source_path=object_directory.source_path,
+                        resource=name,
+                        field="object.yy",
+                    )
+                    or not os.path.isfile(yy_source.filesystem_path)
+                ):
+                    continue
+                self._object_source_paths[name] = yy_source.source_path
+                object_names.append(name)
+                object_subfolders[name] = self._get_subfolder_from_yy(
+                    yy_source.filesystem_path
+                )
 
         if not object_names:
             self.log_callback(get_localized("Console_Convertor_Objects_Complete"))
@@ -1042,6 +1566,7 @@ class ObjectConverter(BaseConverter):
                     project_script_instance_variables,
                     enum_values,
                     macro_values,
+                    self._object_source_paths.get(name),
                 ): name
                 for name in object_names
             }

--- a/src/conversion/path_registry.py
+++ b/src/conversion/path_registry.py
@@ -5,6 +5,10 @@ import os
 from dataclasses import dataclass
 from typing import Iterable, Protocol, cast
 
+from src.conversion.project_source_paths import (
+    ProjectSourcePathError,
+    resolve_project_source_path,
+)
 from src.conversion.type_defs import JsonDict
 
 PATH_REGISTRY_RELATIVE_PATH = os.path.join("gm2godot", "gml_path_registry.gd")
@@ -68,8 +72,14 @@ def build_path_registry_entries(
     for asset_entry in asset_entries:
         if asset_entry.kind != "paths":
             continue
-        yy_path = os.path.join(gm_project_path, asset_entry.source_path)
-        data = _read_json_lenient(yy_path)
+        try:
+            resolved_yy = resolve_project_source_path(
+                gm_project_path,
+                asset_entry.source_path,
+            )
+        except ProjectSourcePathError:
+            continue
+        data = _read_json_lenient(resolved_yy.filesystem_path)
         if data is None:
             continue
         path_entries.append(_path_entry_from_yy(asset_entry, data))

--- a/src/conversion/project_manifest.py
+++ b/src/conversion/project_manifest.py
@@ -6,6 +6,12 @@ import re
 from dataclasses import dataclass, field
 from typing import Callable, Iterable, Literal, Mapping, cast
 
+from src.conversion.project_source_paths import (
+    ProjectSourcePathError,
+    resolve_project_filesystem_source_path,
+    resolve_project_source_path,
+    validate_project_resource_source_path,
+)
 from src.conversion.type_defs import JsonDict, JsonList
 
 
@@ -30,6 +36,11 @@ _RESOURCE_TYPE_KIND = {
     "GMTileSet": "tilesets",
     "GMTimeline": "timelines",
 }
+_RESOURCE_TYPE_BY_KIND = {
+    kind.casefold(): resource_type
+    for resource_type, kind in _RESOURCE_TYPE_KIND.items()
+}
+_KNOWN_RESOURCE_KINDS = frozenset(_RESOURCE_TYPE_BY_KIND)
 
 _KNOWN_PROJECT_FIELDS = frozenset({
     "$GMProject",
@@ -55,6 +66,8 @@ _KNOWN_PROJECT_FIELDS = frozenset({
     "tutorialPath",
 })
 
+_MISSING_RESOURCE_PATH = object()
+
 
 def _empty_json_dict() -> JsonDict:
     return cast(JsonDict, {})
@@ -73,6 +86,9 @@ class ProjectManifestDiagnostic:
     code: str
     message: str
     source: ProjectSourceLocation | None = None
+    resource: str | None = None
+    resource_type: str | None = None
+    resource_kind: str | None = None
 
 
 @dataclass(frozen=True)
@@ -207,8 +223,8 @@ def load_gamemaker_project_manifest(
     *,
     target_platform: str | None = None,
 ) -> GameMakerProjectManifest:
-    yyp_path = _find_yyp_path(gm_project_path)
     diagnostics: list[ProjectManifestDiagnostic] = []
+    yyp_path = _find_yyp_path(gm_project_path, diagnostics)
     if yyp_path is None:
         diagnostics.append(
             ProjectManifestDiagnostic(
@@ -231,9 +247,14 @@ def load_gamemaker_project_manifest(
         )
         return GameMakerProjectManifest(project_name="", yyp_path=yyp_path, diagnostics=tuple(diagnostics))
 
-    resources = _parse_resources(raw_data, yyp_path, raw_source)
+    resources = _parse_resources(
+        raw_data,
+        yyp_path,
+        raw_source,
+        diagnostics,
+    )
     configurations = _parse_configurations(raw_data, yyp_path, raw_source)
-    options = _parse_project_options(gm_project_path)
+    options = _parse_project_options(gm_project_path, diagnostics)
     texture_groups = _parse_texture_groups(raw_data, yyp_path, raw_source)
     audio_groups = _parse_audio_groups(raw_data, yyp_path, raw_source)
     included_files = _parse_included_files(raw_data, yyp_path, raw_source)
@@ -284,14 +305,40 @@ def unsupported_project_option_diagnostics(
     return tuple(diagnostics)
 
 
-def _find_yyp_path(gm_project_path: str) -> str | None:
+def _find_yyp_path(
+    gm_project_path: str,
+    diagnostics: list[ProjectManifestDiagnostic],
+) -> str | None:
     try:
         yyp_files = sorted(name for name in os.listdir(gm_project_path) if name.endswith(".yyp"))
     except OSError:
         return None
-    if not yyp_files:
-        return None
-    return os.path.join(gm_project_path, yyp_files[0])
+    for filename in yyp_files:
+        candidate_path = os.path.join(gm_project_path, filename)
+        try:
+            resolved = resolve_project_source_path(gm_project_path, filename)
+        except ProjectSourcePathError as error:
+            diagnostics.append(
+                _source_path_rejection_diagnostic(
+                    gm_project_path,
+                    candidate_path,
+                    error,
+                )
+            )
+            continue
+        if os.path.isfile(resolved.filesystem_path):
+            return resolved.filesystem_path
+        diagnostics.append(
+            _source_path_rejection_diagnostic(
+                gm_project_path,
+                candidate_path,
+                ProjectSourcePathError(
+                    "GameMaker project candidate is not a regular .yyp file: "
+                    f"{filename!r}"
+                ),
+            )
+        )
+    return None
 
 
 def _read_lenient_json_file(path: str) -> tuple[JsonDict | None, str]:
@@ -308,8 +355,10 @@ def _parse_resources(
     yyp_data: JsonDict,
     yyp_path: str,
     raw_source: str,
+    diagnostics: list[ProjectManifestDiagnostic],
 ) -> tuple[ProjectResourceReference, ...]:
     resources: list[ProjectResourceReference] = []
+    source_search_offset = 0
     raw_resources = yyp_data.get("resources")
     if not isinstance(raw_resources, list):
         return ()
@@ -317,10 +366,173 @@ def _parse_resources(
         if not isinstance(raw_entry, dict):
             continue
         entry = cast(JsonDict, raw_entry)
+        raw_path, path_field = _resource_path_value(entry)
+        field_path = f"resources[{order}].{path_field}"
+        (
+            resource_name,
+            resource_kind,
+            resource_type,
+        ) = _resource_diagnostic_identity(
+            entry,
+            raw_path,
+        )
+        source_line, source_search_offset = _resource_field_line(
+            raw_source,
+            path_field,
+            raw_path,
+            source_search_offset,
+            fallback_needle=resource_name,
+        )
+        if raw_path is _MISSING_RESOURCE_PATH:
+            error = ProjectSourcePathError(
+                "GameMaker resource path is missing"
+            )
+        elif not isinstance(raw_path, str) or not raw_path:
+            error = ProjectSourcePathError(
+                "GameMaker resource path must be a non-empty string: "
+                f"{raw_path!r}"
+            )
+        else:
+            try:
+                resolve_project_source_path(
+                    os.path.dirname(yyp_path),
+                    raw_path,
+                )
+            except ProjectSourcePathError as exc:
+                error = exc
+            else:
+                error = None
+        if error is not None:
+            path_display = (
+                "<missing>"
+                if raw_path is _MISSING_RESOURCE_PATH
+                else repr(raw_path)
+            )
+            diagnostics.append(
+                ProjectManifestDiagnostic(
+                    severity="warning",
+                    code="GM2GD-SOURCE-PATH-REJECTED",
+                    message=(
+                        "Warning: Rejected GameMaker source path "
+                        f"{path_display} from {yyp_path} field "
+                        f"{field_path}: {error}"
+                    ),
+                    source=ProjectSourceLocation(
+                        yyp_path,
+                        source_line,
+                        field_path,
+                    ),
+                    resource=resource_name or None,
+                    resource_type=resource_type or None,
+                    resource_kind=resource_kind or None,
+                )
+            )
+            continue
         reference = _resource_reference_from_entry(entry, order, yyp_path, raw_source)
         if reference is not None:
             resources.append(reference)
     return tuple(resources)
+
+
+def _resource_field_line(
+    source: str,
+    field_path: str,
+    raw_value: object,
+    search_offset: int,
+    *,
+    fallback_needle: str,
+) -> tuple[int, int]:
+    """Locate a resource field after the prior entry, including duplicates."""
+    field_name = field_path.rsplit(".", 1)[-1]
+    match: re.Match[str] | None = None
+    if raw_value is _MISSING_RESOURCE_PATH:
+        if fallback_needle:
+            fallback_index = source.find(fallback_needle, search_offset)
+            if fallback_index >= 0:
+                return (
+                    source.count("\n", 0, fallback_index) + 1,
+                    fallback_index + len(fallback_needle),
+                )
+        return 1, search_offset
+    else:
+        serialized_value = json.dumps(raw_value, ensure_ascii=False)
+        pattern = re.compile(
+            rf'"{re.escape(field_name)}"\s*:\s*{re.escape(serialized_value)}'
+        )
+        match = pattern.search(source, search_offset)
+    if match is None:
+        field_pattern = re.compile(rf'"{re.escape(field_name)}"\s*:')
+        match = field_pattern.search(source, search_offset)
+    if match is None and fallback_needle:
+        fallback_index = source.find(fallback_needle, search_offset)
+        if fallback_index >= 0:
+            return (
+                source.count("\n", 0, fallback_index) + 1,
+                fallback_index + len(fallback_needle),
+            )
+    if match is None:
+        return 1, search_offset
+    return source.count("\n", 0, match.start()) + 1, match.end()
+
+
+def _resource_path_value(entry: JsonDict) -> tuple[object, str]:
+    """Return a raw YYP resource path and its field without coercion."""
+    data = entry
+    field_prefix = ""
+    value = entry.get("Value")
+    if isinstance(value, dict):
+        data = cast(JsonDict, value)
+        field_prefix = "Value."
+    nested_id = data.get("id")
+    if isinstance(nested_id, dict):
+        nested = cast(JsonDict, nested_id)
+        return (
+            nested.get("path", _MISSING_RESOURCE_PATH),
+            f"{field_prefix}id.path",
+        )
+    for key in ("path", "resourcePath", "resource_path"):
+        if key in data:
+            return data[key], f"{field_prefix}{key}"
+    missing_field = "resourcePath" if field_prefix else "id.path"
+    return _MISSING_RESOURCE_PATH, f"{field_prefix}{missing_field}"
+
+
+def _resource_diagnostic_identity(
+    entry: JsonDict,
+    raw_path: object,
+) -> tuple[str, str, str]:
+    data = entry
+    value = entry.get("Value")
+    if isinstance(value, dict):
+        data = cast(JsonDict, value)
+    nested_id = data.get("id")
+    if isinstance(nested_id, dict):
+        nested = cast(JsonDict, nested_id)
+        name = _string_value(nested.get("name"))
+        nested_resource_type = _string_value(nested.get("resourceType"))
+    else:
+        name = _string_value(data.get("name")) or _string_value(data.get("%Name"))
+        nested_resource_type = ""
+    resource_type = (
+        _string_value(data.get("resourceType"))
+        or nested_resource_type
+    )
+    path = raw_path if isinstance(raw_path, str) else ""
+    path_kind = _kind_from_path(path).casefold()
+    if path_kind not in _KNOWN_RESOURCE_KINDS:
+        path_kind = ""
+    declared_kind = _RESOURCE_TYPE_KIND.get(resource_type, "")
+    kind = path_kind or declared_kind
+    effective_resource_type = ""
+    if path_kind:
+        effective_resource_type = _RESOURCE_TYPE_BY_KIND[path_kind]
+    elif declared_kind:
+        effective_resource_type = resource_type
+    return (
+        name or _name_from_path(path),
+        kind,
+        effective_resource_type,
+    )
 
 
 def _resource_reference_from_entry(
@@ -501,16 +713,85 @@ def _config_overrides_from_value(
     )
 
 
-def _parse_project_options(gm_project_path: str) -> tuple[ProjectOption, ...]:
-    options_root = os.path.join(gm_project_path, "options")
+def _parse_project_options(
+    gm_project_path: str,
+    diagnostics: list[ProjectManifestDiagnostic],
+) -> tuple[ProjectOption, ...]:
+    lexical_options_root = os.path.join(gm_project_path, "options")
+    try:
+        resolved_options_root = resolve_project_filesystem_source_path(
+            gm_project_path,
+            lexical_options_root,
+        )
+    except ProjectSourcePathError as error:
+        diagnostics.append(
+            _source_path_rejection_diagnostic(
+                gm_project_path,
+                lexical_options_root,
+                error,
+            )
+        )
+        return ()
+    options_root = resolved_options_root.filesystem_path
     if not os.path.isdir(options_root):
         return ()
     options: list[ProjectOption] = []
-    for root, _dirs, files in os.walk(options_root):
+    for root, dirs, files in os.walk(options_root):
+        contained_dirs: list[str] = []
+        for directory in sorted(dirs):
+            candidate_directory = os.path.join(root, directory)
+            try:
+                resolved_directory = resolve_project_filesystem_source_path(
+                    gm_project_path,
+                    candidate_directory,
+                )
+            except ProjectSourcePathError as error:
+                diagnostics.append(
+                    _source_path_rejection_diagnostic(
+                        gm_project_path,
+                        candidate_directory,
+                        error,
+                    )
+                )
+                continue
+            if os.path.isdir(resolved_directory.filesystem_path):
+                contained_dirs.append(directory)
+        dirs[:] = contained_dirs
         for filename in sorted(files):
             if not filename.endswith(".yy"):
                 continue
-            path = os.path.join(root, filename)
+            candidate_path = os.path.join(root, filename)
+            try:
+                resolved_path = resolve_project_filesystem_source_path(
+                    gm_project_path,
+                    candidate_path,
+                )
+            except ProjectSourcePathError as error:
+                diagnostics.append(
+                    _source_path_rejection_diagnostic(
+                        gm_project_path,
+                        candidate_path,
+                        error,
+                    )
+                )
+                continue
+            try:
+                validate_project_resource_source_path(
+                    resolved_path,
+                    "options",
+                )
+            except ProjectSourcePathError as error:
+                diagnostics.append(
+                    _source_path_rejection_diagnostic(
+                        gm_project_path,
+                        candidate_path,
+                        error,
+                    )
+                )
+                continue
+            path = resolved_path.filesystem_path
+            if not os.path.isfile(path):
+                continue
             data, source = _read_lenient_json_file(path)
             if data is None:
                 continue
@@ -526,6 +807,32 @@ def _parse_project_options(gm_project_path: str) -> tuple[ProjectOption, ...]:
                         )
                     )
     return tuple(options)
+
+
+def _source_path_rejection_diagnostic(
+    gm_project_path: str,
+    candidate_path: str,
+    error: ProjectSourcePathError,
+) -> ProjectManifestDiagnostic:
+    """Describe a rejected candidate without resolving its lexical source link."""
+    lexical_path = os.path.abspath(candidate_path)
+    try:
+        field_path = os.path.relpath(
+            lexical_path,
+            os.path.abspath(gm_project_path),
+        ).replace(os.sep, "/")
+    except ValueError:
+        field_path = os.path.basename(lexical_path)
+    return ProjectManifestDiagnostic(
+        severity="warning",
+        code="GM2GD-SOURCE-PATH-REJECTED",
+        message=f"Rejected GameMaker project source path {field_path!r}: {error}",
+        source=ProjectSourceLocation(
+            path=lexical_path,
+            line=1,
+            field_path=field_path,
+        ),
+    )
 
 
 def _option_platform_from_path(options_root: str, path: str) -> str:

--- a/src/conversion/project_settings.py
+++ b/src/conversion/project_settings.py
@@ -38,32 +38,43 @@ class ProjectSettingsConverter(BaseConverter):
         self.options_main_path = os.path.join(self.gm_project_path, 'options', 'main', 'options_main.yy')
 
     def convert_icon(self) -> bool:
-        gm_icon_path = os.path.join(self.gm_project_path, 'options', self.gm_platform, 'icons')
+        requested_icon_path = os.path.join(
+            self.gm_project_path,
+            'options',
+            self.gm_platform,
+            'icons',
+        )
+        gm_icon_path = self._resolve_icon_directory(
+            requested_icon_path,
+            self.gm_platform,
+        )
+        icon_platform = self.gm_platform
         godot_ico_path = os.path.join(self.godot_project_path, 'icon.ico')
         godot_png_path = os.path.join(self.godot_project_path, 'icon.png')
 
-        if not os.path.exists(gm_icon_path):
-            gm_icon_path = self._find_fallback_icon_path()
-            if gm_icon_path is None:
+        if gm_icon_path is None:
+            fallback_icon = self._find_fallback_icon_path()
+            if fallback_icon is None:
                 self.log_callback(get_localized("Console_Convertor_Icon_Error_DirectoryNotFound").format(
-                    gm_icon_path=os.path.join(self.gm_project_path, 'options', self.gm_platform, 'icons')))
+                    gm_icon_path=requested_icon_path))
                 return False
+            gm_icon_path, icon_platform = fallback_icon
 
-        icon_files = [f for f in os.listdir(gm_icon_path) if f.endswith('.ico') or f.endswith('.png')]
+        icon_files = self._contained_icon_files(gm_icon_path, icon_platform)
 
         if not (icon_files):
             self.log_callback(get_localized("Console_Convertor_Icon_Error_FileNotFound"))
             return False
 
-        source_icon = os.path.join(gm_icon_path, icon_files[0])
+        icon_name, source_icon = icon_files[0]
             
         try:
             shutil.copy2(source_icon, godot_ico_path)
-            self.log_callback(get_localized("Console_Convertor_Icon_Copied").format(icon_files=icon_files[0]))
+            self.log_callback(get_localized("Console_Convertor_Icon_Copied").format(icon_files=icon_name))
 
             with Image.open(source_icon) as img:
                 img.save(godot_png_path, 'PNG')
-            self.log_callback(get_localized("Console_Convertor_Icon_Converted").format(icon_files=icon_files[0]))
+            self.log_callback(get_localized("Console_Convertor_Icon_Converted").format(icon_files=icon_name))
 
             project_godot_path = os.path.join(
                 self.godot_project_path,
@@ -81,23 +92,75 @@ class ProjectSettingsConverter(BaseConverter):
             self.log_callback(get_localized("Console_Convertor_Error_IconGeneric").format(error=str(e)))
             return False
 
-    def _find_fallback_icon_path(self) -> Optional[str]:
+    def _find_fallback_icon_path(self) -> tuple[str, str] | None:
         """Search other platforms for an icon directory when the selected platform has none."""
-        options_dir = os.path.join(self.gm_project_path, 'options')
-        if not os.path.isdir(options_dir):
+        resolved_options = self._resolve_discovered_project_source(
+            os.path.join(self.gm_project_path, 'options'),
+            resource_type="project_options",
+            field="options directory",
+        )
+        if (
+            resolved_options is None
+            or not os.path.isdir(resolved_options.filesystem_path)
+        ):
             return None
 
-        for platform in os.listdir(options_dir):
+        for platform in sorted(os.listdir(resolved_options.filesystem_path)):
             if platform == self.gm_platform:
                 continue
-            candidate = os.path.join(options_dir, platform, 'icons')
-            if os.path.isdir(candidate):
-                icon_files = [f for f in os.listdir(candidate) if f.endswith('.ico') or f.endswith('.png')]
-                if icon_files:
-                    self.log_callback(get_localized("Console_Convertor_Icon_Fallback").format(platform=platform))
-                    return candidate
+            candidate = self._resolve_icon_directory(
+                os.path.join(
+                    resolved_options.filesystem_path,
+                    platform,
+                    'icons',
+                ),
+                platform,
+            )
+            if candidate is not None and self._contained_icon_files(candidate, platform):
+                self.log_callback(get_localized("Console_Convertor_Icon_Fallback").format(platform=platform))
+                return candidate, platform
 
         return None
+
+    def _resolve_icon_directory(
+        self,
+        icon_path: str,
+        platform: str,
+    ) -> str | None:
+        resolved = self._resolve_discovered_project_source(
+            icon_path,
+            owner_source_path=f"options/{platform}",
+            resource=platform,
+            resource_type="project_options",
+            field="icons directory",
+        )
+        if resolved is None or not os.path.isdir(resolved.filesystem_path):
+            return None
+        return resolved.filesystem_path
+
+    def _contained_icon_files(
+        self,
+        icon_directory: str,
+        platform: str,
+    ) -> list[tuple[str, str]]:
+        try:
+            filenames = sorted(os.listdir(icon_directory))
+        except OSError:
+            return []
+        icons: list[tuple[str, str]] = []
+        for filename in filenames:
+            if not filename.casefold().endswith((".ico", ".png")):
+                continue
+            resolved = self._resolve_discovered_project_source(
+                os.path.join(icon_directory, filename),
+                owner_source_path=f"options/{platform}/icons",
+                resource=platform,
+                resource_type="project_options",
+                field="icon file",
+            )
+            if resolved is not None and os.path.isfile(resolved.filesystem_path):
+                icons.append((filename, resolved.filesystem_path))
+        return icons
 
     def get_gm_project_name(self) -> Optional[str]:
         if self.project_manifest.yyp_path is None:

--- a/src/conversion/project_source_paths.py
+++ b/src/conversion/project_source_paths.py
@@ -6,15 +6,14 @@ import os
 import posixpath
 import re
 from dataclasses import dataclass
-from typing import Iterable, cast
+from typing import TYPE_CHECKING, Iterable, cast
 
 from src.conversion.event_mapping import is_input_event, map_event, map_input_event
 from src.conversion.events.base import EventMapping
-from src.conversion.project_manifest import (
-    ProjectResourceReference,
-    load_gamemaker_project_manifest,
-)
 from src.conversion.type_defs import JsonDict, JsonList, StrPath
+
+if TYPE_CHECKING:
+    from src.conversion.project_manifest import ProjectResourceReference
 
 
 class ProjectSourcePathError(ValueError):
@@ -27,9 +26,51 @@ class ResolvedProjectSourcePath:
 
     filesystem_path: str
     source_path: str
+    project_root: str = ""
 
 
 _GML_RESOURCE_KINDS = frozenset({"scripts", "objects", "rooms"})
+_PROJECT_ROOT_SOURCE_DIRECTORIES = frozenset(
+    {
+        "animcurves",
+        "audiogroups",
+        "configs",
+        "datafiles",
+        "extensions",
+        "fonts",
+        "folders",
+        "materials",
+        "notes",
+        "objects",
+        "options",
+        "particles",
+        "particlesystems",
+        "paths",
+        "rooms",
+        "scripts",
+        "sequences",
+        "shaders",
+        "sounds",
+        "sprites",
+        "texturegroups",
+        "tilesets",
+        "timelines",
+    }
+)
+_PROJECT_DIRECTORY_PLACEHOLDER = "${project_dir}"
+
+
+def is_safe_project_source_component(value: str) -> bool:
+    """Return whether a metadata value can name exactly one path component."""
+    drive, _tail = ntpath.splitdrive(value)
+    return (
+        bool(value)
+        and value not in {".", ".."}
+        and not drive
+        and "/" not in value
+        and "\\" not in value
+        and "\0" not in value
+    )
 
 
 def resolve_project_source_path(
@@ -42,23 +83,10 @@ def resolve_project_source_path(
     project was authored on Windows. Backslashes are accepted for compatibility,
     then the stored source path is normalized to GameMaker's portable form.
     """
-    normalized_path = source_path.replace("\\", "/")
-    if not normalized_path or "\0" in normalized_path:
-        raise ProjectSourcePathError(
-            f"YYP resource path is empty or invalid: {source_path!r}"
-        )
-
-    normalized_path = posixpath.normpath(normalized_path)
-    if normalized_path in ("", "."):
-        raise ProjectSourcePathError(
-            f"YYP resource path does not name a project file: {source_path!r}"
-        )
-    drive, _tail = ntpath.splitdrive(normalized_path)
-    if drive or normalized_path.startswith("/"):
-        raise ProjectSourcePathError(
-            "YYP resource path must be relative to the selected GameMaker "
-            f"project root: {source_path!r}"
-        )
+    normalized_path = _normalize_relative_source_path(
+        source_path,
+        description="YYP resource path",
+    )
 
     root_text: str = os.fspath(project_root)
     project_root_path: str = os.path.abspath(root_text)
@@ -84,7 +112,221 @@ def resolve_project_source_path(
     return ResolvedProjectSourcePath(
         filesystem_path=filesystem_path,
         source_path=normalized_path,
+        project_root=project_root_path,
     )
+
+
+def validate_project_resource_source_path(
+    resolved_source: ResolvedProjectSourcePath,
+    declared_kind: str,
+) -> ResolvedProjectSourcePath:
+    """Require resolved resource metadata to remain a ``.yy`` in its kind.
+
+    A manifest path such as ``scripts/../objects/o_test/o_test.yy`` is still
+    contained by the project root, but normalization changes which resource
+    family owns it. Keep benign same-family normalization while rejecting that
+    cross-family reinterpretation and non-``.yy`` resource entries.
+    """
+    normalized_kind = declared_kind.replace("\\", "/").strip("/").casefold()
+    source_kind, separator, _remainder = resolved_source.source_path.partition("/")
+    if (
+        not normalized_kind
+        or "/" in normalized_kind
+        or not separator
+        or source_kind.casefold() != normalized_kind
+    ):
+        raise ProjectSourcePathError(
+            "Resolved GameMaker resource path must remain under its declared "
+            f"{declared_kind!r} resource directory after normalization: "
+            f"{resolved_source.source_path!r}"
+        )
+    if not resolved_source.source_path.casefold().endswith(".yy"):
+        raise ProjectSourcePathError(
+            "Resolved GameMaker resource path must name a .yy metadata file: "
+            f"{resolved_source.source_path!r}"
+        )
+
+    project_root = resolved_source.project_root
+    if not project_root:
+        project_root = resolved_source.filesystem_path
+        for _segment in resolved_source.source_path.split("/"):
+            project_root = os.path.dirname(project_root)
+    canonical_root = os.path.realpath(project_root)
+    canonical_path = os.path.realpath(resolved_source.filesystem_path)
+    try:
+        canonical_relative = os.path.relpath(
+            canonical_path,
+            canonical_root,
+        ).replace(os.sep, "/")
+    except ValueError as exc:
+        raise ProjectSourcePathError(
+            "Resolved GameMaker resource target is on a different filesystem "
+            f"root: {resolved_source.source_path!r}"
+        ) from exc
+    canonical_kind, canonical_separator, _canonical_remainder = (
+        canonical_relative.partition("/")
+    )
+    if (
+        not canonical_separator
+        or canonical_kind.casefold() != normalized_kind
+    ):
+        raise ProjectSourcePathError(
+            "Resolved GameMaker resource target must remain under its declared "
+            f"{declared_kind!r} resource directory after symbolic-link "
+            f"resolution: {canonical_relative!r}"
+        )
+    if not canonical_relative.casefold().endswith(".yy"):
+        raise ProjectSourcePathError(
+            "Resolved GameMaker resource target must remain a .yy metadata "
+            f"file after symbolic-link resolution: {canonical_relative!r}"
+        )
+    return resolved_source
+
+
+def resolve_project_filesystem_source_path(
+    project_root: StrPath,
+    filesystem_path: StrPath,
+) -> ResolvedProjectSourcePath:
+    """Revalidate a discovered filesystem candidate against the project root.
+
+    Disk fallback scans must call this before reading, copying, or inspecting a
+    candidate that may be a file or directory symlink.
+    """
+    root_text = os.fspath(project_root)
+    candidate_text = os.fspath(filesystem_path)
+    if not candidate_text or "\0" in candidate_text:
+        raise ProjectSourcePathError(
+            f"Discovered GameMaker source path is empty or invalid: {candidate_text!r}"
+        )
+    project_root_path = os.path.abspath(root_text)
+    candidate_path = (
+        os.path.abspath(candidate_text)
+        if os.path.isabs(candidate_text)
+        else os.path.abspath(os.path.join(project_root_path, candidate_text))
+    )
+    try:
+        relative_path = os.path.relpath(candidate_path, project_root_path)
+    except ValueError as exc:
+        raise ProjectSourcePathError(
+            "Discovered GameMaker source path is on a different filesystem root "
+            f"than the selected project: {candidate_text!r}"
+        ) from exc
+
+    # On POSIX a backslash can be a literal filename character, while every
+    # GameMaker project path treats it as a separator. Feeding such a disk name
+    # back through metadata normalization would silently redirect the candidate
+    # (``evil\\name.yy`` -> ``evil/name.yy``), so reject the ambiguous host name.
+    if os.sep != "\\" and "\\" in relative_path:
+        raise ProjectSourcePathError(
+            "Discovered GameMaker source path contains a host-literal backslash "
+            f"that cannot be represented portably: {candidate_text!r}"
+        )
+
+    # A caller may hold a canonical path while the selected project root itself
+    # is a symlink. In that case the lexical relative path starts with ``..``
+    # even though both paths identify the same contained tree. Translate that
+    # one case back to a stable project-relative path; metadata paths never get
+    # this exception and leading traversal remains rejected below.
+    normalized_relative = relative_path.replace(os.sep, "/")
+    if normalized_relative == ".." or normalized_relative.startswith("../"):
+        canonical_root = os.path.realpath(project_root_path)
+        canonical_candidate = os.path.realpath(candidate_path)
+        try:
+            canonical_common = os.path.commonpath(
+                (canonical_root, canonical_candidate)
+            )
+        except ValueError:
+            canonical_common = ""
+        if os.path.normcase(canonical_common) == os.path.normcase(canonical_root):
+            normalized_relative = os.path.relpath(
+                canonical_candidate,
+                canonical_root,
+            ).replace(os.sep, "/")
+    return resolve_project_source_path(
+        project_root_path,
+        normalized_relative,
+    )
+
+
+def resolve_project_sidecar_source_path(
+    project_root: StrPath,
+    owner_source_path: StrPath,
+    sidecar_path: str,
+) -> ResolvedProjectSourcePath:
+    """Resolve a nested ``.yy`` path relative to its owning resource.
+
+    GameMaker sidecars are normally relative to the owner directory, while
+    ``${project_dir}/...`` and paths beginning with a known project resource
+    directory are project-root relative. The raw nested value is validated
+    before composition so Windows drive-relative and absolute forms cannot be
+    hidden behind an owner directory on POSIX runners.
+    """
+    raw_sidecar = sidecar_path.replace("\\", "/")
+    project_relative = False
+    if raw_sidecar == _PROJECT_DIRECTORY_PLACEHOLDER:
+        raise ProjectSourcePathError(
+            f"GameMaker sidecar path does not name a project file: {sidecar_path!r}"
+        )
+    placeholder_prefix = _PROJECT_DIRECTORY_PLACEHOLDER + "/"
+    if raw_sidecar.startswith(placeholder_prefix):
+        raw_sidecar = raw_sidecar[len(placeholder_prefix):]
+        project_relative = True
+
+    normalized_sidecar = _normalize_relative_source_path(
+        raw_sidecar,
+        description="GameMaker sidecar path",
+    )
+    first_segment = normalized_sidecar.partition("/")[0].casefold()
+    project_relative = (
+        project_relative
+        or first_segment in _PROJECT_ROOT_SOURCE_DIRECTORIES
+    )
+
+    owner_text = os.fspath(owner_source_path)
+    if os.path.isabs(owner_text):
+        resolved_owner = resolve_project_filesystem_source_path(
+            project_root,
+            owner_text,
+        )
+    else:
+        resolved_owner = resolve_project_source_path(project_root, owner_text)
+    candidate = normalized_sidecar
+    if not project_relative:
+        candidate = posixpath.join(
+            posixpath.dirname(resolved_owner.source_path),
+            normalized_sidecar,
+        )
+    return resolve_project_source_path(project_root, candidate)
+
+
+def _normalize_relative_source_path(
+    source_path: str,
+    *,
+    description: str,
+) -> str:
+    normalized_path = source_path.replace("\\", "/")
+    if not normalized_path or "\0" in normalized_path:
+        raise ProjectSourcePathError(
+            f"{description} is empty or invalid: {source_path!r}"
+        )
+
+    normalized_path = posixpath.normpath(normalized_path)
+    if normalized_path in ("", "."):
+        raise ProjectSourcePathError(
+            f"{description} does not name a project file: {source_path!r}"
+        )
+    drive, _tail = ntpath.splitdrive(normalized_path)
+    if drive or normalized_path.startswith("/"):
+        raise ProjectSourcePathError(
+            f"{description} must be relative to the selected GameMaker "
+            f"project root: {source_path!r}"
+        )
+    if normalized_path == ".." or normalized_path.startswith("../"):
+        raise ProjectSourcePathError(
+            f"{description} escapes the selected GameMaker project root "
+            f"through traversal: {source_path!r}"
+        )
+    return normalized_path
 
 
 def project_gml_source_paths(
@@ -97,6 +339,8 @@ def project_gml_source_paths(
     including deleted resource folders and stale event/creation-code files, are
     intentionally excluded.
     """
+    from src.conversion.project_manifest import load_gamemaker_project_manifest
+
     root_text = os.fspath(project_root)
     manifest = load_gamemaker_project_manifest(root_text)
     if manifest.yyp_path is None or not manifest.raw_data:
@@ -111,6 +355,10 @@ def project_gml_source_paths(
             resolved_resource = resolve_project_source_path(
                 root_text,
                 resource.path,
+            )
+            validate_project_resource_source_path(
+                resolved_resource,
+                resource.kind,
             )
         except ProjectSourcePathError:
             continue
@@ -171,7 +419,11 @@ def _resource_gml_candidates(
             resource_data,
         )
     if kind == "rooms":
-        return _room_gml_candidates(resolved_resource, resource_data)
+        return _room_gml_candidates(
+            project_root,
+            resolved_resource,
+            resource_data,
+        )
     return ()
 
 
@@ -189,13 +441,21 @@ def _script_gml_candidate(
             names.append(value)
     names.append(posixpath.splitext(posixpath.basename(resolved_resource.source_path))[0])
     for name in names:
-        candidate = posixpath.join(resource_directory, f"{name}.gml")
+        if not is_safe_project_source_component(name):
+            continue
         try:
-            resolved_candidate = resolve_project_source_path(project_root, candidate)
+            resolved_candidate = resolve_project_sidecar_source_path(
+                project_root,
+                resolved_resource.source_path,
+                f"{name}.gml",
+            )
         except ProjectSourcePathError:
             continue
-        if os.path.isfile(resolved_candidate.filesystem_path):
-            return candidate
+        if (
+            posixpath.dirname(resolved_candidate.source_path) == resource_directory
+            and os.path.isfile(resolved_candidate.filesystem_path)
+        ):
+            return resolved_candidate.source_path
     return ""
 
 
@@ -204,7 +464,6 @@ def _object_gml_candidates(
     resolved_resource: ResolvedProjectSourcePath,
     resource_data: JsonDict,
 ) -> tuple[str, ...]:
-    resource_directory = posixpath.dirname(resolved_resource.source_path)
     raw_events = resource_data.get("eventList")
     if not isinstance(raw_events, list):
         return ()
@@ -218,7 +477,7 @@ def _object_gml_candidates(
             continue
         candidate = _first_existing_event_candidate(
             project_root,
-            resource_directory,
+            resolved_resource.source_path,
             mapping,
         )
         if candidate:
@@ -228,17 +487,26 @@ def _object_gml_candidates(
 
 def _first_existing_event_candidate(
     project_root: str,
-    resource_directory: str,
+    owner_source_path: str,
     mapping: EventMapping,
 ) -> str:
+    resource_directory = posixpath.dirname(owner_source_path)
     for filename in _event_source_filenames(mapping):
-        candidate = posixpath.join(resource_directory, filename)
+        if not is_safe_project_source_component(filename):
+            continue
         try:
-            resolved_candidate = resolve_project_source_path(project_root, candidate)
+            resolved_candidate = resolve_project_sidecar_source_path(
+                project_root,
+                owner_source_path,
+                filename,
+            )
         except ProjectSourcePathError:
             continue
-        if os.path.isfile(resolved_candidate.filesystem_path):
-            return candidate
+        if (
+            posixpath.dirname(resolved_candidate.source_path) == resource_directory
+            and os.path.isfile(resolved_candidate.filesystem_path)
+        ):
+            return resolved_candidate.source_path
     return ""
 
 
@@ -251,6 +519,7 @@ def _event_source_filenames(mapping: EventMapping) -> tuple[str, ...]:
 
 
 def _room_gml_candidates(
+    project_root: str,
     resolved_resource: ResolvedProjectSourcePath,
     resource_data: JsonDict,
 ) -> tuple[str, ...]:
@@ -258,37 +527,35 @@ def _room_gml_candidates(
     candidates: list[str] = []
     creation_code_file = resource_data.get("creationCodeFile")
     if isinstance(creation_code_file, str) and creation_code_file:
-        candidate = _resource_relative_source_path(
-            resource_directory,
-            creation_code_file,
-        )
-        if candidate:
-            candidates.append(candidate)
+        try:
+            resolved_creation_code = resolve_project_sidecar_source_path(
+                project_root,
+                resolved_resource.source_path,
+                creation_code_file,
+            )
+        except ProjectSourcePathError:
+            pass
+        else:
+            candidates.append(resolved_creation_code.source_path)
     for instance in _iter_room_instances(resource_data.get("layers")):
         if not bool(instance.get("hasCreationCode", False)):
             continue
         instance_name = instance.get("%Name") or instance.get("name")
         if not isinstance(instance_name, str) or not instance_name:
             instance_name = "Instance"
-        candidates.append(
-            posixpath.join(
-                resource_directory,
+        if not is_safe_project_source_component(instance_name):
+            continue
+        try:
+            resolved_instance_code = resolve_project_sidecar_source_path(
+                project_root,
+                resolved_resource.source_path,
                 f"InstanceCreationCode_{instance_name}.gml",
             )
-        )
+        except ProjectSourcePathError:
+            continue
+        if posixpath.dirname(resolved_instance_code.source_path) == resource_directory:
+            candidates.append(resolved_instance_code.source_path)
     return tuple(candidates)
-
-
-def _resource_relative_source_path(
-    resource_directory: str,
-    source_path: str,
-) -> str:
-    normalized = source_path.replace("\\", "/")
-    if normalized.startswith("${project_dir}/"):
-        normalized = normalized[len("${project_dir}/"):]
-    if normalized.startswith("rooms/"):
-        return normalized
-    return posixpath.join(resource_directory, normalized)
 
 
 def _iter_room_instances(layers: object) -> Iterable[JsonDict]:

--- a/src/conversion/resource_index.py
+++ b/src/conversion/resource_index.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field, replace
 from typing import Any, ClassVar, cast
 
 from src.conversion.base_converter import BaseConverter
+from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.generated_paths import generated_nested_resource_path
 from src.conversion.project_manifest import (
     GameMakerProjectManifest,
@@ -12,7 +13,8 @@ from src.conversion.project_manifest import (
 )
 from src.conversion.project_source_paths import (
     ProjectSourcePathError,
-    resolve_project_source_path,
+    resolve_project_sidecar_source_path,
+    validate_project_resource_source_path,
 )
 from src.conversion.type_defs import (
     ConversionRunning,
@@ -100,11 +102,12 @@ class GameMakerResourceIndex(BaseConverter):
                  conversion_running: ConversionRunning | None = None,
                  update_log_callback: LogCallback | None = None,
                  compact_logging: bool = False,
-                 max_workers: int | None = None) -> None:
+                 max_workers: int | None = None,
+                 diagnostics: DiagnosticCollector | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback,
                          progress_callback, conversion_running,
                          update_log_callback, compact_logging,
-                         max_workers=max_workers)
+                         max_workers=max_workers, diagnostics=diagnostics)
         self.yyp_path: str | None = None
         self.yyp_data: JsonDict | None = None
         self.project_manifest: GameMakerProjectManifest | None = None
@@ -126,6 +129,9 @@ class GameMakerResourceIndex(BaseConverter):
         self.room_order = []
         self.used_room_order_fallback = False
         self.project_manifest = load_gamemaker_project_manifest(self.gm_project_path)
+        self._record_project_manifest_source_path_diagnostics(
+            self.project_manifest
+        )
         self.yyp_path = self.project_manifest.yyp_path
         self.yyp_data = self.project_manifest.raw_data if self.project_manifest.raw_data else None
 
@@ -163,9 +169,15 @@ class GameMakerResourceIndex(BaseConverter):
         except OSError:
             return None
 
-        if not yyp_files:
-            return None
-        return os.path.join(self.gm_project_path, yyp_files[0])
+        for filename in yyp_files:
+            resolved = self._resolve_project_source(
+                filename,
+                resource_type="project",
+                field="project file",
+            )
+            if resolved is not None and os.path.isfile(resolved.filesystem_path):
+                return resolved.filesystem_path
+        return None
 
     def get_resource(self, kind: str, name: str) -> IndexedResource | None:
         """Return an indexed non-room resource, or a room resource, by kind/name."""
@@ -265,14 +277,38 @@ class GameMakerResourceIndex(BaseConverter):
             name = resource_ref.name or self._name_from_yyp_path(yyp_path)
             if not name:
                 continue
+            source_owner = (
+                resource_ref.source.path
+                if resource_ref.source is not None
+                else self.yyp_path
+            )
+            source_field = (
+                f"{resource_ref.source.field_path}.id.path"
+                if resource_ref.source is not None
+                else "resource path"
+            )
+            resolved_path = self._resolve_project_source(
+                yyp_path,
+                owner_source_path=source_owner,
+                resource=name,
+                resource_type=resource_ref.resource_type or kind,
+                field=source_field,
+            )
+            if resolved_path is None:
+                continue
             try:
-                resolved_path = resolve_project_source_path(
-                    self.gm_project_path,
-                    yyp_path,
+                validate_project_resource_source_path(
+                    resolved_path,
+                    kind,
                 )
             except ProjectSourcePathError as exc:
-                self._safe_log(
-                    f"Warning: Skipping GameMaker resource {name}: {exc}"
+                self._report_source_path_rejection(
+                    yyp_path,
+                    exc,
+                    owner_source_path=source_owner,
+                    resource=name,
+                    resource_type=resource_ref.resource_type or kind,
+                    field=source_field,
                 )
                 continue
             yyp_path = resolved_path.source_path
@@ -294,29 +330,119 @@ class GameMakerResourceIndex(BaseConverter):
 
     def _index_disk_resources(self) -> None:
         for kind in self.RESOURCE_EXTENSIONS:
-            kind_dir = os.path.join(self.gm_project_path, kind)
-            if not os.path.isdir(kind_dir):
+            resolved_kind_dir = self._resolve_discovered_project_source(
+                os.path.join(self.gm_project_path, kind),
+                resource_type=kind,
+                field="disk fallback directory",
+            )
+            if (
+                resolved_kind_dir is None
+                or not os.path.isdir(resolved_kind_dir.filesystem_path)
+            ):
                 continue
 
-            for name in sorted(os.listdir(kind_dir)):
-                resource_dir = os.path.join(kind_dir, name)
-                yy_path = os.path.join(resource_dir, name + ".yy")
-                if not os.path.isdir(resource_dir) or not os.path.isfile(yy_path):
-                    continue
-                yyp_path = "/".join([kind, name, name + ".yy"])
-                self.resources[kind][name] = self._make_resource(
-                    kind, name, yy_path, yyp_path
+            for name in sorted(os.listdir(resolved_kind_dir.filesystem_path)):
+                resolved_resource_dir = self._resolve_discovered_project_source(
+                    os.path.join(resolved_kind_dir.filesystem_path, name),
+                    owner_source_path=resolved_kind_dir.source_path,
+                    resource=name,
+                    resource_type=kind,
+                    field="disk fallback resource directory",
                 )
-        extensions_dir = os.path.join(self.gm_project_path, "extensions")
-        if not os.path.isdir(extensions_dir):
+                if (
+                    resolved_resource_dir is None
+                    or not os.path.isdir(resolved_resource_dir.filesystem_path)
+                ):
+                    continue
+                resolved_yy = self._resolve_discovered_project_source(
+                    os.path.join(
+                        resolved_resource_dir.filesystem_path,
+                        name + ".yy",
+                    ),
+                    owner_source_path=resolved_resource_dir.source_path,
+                    resource=name,
+                    resource_type=kind,
+                    field="disk fallback resource metadata",
+                )
+                if resolved_yy is None:
+                    continue
+                try:
+                    validate_project_resource_source_path(
+                        resolved_yy,
+                        kind,
+                    )
+                except ProjectSourcePathError as exc:
+                    self._report_source_path_rejection(
+                        resolved_yy.source_path,
+                        exc,
+                        owner_source_path=resolved_resource_dir.source_path,
+                        resource=name,
+                        resource_type=kind,
+                        field="disk fallback resource metadata",
+                    )
+                    continue
+                if not os.path.isfile(resolved_yy.filesystem_path):
+                    continue
+                self.resources[kind][name] = self._make_resource(
+                    kind,
+                    name,
+                    resolved_yy.filesystem_path,
+                    resolved_yy.source_path,
+                )
+        resolved_extensions_dir = self._resolve_discovered_project_source(
+            os.path.join(self.gm_project_path, "extensions"),
+            resource_type="extensions",
+            field="disk fallback directory",
+        )
+        if (
+            resolved_extensions_dir is None
+            or not os.path.isdir(resolved_extensions_dir.filesystem_path)
+        ):
             return
-        for name in sorted(os.listdir(extensions_dir)):
-            extension_dir = os.path.join(extensions_dir, name)
-            yy_path = os.path.join(extension_dir, name + ".yy")
-            if not os.path.isdir(extension_dir) or not os.path.isfile(yy_path):
+        for name in sorted(os.listdir(resolved_extensions_dir.filesystem_path)):
+            resolved_extension_dir = self._resolve_discovered_project_source(
+                os.path.join(resolved_extensions_dir.filesystem_path, name),
+                owner_source_path=resolved_extensions_dir.source_path,
+                resource=name,
+                resource_type="extensions",
+                field="disk fallback resource directory",
+            )
+            if (
+                resolved_extension_dir is None
+                or not os.path.isdir(resolved_extension_dir.filesystem_path)
+            ):
                 continue
-            yyp_path = "/".join(["extensions", name, name + ".yy"])
-            self._index_extension_resource(name, yy_path, yyp_path)
+            resolved_yy = self._resolve_discovered_project_source(
+                os.path.join(resolved_extension_dir.filesystem_path, name + ".yy"),
+                owner_source_path=resolved_extension_dir.source_path,
+                resource=name,
+                resource_type="extensions",
+                field="disk fallback resource metadata",
+            )
+            if resolved_yy is None:
+                continue
+            try:
+                validate_project_resource_source_path(
+                    resolved_yy,
+                    "extensions",
+                )
+            except ProjectSourcePathError as exc:
+                self._report_source_path_rejection(
+                    resolved_yy.source_path,
+                    exc,
+                    owner_source_path=resolved_extension_dir.source_path,
+                    resource=name,
+                    resource_type="extensions",
+                    field="disk fallback resource metadata",
+                )
+                continue
+            if not os.path.isfile(resolved_yy.filesystem_path):
+                continue
+            self._index_extension_resource(
+                name,
+                resolved_yy.filesystem_path,
+                resolved_yy.source_path,
+            )
 
     def _index_extension_resource(self, name: str, yy_path: str, yyp_path: str) -> None:
         if not os.path.isfile(yy_path):
@@ -403,6 +529,28 @@ class GameMakerResourceIndex(BaseConverter):
             )
             return None
 
+        raw_creation_code_file = data.get("creationCodeFile")
+        creation_code_file = (
+            raw_creation_code_file
+            if isinstance(raw_creation_code_file, str)
+            else ""
+        )
+        if (
+            raw_creation_code_file is not None
+            and not isinstance(raw_creation_code_file, str)
+        ):
+            self._report_source_path_rejection(
+                repr(raw_creation_code_file),
+                ProjectSourcePathError(
+                    "GameMaker room creationCodeFile must be a string: "
+                    f"{raw_creation_code_file!r}"
+                ),
+                owner_source_path=resource.yyp_path,
+                resource=resource.name,
+                resource_type="room",
+                field="creationCodeFile",
+            )
+
         return IndexedRoom(
             name=resource.name,
             yy_path=resource.yy_path,
@@ -416,7 +564,7 @@ class GameMakerResourceIndex(BaseConverter):
             layers=data.get("layers") or [],
             instance_creation_order=data.get("instanceCreationOrder") or [],
             parent_room=data.get("parentRoom"),
-            creation_code_file=data.get("creationCodeFile") or "",
+            creation_code_file=creation_code_file,
             inherit_code=bool(data.get("inheritCode", False)),
             inherit_creation_order=bool(data.get("inheritCreationOrder", False)),
             inherit_layers=bool(data.get("inheritLayers", False)),
@@ -575,13 +723,23 @@ class GameMakerResourceIndex(BaseConverter):
     def _inherited_creation_code_file(self, parent: IndexedRoom) -> str:
         if not parent.creation_code_file:
             return ""
-        normalized = parent.creation_code_file.replace("\\", "/")
-        if normalized.startswith("rooms/") or normalized.startswith("${project_dir}/"):
-            return normalized
-        if os.path.isabs(normalized):
-            return normalized
-        parent_dir = os.path.relpath(os.path.dirname(parent.yy_path), self.gm_project_path)
-        return "/".join([parent_dir.replace(os.sep, "/"), normalized])
+        try:
+            resolved = resolve_project_sidecar_source_path(
+                self.gm_project_path,
+                parent.yyp_path,
+                parent.creation_code_file,
+            )
+        except ProjectSourcePathError as exc:
+            self._report_source_path_rejection(
+                parent.creation_code_file,
+                exc,
+                owner_source_path=parent.yyp_path,
+                resource=parent.name,
+                resource_type="room",
+                field="creationCodeFile",
+            )
+            return ""
+        return resolved.source_path
 
     @staticmethod
     def _room_reference_name(reference: JsonDict | None) -> str:

--- a/src/conversion/resource_models.py
+++ b/src/conversion/resource_models.py
@@ -8,6 +8,12 @@ from typing import Literal, cast
 
 from src.conversion.generated_paths import generated_subfolder_path
 from src.conversion.project_manifest import GameMakerProjectManifest, ProjectResourceReference, load_gamemaker_project_manifest
+from src.conversion.project_source_paths import (
+    ProjectSourcePathError,
+    resolve_project_filesystem_source_path,
+    resolve_project_source_path,
+    validate_project_resource_source_path,
+)
 from src.conversion.type_defs import JsonDict, JsonList
 
 
@@ -209,6 +215,8 @@ def parse_gamemaker_resource_models(gm_project_path: str) -> GameMakerResourceMo
             code=diagnostic.code,
             message=diagnostic.message,
             source_path=diagnostic.source.path if diagnostic.source is not None else "",
+            resource_name=diagnostic.resource or "",
+            resource_kind=diagnostic.resource_kind or "",
         )
         for diagnostic in manifest.diagnostics
     ]
@@ -297,7 +305,24 @@ def _parse_resource_model(
     gm_project_path: str,
     reference: ProjectResourceReference,
 ) -> tuple[ResourceModel | None, tuple[ResourceModelDiagnostic, ...]]:
-    yy_path = os.path.join(gm_project_path, *reference.path.replace("\\", "/").split("/"))
+    try:
+        resolved_yy = resolve_project_source_path(
+            gm_project_path,
+            reference.path,
+        )
+        validate_project_resource_source_path(
+            resolved_yy,
+            reference.kind,
+        )
+    except ProjectSourcePathError as exc:
+        return None, (
+            _source_path_diagnostic(
+                reference,
+                reference.path,
+                exc,
+            ),
+        )
+    yy_path = resolved_yy.filesystem_path
     raw_data = _read_lenient_json_file(yy_path)
     if raw_data is None:
         return None, (
@@ -311,7 +336,12 @@ def _parse_resource_model(
             ),
         )
 
-    base = _base_kwargs(reference, yy_path, raw_data)
+    base = _base_kwargs(
+        reference,
+        yy_path,
+        resolved_yy.source_path,
+        raw_data,
+    )
     kind = reference.kind
     if kind == "sprites":
         return SpriteModel(
@@ -354,16 +384,34 @@ def _parse_resource_model(
             layers=layers,
         ), ()
     if kind == "scripts":
+        gml_path, diagnostics = _first_existing_neighbor(
+            gm_project_path,
+            yy_path,
+            ".gml",
+            reference,
+        )
         return ScriptModel(
             **base,
-            gml_path=_first_existing_neighbor(yy_path, ".gml"),
-        ), ()
+            gml_path=gml_path,
+        ), diagnostics
     if kind == "shaders":
+        vertex_path, vertex_diagnostics = _first_existing_neighbor(
+            gm_project_path,
+            yy_path,
+            ".vsh",
+            reference,
+        )
+        fragment_path, fragment_diagnostics = _first_existing_neighbor(
+            gm_project_path,
+            yy_path,
+            ".fsh",
+            reference,
+        )
         return ShaderModel(
             **base,
-            vertex_path=_first_existing_neighbor(yy_path, ".vsh"),
-            fragment_path=_first_existing_neighbor(yy_path, ".fsh"),
-        ), ()
+            vertex_path=vertex_path,
+            fragment_path=fragment_path,
+        ), vertex_diagnostics + fragment_diagnostics
     if kind == "tilesets":
         return TileSetModel(
             **base,
@@ -393,6 +441,7 @@ def _parse_resource_model(
 def _base_kwargs(
     reference: ProjectResourceReference,
     yy_path: str,
+    yyp_path: str,
     raw_data: JsonDict,
 ) -> JsonDict:
     return {
@@ -400,7 +449,7 @@ def _base_kwargs(
         "kind": reference.kind,
         "resource_type": reference.resource_type,
         "yy_path": yy_path,
-        "yyp_path": reference.path,
+        "yyp_path": yyp_path,
         "order": reference.order,
         "subfolder": _subfolder_from_raw_data(raw_data),
         "raw_data": raw_data,
@@ -461,18 +510,70 @@ def _layer_resource_type(layer: JsonDict) -> str:
     return "UnknownLayer"
 
 
-def _first_existing_neighbor(yy_path: str, extension: str) -> str | None:
+def _first_existing_neighbor(
+    gm_project_path: str,
+    yy_path: str,
+    extension: str,
+    reference: ProjectResourceReference,
+) -> tuple[str | None, tuple[ResourceModelDiagnostic, ...]]:
     directory = os.path.dirname(yy_path)
     if not os.path.isdir(directory):
-        return None
+        return None, ()
     preferred = os.path.splitext(yy_path)[0] + extension
-    if os.path.isfile(preferred):
-        return preferred
-    for name in sorted(os.listdir(directory)):
-        candidate = os.path.join(directory, name)
-        if name.lower().endswith(extension) and os.path.isfile(candidate):
-            return candidate
-    return None
+    try:
+        fallback_names = sorted(os.listdir(directory))
+    except OSError:
+        return None, ()
+    candidates = [preferred]
+    candidates.extend(
+        os.path.join(directory, name)
+        for name in fallback_names
+        if name.lower().endswith(extension)
+    )
+    diagnostics: list[ResourceModelDiagnostic] = []
+    seen_candidates: set[str] = set()
+    for candidate in candidates:
+        candidate_key = os.path.normcase(os.path.abspath(candidate))
+        if candidate_key in seen_candidates:
+            continue
+        seen_candidates.add(candidate_key)
+        try:
+            resolved_candidate = resolve_project_filesystem_source_path(
+                gm_project_path,
+                candidate,
+            )
+        except ProjectSourcePathError as exc:
+            if os.path.lexists(candidate):
+                diagnostics.append(
+                    _source_path_diagnostic(reference, candidate, exc)
+                )
+            continue
+        if os.path.isfile(resolved_candidate.filesystem_path):
+            return resolved_candidate.filesystem_path, tuple(diagnostics)
+    return None, tuple(diagnostics)
+
+
+def _source_path_diagnostic(
+    reference: ProjectResourceReference,
+    rejected_path: str,
+    error: ProjectSourcePathError,
+) -> ResourceModelDiagnostic:
+    owner_path = (
+        reference.source.path
+        if reference.source is not None
+        else reference.path
+    )
+    return ResourceModelDiagnostic(
+        severity="warning",
+        code="GM2GD-SOURCE-PATH-REJECTED",
+        message=(
+            "Rejected GameMaker source path "
+            f"{rejected_path!r} declared by {owner_path}: {error}"
+        ),
+        source_path=owner_path,
+        resource_name=reference.name,
+        resource_kind=reference.kind,
+    )
 
 
 def _named_reference(value: object) -> str | None:

--- a/src/conversion/room_creation_code.py
+++ b/src/conversion/room_creation_code.py
@@ -2,9 +2,22 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Protocol, cast
+from pathlib import Path
+from typing import Callable, Protocol, cast
 
+from src.conversion.project_source_paths import (
+    ProjectSourcePathError,
+    is_safe_project_source_component,
+    resolve_project_sidecar_source_path,
+)
 from src.conversion.type_defs import JsonDict, JsonList, LogCallback
+
+
+CreationCodeSourceResolver = Callable[[str, str], str | None]
+
+_INSTANCE_CREATION_CODE_PREFIX = "InstanceCreationCode_"
+_INSTANCE_CREATION_CODE_SUFFIX = ".gml"
+_INSTANCE_CREATION_CODE_FIELD = "layers[].instances[].name"
 
 
 class RoomCreationCodeRoom(Protocol):
@@ -42,16 +55,26 @@ class CreationCodeMetadata:
     exists: bool
     execution_phase: str
     execution_phase_index: int
+    path_rejected: bool = False
 
 
 def resolve_room_creation_code(
     room: RoomCreationCodeRoom,
     gm_project_path: str,
     warn_callback: LogCallback | None = None,
+    *,
+    source_resolver: CreationCodeSourceResolver | None = None,
 ) -> CreationCodeMetadata:
     """Resolve room creation-code metadata without transpiling GML."""
     source_file = room.creation_code_file or ""
-    source_path = _resolve_room_creation_code_path(room, gm_project_path, source_file)
+    source_path, path_rejected = _resolve_creation_code_path(
+        room,
+        gm_project_path,
+        source_file,
+        field="creationCodeFile",
+        source_resolver=source_resolver,
+        warn_callback=warn_callback,
+    )
     metadata = CreationCodeMetadata(
         has_code=bool(source_file),
         inherit_code=bool(room.inherit_code),
@@ -60,9 +83,15 @@ def resolve_room_creation_code(
         exists=bool(source_path and os.path.isfile(source_path)),
         execution_phase="room_creation_code",
         execution_phase_index=ROOM_EXECUTION_ORDER.index("room_creation_code"),
+        path_rejected=path_rejected,
     )
 
-    if metadata.has_code and not metadata.exists and warn_callback is not None:
+    if (
+        metadata.has_code
+        and not metadata.exists
+        and not metadata.path_rejected
+        and warn_callback is not None
+    ):
         warn_callback(
             "Info: Missing GameMaker room creation code file for room {room}: {path}".format(
                 room=room.name,
@@ -77,16 +106,49 @@ def resolve_instance_creation_code(
     room: RoomCreationCodeRoom,
     instance: JsonDict,
     warn_callback: LogCallback | None = None,
+    *,
+    gm_project_path: str | None = None,
+    source_resolver: CreationCodeSourceResolver | None = None,
 ) -> CreationCodeMetadata:
     """Resolve per-instance creation-code metadata without transpiling GML."""
     instance_name = _instance_name(instance)
     has_code = bool(instance.get("hasCreationCode", False))
     source_path = ""
+    path_rejected = False
     if has_code:
-        source_path = os.path.join(
-            os.path.dirname(room.yy_path),
-            f"InstanceCreationCode_{instance_name}.gml",
+        source_file = (
+            f"{_INSTANCE_CREATION_CODE_PREFIX}{instance_name}"
+            f"{_INSTANCE_CREATION_CODE_SUFFIX}"
         )
+        if not is_safe_project_source_component(instance_name):
+            error = ProjectSourcePathError(
+                "GameMaker instance names used to derive creation-code "
+                "filenames must be exactly one safe path component: "
+                f"{instance_name!r}"
+            )
+            if source_resolver is not None:
+                # Let converter-owned resolvers attach the rejection to the
+                # declaring room and metadata field. The result is deliberately
+                # ignored: an unsafe derived component can never be accepted.
+                source_resolver(source_file, _INSTANCE_CREATION_CODE_FIELD)
+            else:
+                _warn_source_path_rejection(
+                    room,
+                    source_file,
+                    field=_INSTANCE_CREATION_CODE_FIELD,
+                    error=error,
+                    warn_callback=warn_callback,
+                )
+            path_rejected = True
+        else:
+            source_path, path_rejected = _resolve_creation_code_path(
+                room,
+                gm_project_path,
+                source_file,
+                field=_INSTANCE_CREATION_CODE_FIELD,
+                source_resolver=source_resolver,
+                warn_callback=warn_callback,
+            )
 
     metadata = CreationCodeMetadata(
         has_code=has_code,
@@ -96,9 +158,15 @@ def resolve_instance_creation_code(
         exists=bool(source_path and os.path.isfile(source_path)),
         execution_phase="instance_creation_code",
         execution_phase_index=ROOM_EXECUTION_ORDER.index("instance_creation_code"),
+        path_rejected=path_rejected,
     )
 
-    if metadata.has_code and not metadata.exists and warn_callback is not None:
+    if (
+        metadata.has_code
+        and not metadata.exists
+        and not metadata.path_rejected
+        and warn_callback is not None
+    ):
         warn_callback(
             "Info: Missing GameMaker instance creation code file for room {room}, "
             "instance {instance}: {path}".format(
@@ -122,25 +190,97 @@ def instance_creation_order_names(room: RoomCreationCodeRoom) -> list[str]:
     return names
 
 
-def _resolve_room_creation_code_path(
+def _resolve_creation_code_path(
     room: RoomCreationCodeRoom,
-    gm_project_path: str,
+    gm_project_path: str | None,
     source_file: str,
-) -> str:
+    *,
+    field: str,
+    source_resolver: CreationCodeSourceResolver | None,
+    warn_callback: LogCallback | None,
+) -> tuple[str, bool]:
     if not source_file:
-        return ""
+        return "", False
 
-    normalized = source_file.replace("\\", "/")
-    if normalized.startswith("${project_dir}/"):
-        normalized = normalized[len("${project_dir}/"):]
+    if source_resolver is not None:
+        source_path = source_resolver(source_file, field)
+        return (source_path or ""), source_path is None
 
-    if os.path.isabs(normalized):
-        return os.path.normpath(normalized)
+    if gm_project_path is None:
+        gm_project_path = _infer_project_root_from_room_yy_path(room.yy_path)
+        if gm_project_path is None:
+            _warn_source_path_rejection(
+                room,
+                source_file,
+                field=field,
+                error=ProjectSourcePathError(
+                    "GameMaker project root cannot be safely inferred from "
+                    "the room .yy path; provide an absolute .yy path with one "
+                    "unambiguous rooms path component or pass gm_project_path"
+                ),
+                warn_callback=warn_callback,
+            )
+            return "", True
 
-    if normalized.startswith("rooms/"):
-        return os.path.normpath(os.path.join(gm_project_path, normalized))
+    try:
+        resolved = resolve_project_sidecar_source_path(
+            gm_project_path,
+            room.yy_path,
+            source_file,
+        )
+    except ProjectSourcePathError as error:
+        _warn_source_path_rejection(
+            room,
+            source_file,
+            field=field,
+            error=error,
+            warn_callback=warn_callback,
+        )
+        return "", True
+    return resolved.filesystem_path, False
 
-    return os.path.normpath(os.path.join(os.path.dirname(room.yy_path), normalized))
+
+def _infer_project_root_from_room_yy_path(room_yy_path: str) -> str | None:
+    """Infer a project root only from an unambiguous absolute room owner."""
+    normalized_path = Path(os.path.normpath(room_yy_path))
+    if (
+        not normalized_path.is_absolute()
+        or normalized_path.suffix.casefold() != ".yy"
+    ):
+        return None
+
+    room_component_indexes = [
+        index
+        for index, component in enumerate(normalized_path.parts[:-1])
+        if component.casefold() == "rooms"
+    ]
+    if len(room_component_indexes) != 1:
+        return None
+    project_root = Path(*normalized_path.parts[:room_component_indexes[0]])
+    if project_root == Path(normalized_path.anchor):
+        return None
+    return str(project_root)
+
+
+def _warn_source_path_rejection(
+    room: RoomCreationCodeRoom,
+    source_file: str,
+    *,
+    field: str,
+    error: ProjectSourcePathError,
+    warn_callback: LogCallback | None,
+) -> None:
+    if warn_callback is None:
+        return
+    warn_callback(
+        "Warning: Rejected GameMaker source path {path!r} from {owner} "
+        "field {field}: {error}".format(
+            path=source_file,
+            owner=room.yy_path,
+            field=field,
+            error=error,
+        )
+    )
 
 
 def _instance_name(instance: JsonDict) -> str:

--- a/src/conversion/room_layers.py
+++ b/src/conversion/room_layers.py
@@ -6,7 +6,10 @@ import re
 from typing import NamedTuple, Protocol, cast
 
 from src.conversion.architecture_policy import layer_policy_metadata_lines
-from src.conversion.room_creation_code import resolve_instance_creation_code
+from src.conversion.room_creation_code import (
+    CreationCodeSourceResolver,
+    resolve_instance_creation_code,
+)
 from src.conversion.type_defs import JsonDict, JsonList, JsonValue, LogCallback
 
 
@@ -109,11 +112,13 @@ class RoomLayerSerializationContext:
         gm_project_path: str | None = None,
         resource_index: RoomLayerResourceIndex | None = None,
         warn_callback: LogCallback | None = None,
+        creation_code_source_resolver: CreationCodeSourceResolver | None = None,
     ) -> None:
         self.room = room
         self.gm_project_path = gm_project_path
         self.resource_index = resource_index
         self.warn_callback = warn_callback
+        self.creation_code_source_resolver = creation_code_source_resolver
         self.ext_resource_ids: dict[tuple[str, str], str] = {}
         self.creation_order = _instance_creation_order(room)
 
@@ -207,9 +212,16 @@ def serialize_room_layers(
     gm_project_path: str | None = None,
     resource_index: RoomLayerResourceIndex | None = None,
     warn_callback: LogCallback | None = None,
+    creation_code_source_resolver: CreationCodeSourceResolver | None = None,
 ) -> SerializedRoomLayers:
     """Serialize GameMaker room layers and supported layer children."""
-    context = RoomLayerSerializationContext(room, gm_project_path, resource_index, warn_callback)
+    context = RoomLayerSerializationContext(
+        room,
+        gm_project_path,
+        resource_index,
+        warn_callback,
+        creation_code_source_resolver,
+    )
     node_lines: list[str] = []
     node_lines.extend(_camera_node_lines(context))
     used_names: dict[str, int] = {}
@@ -1190,6 +1202,8 @@ def _instance_scene_lines(
         context.room,
         instance,
         warn_callback=context.warn,
+        gm_project_path=context.gm_project_path,
+        source_resolver=context.creation_code_source_resolver,
     )
     if ext_resource_id is None:
         lines = [f'[node name={godot_string(node_name)} type="Node2D" parent={godot_string(parent_path)}]']

--- a/src/conversion/rooms.py
+++ b/src/conversion/rooms.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import posixpath
 import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TypedDict, cast
@@ -16,8 +17,13 @@ from src.conversion.architecture_policy import (
 from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.gml_transpiler import GMLTranspileError, transpile_gml_code
 from src.conversion.project_godot import GodotProjectFile
+from src.conversion.project_source_paths import (
+    ProjectSourcePathError,
+    is_safe_project_source_component,
+)
 from src.conversion.resource_index import GameMakerResourceIndex, IndexedRoom
 from src.conversion.room_creation_code import (
+    CreationCodeSourceResolver,
     ROOM_EXECUTION_ORDER,
     instance_creation_order_names,
     resolve_instance_creation_code,
@@ -30,6 +36,9 @@ ROOM_RUNTIME_SCRIPT_RELATIVE_PATH = os.path.join("gm2godot", "gml_room_node.gd")
 ROOM_RUNTIME_SCRIPT_RESOURCE_PATH = "res://gm2godot/gml_room_node.gd"
 ROOM_RUNTIME_EXT_RESOURCE_ID = "gm_room_runtime"
 ROOM_SCRIPT_BASE_RESOURCE_PATH = "res://gm2godot/gml_room_node.gd"
+_INSTANCE_CREATION_CODE_PREFIX = "InstanceCreationCode_"
+_INSTANCE_CREATION_CODE_SUFFIX = ".gml"
+_INSTANCE_CREATION_CODE_FIELD = "layers[].instances[].name"
 
 
 def render_room_runtime_script() -> str:
@@ -91,6 +100,17 @@ def _instance_name(instance: JsonDict) -> str:
     return name if isinstance(name, str) and name else "Instance"
 
 
+def _instance_name_from_creation_code_source(source_path: str) -> str | None:
+    if not (
+        source_path.startswith(_INSTANCE_CREATION_CODE_PREFIX)
+        and source_path.endswith(_INSTANCE_CREATION_CODE_SUFFIX)
+    ):
+        return None
+    return source_path[
+        len(_INSTANCE_CREATION_CODE_PREFIX):-len(_INSTANCE_CREATION_CODE_SUFFIX)
+    ]
+
+
 def _iter_room_instances(layers: object) -> list[JsonDict]:
     instances: list[JsonDict] = []
     for layer in _dict_items(layers):
@@ -149,6 +169,7 @@ class RoomConverter(BaseConverter):
             update_log_callback=self.update_log_callback,
             compact_logging=self.compact_logging,
             max_workers=self.max_workers,
+            diagnostics=self.diagnostics,
         ).build()
 
     def _generate_room_scene(
@@ -156,6 +177,7 @@ class RoomConverter(BaseConverter):
         room: IndexedRoom,
         resource_index: GameMakerResourceIndex | None = None,
         room_script_resource_path: str | None = None,
+        source_resolver: CreationCodeSourceResolver | None = None,
     ) -> str:
         room_settings = room.room_settings
         physics_settings = room.physics_settings
@@ -163,6 +185,7 @@ class RoomConverter(BaseConverter):
             room,
             self.gm_project_path,
             warn_callback=self._safe_log,
+            source_resolver=source_resolver,
         )
         self._record_effect_layer_diagnostics(room)
         serialized_layers = serialize_room_layers(
@@ -170,6 +193,7 @@ class RoomConverter(BaseConverter):
             gm_project_path=self.gm_project_path,
             resource_index=resource_index,
             warn_callback=self._safe_log,
+            creation_code_source_resolver=source_resolver,
         )
 
         script_resource_path = room_script_resource_path or ROOM_RUNTIME_SCRIPT_RESOURCE_PATH
@@ -255,9 +279,14 @@ class RoomConverter(BaseConverter):
         self,
         room: IndexedRoom,
         resource_index: GameMakerResourceIndex | None = None,
+        source_resolver: CreationCodeSourceResolver | None = None,
     ) -> str | None:
         asset_names = self._asset_names(resource_index)
-        room_creation_code = resolve_room_creation_code(room, self.gm_project_path)
+        room_creation_code = resolve_room_creation_code(
+            room,
+            self.gm_project_path,
+            source_resolver=source_resolver,
+        )
         room_creation_body: str | None = None
         if room_creation_code.has_code and room_creation_code.exists:
             room_creation_body = self._transpile_creation_code(
@@ -271,7 +300,12 @@ class RoomConverter(BaseConverter):
         instance_methods: list[InstanceCreationCodeMethod] = []
         used_method_names: dict[str, int] = {}
         for instance in _iter_room_instances(room.layers):
-            creation_code = resolve_instance_creation_code(room, instance)
+            creation_code = resolve_instance_creation_code(
+                room,
+                instance,
+                gm_project_path=self.gm_project_path,
+                source_resolver=source_resolver,
+            )
             if not creation_code.has_code or not creation_code.exists:
                 continue
             instance_name = _instance_name(instance)
@@ -462,8 +496,67 @@ class RoomConverter(BaseConverter):
         if not self.conversion_running():
             return None
 
+        source_cache: dict[tuple[str, str], str | None] = {}
+
+        def resolve_creation_code_source(source_path: str, field: str) -> str | None:
+            cache_key = (source_path, field)
+            if cache_key not in source_cache:
+                if field == _INSTANCE_CREATION_CODE_FIELD:
+                    instance_name = _instance_name_from_creation_code_source(source_path)
+                    if (
+                        instance_name is None
+                        or not is_safe_project_source_component(instance_name)
+                    ):
+                        self._report_source_path_rejection(
+                            source_path,
+                            ProjectSourcePathError(
+                                "GameMaker instance names used to derive "
+                                "creation-code filenames must be exactly one "
+                                "safe path component"
+                            ),
+                            owner_source_path=room.yy_path,
+                            resource=room.name,
+                            resource_type="room",
+                            field=field,
+                        )
+                        source_cache[cache_key] = None
+                        return None
+                resolved = self._resolve_project_source(
+                    source_path,
+                    owner_source_path=room.yy_path,
+                    resource=room.name,
+                    resource_type="room",
+                    field=field,
+                )
+                if (
+                    resolved is not None
+                    and field == _INSTANCE_CREATION_CODE_FIELD
+                    and posixpath.dirname(resolved.source_path)
+                    != posixpath.dirname(room.yyp_path.replace("\\", "/"))
+                ):
+                    self._report_source_path_rejection(
+                        source_path,
+                        ProjectSourcePathError(
+                            "GameMaker instance creation-code filenames must "
+                            "stay beside their declaring room .yy file"
+                        ),
+                        owner_source_path=room.yy_path,
+                        resource=room.name,
+                        resource_type="room",
+                        field=field,
+                    )
+                    resolved = None
+                source_cache[cache_key] = (
+                    resolved.filesystem_path if resolved is not None else None
+                )
+            return source_cache[cache_key]
+
         output_path = self._room_output_path(room)
-        room_script = self._generate_room_script(room, resource_index)
+        room_script = self._generate_room_script(
+            room,
+            resource_index,
+            resolve_creation_code_source,
+        )
         room_script_resource_path: str | None = None
         if room_script is not None:
             room_script_resource_path = _room_script_resource_path(room)
@@ -473,7 +566,14 @@ class RoomConverter(BaseConverter):
                 f.write(room_script)
         os.makedirs(os.path.dirname(output_path), exist_ok=True)
         with open(output_path, "w", encoding="utf-8") as f:
-            f.write(self._generate_room_scene(room, resource_index, room_script_resource_path))
+            f.write(
+                self._generate_room_scene(
+                    room,
+                    resource_index,
+                    room_script_resource_path,
+                    resolve_creation_code_source,
+                )
+            )
 
         width = room.room_settings.get("Width", 1024)
         height = room.room_settings.get("Height", 768)

--- a/src/conversion/scripts.py
+++ b/src/conversion/scripts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import posixpath
 from dataclasses import dataclass
 from typing import Iterable, Mapping
 
@@ -26,6 +27,11 @@ from src.conversion.gml_transpiler import (
     write_gml_source_map,
 )
 from src.conversion.resource_index import GameMakerResourceIndex
+from src.conversion.project_source_paths import (
+    ProjectSourcePathError,
+    ResolvedProjectSourcePath,
+    is_safe_project_source_component,
+)
 from src.conversion.project_enums import collect_project_enum_values
 from src.conversion.project_macros import collect_project_macro_values
 from src.conversion.script_functions import (
@@ -246,17 +252,127 @@ class ScriptConverter(BaseConverter):
     def _asset_entries(self) -> tuple[AssetRegistryEntry, ...]:
         return tuple(entry for entry in self._registry_entries() if entry.asset_type == "script")
 
-    def _source_gml_path(self, entry: AssetRegistryEntry) -> str | None:
-        yy_path = os.path.join(self.gm_project_path, entry.source_path)
-        script_dir = os.path.dirname(yy_path)
-        preferred_path = os.path.join(script_dir, entry.name + ".gml")
-        if os.path.isfile(preferred_path):
-            return preferred_path
-        if not os.path.isdir(script_dir):
+    def _script_yy_source(
+        self,
+        entry: AssetRegistryEntry,
+    ) -> ResolvedProjectSourcePath | None:
+        resolved = self._resolve_project_source(
+            entry.source_path,
+            resource=entry.name,
+            resource_type="script",
+            field="script .yy",
+        )
+        if resolved is None:
             return None
-        for filename in sorted(os.listdir(script_dir)):
-            if filename.endswith(".gml"):
-                return os.path.join(script_dir, filename)
+
+        normalized_source_path = resolved.source_path.casefold()
+        if not (
+            normalized_source_path.startswith("scripts/")
+            and normalized_source_path.endswith(".yy")
+        ):
+            self._report_source_path_rejection(
+                entry.source_path,
+                ProjectSourcePathError(
+                    "GameMaker script reference must name a .yy file under scripts/: "
+                    f"{entry.source_path!r}"
+                ),
+                owner_source_path=None,
+                resource=entry.name,
+                resource_type="script",
+                field="script .yy",
+            )
+            return None
+        if not os.path.isfile(resolved.filesystem_path):
+            return None
+        return resolved
+
+    def _source_gml_path(self, entry: AssetRegistryEntry) -> str | None:
+        yy_source = self._script_yy_source(entry)
+        if yy_source is None:
+            return None
+
+        script_directory = self._resolve_discovered_project_source(
+            os.path.dirname(yy_source.filesystem_path),
+            owner_source_path=yy_source.source_path,
+            resource=entry.name,
+            resource_type="script",
+            field="script source directory",
+        )
+        if script_directory is None or not os.path.isdir(
+            script_directory.filesystem_path
+        ):
+            return None
+
+        preferred_filename = entry.name + ".gml"
+        excluded_filenames = {preferred_filename}
+        preferred_source: ResolvedProjectSourcePath | None = None
+        if is_safe_project_source_component(entry.name):
+            preferred_source = self._resolve_project_source(
+                preferred_filename,
+                owner_source_path=yy_source.source_path,
+                resource=entry.name,
+                resource_type="script",
+                field="preferred script source",
+            )
+        else:
+            normalized_preferred_filename = posixpath.basename(
+                posixpath.normpath(preferred_filename.replace("\\", "/"))
+            )
+            if normalized_preferred_filename:
+                excluded_filenames.add(normalized_preferred_filename)
+            self._report_source_path_rejection(
+                preferred_filename,
+                ProjectSourcePathError(
+                    "GameMaker script resource names used to derive source "
+                    "filenames must be exactly one safe path component: "
+                    f"{entry.name!r}"
+                ),
+                owner_source_path=yy_source.source_path,
+                resource=entry.name,
+                resource_type="script",
+                field="preferred script source",
+            )
+        if preferred_source is not None:
+            owner_directory = posixpath.dirname(yy_source.source_path)
+            preferred_directory = posixpath.dirname(preferred_source.source_path)
+            if preferred_directory != owner_directory:
+                self._report_source_path_rejection(
+                    preferred_filename,
+                    ProjectSourcePathError(
+                        "GameMaker script source derived from the resource name "
+                        "must be next to its script .yy owner: "
+                        f"{preferred_filename!r}"
+                    ),
+                    owner_source_path=yy_source.source_path,
+                    resource=entry.name,
+                    resource_type="script",
+                    field="preferred script source",
+                )
+                preferred_source = None
+            elif os.path.isfile(preferred_source.filesystem_path):
+                return preferred_source.filesystem_path
+
+        try:
+            filenames = sorted(os.listdir(script_directory.filesystem_path))
+        except OSError:
+            return None
+        for filename in filenames:
+            if not filename.endswith(".gml"):
+                continue
+            if filename in excluded_filenames:
+                continue
+            discovered_source = self._resolve_discovered_project_source(
+                os.path.join(script_directory.filesystem_path, filename),
+                owner_source_path=yy_source.source_path,
+                resource=entry.name,
+                resource_type="script",
+                field="discovered script source",
+            )
+            if discovered_source is None or not os.path.isfile(
+                discovered_source.filesystem_path
+            ):
+                continue
+            return discovered_source.filesystem_path
         return None
 
     def _output_path(self, entry: AssetRegistryEntry) -> str | None:
@@ -686,6 +802,7 @@ class ScriptConverter(BaseConverter):
             log_callback=lambda _message: None,
             progress_callback=lambda _value: None,
             conversion_running=self.conversion_running,
+            diagnostics=self.diagnostics,
         ).build()
         return {
             name: GMLExtensionFunction(
@@ -698,11 +815,15 @@ class ScriptConverter(BaseConverter):
         }
 
     def _extension_function_mappings(self) -> dict[str, GMLExtensionFunctionMapping]:
-        mapping_path = os.path.join(self.gm_project_path, EXTENSION_FUNCTION_MAPPING_FILENAME)
-        if not os.path.isfile(mapping_path):
+        mapping_source = self._resolve_project_source(
+            EXTENSION_FUNCTION_MAPPING_FILENAME,
+            resource_type="script",
+            field="extension function mapping",
+        )
+        if mapping_source is None or not os.path.isfile(mapping_source.filesystem_path):
             return {}
         try:
-            return load_gml_extension_function_mappings(mapping_path)
+            return load_gml_extension_function_mappings(mapping_source.filesystem_path)
         except (OSError, ValueError, TypeError) as exc:
             self._safe_log(
                 f"Warning: Could not load {EXTENSION_FUNCTION_MAPPING_FILENAME}: {exc}"

--- a/src/conversion/shaders.py
+++ b/src/conversion/shaders.py
@@ -8,11 +8,13 @@ from dataclasses import dataclass
 
 from src.conversion.asset_output_paths import build_asset_output_paths, resource_filesystem_path
 from src.conversion.base_converter import BaseConverter
+from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.generated_paths import generated_resource_stem, generated_subfolder_path
 from src.conversion.project_manifest import load_gamemaker_project_manifest
 from src.conversion.project_source_paths import (
     ProjectSourcePathError,
-    resolve_project_source_path,
+    ResolvedProjectSourcePath,
+    validate_project_resource_source_path,
 )
 from src.conversion.type_defs import ConversionRunning, LogCallback, ProgressCallback, StrPath
 from src.localization import get_localized
@@ -22,6 +24,7 @@ from src.localization import get_localized
 class _ShaderAsset:
     name: str
     subfolder: str
+    owner_path: str | None = None
     vertex_path: str | None = None
     fragment_path: str | None = None
 
@@ -40,6 +43,7 @@ class _ShaderAssetBuilder:
     name: str
     subfolder: str
     source_directory: str
+    owner_path: str | None = None
     vertex_path: str | None = None
     fragment_path: str | None = None
 
@@ -47,6 +51,7 @@ class _ShaderAssetBuilder:
         return _ShaderAsset(
             name=self.name,
             subfolder=self.subfolder,
+            owner_path=self.owner_path,
             vertex_path=self.vertex_path,
             fragment_path=self.fragment_path,
         )
@@ -66,18 +71,33 @@ class ShaderConverter(BaseConverter):
                  log_callback: LogCallback = print, progress_callback: ProgressCallback | None = None,
                  conversion_running: ConversionRunning | None = None,
                  update_log_callback: LogCallback | None = None, compact_logging: bool = False,
-                 max_workers: int | None = None) -> None:
+                 max_workers: int | None = None,
+                 diagnostics: DiagnosticCollector | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path,
                          log_callback, progress_callback, conversion_running,
-                         update_log_callback, compact_logging, max_workers=max_workers)
+                         update_log_callback, compact_logging, max_workers=max_workers,
+                         diagnostics=diagnostics)
         self.godot_shaders_path = os.path.join(self.godot_project_path, 'shaders')
         self._shader_output_paths: dict[str, str] = {}
 
     def convert_shader(self, input_file: str, output_file: str) -> None:
         """Convert one legacy stage and publish it as a complete shader resource."""
-        with open(input_file, 'r', encoding='utf-8') as f:
+        resolved_input = self._resolve_discovered_project_source(
+            input_file,
+            owner_source_path=input_file,
+            resource=os.path.splitext(os.path.basename(input_file))[0],
+            resource_type="shader",
+            field="shader stage",
+        )
+        if resolved_input is None or not os.path.isfile(resolved_input.filesystem_path):
+            return
+        with open(resolved_input.filesystem_path, 'r', encoding='utf-8') as f:
             content = f.read()
-        stage = "vertex" if input_file.lower().endswith(".vsh") else "fragment"
+        stage = (
+            "vertex"
+            if resolved_input.filesystem_path.lower().endswith(".vsh")
+            else "fragment"
+        )
         translated = self._translate_shader_source(content, stage)
         self._atomic_write_text(
             output_file,
@@ -190,7 +210,22 @@ class ShaderConverter(BaseConverter):
         ):
             if source_path is None:
                 continue
-            with open(source_path, "r", encoding="utf-8") as source_file:
+            resolved_source = self._resolve_discovered_project_source(
+                source_path,
+                owner_source_path=asset.owner_path or source_path,
+                resource=asset.name,
+                resource_type="shader",
+                field=f"{stage} stage",
+            )
+            if resolved_source is None or not os.path.isfile(
+                resolved_source.filesystem_path
+            ):
+                continue
+            with open(
+                resolved_source.filesystem_path,
+                "r",
+                encoding="utf-8",
+            ) as source_file:
                 translated_sources.append(
                     self._translate_shader_source(source_file.read(), stage)
                 )
@@ -221,6 +256,10 @@ class ShaderConverter(BaseConverter):
 
     def _indexed_shader_assets(self) -> tuple[_ShaderAsset, ...] | None:
         manifest = load_gamemaker_project_manifest(self.gm_project_path)
+        self._record_project_manifest_source_path_diagnostics(
+            manifest,
+            resource_type="shader",
+        )
         if manifest.yyp_path is None:
             return None
         if not manifest.raw_data:
@@ -232,16 +271,36 @@ class ShaderConverter(BaseConverter):
         assets: list[_ShaderAsset] = []
         seen_names: set[str] = set()
         for resource in manifest.resources:
-            if resource.kind.casefold() != "shaders" or resource.name in seen_names:
+            is_shader = (
+                resource.kind.casefold() == "shaders"
+                or resource.resource_type.casefold() == "gmshader"
+            )
+            if not is_shader or resource.name in seen_names:
+                continue
+            manifest_field = (
+                f"{resource.source.field_path}.id.path"
+                if resource.source is not None and resource.source.field_path
+                else "resources[].id.path"
+            )
+            resolved = self._resolve_project_source(
+                resource.path,
+                owner_source_path=manifest.yyp_path,
+                resource=resource.name,
+                resource_type="shader",
+                field=manifest_field,
+            )
+            if resolved is None:
                 continue
             try:
-                resolved = resolve_project_source_path(
-                    self.gm_project_path,
-                    resource.path,
-                )
+                validate_project_resource_source_path(resolved, "shaders")
             except ProjectSourcePathError as exc:
-                self._safe_log(
-                    f"Warning: Skipping GameMaker shader {resource.name}: {exc}"
+                self._report_source_path_rejection(
+                    resource.path,
+                    exc,
+                    owner_source_path=manifest.yyp_path,
+                    resource=resource.name,
+                    resource_type="shader",
+                    field=manifest_field,
                 )
                 continue
             yy_path = resolved.filesystem_path
@@ -251,13 +310,38 @@ class ShaderConverter(BaseConverter):
                 )
                 continue
             base_path = os.path.splitext(yy_path)[0]
-            vertex_path = base_path + ".vsh"
-            fragment_path = base_path + ".fsh"
+            vertex_source = self._resolve_discovered_project_source(
+                base_path + ".vsh",
+                owner_source_path=resolved.source_path,
+                resource=resource.name,
+                resource_type="shader",
+                field="derived .vsh stage",
+            )
+            fragment_source = self._resolve_discovered_project_source(
+                base_path + ".fsh",
+                owner_source_path=resolved.source_path,
+                resource=resource.name,
+                resource_type="shader",
+                field="derived .fsh stage",
+            )
+            vertex_path = (
+                vertex_source.filesystem_path
+                if vertex_source is not None
+                and os.path.isfile(vertex_source.filesystem_path)
+                else None
+            )
+            fragment_path = (
+                fragment_source.filesystem_path
+                if fragment_source is not None
+                and os.path.isfile(fragment_source.filesystem_path)
+                else None
+            )
             asset = _ShaderAsset(
                 name=resource.name,
                 subfolder=self._get_subfolder_from_yy(yy_path),
-                vertex_path=vertex_path if os.path.isfile(vertex_path) else None,
-                fragment_path=fragment_path if os.path.isfile(fragment_path) else None,
+                owner_path=resolved.source_path,
+                vertex_path=vertex_path,
+                fragment_path=fragment_path,
             )
             if asset.vertex_path is None and asset.fragment_path is None:
                 self._safe_log(
@@ -268,37 +352,145 @@ class ShaderConverter(BaseConverter):
             assets.append(asset)
         return tuple(assets)
 
-    def _disk_shader_assets(self, gm_shaders_path: str) -> tuple[_ShaderAsset, ...]:
+    def _disk_shader_assets(
+        self,
+        shader_root: ResolvedProjectSourcePath,
+    ) -> tuple[_ShaderAsset, ...]:
         builders: dict[str, _ShaderAssetBuilder] = {}
-        for root, directories, files in os.walk(gm_shaders_path):
-            directories.sort()
-            for filename in sorted(files):
-                extension = os.path.splitext(filename)[1].lower()
-                if extension not in (".vsh", ".fsh"):
-                    continue
-                full_path = os.path.join(root, filename)
-                directory_name = os.path.basename(root)
-                yy_path = os.path.join(root, directory_name + ".yy")
-                yy_data = self._read_yy_file(yy_path)
+        pending_directories = [shader_root]
+        visited_directories: set[str] = set()
+        while pending_directories:
+            directory = pending_directories.pop()
+            resolved_directory = self._resolve_discovered_project_source(
+                directory.filesystem_path,
+                owner_source_path=directory.source_path,
+                resource=os.path.basename(directory.source_path),
+                resource_type="shader",
+                field="discovered shader directory",
+            )
+            if resolved_directory is None or not os.path.isdir(
+                resolved_directory.filesystem_path
+            ):
+                continue
+
+            canonical_directory = os.path.normcase(
+                os.path.realpath(resolved_directory.filesystem_path)
+            )
+            if canonical_directory in visited_directories:
+                continue
+            visited_directories.add(canonical_directory)
+
+            directory_name = os.path.basename(resolved_directory.filesystem_path)
+            expected_yy_name = directory_name + ".yy"
+            stages: list[tuple[str, str]] = []
+            resolved_yy: ResolvedProjectSourcePath | None = None
+            child_directories: list[ResolvedProjectSourcePath] = []
+            try:
+                with os.scandir(resolved_directory.filesystem_path) as entries:
+                    for entry in sorted(entries, key=lambda item: item.name):
+                        extension = os.path.splitext(entry.name)[1].casefold()
+                        is_stage = extension in (".vsh", ".fsh")
+                        is_expected_yy = entry.name == expected_yy_name
+                        try:
+                            is_unlinked_directory = entry.is_dir(
+                                follow_symlinks=False
+                            )
+                            is_symlink = entry.is_symlink()
+                        except OSError:
+                            continue
+                        if (
+                            not is_stage
+                            and not is_expected_yy
+                            and not is_unlinked_directory
+                            and not is_symlink
+                        ):
+                            continue
+
+                        if is_unlinked_directory or (
+                            is_symlink and not is_stage and not is_expected_yy
+                        ):
+                            resource_name = entry.name
+                            field = "discovered shader directory"
+                        elif is_expected_yy:
+                            resource_name = directory_name
+                            field = "discovered .yy"
+                        else:
+                            resource_name = os.path.splitext(entry.name)[0]
+                            field = f"discovered {extension} stage"
+                        resolved_entry = self._resolve_discovered_project_source(
+                            entry.path,
+                            owner_source_path=resolved_directory.source_path,
+                            resource=resource_name,
+                            resource_type="shader",
+                            field=field,
+                        )
+                        if resolved_entry is None:
+                            continue
+
+                        if os.path.isdir(resolved_entry.filesystem_path):
+                            # Validate directory links so escaping targets are
+                            # diagnosed, but never follow links during fallback.
+                            if not is_symlink:
+                                child_directories.append(resolved_entry)
+                            continue
+                        if is_expected_yy and os.path.isfile(
+                            resolved_entry.filesystem_path
+                        ):
+                            try:
+                                validate_project_resource_source_path(
+                                    resolved_entry,
+                                    "shaders",
+                                )
+                            except ProjectSourcePathError as exc:
+                                self._report_source_path_rejection(
+                                    entry.path,
+                                    exc,
+                                    owner_source_path=resolved_directory.source_path,
+                                    resource=directory_name,
+                                    resource_type="shader",
+                                    field="discovered .yy",
+                                )
+                                continue
+                            resolved_yy = resolved_entry
+                        elif is_stage and os.path.isfile(
+                            resolved_entry.filesystem_path
+                        ):
+                            stages.append((extension, resolved_entry.filesystem_path))
+            except OSError:
+                continue
+            pending_directories.extend(reversed(child_directories))
+            if not stages:
+                continue
+
+            yy_path = resolved_yy.filesystem_path if resolved_yy is not None else None
+            yy_data = self._read_yy_file(yy_path) if yy_path is not None else None
+            subfolder = (
+                self._get_subfolder_from_yy(yy_path)
+                if yy_path is not None
+                else ""
+            )
+            owner_path = (
+                resolved_yy.source_path
+                if resolved_yy is not None
+                else resolved_directory.source_path
+            )
+            for extension, full_path in stages:
                 raw_resource_name = yy_data.get("name") if yy_data is not None else None
                 resource_name = (
                     raw_resource_name
                     if isinstance(raw_resource_name, str) and raw_resource_name
-                    else os.path.splitext(filename)[0]
+                    else os.path.splitext(os.path.basename(full_path))[0]
                 )
                 builder = builders.get(resource_name)
                 if builder is None:
                     builder = _ShaderAssetBuilder(
                         name=resource_name,
-                        subfolder=(
-                            self._get_subfolder_from_yy(yy_path)
-                            if os.path.isfile(yy_path)
-                            else ""
-                        ),
-                        source_directory=root,
+                        subfolder=subfolder,
+                        source_directory=resolved_directory.filesystem_path,
+                        owner_path=owner_path,
                     )
                     builders[resource_name] = builder
-                elif builder.source_directory != root:
+                elif builder.source_directory != resolved_directory.filesystem_path:
                     continue
                 if extension == ".vsh" and builder.vertex_path is None:
                     builder.vertex_path = full_path
@@ -310,12 +502,15 @@ class ShaderConverter(BaseConverter):
         )
 
     def convert_all(self) -> None:
-        gm_shaders_path = os.path.join(self.gm_project_path, 'shaders')
+        shader_root = self._resolve_discovered_project_source(
+            os.path.join(self.gm_project_path, 'shaders'),
+            resource_type="shader",
+            field="shaders directory",
+        )
 
-        if not os.path.exists(gm_shaders_path):
+        if shader_root is None or not os.path.isdir(shader_root.filesystem_path):
             self.log_callback("No shaders directory found. Skipping shader conversion.")
             return
-
         os.makedirs(self.godot_shaders_path, exist_ok=True)
 
         self._shader_output_paths = build_asset_output_paths(
@@ -326,7 +521,7 @@ class ShaderConverter(BaseConverter):
 
         shader_assets = self._indexed_shader_assets()
         if shader_assets is None:
-            shader_assets = self._disk_shader_assets(gm_shaders_path)
+            shader_assets = self._disk_shader_assets(shader_root)
 
         if not shader_assets:
             self.log_callback("No shader files (.vsh/.fsh) found.")

--- a/src/conversion/sounds.py
+++ b/src/conversion/sounds.py
@@ -11,9 +11,15 @@ from typing import TypedDict, cast
 from src.localization import get_localized
 from src.conversion.asset_output_paths import build_asset_output_paths, resource_filesystem_path
 from src.conversion.base_converter import BaseConverter
+from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.generated_paths import generated_path_segment, generated_resource_stem, generated_subfolder_path
 from src.conversion.project_manifest import load_gamemaker_project_manifest
-from src.conversion.project_source_paths import ProjectSourcePathError, resolve_project_source_path
+from src.conversion.project_godot import format_godot_string
+from src.conversion.project_source_paths import (
+    ProjectSourcePathError,
+    ResolvedProjectSourcePath,
+    validate_project_resource_source_path,
+)
 from src.conversion.type_defs import ConversionRunning, JsonDict, LogCallback, ProgressCallback, StrPath
 
 
@@ -40,45 +46,155 @@ class SoundConverter(BaseConverter):
     def __init__(self, gm_project_path: StrPath, godot_project_path: StrPath, log_callback: LogCallback = print,
                  progress_callback: ProgressCallback | None = None, conversion_running: ConversionRunning | None = None,
                  update_log_callback: LogCallback | None = None, compact_logging: bool = False, max_workers: int | None = None,
-                 organize_by_audio_group: bool = False) -> None:
+                 organize_by_audio_group: bool = False,
+                 diagnostics: DiagnosticCollector | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback, progress_callback, conversion_running,
-                         update_log_callback, compact_logging, max_workers=max_workers)
+                         update_log_callback, compact_logging, max_workers=max_workers,
+                         diagnostics=diagnostics)
         self.godot_sounds_path = os.path.join(self.godot_project_path, 'sounds')
         self.organize_by_audio_group = bool(organize_by_audio_group)
         self._sound_output_paths: dict[str, str] = {}
 
     def find_sound_files(self) -> list[str]:
         manifest = load_gamemaker_project_manifest(self.gm_project_path)
+        self._record_project_manifest_source_path_diagnostics(
+            manifest,
+            resource_type="sound",
+        )
         if manifest.yyp_path is not None:
             referenced_files: list[str] = []
             for resource in manifest.resources:
                 if resource.kind.casefold() != "sounds":
                     continue
+                manifest_field = (
+                    f"{resource.source.field_path}.id.path"
+                    if resource.source is not None and resource.source.field_path
+                    else "resources[].id.path"
+                )
+                resolved = self._resolve_project_source(
+                    resource.path,
+                    owner_source_path=manifest.yyp_path,
+                    resource=resource.name,
+                    resource_type="sound",
+                    field=manifest_field,
+                )
+                if resolved is None:
+                    continue
                 try:
-                    resolved = resolve_project_source_path(
-                        self.gm_project_path,
-                        resource.path,
-                    )
+                    validate_project_resource_source_path(resolved, "sounds")
                 except ProjectSourcePathError as exc:
-                    self._safe_log(
-                        f"Warning: Skipping GameMaker sound {resource.name}: {exc}"
+                    self._report_source_path_rejection(
+                        resource.path,
+                        exc,
+                        owner_source_path=manifest.yyp_path,
+                        resource=resource.name,
+                        resource_type="sound",
+                        field=manifest_field,
                     )
                     continue
-                if resolved.source_path.casefold().endswith(".yy") and os.path.isfile(
-                    resolved.filesystem_path
-                ):
+                if os.path.isfile(resolved.filesystem_path):
                     referenced_files.append(resolved.filesystem_path)
             return referenced_files
 
-        sound_folder = os.path.join(self.gm_project_path, 'sounds')
+        sound_folder = self._resolve_discovered_project_source(
+            os.path.join(self.gm_project_path, 'sounds'),
+            resource_type="sound",
+            field="sounds directory",
+        )
+        if sound_folder is None:
+            return []
+
         sound_files: list[str] = []
-        for root, _, files in os.walk(sound_folder):
-            sound_files.extend(
-                os.path.join(root, file)
-                for file in files
-                if file.lower().endswith('.yy') and not file.lower().endswith('.old.yy')
+        pending_directories = [sound_folder]
+        visited_directories: set[str] = set()
+        while pending_directories:
+            directory = pending_directories.pop()
+            resolved_directory = self._resolve_discovered_project_source(
+                directory.filesystem_path,
+                owner_source_path=directory.source_path,
+                resource=os.path.basename(directory.source_path),
+                resource_type="sound",
+                field="discovered sound directory",
             )
-        return sound_files
+            if resolved_directory is None or not os.path.isdir(
+                resolved_directory.filesystem_path
+            ):
+                continue
+
+            canonical_directory = os.path.normcase(
+                os.path.realpath(resolved_directory.filesystem_path)
+            )
+            if canonical_directory in visited_directories:
+                continue
+            visited_directories.add(canonical_directory)
+
+            child_directories: list[ResolvedProjectSourcePath] = []
+            try:
+                with os.scandir(resolved_directory.filesystem_path) as entries:
+                    for entry in sorted(entries, key=lambda item: item.name):
+                        filename = entry.name
+                        lower_filename = filename.casefold()
+                        is_sound_yy = (
+                            lower_filename.endswith('.yy')
+                            and not lower_filename.endswith('.old.yy')
+                        )
+                        try:
+                            is_unlinked_directory = entry.is_dir(
+                                follow_symlinks=False
+                            )
+                            is_symlink = entry.is_symlink()
+                        except OSError:
+                            continue
+                        if not is_sound_yy and not is_unlinked_directory and not is_symlink:
+                            continue
+
+                        resolved_entry = self._resolve_discovered_project_source(
+                            entry.path,
+                            owner_source_path=resolved_directory.source_path,
+                            resource=(
+                                os.path.splitext(filename)[0]
+                                if is_sound_yy
+                                else filename
+                            ),
+                            resource_type="sound",
+                            field=(
+                                "discovered .yy"
+                                if is_sound_yy
+                                else "discovered sound entry"
+                            ),
+                        )
+                        if resolved_entry is None:
+                            continue
+
+                        if os.path.isdir(resolved_entry.filesystem_path):
+                            # Preserve os.walk's historical behavior for contained
+                            # directory links while still rejecting escaping links.
+                            if not is_symlink:
+                                child_directories.append(resolved_entry)
+                            continue
+                        if is_sound_yy and os.path.isfile(
+                            resolved_entry.filesystem_path
+                        ):
+                            try:
+                                validate_project_resource_source_path(
+                                    resolved_entry,
+                                    "sounds",
+                                )
+                            except ProjectSourcePathError as exc:
+                                self._report_source_path_rejection(
+                                    entry.path,
+                                    exc,
+                                    owner_source_path=resolved_directory.source_path,
+                                    resource=os.path.splitext(filename)[0],
+                                    resource_type="sound",
+                                    field="discovered .yy",
+                                )
+                                continue
+                            sound_files.append(resolved_entry.filesystem_path)
+            except OSError:
+                continue
+            pending_directories.extend(reversed(child_directories))
+        return sorted(sound_files)
 
     def _parse_sound_yy(self, yy_path: str) -> SoundData | None:
         data = self._read_yy_file(yy_path)
@@ -86,10 +202,36 @@ class SoundConverter(BaseConverter):
             self._safe_log(get_localized("Console_Convertor_Sounds_ParseError").format(yy_path=yy_path))
             return None
 
+        raw_sound_file = data.get('soundFile')
+        if not isinstance(raw_sound_file, str) or not raw_sound_file:
+            raw_name = data.get('name')
+            sound_name = (
+                raw_name
+                if isinstance(raw_name, str) and raw_name
+                else os.path.splitext(os.path.basename(yy_path))[0]
+            )
+            rejected_value = (
+                raw_sound_file
+                if isinstance(raw_sound_file, str)
+                else repr(raw_sound_file)
+            )
+            self._report_source_path_rejection(
+                rejected_value,
+                ProjectSourcePathError(
+                    "GameMaker soundFile must be a non-empty string: "
+                    f"{raw_sound_file!r}"
+                ),
+                owner_source_path=yy_path,
+                resource=sound_name,
+                resource_type="sound",
+                field="soundFile",
+            )
+            return None
+
         try:
             return {
                 'name': str(data['name']),
-                'soundFile': str(data.get('soundFile', '')),
+                'soundFile': raw_sound_file,
                 'volume': float(data.get('volume', 1.0)),
                 'type': int(data.get('type', 0)),
                 'bitDepth': int(data.get('bitDepth', 16)),
@@ -159,7 +301,7 @@ class SoundConverter(BaseConverter):
                 f'path=""\n'
                 f'\n'
                 f'[deps]\n'
-                f'source_file="{res_path}"\n'
+                f'source_file={format_godot_string(res_path)}\n'
                 f'dest_files=[]\n'
                 f'\n'
                 f'[params]\n'
@@ -183,7 +325,7 @@ class SoundConverter(BaseConverter):
                 f'path=""\n'
                 f'\n'
                 f'[deps]\n'
-                f'source_file="{res_path}"\n'
+                f'source_file={format_godot_string(res_path)}\n'
                 f'dest_files=[]\n'
                 f'\n'
                 f'[params]\n'
@@ -202,7 +344,7 @@ class SoundConverter(BaseConverter):
                 f'path=""\n'
                 f'\n'
                 f'[deps]\n'
-                f'source_file="{res_path}"\n'
+                f'source_file={format_godot_string(res_path)}\n'
                 f'dest_files=[]\n'
                 f'\n'
                 f'[params]\n'
@@ -218,25 +360,70 @@ class SoundConverter(BaseConverter):
         if not self.conversion_running():
             return None
 
-        sound_data = self._parse_sound_yy(yy_path)
+        discovered_name = os.path.splitext(os.path.basename(yy_path))[0]
+        resolved_yy = self._resolve_discovered_project_source(
+            yy_path,
+            owner_source_path=yy_path,
+            resource=discovered_name,
+            resource_type="sound",
+            field="sound .yy",
+        )
+        if resolved_yy is None:
+            return {
+                'success': False,
+                'name': discovered_name,
+                'audio_group': 'audiogroup_default',
+            }
+        try:
+            validate_project_resource_source_path(resolved_yy, "sounds")
+        except ProjectSourcePathError as exc:
+            self._report_source_path_rejection(
+                yy_path,
+                exc,
+                owner_source_path=yy_path,
+                resource=discovered_name,
+                resource_type="sound",
+                field="sound .yy",
+            )
+            return {
+                'success': False,
+                'name': discovered_name,
+                'audio_group': 'audiogroup_default',
+            }
+
+        sound_data = self._parse_sound_yy(resolved_yy.filesystem_path)
         if sound_data is None:
-            sound_name = os.path.splitext(os.path.basename(yy_path))[0]
-            return {'success': False, 'name': sound_name, 'audio_group': 'audiogroup_default'}
+            return {
+                'success': False,
+                'name': discovered_name,
+                'audio_group': 'audiogroup_default',
+            }
 
         sound_name = sound_data['name']
-        sound_file = sound_data['soundFile']
+        sound_file_reference = sound_data['soundFile']
         audio_group = sound_data['audioGroupId'] or 'audiogroup_default'
 
-        if not sound_file:
+        if not sound_file_reference:
             self._safe_log(get_localized("Console_Convertor_Sounds_NoFile").format(name=sound_name))
             return {'success': False, 'name': sound_name, 'audio_group': audio_group}
 
-        audio_path = os.path.join(os.path.dirname(yy_path), sound_file)
-        if not os.path.isfile(audio_path):
-            self._safe_log(get_localized("Console_Convertor_Sounds_FileMissing").format(
-                name=sound_name, sound_file=sound_file))
+        resolved_audio = self._resolve_project_source(
+            sound_file_reference,
+            owner_source_path=resolved_yy.source_path,
+            resource=sound_name,
+            resource_type="sound",
+            field="soundFile",
+        )
+        if resolved_audio is None:
             return {'success': False, 'name': sound_name, 'audio_group': audio_group}
 
+        audio_path = resolved_audio.filesystem_path
+        if not os.path.isfile(audio_path):
+            self._safe_log(get_localized("Console_Convertor_Sounds_FileMissing").format(
+                name=sound_name, sound_file=sound_file_reference))
+            return {'success': False, 'name': sound_name, 'audio_group': audio_group}
+
+        sound_file = os.path.basename(audio_path)
         resource_path = self._sound_output_paths.get(sound_name, "")
         if resource_path:
             dest_path = resource_filesystem_path(self.godot_project_path, resource_path)
@@ -245,7 +432,7 @@ class SoundConverter(BaseConverter):
             res_subfolder = os.path.dirname(resource_relative).replace("\\", "/")
             sound_file = os.path.basename(dest_path)
         else:
-            subfolder = self._get_subfolder_from_yy(yy_path)
+            subfolder = self._get_subfolder_from_yy(resolved_yy.filesystem_path)
             output_dir, res_subfolder = self._build_output_paths(sound_name, subfolder, audio_group)
             dest_path = os.path.join(output_dir, sound_file)
         os.makedirs(output_dir, exist_ok=True)
@@ -277,12 +464,6 @@ class SoundConverter(BaseConverter):
     def convert_sounds(self) -> None:
         os.makedirs(self.godot_project_path, exist_ok=True)
         os.makedirs(self.godot_sounds_path, exist_ok=True)
-
-        gm_sounds_path = os.path.join(self.gm_project_path, 'sounds')
-
-        if not os.path.exists(gm_sounds_path):
-            self.log_callback(get_localized("Console_Convertor_Sounds_Error_NotFound"))
-            return
 
         sound_files = sorted(self.find_sound_files())
 

--- a/src/conversion/sprites.py
+++ b/src/conversion/sprites.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import os
-import re
-import json
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from PIL import Image
 from collections import defaultdict
@@ -10,10 +8,13 @@ from typing import TypedDict, cast
 
 from src.localization import get_localized
 from src.conversion.base_converter import BaseConverter
+from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.generated_paths import generated_nested_resource_path, generated_resource_directory, generated_resource_stem
+from src.conversion.project_manifest import load_gamemaker_project_manifest
 from src.conversion.project_source_paths import (
     ProjectSourcePathError,
-    resolve_project_source_path,
+    ResolvedProjectSourcePath,
+    validate_project_resource_source_path,
 )
 from src.conversion.type_defs import ConversionRunning, JsonDict, LogCallback, ProgressCallback, StrPath
 
@@ -47,12 +48,17 @@ class SpriteConverter(BaseConverter):
     def __init__(self, gm_project_path: StrPath, godot_project_path: StrPath, log_callback: LogCallback = print,
                  progress_callback: ProgressCallback | None = None, conversion_running: ConversionRunning | None = None,
                  update_log_callback: LogCallback | None = None, compact_logging: bool = False,
-                 max_workers: int | None = None) -> None:
+                 max_workers: int | None = None,
+                 diagnostics: DiagnosticCollector | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback, progress_callback, conversion_running,
-                         update_log_callback, compact_logging, max_workers=max_workers)
+                         update_log_callback, compact_logging, max_workers=max_workers,
+                         diagnostics=diagnostics)
         self.godot_sprites_path = os.path.join(self.godot_project_path, 'sprites')
         self._sprite_path_suffixes: dict[str, str] = {}
         self._yyp_sprite_yy_paths: dict[str, str] = {}
+        self._sprite_yy_paths: dict[str, str] = {}
+        self._sprite_owner_yy_paths: dict[str, str] = {}
+        self._sprites_without_yy: set[str] = set()
 
     def _get_valid_sprite_names(self) -> dict[str, str] | None:
         """Parse the .yyp project file and return a dict of sprite name -> subfolder.
@@ -61,26 +67,38 @@ class SpriteConverter(BaseConverter):
         the caller to fall back to converting all sprites on disk.
         """
         self._yyp_sprite_yy_paths = {}
+        self._sprite_yy_paths = {}
+        self._sprite_owner_yy_paths = {}
+        self._sprites_without_yy = set()
+        manifest = load_gamemaker_project_manifest(self.gm_project_path)
+        manifest_rejected_fields = self._record_project_manifest_source_path_diagnostics(
+            manifest,
+            resource_type="sprite",
+            include_project_sources=True,
+        )
         try:
-            yyp_files = sorted(f for f in os.listdir(self.gm_project_path) if f.endswith('.yyp'))
-            if not yyp_files:
+            if manifest.yyp_path is None:
                 return None
-
-            yyp_path = os.path.join(self.gm_project_path, yyp_files[0])
-            with open(yyp_path, 'r', encoding='utf-8') as f:
-                content = f.read()
-
-            cleaned = re.sub(r',\s*([}\]])', r'\1', content)
-            raw_data = json.loads(cleaned)
-            if not isinstance(raw_data, dict):
+            resolved_yyp = self._resolve_discovered_project_source(
+                manifest.yyp_path,
+                owner_source_path=manifest.yyp_path,
+                resource_type="sprite",
+                field="project .yyp",
+            )
+            if resolved_yyp is None:
+                return None
+            if any(
+                diagnostic.code == "GM2GD-PROJECT-YYP-MALFORMED"
+                for diagnostic in manifest.diagnostics
+            ):
                 raise TypeError("GameMaker project root must be an object")
-            data = cast(JsonDict, raw_data)
+            data = manifest.raw_data
 
             valid_sprites: dict[str, str] = {}
             raw_resources = data.get('resources', [])
             if not isinstance(raw_resources, list):
                 raise TypeError("GameMaker project resources must be an array")
-            for raw_resource in cast(list[object], raw_resources):
+            for resource_index, raw_resource in enumerate(cast(list[object], raw_resources)):
                 if not isinstance(raw_resource, dict):
                     continue
                 resource = cast(JsonDict, raw_resource)
@@ -91,8 +109,18 @@ class SpriteConverter(BaseConverter):
                 raw_path = res_id.get('path', '')
                 if not isinstance(raw_path, str):
                     continue
+                manifest_field = f"resources[{resource_index}].id.path"
+                if manifest_field in manifest_rejected_fields:
+                    continue
                 path = raw_path.replace('\\', '/')
-                if path.startswith('sprites/'):
+                resource_type = resource.get('resourceType')
+                id_resource_type = res_id.get('resourceType')
+                is_sprite = (
+                    path.casefold().startswith('sprites/')
+                    or resource_type == "GMSprite"
+                    or id_resource_type == "GMSprite"
+                )
+                if is_sprite:
                     raw_name = res_id.get('name', '')
                     name = (
                         raw_name
@@ -101,22 +129,43 @@ class SpriteConverter(BaseConverter):
                     )
                     if not name:
                         continue
+                    resolved_path = self._resolve_project_source(
+                        path,
+                        owner_source_path=resolved_yyp.source_path,
+                        resource=name,
+                        resource_type="sprite",
+                        field=manifest_field,
+                    )
+                    if resolved_path is None:
+                        continue
                     try:
-                        resolved_path = resolve_project_source_path(
-                            self.gm_project_path,
-                            path,
+                        validate_project_resource_source_path(
+                            resolved_path,
+                            "sprites",
                         )
                     except ProjectSourcePathError as exc:
-                        self._safe_log(
-                            f"Warning: Skipping GameMaker sprite {name}: {exc}"
+                        self._report_source_path_rejection(
+                            path,
+                            exc,
+                            owner_source_path=resolved_yyp.source_path,
+                            resource=name,
+                            resource_type="sprite",
+                            field=manifest_field,
                         )
                         continue
                     yy_path = resolved_path.filesystem_path
                     self._yyp_sprite_yy_paths[name] = yy_path
-                    valid_sprites[name] = self._get_subfolder_from_yy(yy_path)
+                    self._sprite_yy_paths[name] = yy_path
+                    self._sprite_owner_yy_paths[name] = yy_path
+                    validated_yy_path = self._sprite_yy_path(name)
+                    valid_sprites[name] = (
+                        self._get_subfolder_from_yy(validated_yy_path)
+                        if validated_yy_path is not None
+                        else ""
+                    )
 
             return valid_sprites
-        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        except (OSError, KeyError, TypeError, ValueError):
             self._safe_log(get_localized("Console_Convertor_Sprites_YYPFilterWarning"))
             return None
 
@@ -167,20 +216,104 @@ class SpriteConverter(BaseConverter):
             suffixes[sprite_name] = suffix
         return suffixes
 
-    def _disk_sprite_yy_paths(self) -> dict[str, str]:
-        sprite_root = os.path.join(self.gm_project_path, 'sprites')
+    def _disk_sprite_directories(self) -> dict[str, str]:
+        sprite_root = self._resolve_discovered_project_source(
+            os.path.join(self.gm_project_path, 'sprites'),
+            resource_type="sprite",
+            field="sprites directory",
+        )
+        if sprite_root is None or not os.path.isdir(sprite_root.filesystem_path):
+            return {}
         try:
-            sprite_names = sorted(os.listdir(sprite_root))
+            sprite_names = sorted(os.listdir(sprite_root.filesystem_path))
         except OSError:
             return {}
 
-        yy_paths: dict[str, str] = {}
+        sprite_directories: dict[str, str] = {}
         for sprite_name in sprite_names:
-            sprite_dir = os.path.join(sprite_root, sprite_name)
+            sprite_dir = os.path.join(sprite_root.filesystem_path, sprite_name)
+            resolved_dir = self._resolve_discovered_project_source(
+                sprite_dir,
+                owner_source_path=sprite_root.source_path,
+                resource=sprite_name,
+                resource_type="sprite",
+                field="discovered sprite directory",
+            )
+            if resolved_dir is not None and os.path.isdir(resolved_dir.filesystem_path):
+                sprite_directories[sprite_name] = resolved_dir.filesystem_path
+                # Until a real .yy has been validated, use the containing
+                # directory as provenance. A malicious .yy symlink must never
+                # become its own diagnostic owner.
+                self._sprite_owner_yy_paths.setdefault(
+                    sprite_name,
+                    resolved_dir.source_path,
+                )
+        return sprite_directories
+
+    def _disk_sprite_yy_paths(
+        self,
+        sprite_directories: dict[str, str] | None = None,
+    ) -> dict[str, str]:
+        directories = (
+            sprite_directories
+            if sprite_directories is not None
+            else self._disk_sprite_directories()
+        )
+        yy_paths: dict[str, str] = {}
+        for sprite_name, sprite_dir in directories.items():
             yy_path = os.path.join(sprite_dir, sprite_name + '.yy')
-            if os.path.isdir(sprite_dir) and os.path.isfile(yy_path):
-                yy_paths[sprite_name] = yy_path
+            resolved_yy = self._resolve_discovered_project_source(
+                yy_path,
+                owner_source_path=self._sprite_owner_yy_paths.get(
+                    sprite_name,
+                    sprite_dir,
+                ),
+                resource=sprite_name,
+                resource_type="sprite",
+                field="discovered sprite .yy",
+            )
+            if (
+                resolved_yy is not None
+                and self._source_has_resource_kind(
+                    resolved_yy,
+                    rejected_path=yy_path,
+                    owner_source_path=self._sprite_owner_yy_paths.get(
+                        sprite_name,
+                        sprite_dir,
+                    ),
+                    resource=sprite_name,
+                    field="discovered sprite .yy",
+                )
+                and os.path.isfile(resolved_yy.filesystem_path)
+            ):
+                yy_paths[sprite_name] = resolved_yy.filesystem_path
+                self._sprite_owner_yy_paths[sprite_name] = (
+                    resolved_yy.source_path
+                )
         return yy_paths
+
+    def _source_has_resource_kind(
+        self,
+        resolved: ResolvedProjectSourcePath,
+        *,
+        rejected_path: str,
+        owner_source_path: StrPath,
+        resource: str,
+        field: str,
+    ) -> bool:
+        try:
+            validate_project_resource_source_path(resolved, "sprites")
+            return True
+        except ProjectSourcePathError as error:
+            self._report_source_path_rejection(
+                rejected_path,
+                error,
+                owner_source_path=owner_source_path,
+                resource=resource,
+                resource_type="sprite",
+                field=field,
+            )
+            return False
 
     def _sprite_output_stem(self, sprite_name: str) -> str:
         return generated_resource_stem(sprite_name) + self._sprite_path_suffixes.get(sprite_name, "")
@@ -193,33 +326,159 @@ class SpriteConverter(BaseConverter):
             suffix=self._sprite_path_suffixes.get(sprite_name, ""),
         )
 
-    def _find_all_sprite_images(self) -> defaultdict[str, list[str]]:
-        sprite_folder = os.path.join(self.gm_project_path, 'sprites')
+    def _find_all_sprite_images(
+        self,
+        sprite_directories: dict[str, str] | None = None,
+        owner_yy_paths: dict[str, str] | None = None,
+    ) -> defaultdict[str, list[str]]:
+        directories = (
+            sprite_directories
+            if sprite_directories is not None
+            else self._disk_sprite_directories()
+        )
+        owners = owner_yy_paths or {}
         image_files: defaultdict[str, list[str]] = defaultdict(list)
-        for root, _, files in os.walk(sprite_folder):
-            if 'layers' in root.split(os.path.sep):
-                sprite_name = root.split(os.path.sep)[-3]
-                images = [
-                    os.path.join(root, file)
-                    for file in files
-                    if file.lower().endswith(('.png', '.jpg', '.jpeg'))
-                ]
-                if images:
-                    image_files[sprite_name].extend(images)
+        for sprite_name, sprite_directory in directories.items():
+            owner_yy = owners.get(
+                sprite_name,
+                self._sprite_owner_yy_paths.get(
+                    sprite_name,
+                    sprite_directory,
+                ),
+            )
+            self._sprite_owner_yy_paths.setdefault(sprite_name, owner_yy)
+            image_files[sprite_name].extend(
+                self._find_sprite_images(
+                    sprite_name,
+                    sprite_directory,
+                    owner_yy,
+                )
+            )
+            if not image_files[sprite_name]:
+                del image_files[sprite_name]
         return image_files
+
+    def _find_sprite_images(
+        self,
+        sprite_name: str,
+        sprite_directory: str,
+        owner_yy_path: str,
+    ) -> list[str]:
+        resolved_sprite_directory = self._resolve_discovered_project_source(
+            sprite_directory,
+            owner_source_path=owner_yy_path,
+            resource=sprite_name,
+            resource_type="sprite",
+            field="sprite resource directory",
+        )
+        if (
+            resolved_sprite_directory is None
+            or not os.path.isdir(resolved_sprite_directory.filesystem_path)
+        ):
+            return []
+
+        layers_directory = self._resolve_discovered_project_source(
+            os.path.join(resolved_sprite_directory.filesystem_path, 'layers'),
+            owner_source_path=owner_yy_path,
+            resource=sprite_name,
+            resource_type="sprite",
+            field="layers directory",
+        )
+        if layers_directory is None or not os.path.isdir(layers_directory.filesystem_path):
+            return []
+
+        image_paths: list[str] = []
+        pending_directories = [layers_directory.filesystem_path]
+        while pending_directories:
+            root = pending_directories.pop()
+            resolved_root = self._resolve_discovered_project_source(
+                root,
+                owner_source_path=owner_yy_path,
+                resource=sprite_name,
+                resource_type="sprite",
+                field="frames[].name",
+            )
+            if resolved_root is None or not os.path.isdir(
+                resolved_root.filesystem_path
+            ):
+                continue
+            try:
+                entries = sorted(
+                    os.listdir(resolved_root.filesystem_path),
+                    reverse=True,
+                )
+            except OSError:
+                continue
+            for entry in entries:
+                candidate = os.path.join(resolved_root.filesystem_path, entry)
+                is_image = entry.lower().endswith(('.png', '.jpg', '.jpeg'))
+                resolved_candidate = self._resolve_discovered_project_source(
+                    candidate,
+                    owner_source_path=owner_yy_path,
+                    resource=sprite_name,
+                    resource_type="sprite",
+                    field=(
+                        "frames[].name/layers[].name"
+                        if is_image
+                        else "frames[].name"
+                    ),
+                )
+                if resolved_candidate is None:
+                    continue
+                if is_image and os.path.isfile(resolved_candidate.filesystem_path):
+                    image_paths.append(resolved_candidate.filesystem_path)
+                elif (
+                    not os.path.islink(candidate)
+                    and os.path.isdir(resolved_candidate.filesystem_path)
+                ):
+                    pending_directories.append(resolved_candidate.filesystem_path)
+        return image_paths
+
+    def _sprite_yy_path(self, sprite_name: str) -> str | None:
+        if sprite_name in self._sprites_without_yy:
+            return None
+        candidate = self._sprite_yy_paths.get(sprite_name)
+        if candidate is None:
+            candidate = os.path.join(
+                self.gm_project_path,
+                'sprites',
+                sprite_name,
+                sprite_name + '.yy',
+            )
+        owner_yy = self._sprite_owner_yy_paths.get(
+            sprite_name,
+            os.path.dirname(candidate),
+        )
+        resolved_yy = self._resolve_discovered_project_source(
+            candidate,
+            owner_source_path=owner_yy,
+            resource=sprite_name,
+            resource_type="sprite",
+            field="sprite .yy",
+        )
+        if resolved_yy is None or not self._source_has_resource_kind(
+            resolved_yy,
+            rejected_path=candidate,
+            owner_source_path=owner_yy,
+            resource=sprite_name,
+            field="sprite .yy",
+        ):
+            return None
+        self._sprite_owner_yy_paths[sprite_name] = resolved_yy.source_path
+        return resolved_yy.filesystem_path
 
     def _parse_collision_data(self, sprite_name: str) -> CollisionData | None:
         """Parse collision mask properties from a sprite .yy file.
 
         Returns a dict with collision fields or None if parsing fails.
         """
-        yy_path = os.path.join(self.gm_project_path, 'sprites', sprite_name, sprite_name + '.yy')
+        yy_path = self._sprite_yy_path(sprite_name)
+        if yy_path is None:
+            return None
+        data = self._read_yy_file(yy_path)
+        if data is None:
+            return None
         try:
-            with open(yy_path, 'r', encoding='utf-8') as f:
-                content = f.read()
-            cleaned = re.sub(r',\s*([}\]])', r'\1', content)
-            data = cast(JsonDict, json.loads(cleaned))
-
             return {
                 "collisionKind": int(data.get("collisionKind", 1)),
                 "bboxMode": int(data.get("bboxMode", 0)),
@@ -233,7 +492,7 @@ class SpriteConverter(BaseConverter):
                 "xorigin": int(data.get("xorigin", 0)),
                 "yorigin": int(data.get("yorigin", 0)),
             }
-        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        except (KeyError, TypeError, ValueError):
             return None
 
     def _parse_animation_data(self, sprite_name: str) -> AnimationData | None:
@@ -241,13 +500,13 @@ class SpriteConverter(BaseConverter):
 
         Returns a dict with animation fields or None if parsing fails.
         """
-        yy_path = os.path.join(self.gm_project_path, 'sprites', sprite_name, sprite_name + '.yy')
+        yy_path = self._sprite_yy_path(sprite_name)
+        if yy_path is None:
+            return None
+        data = self._read_yy_file(yy_path)
+        if data is None:
+            return None
         try:
-            with open(yy_path, 'r', encoding='utf-8') as f:
-                content = f.read()
-            cleaned = re.sub(r',\s*([}\]])', r'\1', content)
-            data = cast(JsonDict, json.loads(cleaned))
-
             sequence = data.get("sequence")
             if not isinstance(sequence, dict):
                 return None
@@ -271,7 +530,7 @@ class SpriteConverter(BaseConverter):
                 "loop": loop,
                 "frame_durations": frame_durations,
             }
-        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError, IndexError):
+        except (KeyError, TypeError, ValueError, IndexError):
             return None
 
     @staticmethod
@@ -508,12 +767,11 @@ class SpriteConverter(BaseConverter):
             self._write_static_scene(sprite_name, collision_data, collision_sub, collision_node, subfolder)
 
     def _parse_sprite_yy(self, sprite_name: str) -> SpriteParseResult | None:
-        yy_path = os.path.join(self.gm_project_path, 'sprites', sprite_name, sprite_name + '.yy')
+        yy_path = self._sprite_yy_path(sprite_name)
+        data = self._read_yy_file(yy_path) if yy_path is not None else None
         try:
-            with open(yy_path, 'r', encoding='utf-8') as f:
-                content = f.read()
-            cleaned = re.sub(r',\s*([}\]])', r'\1', content)
-            data = cast(JsonDict, json.loads(cleaned))
+            if data is None:
+                raise TypeError("Sprite metadata must be an object")
 
             frames = cast(list[JsonDict], data['frames'])
             frame_guids = [str(frame['name']) for frame in frames]
@@ -528,9 +786,18 @@ class SpriteConverter(BaseConverter):
                 visible_layer_guids = [str(layers[0]['name'])]
 
             return (frame_guids, visible_layer_guids)
-        except (OSError, json.JSONDecodeError, KeyError, TypeError, IndexError):
+        except (KeyError, TypeError, IndexError):
+            diagnostic_path = yy_path or self._sprite_owner_yy_paths.get(
+                sprite_name,
+                os.path.join(
+                    self.gm_project_path,
+                    'sprites',
+                    sprite_name,
+                    sprite_name + '.yy',
+                ),
+            )
             self._safe_log(get_localized("Console_Convertor_Sprites_YYParseFailed").format(
-                yy_path=yy_path, sprite_name=sprite_name))
+                yy_path=diagnostic_path, sprite_name=sprite_name))
             return None
 
     def _build_ordered_frame_list(self, sprite_name: str, all_image_paths: list[str]) -> list[list[str]]:
@@ -569,17 +836,41 @@ class SpriteConverter(BaseConverter):
         if not self.conversion_running():
             return None
 
+        owner_yy_path = self._sprite_owner_yy_paths.get(
+            sprite_name,
+            os.path.join(
+                self.gm_project_path,
+                'sprites',
+                sprite_name,
+                sprite_name + '.yy',
+            ),
+        )
+        resolved_sprite_paths: list[str] = []
+        for gm_sprite_path in gm_sprite_paths:
+            resolved_image = self._resolve_discovered_project_source(
+                gm_sprite_path,
+                owner_source_path=owner_yy_path,
+                resource=sprite_name,
+                resource_type="sprite",
+                field="frames[].name/layers[].name",
+            )
+            if resolved_image is None or not os.path.isfile(
+                resolved_image.filesystem_path
+            ):
+                return (sprite_name, index, images_count, gm_sprite_paths[0], "")
+            resolved_sprite_paths.append(resolved_image.filesystem_path)
+
         sprite_stem = self._sprite_output_stem(sprite_name)
         new_filename = f"{sprite_stem}_{index}.png" if images_count > 1 else f"{sprite_stem}.png"
         sprite_dir = self._sprite_output_directory(subfolder, sprite_name)
         godot_sprite_path = os.path.join(sprite_dir, new_filename)
 
-        if len(gm_sprite_paths) == 1:
-            with Image.open(gm_sprite_paths[0]) as img:
+        if len(resolved_sprite_paths) == 1:
+            with Image.open(resolved_sprite_paths[0]) as img:
                 img.save(godot_sprite_path, 'PNG')
         else:
             composed = None
-            for gm_sprite_path in gm_sprite_paths:
+            for gm_sprite_path in resolved_sprite_paths:
                 with Image.open(gm_sprite_path) as img:
                     layer = img.convert('RGBA')
                 if composed is None:
@@ -588,12 +879,10 @@ class SpriteConverter(BaseConverter):
             assert composed is not None
             composed.save(godot_sprite_path, 'PNG')
 
-        return (sprite_name, index, images_count, gm_sprite_paths[0], new_filename)
+        return (sprite_name, index, images_count, resolved_sprite_paths[0], new_filename)
 
     def convert_sprites(self) -> None:
         os.makedirs(self.godot_sprites_path, exist_ok=True)
-
-        sprite_images = self._find_all_sprite_images()
 
         valid_names = self._get_valid_sprite_names()
         sprite_subfolders: dict[str, str] = {}
@@ -602,37 +891,82 @@ class SpriteConverter(BaseConverter):
         source_paths: dict[str, str]
         if valid_names is not None:
             source_paths = dict(self._yyp_sprite_yy_paths)
-            indexed_sprite_names = {
-                name
+            declared_directories = {
+                name: os.path.dirname(yy_path)
                 for name, yy_path in source_paths.items()
-                if os.path.isfile(yy_path)
             }
-            filtered: defaultdict[str, list[str]] = defaultdict(list)
-            for name, images in sprite_images.items():
-                if name in valid_names:
-                    filtered[name] = images
-                    sprite_subfolders[name] = valid_names[name]
-                else:
-                    self._safe_log(get_localized("Console_Convertor_Sprites_Skipped").format(
-                        sprite_name=name))
-            sprite_images = filtered
+            sprite_images = self._find_all_sprite_images(
+                declared_directories,
+                source_paths,
+            )
+            indexed_sprite_names = set()
+            for name in source_paths:
+                validated_yy_path = self._sprite_yy_path(name)
+                if validated_yy_path is not None and os.path.isfile(
+                    validated_yy_path
+                ):
+                    indexed_sprite_names.add(name)
+            sprite_subfolders = {
+                name: valid_names[name]
+                for name in sprite_images
+            }
+
+            declared_directory_keys = {
+                os.path.normcase(os.path.realpath(directory))
+                for directory in declared_directories.values()
+            }
+            disk_directories = self._disk_sprite_directories()
+            orphan_directories = {
+                name: directory
+                for name, directory in disk_directories.items()
+                if os.path.normcase(os.path.realpath(directory))
+                not in declared_directory_keys
+            }
+            orphan_images = self._find_all_sprite_images(orphan_directories)
+            for name in orphan_images:
+                self._safe_log(get_localized("Console_Convertor_Sprites_Skipped").format(
+                    sprite_name=name))
+
             path_subfolders = {
                 name: subfolder
                 for name, subfolder in valid_names.items()
                 if name in indexed_sprite_names or name in sprite_images
             }
         else:
-            source_paths = self._disk_sprite_yy_paths()
-            indexed_sprite_names = set(source_paths)
-            path_subfolders = {
-                name: self._get_subfolder_from_yy(yy_path)
-                for name, yy_path in source_paths.items()
+            disk_directories = self._disk_sprite_directories()
+            discovered_yy_paths = self._disk_sprite_yy_paths(disk_directories)
+            self._sprite_yy_paths = dict(discovered_yy_paths)
+            self._sprites_without_yy = set(disk_directories) - set(
+                discovered_yy_paths
+            )
+            owner_yy_paths = {
+                name: self._sprite_owner_yy_paths.get(
+                    name,
+                    discovered_yy_paths.get(name, directory),
+                )
+                for name, directory in disk_directories.items()
             }
+            self._sprite_owner_yy_paths.update(owner_yy_paths)
+            sprite_images = self._find_all_sprite_images(
+                disk_directories,
+                owner_yy_paths,
+            )
+            indexed_sprite_names = set(discovered_yy_paths)
+            path_subfolders = {}
+            for name in discovered_yy_paths:
+                validated_yy_path = self._sprite_yy_path(name)
+                path_subfolders[name] = (
+                    self._get_subfolder_from_yy(validated_yy_path)
+                    if validated_yy_path is not None
+                    else ""
+                )
             for name in sprite_images:
-                yy_path = os.path.join(self.gm_project_path, 'sprites', name, name + '.yy')
-                sprite_subfolders[name] = self._get_subfolder_from_yy(yy_path)
+                sprite_subfolders[name] = path_subfolders.get(name, "")
                 path_subfolders.setdefault(name, sprite_subfolders[name])
-                source_paths.setdefault(name, yy_path)
+            source_paths = {
+                name: owner_yy_paths[name]
+                for name in path_subfolders
+            }
 
         if not sprite_images:
             self.log_callback(get_localized("Console_Convertor_Sprites_Error_NotFound"))
@@ -674,6 +1008,10 @@ class SpriteConverter(BaseConverter):
 
                 sprite_name, _index, _images_count, gm_sprite_path, new_filename = result
                 processed_images += 1
+
+                if not new_filename:
+                    self._safe_progress(int(processed_images / total_images * 100))
+                    continue
 
                 if self.compact_logging:
                     self._safe_log_progress(sprite_name, processed_images, total_images)

--- a/src/conversion/tilesets.py
+++ b/src/conversion/tilesets.py
@@ -4,6 +4,7 @@ import os
 import re
 import json
 import shutil
+import posixpath
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from typing import Literal, NotRequired, TypedDict, cast
 
@@ -14,19 +15,25 @@ from src.conversion.asset_output_paths import (
     resource_sibling_path,
 )
 from src.conversion.base_converter import BaseConverter
+from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.generated_paths import (
     generated_nested_resource_path,
 )
+from src.conversion.project_manifest import load_gamemaker_project_manifest
 from src.conversion.project_source_paths import (
+    is_safe_project_source_component,
     ProjectSourcePathError,
-    resolve_project_source_path,
+    ResolvedProjectSourcePath,
+    validate_project_resource_source_path,
 )
 from src.conversion.type_defs import ConversionRunning, JsonDict, LogCallback, ProgressCallback, StrPath
 
 
 class TilesetData(TypedDict):
+    source_path: str
     sprite_name: str
     sprite_path: str
+    sprite_reference_field: str
     tileWidth: int
     tileHeight: int
     tilehsep: int
@@ -64,12 +71,15 @@ class TileSetConverter(BaseConverter):
     def __init__(self, gm_project_path: StrPath, godot_project_path: StrPath, log_callback: LogCallback = print,
                  progress_callback: ProgressCallback | None = None, conversion_running: ConversionRunning | None = None,
                  update_log_callback: LogCallback | None = None, compact_logging: bool = False,
-                 max_workers: int | None = None) -> None:
+                 max_workers: int | None = None,
+                 diagnostics: DiagnosticCollector | None = None) -> None:
         super().__init__(gm_project_path, godot_project_path, log_callback,
                          progress_callback, conversion_running,
-                         update_log_callback, compact_logging, max_workers=max_workers)
+                         update_log_callback, compact_logging, max_workers=max_workers,
+                         diagnostics=diagnostics)
         self.godot_tilesets_path = os.path.join(self.godot_project_path, 'tilesets')
         self._tileset_output_paths: dict[str, str] = {}
+        self._tileset_source_paths: dict[str, str] = {}
 
     def _get_valid_tileset_names(self) -> dict[str, str] | None:
         """Parse the .yyp project file and return a dict of tileset name -> subfolder.
@@ -77,26 +87,49 @@ class TileSetConverter(BaseConverter):
         Returns None if the .yyp file cannot be found or parsed, allowing
         the caller to fall back to converting all tilesets on disk.
         """
+        self._tileset_source_paths = {}
+        manifest = load_gamemaker_project_manifest(self.gm_project_path)
+        manifest_rejected_fields = self._record_project_manifest_source_path_diagnostics(
+            manifest,
+            resource_type="tileset",
+            include_project_sources=True,
+        )
         try:
-            yyp_files = [f for f in os.listdir(self.gm_project_path) if f.endswith('.yyp')]
-            if not yyp_files:
+            if manifest.yyp_path is None:
                 return None
-
-            yyp_path = os.path.join(self.gm_project_path, yyp_files[0])
-            with open(yyp_path, 'r', encoding='utf-8') as f:
-                content = f.read()
-
-            cleaned = re.sub(r',\s*([}\]])', r'\1', content)
-            data = cast(JsonDict, json.loads(cleaned))
+            yyp_source = self._resolve_discovered_project_source(
+                manifest.yyp_path,
+                resource_type="project",
+                field="projectFile",
+            )
+            if yyp_source is None:
+                return None
+            if any(
+                diagnostic.code == "GM2GD-PROJECT-YYP-MALFORMED"
+                for diagnostic in manifest.diagnostics
+            ):
+                raise TypeError("GameMaker project root must be an object")
+            data = manifest.raw_data
 
             valid_tilesets: dict[str, str] = {}
-            for resource in cast(list[JsonDict], data.get('resources', [])):
-                res_id = cast(JsonDict, resource.get('id', {}))
+            resources = data.get('resources', [])
+            if not isinstance(resources, list):
+                return valid_tilesets
+            for index, resource in enumerate(cast(list[object], resources)):
+                if not isinstance(resource, dict):
+                    continue
+                raw_id = cast(JsonDict, resource).get('id', {})
+                if not isinstance(raw_id, dict):
+                    continue
+                res_id = cast(JsonDict, raw_id)
                 raw_path = res_id.get('path', '')
                 if not isinstance(raw_path, str):
                     continue
+                field = f"resources[{index}].id.path"
+                if field in manifest_rejected_fields:
+                    continue
                 path = raw_path.replace('\\', '/')
-                if path.startswith('tilesets/'):
+                if path.partition('/')[0].casefold() == 'tilesets':
                     raw_name = res_id.get('name', '')
                     name = (
                         raw_name
@@ -105,39 +138,140 @@ class TileSetConverter(BaseConverter):
                     )
                     if not name:
                         continue
-                    try:
-                        resolved_path = resolve_project_source_path(
-                            self.gm_project_path,
-                            path,
-                        )
-                    except ProjectSourcePathError as exc:
-                        self._safe_log(
-                            f"Warning: Skipping GameMaker tileset {name}: {exc}"
-                        )
+                    resolved_path = self._resolve_project_source(
+                        path,
+                        owner_source_path=yyp_source.source_path,
+                        resource=name,
+                        resource_type="tileset",
+                        field=field,
+                    )
+                    if resolved_path is None or not self._source_has_resource_kind(
+                        resolved_path,
+                        "tilesets",
+                        rejected_path=path,
+                        owner_source_path=yyp_source.source_path,
+                        resource=name,
+                        field=field,
+                    ):
                         continue
                     yy_path = resolved_path.filesystem_path
+                    if not os.path.isfile(yy_path):
+                        continue
+                    self._tileset_source_paths[name] = resolved_path.source_path
                     valid_tilesets[name] = self._get_subfolder_from_yy(yy_path)
 
             return valid_tilesets
         except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
             return None
 
-    def _parse_tileset_yy(self, tileset_name: str) -> TilesetData | None:
+    def _source_has_resource_kind(
+        self,
+        resolved: ResolvedProjectSourcePath,
+        resource_kind: str,
+        *,
+        rejected_path: str,
+        owner_source_path: StrPath,
+        resource: str,
+        field: str,
+    ) -> bool:
+        try:
+            validate_project_resource_source_path(resolved, resource_kind)
+            return True
+        except ProjectSourcePathError as error:
+            self._report_source_path_rejection(
+                rejected_path,
+                error,
+                owner_source_path=owner_source_path,
+                resource=resource,
+                resource_type="tileset",
+                field=field,
+            )
+            return False
+
+    def _resolve_tileset_yy_source(
+        self,
+        tileset_name: str,
+        source_path: str | None = None,
+    ) -> ResolvedProjectSourcePath | None:
+        declared_source_path = source_path or self._tileset_source_paths.get(
+            tileset_name
+        )
+        if declared_source_path is not None:
+            rejected_path = declared_source_path
+            owner_source_path = os.path.dirname(declared_source_path)
+            resolved = self._resolve_project_source(
+                declared_source_path,
+                resource=tileset_name,
+                resource_type="tileset",
+                field="tileset .yy",
+            )
+        else:
+            candidate = os.path.join(
+                self.gm_project_path,
+                'tilesets',
+                tileset_name,
+                tileset_name + '.yy',
+            )
+            rejected_path = candidate
+            owner_source_path = os.path.dirname(candidate)
+            resolved = self._resolve_discovered_project_source(
+                candidate,
+                owner_source_path=os.path.dirname(candidate),
+                resource=tileset_name,
+                resource_type="tileset",
+                field="tileset .yy",
+            )
+        if resolved is None:
+            return None
+        if not self._source_has_resource_kind(
+            resolved,
+            "tilesets",
+            rejected_path=rejected_path,
+            owner_source_path=owner_source_path,
+            resource=tileset_name,
+            field="tileset .yy",
+        ):
+            return None
+        self._tileset_source_paths[tileset_name] = resolved.source_path
+        return resolved
+
+    def _parse_tileset_yy(
+        self,
+        tileset_name: str,
+        source_path: str | None = None,
+    ) -> TilesetData | None:
         """Read and parse a tileset .yy file.
 
         Returns a dict with tileset properties, or None on failure.
         """
-        yy_path = os.path.join(self.gm_project_path, 'tilesets', tileset_name, tileset_name + '.yy')
+        resolved_tileset = self._resolve_tileset_yy_source(
+            tileset_name,
+            source_path,
+        )
+        if resolved_tileset is None:
+            return None
+        yy_path = resolved_tileset.filesystem_path
         try:
             with open(yy_path, 'r', encoding='utf-8') as f:
                 content = f.read()
             cleaned = re.sub(r',\s*([}\]])', r'\1', content)
             data = cast(JsonDict, json.loads(cleaned))
 
-            sprite_id = cast(JsonDict, data.get('spriteId', {}))
+            sprite_reference = self._resolve_sprite_reference(
+                tileset_name,
+                resolved_tileset.source_path,
+                data.get('spriteId'),
+            )
+            sprite_name = ""
+            sprite_path = ""
+            sprite_reference_field = "spriteId"
+            if sprite_reference is not None:
+                sprite_name, sprite_path, sprite_reference_field = sprite_reference
             return {
-                "sprite_name": str(sprite_id.get('name', '')),
-                "sprite_path": str(sprite_id.get('path', '')),
+                "source_path": resolved_tileset.source_path,
+                "sprite_name": sprite_name,
+                "sprite_path": sprite_path,
+                "sprite_reference_field": sprite_reference_field,
                 "tileWidth": int(data.get('tileWidth', 16)),
                 "tileHeight": int(data.get('tileHeight', 16)),
                 "tilehsep": int(data.get('tilehsep', 0)),
@@ -157,15 +291,151 @@ class TileSetConverter(BaseConverter):
         except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
             return None
 
-    def _find_sprite_image(self, sprite_name: str) -> str | None:
+    def _resolve_sprite_reference(
+        self,
+        tileset_name: str,
+        tileset_source_path: str,
+        raw_sprite_id: object,
+    ) -> tuple[str, str, str] | None:
+        if raw_sprite_id is None:
+            return None
+        if not isinstance(raw_sprite_id, dict):
+            self._reject_sprite_reference(
+                tileset_name,
+                tileset_source_path,
+                repr(raw_sprite_id),
+                "spriteId",
+                "GameMaker tileset spriteId must be an object",
+            )
+            return None
+
+        sprite_id = cast(JsonDict, raw_sprite_id)
+        if "path" in sprite_id:
+            raw_path = sprite_id.get("path")
+            if not isinstance(raw_path, str) or not raw_path:
+                self._reject_sprite_reference(
+                    tileset_name,
+                    tileset_source_path,
+                    raw_path if isinstance(raw_path, str) else repr(raw_path),
+                    "spriteId.path",
+                    "GameMaker tileset spriteId.path must be a non-empty string",
+                )
+                return None
+            resolved = self._resolve_project_source(
+                raw_path,
+                owner_source_path=tileset_source_path,
+                resource=tileset_name,
+                resource_type="tileset",
+                field="spriteId.path",
+            )
+            if resolved is None or not self._source_has_resource_kind(
+                resolved,
+                "sprites",
+                rejected_path=raw_path,
+                owner_source_path=tileset_source_path,
+                resource=tileset_name,
+                field="spriteId.path",
+            ):
+                return None
+            sprite_name = posixpath.splitext(
+                posixpath.basename(resolved.source_path)
+            )[0]
+            return sprite_name, resolved.source_path, "spriteId.path"
+
+        raw_name = sprite_id.get("name")
+        if not isinstance(raw_name, str) or not self._valid_reference_component(
+            raw_name
+        ):
+            self._reject_sprite_reference(
+                tileset_name,
+                tileset_source_path,
+                raw_name if isinstance(raw_name, str) else repr(raw_name),
+                "spriteId.name",
+                "Legacy GameMaker tileset spriteId.name must be a safe resource name",
+            )
+            return None
+
+        legacy_path = f"sprites/{raw_name}/{raw_name}.yy"
+        resolved = self._resolve_project_source(
+            legacy_path,
+            owner_source_path=tileset_source_path,
+            resource=tileset_name,
+            resource_type="tileset",
+            field="spriteId.name",
+        )
+        if resolved is None or not self._source_has_resource_kind(
+            resolved,
+            "sprites",
+            rejected_path=legacy_path,
+            owner_source_path=tileset_source_path,
+            resource=tileset_name,
+            field="spriteId.name",
+        ):
+            return None
+        return raw_name, resolved.source_path, "spriteId.name"
+
+    def _reject_sprite_reference(
+        self,
+        tileset_name: str,
+        tileset_source_path: str,
+        rejected_path: str,
+        field: str,
+        message: str,
+    ) -> None:
+        self._report_source_path_rejection(
+            rejected_path,
+            ProjectSourcePathError(f"{message}: {rejected_path!r}"),
+            owner_source_path=tileset_source_path,
+            resource=tileset_name,
+            resource_type="tileset",
+            field=field,
+        )
+
+    @staticmethod
+    def _valid_reference_component(value: str) -> bool:
+        return is_safe_project_source_component(value)
+
+    def _find_sprite_image(
+        self,
+        sprite_name: str,
+        sprite_source_path: str | None = None,
+        *,
+        tileset_name: str | None = None,
+        tileset_source_path: str | None = None,
+        sprite_reference_field: str = "spriteId.path",
+    ) -> tuple[ResolvedProjectSourcePath, str] | None:
         """Find the primary layer image for a sprite referenced by a tileset.
 
         Parses the sprite's .yy to identify the first visible layer, then
         locates the corresponding PNG under layers/{frame_guid}/{layer_guid}.png.
-        Returns the image path or None.
+        Returns the contained image source and owning sprite field, or None.
         """
-        sprite_dir = os.path.join(self.gm_project_path, 'sprites', sprite_name)
-        yy_path = os.path.join(sprite_dir, sprite_name + '.yy')
+        resource_name = tileset_name or sprite_name
+        if sprite_source_path is None:
+            if not self._valid_reference_component(sprite_name):
+                return None
+            sprite_source_path = f"sprites/{sprite_name}/{sprite_name}.yy"
+            sprite_reference_field = "spriteId.name"
+
+        resolved_sprite = self._resolve_project_source(
+            sprite_source_path,
+            owner_source_path=tileset_source_path,
+            resource=resource_name,
+            resource_type="tileset",
+            field=sprite_reference_field,
+        )
+        if resolved_sprite is None or not self._source_has_resource_kind(
+            resolved_sprite,
+            "sprites",
+            rejected_path=sprite_source_path,
+            owner_source_path=tileset_source_path or resolved_sprite.source_path,
+            resource=resource_name,
+            field=sprite_reference_field,
+        ):
+            return None
+
+        sprite_dir = os.path.dirname(resolved_sprite.filesystem_path)
+        yy_path = resolved_sprite.filesystem_path
 
         try:
             with open(yy_path, 'r', encoding='utf-8') as f:
@@ -174,40 +444,180 @@ class TileSetConverter(BaseConverter):
             data = cast(JsonDict, json.loads(cleaned))
 
             # Get the first frame GUID
-            frames = cast(list[JsonDict], data.get('frames', []))
-            if not frames:
+            raw_frames = data.get('frames', [])
+            if not isinstance(raw_frames, list) or not raw_frames:
                 return None
-            frame_guid = str(frames[0].get('name', ''))
+            raw_frame = cast(list[object], raw_frames)[0]
+            if not isinstance(raw_frame, dict):
+                self._reject_sprite_reference(
+                    resource_name,
+                    resolved_sprite.source_path,
+                    repr(raw_frame),
+                    "frames[0]",
+                    "GameMaker sprite frame reference must be an object",
+                )
+                return None
+            frame_value = cast(JsonDict, raw_frame).get('name', '')
+            if not isinstance(frame_value, str) or not self._valid_reference_component(
+                frame_value
+            ):
+                self._reject_sprite_reference(
+                    resource_name,
+                    resolved_sprite.source_path,
+                    frame_value if isinstance(frame_value, str) else repr(frame_value),
+                    "frames[0].name",
+                    "GameMaker sprite frame name must be a safe path component",
+                )
+                return None
+            frame_guid = frame_value
 
             # Get the primary visible layer GUID
-            primary_layer_guid = None
-            layers = cast(list[JsonDict], data.get('layers', []))
-            for layer in layers:
-                if layer.get('visible', True):
-                    primary_layer_guid = str(layer.get('name', ''))
-                    break
-            if primary_layer_guid is None and layers:
-                primary_layer_guid = str(layers[0].get('name', ''))
-
-            if not frame_guid or not primary_layer_guid:
+            raw_layers = data.get('layers', [])
+            if not isinstance(raw_layers, list) or not raw_layers:
+                return None
+            layers: list[tuple[int, JsonDict]] = []
+            for index, raw_layer in enumerate(cast(list[object], raw_layers)):
+                if not isinstance(raw_layer, dict):
+                    continue
+                layers.append((index, cast(JsonDict, raw_layer)))
+            if not layers:
                 return None
 
+            primary_layer: tuple[int, JsonDict] | None = None
+            for index, layer in layers:
+                if layer.get('visible', True):
+                    primary_layer = (index, layer)
+                    break
+            if primary_layer is None:
+                primary_layer = layers[0]
+
+            layer_index, layer = primary_layer
+            layer_value = layer.get('name', '')
+            if not isinstance(layer_value, str) or not self._valid_reference_component(
+                layer_value
+            ):
+                self._reject_sprite_reference(
+                    resource_name,
+                    resolved_sprite.source_path,
+                    layer_value if isinstance(layer_value, str) else repr(layer_value),
+                    f"layers[{layer_index}].name",
+                    "GameMaker sprite layer name must be a safe path component",
+                )
+                return None
+            primary_layer_guid = layer_value
+
             # Look for the image at layers/{frame_guid}/{layer_guid}.png
-            image_path = os.path.join(sprite_dir, 'layers', frame_guid, primary_layer_guid + '.png')
-            if os.path.isfile(image_path):
-                return image_path
+            layers_path = os.path.join(sprite_dir, 'layers')
+            resolved_layers = self._resolve_discovered_project_source(
+                layers_path,
+                owner_source_path=resolved_sprite.source_path,
+                resource=resource_name,
+                resource_type="tileset",
+                field="layers",
+            )
+            if resolved_layers is None:
+                return None
+
+            frame_path = os.path.join(
+                resolved_layers.filesystem_path,
+                frame_guid,
+            )
+            resolved_frame = self._resolve_discovered_project_source(
+                frame_path,
+                owner_source_path=resolved_sprite.source_path,
+                resource=resource_name,
+                resource_type="tileset",
+                field="frames[0].name",
+            )
+            if resolved_frame is None:
+                return None
+
+            image_path = os.path.join(
+                resolved_frame.filesystem_path,
+                primary_layer_guid + '.png',
+            )
+            resolved_image = self._resolve_discovered_project_source(
+                image_path,
+                owner_source_path=resolved_sprite.source_path,
+                resource=resource_name,
+                resource_type="tileset",
+                field=f"layers[{layer_index}].name",
+            )
+            if resolved_image is None:
+                return None
+            if os.path.isfile(resolved_image.filesystem_path):
+                return resolved_image, f"layers[{layer_index}].name"
 
         except (OSError, json.JSONDecodeError, KeyError, TypeError, IndexError, ValueError):
             pass
 
         # Fallback: look for any PNG in the layers directory
         layers_dir = os.path.join(sprite_dir, 'layers')
-        if os.path.isdir(layers_dir):
-            for root, _, files in os.walk(layers_dir):
-                for file in files:
-                    if file.lower().endswith('.png'):
-                        return os.path.join(root, file)
+        return self._find_fallback_sprite_png(
+            layers_dir,
+            tileset_name=resource_name,
+            sprite_source_path=resolved_sprite.source_path,
+            field="layers",
+        )
 
+    def _find_fallback_sprite_png(
+        self,
+        directory: str,
+        *,
+        tileset_name: str,
+        sprite_source_path: str,
+        field: str,
+    ) -> tuple[ResolvedProjectSourcePath, str] | None:
+        resolved_directory = self._resolve_discovered_project_source(
+            directory,
+            owner_source_path=sprite_source_path,
+            resource=tileset_name,
+            resource_type="tileset",
+            field=field,
+        )
+        if resolved_directory is None or not os.path.isdir(
+            resolved_directory.filesystem_path
+        ):
+            return None
+
+        try:
+            entries = os.listdir(resolved_directory.filesystem_path)
+        except OSError:
+            return None
+
+        resolved_entries: list[tuple[str, ResolvedProjectSourcePath]] = []
+        for entry in entries:
+            candidate = os.path.join(resolved_directory.filesystem_path, entry)
+            resolved_candidate = self._resolve_discovered_project_source(
+                candidate,
+                owner_source_path=sprite_source_path,
+                resource=tileset_name,
+                resource_type="tileset",
+                field=field,
+            )
+            if resolved_candidate is not None:
+                resolved_entries.append((entry, resolved_candidate))
+
+        for entry, resolved_candidate in resolved_entries:
+            if entry.lower().endswith('.png') and os.path.isfile(
+                resolved_candidate.filesystem_path
+            ):
+                return resolved_candidate, field
+
+        for _entry, resolved_candidate in resolved_entries:
+            if (
+                not os.path.isdir(resolved_candidate.filesystem_path)
+                or os.path.islink(resolved_candidate.filesystem_path)
+            ):
+                continue
+            image_path = self._find_fallback_sprite_png(
+                resolved_candidate.filesystem_path,
+                tileset_name=tileset_name,
+                sprite_source_path=sprite_source_path,
+                field=field,
+            )
+            if image_path is not None:
+                return image_path
         return None
 
     def _generate_tileset_tres(
@@ -276,7 +686,12 @@ class TileSetConverter(BaseConverter):
         columns = max(1, columns)
         return [(index % columns, index // columns) for index in range(tile_count)]
 
-    def _process_tileset(self, tileset_name: str, subfolder: str = "") -> TilesetResult | None:
+    def _process_tileset(
+        self,
+        tileset_name: str,
+        subfolder: str = "",
+        tileset_source_path: str | None = None,
+    ) -> TilesetResult | None:
         """Process a single tileset: parse, copy image, generate .tres.
 
         Returns a dict with conversion results, or None if stopped.
@@ -284,13 +699,27 @@ class TileSetConverter(BaseConverter):
         if not self.conversion_running():
             return None
 
-        tileset_data = self._parse_tileset_yy(tileset_name)
+        tileset_data = self._parse_tileset_yy(
+            tileset_name,
+            tileset_source_path,
+        )
         if tileset_data is None:
             return {"success": False, "name": tileset_name, "error": "parse_failed"}
 
         sprite_name = tileset_data["sprite_name"]
-        image_path = self._find_sprite_image(sprite_name)
-        if image_path is None:
+        sprite_path = tileset_data["sprite_path"]
+        image_match = (
+            self._find_sprite_image(
+                sprite_name,
+                sprite_path,
+                tileset_name=tileset_name,
+                tileset_source_path=tileset_data["source_path"],
+                sprite_reference_field=tileset_data["sprite_reference_field"],
+            )
+            if sprite_path
+            else None
+        )
+        if image_match is None:
             self._safe_log(get_localized("Console_Convertor_Tilesets_SpriteNotFound").format(
                 name=tileset_name, sprite_name=sprite_name))
             return {"success": False, "name": tileset_name, "error": "sprite_not_found",
@@ -313,7 +742,24 @@ class TileSetConverter(BaseConverter):
         # Copy the sprite image as the tileset texture
         tileset_stem = os.path.splitext(os.path.basename(tres_path))[0]
         dest_image = os.path.join(output_dir, tileset_stem + '.png')
-        shutil.copy2(image_path, dest_image)
+        image_source, image_field = image_match
+        resolved_image = self._resolve_discovered_project_source(
+            image_source.filesystem_path,
+            owner_source_path=sprite_path,
+            resource=tileset_name,
+            resource_type="tileset",
+            field=image_field,
+        )
+        if resolved_image is None or not os.path.isfile(
+            resolved_image.filesystem_path
+        ):
+            return {
+                "success": False,
+                "name": tileset_name,
+                "error": "sprite_not_found",
+                "sprite_name": sprite_name,
+            }
+        shutil.copy2(resolved_image.filesystem_path, dest_image)
 
         # Generate and write the .tres file
         tres_content = self._generate_tileset_tres(
@@ -353,31 +799,77 @@ class TileSetConverter(BaseConverter):
         os.makedirs(self.godot_project_path, exist_ok=True)
         os.makedirs(self.godot_tilesets_path, exist_ok=True)
 
-        gm_tilesets_path = os.path.join(self.gm_project_path, 'tilesets')
-
-        if not os.path.exists(gm_tilesets_path):
+        resolved_tilesets_root = self._resolve_discovered_project_source(
+            os.path.join(self.gm_project_path, 'tilesets'),
+            resource_type="tileset",
+            field="tilesets directory",
+        )
+        if (
+            resolved_tilesets_root is None
+            or not os.path.isdir(resolved_tilesets_root.filesystem_path)
+        ):
             self.log_callback(get_localized("Console_Convertor_Tilesets_Error_NotFound").format(
                 gm_project_path=self.gm_project_path))
             return
 
-        # Discover tileset directories by walking the tilesets folder
         tileset_names: list[str] = []
-        for entry in os.listdir(gm_tilesets_path):
-            entry_path = os.path.join(gm_tilesets_path, entry)
-            yy_path = os.path.join(entry_path, entry + '.yy')
-            if os.path.isdir(entry_path) and os.path.isfile(yy_path):
-                tileset_names.append(entry)
-
-        # Filter against .yyp if available
-        valid_names = self._get_valid_tileset_names()
         tileset_subfolders: dict[str, str] = {}
+        valid_names = self._get_valid_tileset_names()
         if valid_names is not None:
-            tileset_names = [n for n in tileset_names if n in valid_names]
-            tileset_subfolders = {n: valid_names[n] for n in tileset_names}
+            for name, subfolder in valid_names.items():
+                source_path = self._tileset_source_paths.get(name)
+                resolved = self._resolve_tileset_yy_source(name, source_path)
+                if resolved is None or not os.path.isfile(resolved.filesystem_path):
+                    continue
+                tileset_names.append(name)
+                tileset_subfolders[name] = subfolder
         else:
-            for name in tileset_names:
-                yy_path = os.path.join(self.gm_project_path, 'tilesets', name, name + '.yy')
-                tileset_subfolders[name] = self._get_subfolder_from_yy(yy_path)
+            for entry in os.listdir(resolved_tilesets_root.filesystem_path):
+                entry_path = os.path.join(
+                    resolved_tilesets_root.filesystem_path,
+                    entry,
+                )
+                resolved_directory = self._resolve_discovered_project_source(
+                    entry_path,
+                    owner_source_path=resolved_tilesets_root.source_path,
+                    resource=entry,
+                    resource_type="tileset",
+                    field="tileset directory",
+                )
+                if resolved_directory is None or not os.path.isdir(
+                    resolved_directory.filesystem_path
+                ):
+                    continue
+
+                yy_path = os.path.join(
+                    resolved_directory.filesystem_path,
+                    entry + '.yy',
+                )
+                resolved_yy = self._resolve_discovered_project_source(
+                    yy_path,
+                    owner_source_path=resolved_directory.source_path,
+                    resource=entry,
+                    resource_type="tileset",
+                    field="tileset .yy",
+                )
+                if (
+                    resolved_yy is None
+                    or not self._source_has_resource_kind(
+                        resolved_yy,
+                        "tilesets",
+                        rejected_path=yy_path,
+                        owner_source_path=resolved_directory.source_path,
+                        resource=entry,
+                        field="tileset .yy",
+                    )
+                    or not os.path.isfile(resolved_yy.filesystem_path)
+                ):
+                    continue
+                self._tileset_source_paths[entry] = resolved_yy.source_path
+                tileset_names.append(entry)
+                tileset_subfolders[entry] = self._get_subfolder_from_yy(
+                    resolved_yy.filesystem_path
+                )
 
         if not tileset_names:
             self.log_callback(get_localized("Console_Convertor_Tilesets_Complete"))
@@ -394,7 +886,12 @@ class TileSetConverter(BaseConverter):
 
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             futures_map: dict[Future[TilesetResult | None], str] = {
-                executor.submit(self._process_tileset, name, tileset_subfolders.get(name, "")): name
+                executor.submit(
+                    self._process_tileset,
+                    name,
+                    tileset_subfolders.get(name, ""),
+                    self._tileset_source_paths.get(name),
+                ): name
                 for name in tileset_names
             }
             for future in as_completed(futures_map):

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.1"
+VERSION = "0.7.2"
 
 
 def get_version():

--- a/tests/test_animation_curve_registry.py
+++ b/tests/test_animation_curve_registry.py
@@ -89,6 +89,39 @@ class TestAnimationCurveRegistry(unittest.TestCase):
             "extends RefCounted\n\nstatic func entries():\n\treturn []\n",
         )
 
+    def test_skips_uncontained_animation_curve_metadata_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as gm_dir, tempfile.TemporaryDirectory() as outside_dir:
+            outside_yy = os.path.join(outside_dir, "ac_outside.yy")
+            with open(outside_yy, "w", encoding="utf-8") as source_file:
+                source_file.write('{"name":"ac_outside","channels":[]}')
+            linked_dir = os.path.join(gm_dir, "animcurves", "ac_linked")
+            os.makedirs(linked_dir)
+            linked_yy = os.path.join(linked_dir, "ac_linked.yy")
+            try:
+                os.symlink(outside_yy, linked_yy)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            entries = build_animation_curve_registry_entries(
+                gm_dir,
+                (
+                    _AssetEntry(
+                        1,
+                        "ac_parent",
+                        "animcurves",
+                        "../../../outside.yy",
+                    ),
+                    _AssetEntry(
+                        2,
+                        "ac_linked",
+                        "animcurves",
+                        "animcurves/ac_linked/ac_linked.yy",
+                    ),
+                ),
+            )
+
+        self.assertEqual(entries, ())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_architecture_policy.py
+++ b/tests/test_architecture_policy.py
@@ -95,6 +95,26 @@ class TestArchitecturePolicy(unittest.TestCase):
         self.assertEqual(report["room_root"]["id"], "gm_room_node2d")
         self.assertEqual(report["renderer"]["mode"], "godot_node_scene")
 
+    def test_feature_scan_ignores_gml_file_symlink_outside_project(self) -> None:
+        self._write_minimal_project()
+        outside_source = self.temp_dir / "outside.gml"
+        _write_text(outside_source, "network_create_socket(0);")
+        linked_source = self.gm_dir / "scripts" / "linked.gml"
+        linked_source.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            linked_source.symlink_to(outside_source)
+        except (NotImplementedError, OSError) as exc:
+            self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+        report = build_architecture_policy_report(
+            str(self.gm_dir),
+            target_platform="windows",
+            enabled_converters=["scripts"],
+        )
+        features = cast(dict[str, object], report["project_features"])
+
+        self.assertEqual(features["has_network_code"], False)
+
     def _write_minimal_project(self) -> None:
         _write_json(
             self.gm_dir / "PolicyProject.yyp",

--- a/tests/test_asset_registry.py
+++ b/tests/test_asset_registry.py
@@ -7,7 +7,8 @@ import shutil
 import sys
 import tempfile
 import unittest
-from typing import Iterable
+from typing import Iterable, cast
+from unittest.mock import patch
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
@@ -17,12 +18,15 @@ from src.conversion.asset_registry import (
     ASSET_REGISTRY_RELATIVE_PATH,
     AssetRegistryConverter,
     GROUP_COMPATIBILITY_REPORT_RELATIVE_PATH,
+    _ProjectResource,
 )
 from src.conversion.animation_curve_registry import ANIMATION_CURVE_REGISTRY_RELATIVE_PATH
+from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.extension_registry import (
     EXTENSION_COMPATIBILITY_REPORT_RELATIVE_PATH,
     extension_stub_relative_script_path,
 )
+from src.conversion.fonts import FontConverter
 from src.conversion.path_registry import PATH_REGISTRY_RELATIVE_PATH
 
 
@@ -102,6 +106,7 @@ class TestAssetRegistryConverter(unittest.TestCase):
         self,
         organize_sounds_by_audio_group: bool = False,
         macro_configuration: str | None = None,
+        diagnostics: DiagnosticCollector | None = None,
     ) -> AssetRegistryConverter:
         return AssetRegistryConverter(
             self.gm_dir,
@@ -111,6 +116,7 @@ class TestAssetRegistryConverter(unittest.TestCase):
             conversion_running=lambda: True,
             organize_sounds_by_audio_group=organize_sounds_by_audio_group,
             macro_configuration=macro_configuration,
+            diagnostics=diagnostics,
         )
 
     def test_bundled_font_registry_path_matches_safe_emitted_filename(self) -> None:
@@ -134,6 +140,69 @@ class TestAssetRegistryConverter(unittest.TestCase):
 
         self.assertEqual(len(entries), 1)
         self.assertEqual(entries[0].godot_path, "res://fonts/ui/custom_font.ttf")
+
+    def test_project_root_bundled_font_paths_match_converted_outputs(self) -> None:
+        _write_yyp(
+            self.gm_dir,
+            [("fonts", "fnt_root"), ("fonts", "fnt_placeholder")],
+        )
+        references = {
+            "fnt_root": ("fonts/shared/Root.ttf", b"root font bytes"),
+            "fnt_placeholder": (
+                "${project_dir}/fonts/shared/Placeholder.ttf",
+                b"placeholder font bytes",
+            ),
+        }
+        for font_name, (reference, _payload) in references.items():
+            self._write_resource(
+                "fonts",
+                font_name,
+                "GMFont",
+                "folders/Fonts.yy",
+                {
+                    "fontName": font_name,
+                    "includeTTF": True,
+                    "TTFName": reference,
+                },
+            )
+        for reference, payload in references.values():
+            normalized_reference = reference.removeprefix("${project_dir}/")
+            font_path = os.path.join(
+                self.gm_dir,
+                *normalized_reference.split("/"),
+            )
+            os.makedirs(os.path.dirname(font_path), exist_ok=True)
+            with open(font_path, "wb") as font_file:
+                font_file.write(payload)
+
+        entries = self._converter().build_entries()
+        by_name = {entry.name: entry for entry in entries}
+
+        self.assertEqual(
+            by_name["fnt_root"].godot_path,
+            "res://fonts/root.ttf",
+        )
+        self.assertEqual(
+            by_name["fnt_placeholder"].godot_path,
+            "res://fonts/placeholder.ttf",
+        )
+
+        FontConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=lambda _message: None,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            max_workers=1,
+        ).convert_all()
+
+        for font_name, (_reference, payload) in references.items():
+            output_path = os.path.join(
+                self.godot_dir,
+                *by_name[font_name].godot_path.removeprefix("res://").split("/"),
+            )
+            with open(output_path, "rb") as font_file:
+                self.assertEqual(font_file.read(), payload)
 
     def test_builds_registry_entries_for_core_asset_types(self) -> None:
         _write_yyp(
@@ -332,6 +401,270 @@ class TestAssetRegistryConverter(unittest.TestCase):
         self.assertEqual(by_name["config/game.json"].asset_type, "included_file")
         self.assertEqual(by_name["config/game.json"].godot_path, "res://included_files/config/game.json")
 
+    def test_timeline_source_fields_resolve_owner_and_project_relative_paths(self) -> None:
+        _write_yyp(self.gm_dir, [("timelines", "tl_paths")])
+        fields = (
+            ("gmlFile", "Moment_1.gml"),
+            ("eventFile", "timelines/tl_paths/Moment_2.gml"),
+            ("filename", "${project_dir}/timelines/tl_paths/Moment_3.gml"),
+            ("source", "Moment_4.gml"),
+            ("sourceFile", r"timelines\tl_paths\Moment_5.gml"),
+        )
+        self._write_resource(
+            "timelines",
+            "tl_paths",
+            "GMTimeline",
+            "folders/Timelines.yy",
+            {
+                "momentList": [
+                    {"moment": frame, field: value}
+                    for frame, (field, value) in enumerate(fields, start=1)
+                ]
+            },
+        )
+        for frame in range(1, 6):
+            _write_file(
+                os.path.join(
+                    self.gm_dir,
+                    "timelines",
+                    "tl_paths",
+                    f"Moment_{frame}.gml",
+                ),
+                f"x = {frame};\n",
+            )
+
+        entry = self._converter().build_entries()[0]
+        assert entry.metadata is not None
+        moments = entry.metadata["moments"]
+        assert isinstance(moments, list)
+        typed_moments = cast(list[dict[str, list[dict[str, str]]]], moments)
+
+        self.assertEqual(
+            [moment["actions"][0]["source_path"] for moment in typed_moments],
+            [
+                f"timelines/tl_paths/Moment_{frame}.gml"
+                for frame in range(1, 6)
+            ],
+        )
+
+    def test_timeline_rejects_uncontained_source_fields_without_losing_actions(self) -> None:
+        _write_yyp(self.gm_dir, [("timelines", "tl_paths")])
+        timeline_directory = os.path.join(
+            self.gm_dir,
+            "timelines",
+            "tl_paths",
+        )
+        os.makedirs(timeline_directory)
+        explicit_fields = ("gmlFile", "eventFile", "filename", "source", "sourceFile")
+        expected_cases: list[tuple[int, str, str]] = []
+        moments: list[dict[str, object]] = []
+        diagnostics = DiagnosticCollector()
+
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_source = os.path.join(outside_dir, "outside.gml")
+            outside_contents = "outside_read = true;\n"
+            _write_file(outside_source, outside_contents)
+            traversal = os.path.relpath(
+                outside_source,
+                timeline_directory,
+            ).replace(os.sep, "/")
+            frame = 0
+            for field in explicit_fields:
+                linked_filename = f"linked_{field}.gml"
+                try:
+                    os.symlink(
+                        outside_source,
+                        os.path.join(timeline_directory, linked_filename),
+                    )
+                except (NotImplementedError, OSError) as exc:
+                    self.skipTest(f"Symbolic links are unavailable: {exc}")
+                unsafe_values = (
+                    ("traversal", traversal),
+                    ("posix_absolute", "/tmp/outside.gml"),
+                    ("drive_absolute", r"C:\outside.gml"),
+                    ("drive_relative", r"C:outside.gml"),
+                    ("unc", r"\\server\share\outside.gml"),
+                    ("nul", "invalid\0source.gml"),
+                    ("external_file_symlink", linked_filename),
+                )
+                for case_name, value in unsafe_values:
+                    frame += 1
+                    expected_cases.append((frame, field, case_name))
+                    moments.append(
+                        {
+                            "moment": frame,
+                            field: value,
+                            "actions": [
+                                {"script": f"scr_keep_{frame}"},
+                                {"callable": f"callable_keep_{frame}"},
+                            ],
+                        }
+                    )
+
+            self._write_resource(
+                "timelines",
+                "tl_paths",
+                "GMTimeline",
+                "folders/Timelines.yy",
+                {"momentList": moments},
+            )
+            converter = self._converter(diagnostics=diagnostics)
+            with patch("builtins.open", wraps=open) as tracked_open:
+                entry = converter.build_entries()[0]
+                converter._write_timeline_action_scripts((entry,))
+
+            outside_accesses = [
+                call
+                for call in tracked_open.call_args_list
+                if call.args
+                and isinstance(call.args[0], (str, os.PathLike))
+                and os.path.realpath(os.fspath(call.args[0]))
+                == os.path.realpath(outside_source)
+            ]
+            self.assertEqual(outside_accesses, [])
+            with open(outside_source, "r", encoding="utf-8") as outside_file:
+                self.assertEqual(outside_file.read(), outside_contents)
+
+        assert entry.metadata is not None
+        raw_moments = entry.metadata["moments"]
+        assert isinstance(raw_moments, list)
+        typed_moments = cast(list[dict[str, object]], raw_moments)
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+
+        self.assertEqual(len(typed_moments), len(expected_cases))
+        for moment, (frame, field, case_name) in zip(
+            typed_moments,
+            expected_cases,
+            strict=True,
+        ):
+            with self.subTest(field=field, case=case_name):
+                self.assertEqual(moment["frame"], frame)
+                self.assertEqual(
+                    moment["actions"],
+                    [
+                        {"kind": "script", "script": f"scr_keep_{frame}"},
+                        {
+                            "kind": "callable",
+                            "callable": f"callable_keep_{frame}",
+                        },
+                    ],
+                )
+                self.assertFalse(
+                    os.path.exists(
+                        os.path.join(
+                            self.godot_dir,
+                            "gm2godot",
+                            "timelines",
+                            f"tl_paths_{frame}.gd",
+                        )
+                    )
+                )
+        self.assertEqual(len(rejected), len(expected_cases))
+        self.assertTrue(
+            all(
+                diagnostic.source_path == "timelines/tl_paths/tl_paths.yy"
+                and diagnostic.resource == "tl_paths"
+                and diagnostic.resource_type == "timeline"
+                for diagnostic in rejected
+            )
+        )
+        self.assertEqual(
+            [diagnostic.manifest_entry for diagnostic in rejected],
+            [field for _frame, field, _case_name in expected_cases],
+        )
+
+    def test_timeline_disk_discovery_skips_directory_link_outside_project(self) -> None:
+        _write_yyp(self.gm_dir, [])
+        diagnostics = DiagnosticCollector()
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_timeline = os.path.join(outside_dir, "tl_paths")
+            _write_file(
+                os.path.join(outside_timeline, "Moment_7.gml"),
+                "x = 7;\n",
+            )
+            linked_directory = os.path.join(
+                self.gm_dir,
+                "timelines",
+                "tl_paths",
+            )
+            os.makedirs(os.path.dirname(linked_directory))
+            try:
+                os.symlink(outside_timeline, linked_directory)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+            owner_source_path = "timelines/tl_owner/tl_paths.yy"
+            _write_json(
+                os.path.join(self.gm_dir, *owner_source_path.split("/")),
+                _minimal_yy(
+                    "tl_paths",
+                    "GMTimeline",
+                    "folders/Timelines.yy",
+                ),
+            )
+            resource = _ProjectResource(
+                kind="timelines",
+                name="tl_paths",
+                yy_path=os.path.join(linked_directory, "tl_paths.yy"),
+                source_path=owner_source_path,
+                raw_data={},
+            )
+
+            actions = self._converter(
+                diagnostics=diagnostics,
+            )._timeline_discovered_source_actions(resource)
+
+        self.assertEqual(actions, [])
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertEqual(rejected[0].source_path, resource.source_path)
+        self.assertEqual(rejected[0].resource, resource.name)
+        self.assertEqual(rejected[0].resource_type, "timeline")
+        self.assertEqual(rejected[0].manifest_entry, "timeline source directory")
+
+    def test_timeline_disk_discovery_skips_file_link_outside_project(self) -> None:
+        _write_yyp(self.gm_dir, [("timelines", "tl_paths")])
+        self._write_resource(
+            "timelines",
+            "tl_paths",
+            "GMTimeline",
+            "folders/Timelines.yy",
+        )
+        diagnostics = DiagnosticCollector()
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_source = os.path.join(outside_dir, "Moment_7.gml")
+            _write_file(outside_source, "x = 7;\n")
+            linked_source = os.path.join(
+                self.gm_dir,
+                "timelines",
+                "tl_paths",
+                "Moment_7.gml",
+            )
+            try:
+                os.symlink(outside_source, linked_source)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            entry = self._converter(diagnostics=diagnostics).build_entries()[0]
+
+        assert entry.metadata is not None
+        self.assertEqual(entry.metadata["moments"], [])
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertEqual(rejected[0].source_path, "timelines/tl_paths/tl_paths.yy")
+        self.assertEqual(rejected[0].manifest_entry, "discovered timeline moment source")
+
     def test_static_ids_are_stable_across_yyp_resource_order(self) -> None:
         resources = [("sprites", "s_player"), ("sounds", "snd_jump")]
         _write_yyp(self.gm_dir, resources)
@@ -423,25 +756,870 @@ class TestAssetRegistryConverter(unittest.TestCase):
                 "resourceType": "GMProject",
             },
         )
+        diagnostics = DiagnosticCollector()
 
-        entries = self._converter().build_entries()
+        entries = self._converter(diagnostics=diagnostics).build_entries()
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
 
         self.assertEqual([entry.name for entry in entries], ["s_player"])
+        self.assertEqual(
+            [
+                (
+                    diagnostic.source_path,
+                    diagnostic.resource,
+                    diagnostic.resource_type,
+                    diagnostic.manifest_entry,
+                )
+                for diagnostic in rejected
+            ],
+            [
+                (
+                    "AssetRegistryTest.yyp",
+                    "s_traversal",
+                    "GMSprite",
+                    "resources[1].id.path",
+                ),
+                (
+                    "AssetRegistryTest.yyp",
+                    "s_absolute",
+                    "project",
+                    "resources[2].id.path",
+                ),
+            ],
+        )
         self.assertTrue(
             any(
-                "s_traversal" in message
-                and "escapes the selected GameMaker project root" in message
+                "escapes the selected GameMaker project root" in message
                 for message in self.logs
             ),
             self.logs,
         )
         self.assertTrue(
             any(
-                "s_absolute" in message and "must be relative" in message
+                "must be relative" in message
                 for message in self.logs
             ),
             self.logs,
         )
+
+    def test_malformed_yyp_resource_paths_are_diagnosed_without_rereading_yyp(
+        self,
+    ) -> None:
+        self._write_resource(
+            "sprites",
+            "s_safe",
+            "GMSprite",
+            "folders/Sprites.yy",
+        )
+        self._write_resource(
+            "rooms",
+            "r_safe",
+            "GMRoom",
+            "folders/Rooms.yy",
+        )
+        yyp_path = os.path.join(self.gm_dir, "AssetRegistryTest.yyp")
+        malformed_entries: list[dict[str, object]] = [
+            {"id": {"name": "s_missing"}, "resourceType": "GMSprite"},
+            {
+                "id": {"name": "s_null", "path": None},
+                "resourceType": "GMSprite",
+            },
+            {
+                "id": {"name": "s_empty", "path": ""},
+                "resourceType": "GMSprite",
+            },
+            {
+                "id": {"name": "s_non_string", "path": 7},
+                "resourceType": "GMSprite",
+            },
+        ]
+        _write_json(
+            yyp_path,
+            {
+                "resources": [
+                    *malformed_entries,
+                    _resource_entry("sprites", "s_safe"),
+                    _resource_entry("rooms", "r_safe"),
+                ],
+                "RoomOrderNodes": [
+                    {
+                        "roomId": {
+                            "name": "r_safe",
+                            "path": "rooms/r_safe/r_safe.yy",
+                        }
+                    }
+                ],
+                "resourceType": "GMProject",
+            },
+        )
+        diagnostics = DiagnosticCollector()
+
+        with patch("builtins.open", wraps=open) as tracked_open:
+            entries = self._converter(diagnostics=diagnostics).build_entries()
+
+        self.assertEqual(
+            {entry.name for entry in entries},
+            {"r_safe", "s_safe"},
+        )
+        yyp_reads = [
+            call
+            for call in tracked_open.call_args_list
+            if call.args
+            and isinstance(call.args[0], str)
+            and os.path.realpath(call.args[0]) == os.path.realpath(yyp_path)
+        ]
+        self.assertEqual(len(yyp_reads), 1, yyp_reads)
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), len(malformed_entries), rejected)
+        self.assertEqual(
+            {diagnostic.resource for diagnostic in rejected},
+            {"s_empty", "s_missing", "s_non_string", "s_null"},
+        )
+        self.assertTrue(
+            all(
+                diagnostic.source_path == "AssetRegistryTest.yyp"
+                and diagnostic.manifest_entry
+                == f"resources[{index}].id.path"
+                for index, diagnostic in enumerate(rejected)
+            )
+        )
+
+    def test_manifest_path_cannot_normalize_into_another_resource_family(
+        self,
+    ) -> None:
+        wrong_family_path = os.path.join(
+            self.gm_dir,
+            "objects",
+            "o_cross_family",
+            "o_cross_family.yy",
+        )
+        _write_json(
+            wrong_family_path,
+            _minimal_yy(
+                "o_cross_family",
+                "GMObject",
+                "folders/Objects.yy",
+            ),
+        )
+        self._write_resource(
+            "scripts",
+            "scr_safe",
+            "GMScript",
+            "folders/Scripts.yy",
+        )
+        _write_json(
+            os.path.join(self.gm_dir, "AssetRegistryTest.yyp"),
+            {
+                "resources": [
+                    {
+                        "id": {
+                            "name": "o_cross_family",
+                            "path": (
+                                "scripts/../objects/o_cross_family/"
+                                "o_cross_family.yy"
+                            ),
+                        }
+                    },
+                    _resource_entry("scripts", "scr_safe"),
+                ],
+                "RoomOrderNodes": [],
+                "resourceType": "GMProject",
+            },
+        )
+        diagnostics = DiagnosticCollector()
+        converter = self._converter(diagnostics=diagnostics)
+        read_paths: list[str] = []
+        original_read = converter._read_yy_file
+
+        def tracking_read(path: str) -> dict[str, object] | None:
+            read_paths.append(os.path.realpath(path))
+            return original_read(path)
+
+        with patch.object(converter, "_read_yy_file", side_effect=tracking_read):
+            entries = converter.build_entries()
+
+        self.assertEqual([entry.name for entry in entries], ["scr_safe"])
+        self.assertNotIn(os.path.realpath(wrong_family_path), read_paths)
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "AssetRegistryTest.yyp")
+        self.assertEqual(rejected[0].resource, "o_cross_family")
+        self.assertEqual(rejected[0].resource_type, "script")
+        self.assertEqual(
+            rejected[0].manifest_entry,
+            "resources[0].id.path",
+        )
+
+    def test_declared_resource_and_preferred_script_paths_are_authoritative(self) -> None:
+        declared_source_path = "scripts/custom/location/source.yy"
+        _write_json(
+            os.path.join(self.gm_dir, "AssetRegistryTest.yyp"),
+            {
+                "resources": [
+                    {
+                        "id": {
+                            "name": "scr_declared",
+                            "path": declared_source_path,
+                        }
+                    }
+                ],
+                "RoomOrderNodes": [],
+                "resourceType": "GMProject",
+            },
+        )
+        script_metadata = _minimal_yy(
+            "scr_declared",
+            "GMScript",
+            "folders/Scripts/Declared.yy",
+        )
+        _write_json(
+            os.path.join(self.gm_dir, *declared_source_path.split("/")),
+            script_metadata,
+        )
+        _write_file(
+            os.path.join(
+                self.gm_dir,
+                "scripts",
+                "custom",
+                "location",
+                "scr_declared.gml",
+            ),
+            "function from_declared_source() { return 41; }\n",
+        )
+        _write_json(
+            os.path.join(
+                self.gm_dir,
+                "scripts",
+                "scr_declared",
+                "scr_declared.yy",
+            ),
+            script_metadata,
+        )
+        _write_file(
+            os.path.join(
+                self.gm_dir,
+                "scripts",
+                "scr_declared",
+                "scr_declared.gml",
+            ),
+            "function from_reconstructed_source() { return 99; }\n",
+        )
+
+        entries = self._converter().build_entries()
+        by_name = {entry.name: entry for entry in entries}
+
+        self.assertEqual(by_name["scr_declared"].source_path, declared_source_path)
+        self.assertIn("from_declared_source", by_name)
+        self.assertNotIn("from_reconstructed_source", by_name)
+        self.assertEqual(
+            by_name["from_declared_source"].metadata,
+            {
+                "script_function": True,
+                "script_asset": "scr_declared",
+                "script_source_path": declared_source_path,
+            },
+        )
+
+    def test_script_fallback_revalidates_sources_and_links_diagnostic_to_yy(self) -> None:
+        declared_source_path = "scripts/custom/location/source.yy"
+        _write_json(
+            os.path.join(self.gm_dir, "AssetRegistryTest.yyp"),
+            {
+                "resources": [
+                    {
+                        "id": {
+                            "name": "scr_fallback",
+                            "path": declared_source_path,
+                        }
+                    }
+                ],
+                "RoomOrderNodes": [],
+                "resourceType": "GMProject",
+            },
+        )
+        script_directory = os.path.join(
+            self.gm_dir,
+            "scripts",
+            "custom",
+            "location",
+        )
+        _write_json(
+            os.path.join(script_directory, "source.yy"),
+            _minimal_yy(
+                "scr_fallback",
+                "GMScript",
+                "folders/Scripts/Declared.yy",
+            ),
+        )
+        _write_file(
+            os.path.join(script_directory, "z_valid.gml"),
+            "function from_valid_fallback() { return 7; }\n",
+        )
+        diagnostics = DiagnosticCollector()
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_source = os.path.join(outside_dir, "a_external.gml")
+            _write_file(
+                outside_source,
+                "function from_external_fallback() { return 99; }\n",
+            )
+            try:
+                os.symlink(
+                    outside_source,
+                    os.path.join(script_directory, "a_external.gml"),
+                )
+                os.symlink(
+                    outside_source,
+                    os.path.join(script_directory, "scr_fallback.gml"),
+                )
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            entries = self._converter(diagnostics=diagnostics).build_entries()
+
+        names = {entry.name for entry in entries}
+        self.assertIn("from_valid_fallback", names)
+        self.assertNotIn("from_external_fallback", names)
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 2)
+        self.assertTrue(
+            all(
+                diagnostic.source_path == declared_source_path
+                and diagnostic.resource == "scr_fallback"
+                and diagnostic.resource_type == "script"
+                for diagnostic in rejected
+            )
+        )
+        self.assertEqual(
+            {diagnostic.manifest_entry for diagnostic in rejected},
+            {"preferred script source", "discovered script source"},
+        )
+
+    def test_script_name_alias_cannot_select_normalized_preferred_source(
+        self,
+    ) -> None:
+        owner_source_path = "scripts/owner/custom.yy"
+        owner_path = os.path.join(
+            self.gm_dir,
+            *owner_source_path.split("/"),
+        )
+        _write_json(
+            owner_path,
+            _minimal_yy(
+                "nested/../safe",
+                "GMScript",
+                "folders/Scripts.yy",
+            ),
+        )
+        alias_target = os.path.join(
+            self.gm_dir,
+            "scripts",
+            "owner",
+            "safe.gml",
+        )
+        safe_fallback = os.path.join(
+            self.gm_dir,
+            "scripts",
+            "owner",
+            "z_fallback.gml",
+        )
+        _write_file(
+            alias_target,
+            "function from_normalized_alias() { return 99; }\n",
+        )
+        _write_file(
+            safe_fallback,
+            "function from_safe_fallback() { return 7; }\n",
+        )
+        diagnostics = DiagnosticCollector()
+        resource = _ProjectResource(
+            kind="scripts",
+            name="nested/../safe",
+            yy_path=owner_path,
+            source_path=owner_source_path,
+            raw_data={},
+        )
+
+        selected = self._converter(
+            diagnostics=diagnostics,
+        )._script_source_gml_path(resource)
+
+        self.assertEqual(selected, safe_fallback)
+        self.assertNotEqual(selected, alias_target)
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, owner_source_path)
+        self.assertEqual(rejected[0].resource, "nested/../safe")
+        self.assertEqual(rejected[0].resource_type, "script")
+        self.assertEqual(
+            rejected[0].manifest_entry,
+            "preferred script source",
+        )
+
+    def test_manifest_resource_symlink_is_skipped_with_yyp_diagnostic(self) -> None:
+        declared_source_path = "sprites/linked/custom.yy"
+        _write_json(
+            os.path.join(self.gm_dir, "AssetRegistryTest.yyp"),
+            {
+                "resources": [
+                    {
+                        "id": {
+                            "name": "s_external",
+                            "path": declared_source_path,
+                        }
+                    }
+                ],
+                "RoomOrderNodes": [],
+                "resourceType": "GMProject",
+            },
+        )
+        diagnostics = DiagnosticCollector()
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_yy = os.path.join(outside_dir, "custom.yy")
+            _write_json(
+                outside_yy,
+                _minimal_yy(
+                    "s_external",
+                    "GMSprite",
+                    "folders/Sprites.yy",
+                ),
+            )
+            linked_yy = os.path.join(
+                self.gm_dir,
+                *declared_source_path.split("/"),
+            )
+            os.makedirs(os.path.dirname(linked_yy), exist_ok=True)
+            try:
+                os.symlink(outside_yy, linked_yy)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            entries = self._converter(diagnostics=diagnostics).build_entries()
+
+        self.assertEqual(entries, ())
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertEqual(rejected[0].source_path, "AssetRegistryTest.yyp")
+        self.assertEqual(rejected[0].resource, "s_external")
+        self.assertEqual(rejected[0].resource_type, "GMSprite")
+        self.assertEqual(rejected[0].manifest_entry, "resources[0].id.path")
+
+    def test_included_file_registry_does_not_follow_directory_symlinks(
+        self,
+    ) -> None:
+        real_directory = os.path.join(self.gm_dir, "datafiles", "real")
+        payload_path = os.path.join(real_directory, "payload.txt")
+        _write_file(payload_path, "contained payload")
+        alias_directory = os.path.join(self.gm_dir, "datafiles", "alias")
+        try:
+            os.symlink(real_directory, alias_directory)
+        except (NotImplementedError, OSError) as exc:
+            self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+        entries = self._converter().build_entries()
+        included_entries = [
+            entry for entry in entries if entry.kind == "included_files"
+        ]
+
+        self.assertEqual(len(included_entries), 1)
+        self.assertEqual(
+            included_entries[0].source_path,
+            "datafiles/real/payload.txt",
+        )
+        self.assertEqual(
+            included_entries[0].godot_path,
+            "res://included_files/real/payload.txt",
+        )
+
+    def test_project_yyp_link_is_rejected_before_disk_fallback(self) -> None:
+        self._write_resource(
+            "sprites",
+            "s_local",
+            "GMSprite",
+            "folders/Sprites.yy",
+        )
+        diagnostics = DiagnosticCollector()
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_yyp = os.path.join(outside_dir, "External.yyp")
+            _write_json(outside_yyp, {"resources": []})
+            try:
+                os.symlink(
+                    outside_yyp,
+                    os.path.join(self.gm_dir, "External.yyp"),
+                )
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            entries = self._converter(diagnostics=diagnostics).build_entries()
+
+        self.assertEqual([entry.name for entry in entries], ["s_local"])
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertIsNone(rejected[0].source_path)
+        self.assertEqual(rejected[0].resource_type, "project")
+        self.assertEqual(rejected[0].manifest_entry, "External.yyp")
+
+    def test_disk_fallback_revalidates_resource_directory_and_yy_links(self) -> None:
+        self._write_resource(
+            "sprites",
+            "s_local",
+            "GMSprite",
+            "folders/Sprites.yy",
+        )
+        linked_yy_directory = os.path.join(
+            self.gm_dir,
+            "sprites",
+            "s_linked_yy",
+        )
+        os.makedirs(linked_yy_directory)
+        diagnostics = DiagnosticCollector()
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_resource_directory = os.path.join(outside_dir, "s_linked_dir")
+            os.makedirs(outside_resource_directory)
+            _write_json(
+                os.path.join(outside_resource_directory, "s_linked_dir.yy"),
+                _minimal_yy(
+                    "s_linked_dir",
+                    "GMSprite",
+                    "folders/Sprites.yy",
+                ),
+            )
+            outside_yy = os.path.join(outside_dir, "s_linked_yy.yy")
+            _write_json(
+                outside_yy,
+                _minimal_yy(
+                    "s_linked_yy",
+                    "GMSprite",
+                    "folders/Sprites.yy",
+                ),
+            )
+            try:
+                os.symlink(
+                    outside_resource_directory,
+                    os.path.join(self.gm_dir, "sprites", "s_linked_dir"),
+                )
+                os.symlink(
+                    outside_yy,
+                    os.path.join(linked_yy_directory, "s_linked_yy.yy"),
+                )
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            entries = self._converter(diagnostics=diagnostics).build_entries()
+
+        self.assertEqual([entry.name for entry in entries], ["s_local"])
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(
+            {
+                (
+                    diagnostic.source_path,
+                    diagnostic.resource,
+                    diagnostic.resource_type,
+                    diagnostic.manifest_entry,
+                )
+                for diagnostic in rejected
+            },
+            {
+                (
+                    "sprites",
+                    "s_linked_dir",
+                    "sprite",
+                    "disk fallback resource directory",
+                ),
+                (
+                    "sprites/s_linked_yy",
+                    "s_linked_yy",
+                    "sprite",
+                    "disk fallback resource metadata",
+                ),
+            },
+        )
+
+    def test_disk_fallback_validates_canonical_resource_family_before_read(
+        self,
+    ) -> None:
+        self._write_resource(
+            "sprites",
+            "s_local",
+            "GMSprite",
+            "folders/Sprites.yy",
+        )
+        same_family_target = os.path.join(
+            self.gm_dir,
+            "sprites",
+            "targets",
+            "shared.yy",
+        )
+        cross_family_target = os.path.join(
+            self.gm_dir,
+            "objects",
+            "targets",
+            "shared.yy",
+        )
+        _write_json(
+            same_family_target,
+            _minimal_yy(
+                "s_alias_target",
+                "GMSprite",
+                "folders/Sprites.yy",
+            ),
+        )
+        _write_json(
+            cross_family_target,
+            _minimal_yy(
+                "o_cross_target",
+                "GMObject",
+                "folders/Objects.yy",
+            ),
+        )
+        same_family_alias = os.path.join(
+            self.gm_dir,
+            "sprites",
+            "s_alias",
+            "s_alias.yy",
+        )
+        cross_family_alias = os.path.join(
+            self.gm_dir,
+            "sprites",
+            "s_cross",
+            "s_cross.yy",
+        )
+        os.makedirs(os.path.dirname(same_family_alias))
+        os.makedirs(os.path.dirname(cross_family_alias))
+        try:
+            os.symlink(same_family_target, same_family_alias)
+            os.symlink(cross_family_target, cross_family_alias)
+        except (NotImplementedError, OSError) as exc:
+            self.skipTest(f"Symbolic links are unavailable: {exc}")
+        diagnostics = DiagnosticCollector()
+        converter = self._converter(diagnostics=diagnostics)
+        read_paths: list[str] = []
+        original_read = converter._read_yy_file
+
+        def tracking_read(path: str) -> dict[str, object] | None:
+            read_paths.append(os.path.realpath(path))
+            return original_read(path)
+
+        with patch.object(converter, "_read_yy_file", side_effect=tracking_read):
+            resources = converter._resources_from_disk()
+
+        self.assertEqual(
+            {resource.name for resource in resources},
+            {"s_alias", "s_local"},
+        )
+        self.assertIn(os.path.realpath(same_family_target), read_paths)
+        self.assertNotIn(os.path.realpath(cross_family_target), read_paths)
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "sprites/s_cross")
+        self.assertEqual(rejected[0].resource, "s_cross")
+        self.assertEqual(rejected[0].resource_type, "sprite")
+        self.assertEqual(
+            rejected[0].manifest_entry,
+            "disk fallback resource metadata",
+        )
+
+    def test_disk_fallback_revalidates_kind_directory_link(self) -> None:
+        self._write_resource(
+            "objects",
+            "o_local",
+            "GMObject",
+            "folders/Objects.yy",
+        )
+        diagnostics = DiagnosticCollector()
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_sprites = os.path.join(outside_dir, "sprites")
+            _write_json(
+                os.path.join(outside_sprites, "s_external", "s_external.yy"),
+                _minimal_yy(
+                    "s_external",
+                    "GMSprite",
+                    "folders/Sprites.yy",
+                ),
+            )
+            try:
+                os.symlink(
+                    outside_sprites,
+                    os.path.join(self.gm_dir, "sprites"),
+                )
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            entries = self._converter(diagnostics=diagnostics).build_entries()
+
+        self.assertEqual([entry.name for entry in entries], ["o_local"])
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertIsNone(rejected[0].source_path)
+        self.assertEqual(rejected[0].resource_type, "sprite")
+        self.assertEqual(
+            rejected[0].manifest_entry,
+            "disk fallback kind directory",
+        )
+
+    def test_datafiles_discovery_preserves_targets_and_rejects_links(self) -> None:
+        _write_file(
+            os.path.join(self.gm_dir, "datafiles", "config", "game.json"),
+            "{}",
+        )
+        diagnostics = DiagnosticCollector()
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_file = os.path.join(outside_dir, "external.txt")
+            outside_subdirectory = os.path.join(outside_dir, "external_directory")
+            _write_file(outside_file, "external")
+            os.makedirs(outside_subdirectory)
+            _write_file(os.path.join(outside_subdirectory, "hidden.txt"), "hidden")
+            try:
+                os.symlink(
+                    outside_file,
+                    os.path.join(self.gm_dir, "datafiles", "escape.txt"),
+                )
+                os.symlink(
+                    outside_subdirectory,
+                    os.path.join(self.gm_dir, "datafiles", "external"),
+                )
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            entries = self._converter(diagnostics=diagnostics).build_entries()
+
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].name, "config/game.json")
+        self.assertEqual(entries[0].source_path, "datafiles/config/game.json")
+        self.assertEqual(
+            entries[0].godot_path,
+            "res://included_files/config/game.json",
+        )
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 2)
+        self.assertTrue(
+            all(
+                diagnostic.source_path == "datafiles"
+                and diagnostic.resource_type == "included_file"
+                and diagnostic.manifest_entry == "discovered datafiles entry"
+                for diagnostic in rejected
+            )
+        )
+
+    def test_sound_output_uses_resolved_basename_and_rejects_escape(self) -> None:
+        safe_yy_source = "sounds/declared/safe/custom.yy"
+        unsafe_yy_source = "sounds/declared/unsafe/custom.yy"
+        _write_json(
+            os.path.join(self.gm_dir, "AssetRegistryTest.yyp"),
+            {
+                "resources": [
+                    {
+                        "id": {
+                            "name": "snd_safe",
+                            "path": safe_yy_source,
+                        }
+                    },
+                    {
+                        "id": {
+                            "name": "snd_unsafe",
+                            "path": unsafe_yy_source,
+                        }
+                    },
+                ],
+                "RoomOrderNodes": [],
+                "resourceType": "GMProject",
+            },
+        )
+        _write_json(
+            os.path.join(self.gm_dir, *safe_yy_source.split("/")),
+            _minimal_yy(
+                "snd_safe",
+                "GMSound",
+                "folders/Sounds/Safe.yy",
+                {
+                    "soundFile": (
+                        "${project_dir}/sounds/shared/theme.final.ogg"
+                    )
+                },
+            ),
+        )
+        _write_file(
+            os.path.join(
+                self.gm_dir,
+                "sounds",
+                "shared",
+                "theme.final.ogg",
+            ),
+            "audio",
+        )
+        _write_json(
+            os.path.join(self.gm_dir, *unsafe_yy_source.split("/")),
+            _minimal_yy(
+                "snd_unsafe",
+                "GMSound",
+                "folders/Sounds/Unsafe.yy",
+                {"soundFile": "../../../../../outside/escape.wav"},
+            ),
+        )
+        diagnostics = DiagnosticCollector()
+
+        entries = self._converter(diagnostics=diagnostics).build_entries()
+        by_name = {entry.name: entry for entry in entries}
+
+        self.assertEqual(
+            by_name["snd_safe"].godot_path,
+            "res://sounds/safe/snd_safe/theme.final.ogg",
+        )
+        self.assertNotIn("shared", by_name["snd_safe"].godot_path)
+        self.assertEqual(by_name["snd_unsafe"].godot_path, "")
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertEqual(rejected[0].source_path, unsafe_yy_source)
+        self.assertEqual(rejected[0].resource, "snd_unsafe")
+        self.assertEqual(rejected[0].resource_type, "sound")
+        self.assertEqual(rejected[0].manifest_entry, "soundFile")
 
     def test_build_entries_includes_modern_script_function_assets(self) -> None:
         _write_yyp(self.gm_dir, [("scripts", "ending")])

--- a/tests/test_base_converter.py
+++ b/tests/test_base_converter.py
@@ -15,6 +15,13 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from src.conversion.base_converter import BaseConverter
+from src.conversion.diagnostics import DiagnosticCollector
+from src.conversion.project_manifest import (
+    GameMakerProjectManifest,
+    ProjectManifestDiagnostic,
+    ProjectSourceLocation,
+    load_gamemaker_project_manifest,
+)
 
 
 class TestBaseConverterAbstract(unittest.TestCase):
@@ -65,6 +72,178 @@ class TestBaseConverterDefaults(unittest.TestCase):
         """When conversion_running is not provided it should default to a callable returning True."""
         self.assertTrue(callable(self.converter.conversion_running))
         self.assertTrue(self.converter.conversion_running())
+
+    def test_source_path_rejection_is_structured_and_owner_linked(self) -> None:
+        class StubConverter(BaseConverter):
+            def convert_all(self) -> None:
+                pass
+
+        with tempfile.TemporaryDirectory() as root:
+            messages: list[str] = []
+            diagnostics = DiagnosticCollector()
+            converter = StubConverter(
+                root,
+                os.path.join(root, "godot"),
+                log_callback=diagnostics.wrap_log_callback(messages.append),
+                diagnostics=diagnostics,
+            )
+
+            resolved = converter._resolve_project_source(
+                "../../../outside.gml",
+                owner_source_path="rooms/r_test/r_test.yy",
+                resource="r_test",
+                resource_type="room",
+                field="creationCodeFile",
+            )
+
+            self.assertIsNone(resolved)
+            diagnostic = diagnostics.diagnostics()[0]
+            self.assertEqual(diagnostic.code, "GM2GD-SOURCE-PATH-REJECTED")
+            self.assertEqual(diagnostic.source_path, "rooms/r_test/r_test.yy")
+            self.assertEqual(diagnostic.resource, "r_test")
+            self.assertEqual(diagnostic.resource_type, "room")
+            self.assertEqual(diagnostic.manifest_entry, "creationCodeFile")
+            self.assertEqual(len(diagnostics.diagnostics()), 1)
+            self.assertEqual(len(messages), 1)
+            self.assertIn("Warning: Rejected GameMaker source path", messages[0])
+
+
+class TestProjectManifestSourcePathDiagnosticBridge(unittest.TestCase):
+    class StubConverter(BaseConverter):
+        def convert_all(self) -> None:
+            pass
+
+    def test_logs_and_returns_rejected_fields_without_collector(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            with open(
+                os.path.join(root, "Manifest.yyp"),
+                "w",
+                encoding="utf-8",
+            ) as yyp_file:
+                yyp_file.write(
+                    '{"resources":[{"id":{"name":"snd_bad",'
+                    '"path":"sounds/../../outside.yy"},'
+                    '"resourceType":"GMSound"}]}'
+                )
+            manifest = load_gamemaker_project_manifest(root)
+            messages: list[str] = []
+            converter = self.StubConverter(
+                root,
+                os.path.join(root, "godot"),
+                log_callback=messages.append,
+            )
+
+            rejected_fields = (
+                converter._record_project_manifest_source_path_diagnostics(
+                    manifest,
+                    resource_type="sound",
+                )
+            )
+
+        self.assertEqual(
+            rejected_fields,
+            frozenset({"resources[0].id.path"}),
+        )
+        self.assertEqual(len(messages), 1, messages)
+        self.assertIn("Rejected GameMaker source path", messages[0])
+
+    def test_unknown_resource_diagnostic_is_project_typed_and_order_independent(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            with open(
+                os.path.join(root, "Manifest.yyp"),
+                "w",
+                encoding="utf-8",
+            ) as yyp_file:
+                yyp_file.write(
+                    '{"resources":[{"id":{"name":"unknown",'
+                    '"path":"../../outside.yy"}}]}'
+                )
+            manifest = load_gamemaker_project_manifest(root)
+
+            for resource_order in (("sound", "shader"), ("shader", "sound")):
+                with self.subTest(resource_order=resource_order):
+                    diagnostics = DiagnosticCollector()
+                    messages: list[str] = []
+                    returned_fields: list[frozenset[str]] = []
+                    for resource_type in resource_order:
+                        converter = self.StubConverter(
+                            root,
+                            os.path.join(root, "godot"),
+                            log_callback=messages.append,
+                            diagnostics=diagnostics,
+                        )
+                        returned_fields.append(
+                            converter._record_project_manifest_source_path_diagnostics(
+                                manifest,
+                                resource_type=resource_type,
+                            )
+                        )
+
+                    emitted = diagnostics.diagnostics()
+                    self.assertEqual(len(emitted), 1, emitted)
+                    self.assertEqual(emitted[0].resource_type, "project")
+                    self.assertEqual(
+                        emitted[0].manifest_entry,
+                        "resources[0].id.path",
+                    )
+                    self.assertEqual(len(messages), 1, messages)
+                    self.assertEqual(
+                        returned_fields,
+                        [
+                            frozenset({"resources[0].id.path"}),
+                            frozenset({"resources[0].id.path"}),
+                        ],
+                    )
+
+    def test_project_sources_require_explicit_bridge_opt_in(self) -> None:
+        manifest = GameMakerProjectManifest(
+            project_name="",
+            yyp_path=None,
+            diagnostics=(
+                ProjectManifestDiagnostic(
+                    severity="warning",
+                    code="GM2GD-SOURCE-PATH-REJECTED",
+                    message="Rejected external project source",
+                    source=ProjectSourceLocation(
+                        path="AOutside.yyp",
+                        line=1,
+                        field_path="AOutside.yyp",
+                    ),
+                ),
+            ),
+        )
+        with tempfile.TemporaryDirectory() as root:
+            diagnostics = DiagnosticCollector()
+            messages: list[str] = []
+            converter = self.StubConverter(
+                root,
+                os.path.join(root, "godot"),
+                log_callback=messages.append,
+                diagnostics=diagnostics,
+            )
+
+            default_fields = (
+                converter._record_project_manifest_source_path_diagnostics(
+                    manifest
+                )
+            )
+            included_fields = (
+                converter._record_project_manifest_source_path_diagnostics(
+                    manifest,
+                    resource_type="sprite",
+                    include_project_sources=True,
+                )
+            )
+
+        self.assertEqual(default_fields, frozenset())
+        self.assertEqual(included_fields, frozenset({"AOutside.yyp"}))
+        emitted = diagnostics.diagnostics()
+        self.assertEqual(len(emitted), 1, emitted)
+        self.assertEqual(emitted[0].resource_type, "project")
+        self.assertEqual(emitted[0].manifest_entry, "AOutside.yyp")
+        self.assertEqual(messages, ["Rejected external project source"])
 
 
 class TestBaseConverterThreadSafety(unittest.TestCase):
@@ -189,8 +368,8 @@ class TestReadYYFile(unittest.TestCase):
             def convert_all(self) -> None:
                 pass
 
-        self.converter: BaseConverter = StubConverter("/gm", "/godot")
         self.tmp_dir = tempfile.mkdtemp()
+        self.converter: BaseConverter = StubConverter(self.tmp_dir, "/godot")
 
     def tearDown(self):
         shutil.rmtree(self.tmp_dir)
@@ -222,6 +401,16 @@ class TestReadYYFile(unittest.TestCase):
         result = self.converter._read_yy_file(yy_path)
         self.assertIsNone(result)
 
+    def test_does_not_read_valid_json_outside_project(self):
+        with tempfile.TemporaryDirectory() as outside_dir:
+            yy_path = os.path.join(outside_dir, "outside.yy")
+            with open(yy_path, "w", encoding="utf-8") as source_file:
+                source_file.write('{"outside": true}')
+
+            result = self.converter._read_yy_file(yy_path)
+
+        self.assertIsNone(result)
+
 
 class TestGetSubfolderFromYY(unittest.TestCase):
     """Test _get_subfolder_from_yy() extraction of IDE folder paths."""
@@ -231,8 +420,8 @@ class TestGetSubfolderFromYY(unittest.TestCase):
             def convert_all(self) -> None:
                 pass
 
-        self.converter: BaseConverter = StubConverter("/gm", "/godot")
         self.tmp_dir = tempfile.mkdtemp()
+        self.converter: BaseConverter = StubConverter(self.tmp_dir, "/godot")
 
     def tearDown(self):
         shutil.rmtree(self.tmp_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,7 @@ class TestCLIReports(unittest.TestCase):
             exit_code = cli.main(["--version"])
 
         self.assertEqual(exit_code, 0)
-        self.assertEqual(output.getvalue().strip(), "GM2Godot 0.7.1")
+        self.assertEqual(output.getvalue().strip(), "GM2Godot 0.7.2")
 
     def test_list_converters_writes_text_inventory(self) -> None:
         output = io.StringIO()
@@ -108,7 +108,7 @@ class TestCLIReports(unittest.TestCase):
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.strip(), "GM2Godot 0.7.1")
+        self.assertEqual(result.stdout.strip(), "GM2Godot 0.7.2")
 
     def test_app_entrypoint_routes_global_cli_flags(self) -> None:
         app_entrypoint = importlib.import_module("main")

--- a/tests/test_conversion_architecture.py
+++ b/tests/test_conversion_architecture.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 import os
+import json
+import shutil
+import tempfile
 import unittest
 
 from src.conversion.conversion_plan import (
@@ -111,6 +114,160 @@ class TestResourceModels(unittest.TestCase):
         self.assertIn(("GM2GD-RESOURCE-YY-MISSING", "spr_missing"), diagnostics)
         self.assertEqual(models.project.resource_count, 1)
         self.assertEqual(models.sprites, ())
+
+    def test_resource_model_rejects_manifest_path_outside_project(self) -> None:
+        project_dir = tempfile.mkdtemp()
+        try:
+            with open(
+                os.path.join(project_dir, "Unsafe.yyp"),
+                "w",
+                encoding="utf-8",
+            ) as project_file:
+                json.dump(
+                    {
+                        "%Name": "Unsafe",
+                        "resourceType": "GMProject",
+                        "resources": [
+                            {
+                                "id": {
+                                    "name": "scr_outside",
+                                    "path": "scripts/../../../outside.yy",
+                                }
+                            }
+                        ],
+                    },
+                    project_file,
+                )
+
+            models = parse_gamemaker_resource_models(project_dir)
+
+            rejected = [
+                diagnostic
+                for diagnostic in models.diagnostics
+                if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+            ]
+            self.assertEqual(models.scripts, ())
+            self.assertEqual(len(rejected), 1)
+            self.assertEqual(rejected[0].resource_name, "scr_outside")
+            self.assertEqual(rejected[0].source_path, os.path.join(project_dir, "Unsafe.yyp"))
+        finally:
+            shutil.rmtree(project_dir)
+
+    def test_resource_model_rejects_path_normalized_into_another_kind(self) -> None:
+        project_dir = tempfile.mkdtemp()
+        try:
+            resource_dir = os.path.join(project_dir, "objects", "o_cross")
+            os.makedirs(resource_dir)
+            yyp_path = os.path.join(project_dir, "CrossKind.yyp")
+            with open(yyp_path, "w", encoding="utf-8") as project_file:
+                json.dump(
+                    {
+                        "%Name": "CrossKind",
+                        "resourceType": "GMProject",
+                        "resources": [
+                            {
+                                "id": {
+                                    "name": "s_cross",
+                                    "path": "sprites/../objects/o_cross/o_cross.yy",
+                                }
+                            }
+                        ],
+                    },
+                    project_file,
+                )
+            with open(
+                os.path.join(resource_dir, "o_cross.yy"),
+                "w",
+                encoding="utf-8",
+            ) as resource_file:
+                json.dump(
+                    {
+                        "%Name": "o_cross",
+                        "resourceType": "GMObject",
+                    },
+                    resource_file,
+                )
+
+            models = parse_gamemaker_resource_models(project_dir)
+
+            rejected = [
+                diagnostic
+                for diagnostic in models.diagnostics
+                if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+            ]
+            self.assertEqual(models.sprites, ())
+            self.assertEqual(len(rejected), 1)
+            self.assertEqual(rejected[0].source_path, yyp_path)
+            self.assertEqual(rejected[0].resource_name, "s_cross")
+            self.assertEqual(rejected[0].resource_kind, "sprites")
+        finally:
+            shutil.rmtree(project_dir)
+
+    def test_resource_model_rejects_script_sidecar_link_outside_project(self) -> None:
+        project_dir = tempfile.mkdtemp()
+        outside_dir = tempfile.mkdtemp()
+        try:
+            script_dir = os.path.join(project_dir, "scripts", "scr_linked")
+            os.makedirs(script_dir)
+            with open(
+                os.path.join(project_dir, "Linked.yyp"),
+                "w",
+                encoding="utf-8",
+            ) as project_file:
+                json.dump(
+                    {
+                        "%Name": "Linked",
+                        "resourceType": "GMProject",
+                        "resources": [
+                            {
+                                "id": {
+                                    "name": "scr_linked",
+                                    "path": "scripts/scr_linked/scr_linked.yy",
+                                },
+                                "resourceType": "GMScript",
+                            }
+                        ],
+                    },
+                    project_file,
+                )
+            with open(
+                os.path.join(script_dir, "scr_linked.yy"),
+                "w",
+                encoding="utf-8",
+            ) as resource_file:
+                json.dump(
+                    {
+                        "%Name": "scr_linked",
+                        "resourceType": "GMScript",
+                    },
+                    resource_file,
+                )
+            outside_source = os.path.join(outside_dir, "scr_linked.gml")
+            with open(outside_source, "w", encoding="utf-8") as source_file:
+                source_file.write("return 42;\n")
+            try:
+                os.symlink(
+                    outside_source,
+                    os.path.join(script_dir, "scr_linked.gml"),
+                )
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            models = parse_gamemaker_resource_models(project_dir)
+
+            self.assertEqual(len(models.scripts), 1)
+            self.assertIsNone(models.scripts[0].gml_path)
+            rejected = [
+                diagnostic
+                for diagnostic in models.diagnostics
+                if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+            ]
+            self.assertEqual(len(rejected), 1)
+            self.assertEqual(rejected[0].resource_name, "scr_linked")
+            self.assertEqual(rejected[0].resource_kind, "scripts")
+        finally:
+            shutil.rmtree(project_dir)
+            shutil.rmtree(outside_dir)
 
 
 class TestGMLPipelineBoundaries(unittest.TestCase):

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -67,6 +67,39 @@ class TestDiagnosticCollector(unittest.TestCase):
         self.assertEqual(diagnostic.resource_type, "object")
         self.assertEqual(diagnostic.event, "_ready")
 
+    def test_exact_structured_duplicates_are_deduped(self):
+        diagnostics = DiagnosticCollector()
+
+        diagnostics.add(
+            "warning",
+            "GM2GD-SOURCE-PATH-REJECTED",
+            "Warning: Rejected GameMaker source path '../outside.wav'.",
+            source_path="sounds/snd_test/snd_test.yy",
+            resource="snd_test",
+            resource_type="sound",
+            manifest_entry="soundFile",
+        )
+        diagnostics.add(
+            "warning",
+            "GM2GD-SOURCE-PATH-REJECTED",
+            "Warning: Rejected GameMaker source path '../outside.wav'.",
+            source_path="sounds/snd_test/snd_test.yy",
+            resource="snd_test",
+            resource_type="sound",
+            manifest_entry="soundFile",
+        )
+        diagnostics.add(
+            "warning",
+            "GM2GD-SOURCE-PATH-REJECTED",
+            "Warning: Rejected GameMaker source path '../outside.wav'.",
+            source_path="sounds/snd_test/snd_test.yy",
+            resource="snd_other",
+            resource_type="sound",
+            manifest_entry="soundFile",
+        )
+
+        self.assertEqual(len(diagnostics.diagnostics()), 2)
+
     def test_reports_are_written_as_deterministic_json_and_markdown(self):
         tmp_dir = tempfile.mkdtemp()
         try:

--- a/tests/test_extension_registry.py
+++ b/tests/test_extension_registry.py
@@ -7,6 +7,7 @@ import sys
 import tempfile
 import textwrap
 import unittest
+from unittest.mock import patch
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
@@ -21,6 +22,9 @@ from src.conversion.extension_registry import (
     render_extension_stub_script,
     write_extension_compatibility_outputs,
 )
+from src.conversion.diagnostics import DiagnosticCollector
+from src.conversion.project_source_paths import ResolvedProjectSourcePath
+import src.conversion.extension_registry as extension_registry
 
 
 def _write_file(path: str, content: str) -> None:
@@ -33,10 +37,46 @@ class TestExtensionRegistry(unittest.TestCase):
     def setUp(self) -> None:
         self.gm_dir = tempfile.mkdtemp()
         self.godot_dir = tempfile.mkdtemp()
+        self.outside_dir = tempfile.mkdtemp()
 
     def tearDown(self) -> None:
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
+        shutil.rmtree(self.outside_dir)
+
+    @staticmethod
+    def _write_minimal_extension(path: str, name: str) -> None:
+        _write_file(
+            path,
+            json.dumps(
+                {
+                    "name": name,
+                    "files": [
+                        {
+                            "filename": "native.dll",
+                            "functions": [{"name": "extension_call"}],
+                        }
+                    ],
+                    "resourceType": "GMExtension",
+                }
+            ),
+        )
+
+    @staticmethod
+    def _source_path_rejections(
+        diagnostics: DiagnosticCollector,
+    ):
+        return [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+
+    def _make_symlink(self, target: str, link_path: str) -> None:
+        try:
+            os.symlink(target, link_path)
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
 
     def _write_extension(self, folder_name: str = "AdSDK", display_name: str = "AdSDK") -> None:
         _write_file(
@@ -173,6 +213,220 @@ class TestExtensionRegistry(unittest.TestCase):
         with open(plugin_path, "r", encoding="utf-8") as f:
             plugin = f.read()
         self.assertIn('script="ad_sdk_extension.gd"', plugin)
+
+    def test_rejects_extensions_root_symlink_outside_project(self) -> None:
+        outside_extensions = os.path.join(self.outside_dir, "extensions")
+        self._write_minimal_extension(
+            os.path.join(outside_extensions, "Outside", "Outside.yy"),
+            "Outside",
+        )
+        self._make_symlink(
+            outside_extensions,
+            os.path.join(self.gm_dir, "extensions"),
+        )
+        diagnostics = DiagnosticCollector()
+        logs: list[str] = []
+
+        entries = build_extension_entries(
+            self.gm_dir,
+            diagnostics=diagnostics,
+            log_callback=logs.append,
+        )
+
+        self.assertEqual(entries, ())
+        rejected = self._source_path_rejections(diagnostics)
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "extensions")
+        self.assertEqual(rejected[0].resource, "extensions")
+        self.assertEqual(rejected[0].manifest_entry, "extensions directory")
+        self.assertEqual(logs, [rejected[0].message])
+
+    def test_rejects_extension_directory_symlink_outside_project(self) -> None:
+        os.makedirs(os.path.join(self.gm_dir, "extensions"))
+        outside_extension = os.path.join(self.outside_dir, "ExternalSDK")
+        self._write_minimal_extension(
+            os.path.join(outside_extension, "ExternalSDK.yy"),
+            "ExternalSDK",
+        )
+        self._make_symlink(
+            outside_extension,
+            os.path.join(self.gm_dir, "extensions", "ExternalSDK"),
+        )
+        diagnostics = DiagnosticCollector()
+
+        entries = build_extension_entries(
+            self.gm_dir,
+            diagnostics=diagnostics,
+        )
+
+        self.assertEqual(entries, ())
+        rejected = self._source_path_rejections(diagnostics)
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "extensions/ExternalSDK")
+        self.assertEqual(rejected[0].resource, "ExternalSDK")
+        self.assertEqual(rejected[0].manifest_entry, "extension directory")
+
+    def test_rejects_extension_metadata_symlink_outside_project(self) -> None:
+        extension_dir = os.path.join(self.gm_dir, "extensions", "ExternalSDK")
+        os.makedirs(extension_dir)
+        outside_yy = os.path.join(self.outside_dir, "ExternalSDK.yy")
+        self._write_minimal_extension(outside_yy, "ExternalSDK")
+        self._make_symlink(
+            outside_yy,
+            os.path.join(extension_dir, "ExternalSDK.yy"),
+        )
+        diagnostics = DiagnosticCollector()
+
+        entries = build_extension_entries(
+            self.gm_dir,
+            diagnostics=diagnostics,
+        )
+
+        self.assertEqual(entries, ())
+        rejected = self._source_path_rejections(diagnostics)
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(
+            rejected[0].source_path,
+            "extensions/ExternalSDK/ExternalSDK.yy",
+        )
+        self.assertEqual(rejected[0].manifest_entry, "extension metadata")
+
+    def test_rejects_extension_metadata_symlink_to_contained_wrong_family(
+        self,
+    ) -> None:
+        wrong_family_target = os.path.join(
+            self.gm_dir,
+            "objects",
+            "o_extension_decoy",
+            "o_extension_decoy.yy",
+        )
+        self._write_minimal_extension(wrong_family_target, "WrongFamilySDK")
+
+        linked_name = "LinkedSDK"
+        linked_metadata = os.path.join(
+            self.gm_dir,
+            "extensions",
+            linked_name,
+            linked_name + ".yy",
+        )
+        os.makedirs(os.path.dirname(linked_metadata), exist_ok=True)
+        self._make_symlink(wrong_family_target, linked_metadata)
+
+        safe_name = "SafeSDK"
+        self._write_minimal_extension(
+            os.path.join(
+                self.gm_dir,
+                "extensions",
+                safe_name,
+                safe_name + ".yy",
+            ),
+            safe_name,
+        )
+        diagnostics = DiagnosticCollector()
+
+        with patch("builtins.open", wraps=open) as tracked_open:
+            entries = build_extension_entries(
+                self.gm_dir,
+                diagnostics=diagnostics,
+            )
+
+        self.assertEqual([entry.name for entry in entries], [safe_name])
+        opened_paths = {
+            os.path.realpath(call.args[0])
+            for call in tracked_open.call_args_list
+            if call.args and isinstance(call.args[0], str)
+        }
+        self.assertNotIn(os.path.realpath(wrong_family_target), opened_paths)
+        rejected = self._source_path_rejections(diagnostics)
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(
+            rejected[0].source_path,
+            f"extensions/{linked_name}/{linked_name}.yy",
+        )
+        self.assertEqual(rejected[0].resource, linked_name)
+        self.assertEqual(rejected[0].manifest_entry, "extension metadata")
+
+    def test_rejects_external_extension_mapping_symlink(self) -> None:
+        self._write_extension()
+        outside_mapping = os.path.join(
+            self.outside_dir,
+            "gm2godot_extension_functions.json",
+        )
+        _write_file(
+            outside_mapping,
+            json.dumps(
+                {"functions": {"ads_show_rewarded": "AdBridge.show"}}
+            ),
+        )
+        self._make_symlink(
+            outside_mapping,
+            os.path.join(
+                self.gm_dir,
+                "gm2godot_extension_functions.json",
+            ),
+        )
+        diagnostics = DiagnosticCollector()
+
+        report_path = write_extension_compatibility_outputs(
+            self.gm_dir,
+            self.godot_dir,
+            diagnostics=diagnostics,
+        )
+
+        with open(report_path, "r", encoding="utf-8") as report_file:
+            report = json.load(report_file)
+        self.assertEqual(report["mapped_functions"], [])
+        rejected = self._source_path_rejections(diagnostics)
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(
+            rejected[0].source_path,
+            "gm2godot_extension_functions.json",
+        )
+        self.assertEqual(
+            rejected[0].manifest_entry,
+            "extension function mapping",
+        )
+
+    def test_revalidates_extension_metadata_immediately_before_read(self) -> None:
+        yy_path = os.path.join(
+            self.gm_dir,
+            "extensions",
+            "SwapSDK",
+            "SwapSDK.yy",
+        )
+        self._write_minimal_extension(yy_path, "SafeSDK")
+        outside_yy = os.path.join(self.outside_dir, "SwapSDK.yy")
+        self._write_minimal_extension(outside_yy, "OutsideSDK")
+        diagnostics = DiagnosticCollector()
+        real_resolver = extension_registry.resolve_project_filesystem_source_path
+        metadata_resolutions = 0
+
+        def _swap_before_revalidation(
+            project_root: str,
+            candidate: str,
+        ) -> ResolvedProjectSourcePath:
+            nonlocal metadata_resolutions
+            if os.path.abspath(candidate) == os.path.abspath(yy_path):
+                metadata_resolutions += 1
+                if metadata_resolutions == 2:
+                    os.unlink(yy_path)
+                    self._make_symlink(outside_yy, yy_path)
+            return real_resolver(project_root, candidate)
+
+        with patch(
+            "src.conversion.extension_registry.resolve_project_filesystem_source_path",
+            side_effect=_swap_before_revalidation,
+        ):
+            entries = build_extension_entries(
+                self.gm_dir,
+                diagnostics=diagnostics,
+            )
+
+        self.assertEqual(metadata_resolutions, 2)
+        self.assertEqual(entries, ())
+        rejected = self._source_path_rejections(diagnostics)
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].manifest_entry, "extension metadata")
 
 
 if __name__ == "__main__":

--- a/tests/test_fonts.py
+++ b/tests/test_fonts.py
@@ -18,6 +18,7 @@ from src.conversion.asset_output_paths import (
     build_asset_output_paths,
     resource_filesystem_path,
 )
+from src.conversion.diagnostics import ConversionDiagnostic, DiagnosticCollector
 
 
 FontYY: TypeAlias = dict[str, object]
@@ -313,6 +314,500 @@ class TestFontConverterTTFMissing(unittest.TestCase):
         self.assertEqual(warning_logs, [])
 
 
+class TestFontConverterSourcePathContainment(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.outside_dir = tempfile.mkdtemp()
+        self.logs: list[str] = []
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+        shutil.rmtree(self.outside_dir)
+
+    def _make_converter(
+        self,
+        diagnostics: DiagnosticCollector | None = None,
+    ) -> FontConverter:
+        return FontConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=self.logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            max_workers=1,
+            diagnostics=diagnostics,
+        )
+
+    def _write_font_at(
+        self,
+        relative_path: str,
+        font_name: str,
+        overrides: FontYY | None = None,
+    ) -> str:
+        yy_path = os.path.join(self.gm_dir, *relative_path.split("/"))
+        os.makedirs(os.path.dirname(yy_path), exist_ok=True)
+        data = dict(MINIMAL_FONT_YY)
+        data["name"] = font_name
+        data["%Name"] = font_name
+        if overrides:
+            data.update(overrides)
+        with open(yy_path, "w", encoding="utf-8") as yy_file:
+            json.dump(data, yy_file)
+        return yy_path
+
+    def _write_yyp(self, resources: list[tuple[str, str]]) -> None:
+        with open(
+            os.path.join(self.gm_dir, "FontPaths.yyp"),
+            "w",
+            encoding="utf-8",
+        ) as project_file:
+            json.dump(
+                {
+                    "resources": [
+                        {"id": {"name": name, "path": path}}
+                        for name, path in resources
+                    ],
+                    "resourceType": "GMProject",
+                },
+                project_file,
+            )
+
+    @staticmethod
+    def _rejections(
+        diagnostics: DiagnosticCollector,
+    ) -> list[ConversionDiagnostic]:
+        return [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+
+    @patch("src.conversion.fonts._find_system_font", return_value=None)
+    def test_uses_exact_declared_nested_font_yy_path(
+        self,
+        _find_system_font: Mock,
+    ) -> None:
+        declared_yy = self._write_font_at(
+            "fonts/nested/custom_font.yy",
+            "fnt_declared",
+            {"fontName": "DeclaredNestedFamily"},
+        )
+        _make_font_yy(
+            self.gm_dir,
+            "fnt_declared",
+            {"fontName": "ReconstructedDecoyFamily"},
+        )
+        self._write_yyp(
+            [("fnt_declared", "fonts/nested/custom_font.yy")]
+        )
+        diagnostics = DiagnosticCollector()
+        converter = self._make_converter(diagnostics)
+
+        self.assertEqual(converter.find_font_files(), [declared_yy])
+        converter.convert_all()
+
+        output_path = os.path.join(
+            self.godot_dir,
+            "fonts",
+            "fnt_declared.tres",
+        )
+        with open(output_path, "r", encoding="utf-8") as output_file:
+            output = output_file.read()
+        self.assertIn("DeclaredNestedFamily", output)
+        self.assertNotIn("ReconstructedDecoyFamily", output)
+        self.assertEqual(self._rejections(diagnostics), [])
+
+    @patch("src.conversion.fonts._find_system_font", return_value=None)
+    def test_rejects_normalized_cross_family_manifest_path_and_keeps_safe_sibling(
+        self,
+        _find_system_font: Mock,
+    ) -> None:
+        font_name = "fnt_cross_family"
+        self._write_font_at(
+            "sprites/fnt_cross_family/decoy.yy",
+            font_name,
+            {"fontName": "CrossFamilyDecoy"},
+        )
+        safe_yy = self._write_font_at(
+            "fonts/fnt_cross_family/safe.yy",
+            font_name,
+            {"fontName": "SafeFontFamily"},
+        )
+        self._write_yyp(
+            [
+                (
+                    font_name,
+                    "fonts/../sprites/fnt_cross_family/decoy.yy",
+                ),
+                (font_name, "fonts/fnt_cross_family/safe.yy"),
+            ]
+        )
+        diagnostics = DiagnosticCollector()
+        converter = self._make_converter(diagnostics)
+
+        self.assertEqual(converter.find_font_files(), [safe_yy])
+        converter.convert_all()
+
+        output_path = os.path.join(
+            self.godot_dir,
+            "fonts",
+            font_name + ".tres",
+        )
+        with open(output_path, "r", encoding="utf-8") as output_file:
+            output = output_file.read()
+        self.assertIn("SafeFontFamily", output)
+        self.assertNotIn("CrossFamilyDecoy", output)
+        rejected = self._rejections(diagnostics)
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "FontPaths.yyp")
+        self.assertEqual(rejected[0].resource, font_name)
+        self.assertEqual(rejected[0].resource_type, "font")
+        self.assertEqual(
+            rejected[0].manifest_entry,
+            "resources[0].id.path",
+        )
+
+    @patch("src.conversion.fonts._find_system_font", return_value=None)
+    def test_copies_normal_owner_relative_bundled_font(
+        self,
+        _find_system_font: Mock,
+    ) -> None:
+        yy_path = _make_font_yy(
+            self.gm_dir,
+            "fnt_owner_relative",
+            {
+                "fontName": "OwnerRelativeFamily",
+                "includeTTF": True,
+                "TTFName": "bundled/Owner Relative.otf",
+            },
+        )
+        bundled_path = os.path.join(
+            os.path.dirname(yy_path),
+            "bundled",
+            "Owner Relative.otf",
+        )
+        os.makedirs(os.path.dirname(bundled_path))
+        with open(bundled_path, "wb") as bundled_file:
+            bundled_file.write(b"owner-relative font")
+        diagnostics = DiagnosticCollector()
+
+        self._make_converter(diagnostics).convert_all()
+
+        output_path = os.path.join(
+            self.godot_dir,
+            "fonts",
+            "owner_relative.otf",
+        )
+        with open(output_path, "rb") as output_file:
+            self.assertEqual(output_file.read(), b"owner-relative font")
+        self.assertEqual(self._rejections(diagnostics), [])
+
+    def test_rejects_disk_fallback_font_directory_link(self) -> None:
+        outside_resource = os.path.join(self.outside_dir, "fnt_dir_link")
+        os.makedirs(outside_resource)
+        data = dict(MINIMAL_FONT_YY)
+        data["name"] = "fnt_dir_link"
+        with open(
+            os.path.join(outside_resource, "fnt_dir_link.yy"),
+            "w",
+            encoding="utf-8",
+        ) as yy_file:
+            json.dump(data, yy_file)
+        fonts_directory = os.path.join(self.gm_dir, "fonts")
+        os.makedirs(fonts_directory)
+        try:
+            os.symlink(
+                outside_resource,
+                os.path.join(fonts_directory, "fnt_dir_link"),
+            )
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+        diagnostics = DiagnosticCollector()
+
+        font_files = self._make_converter(diagnostics).find_font_files()
+
+        self.assertEqual(font_files, [])
+        rejected = self._rejections(diagnostics)
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "fonts")
+        self.assertEqual(rejected[0].resource, "fnt_dir_link")
+        self.assertEqual(
+            rejected[0].manifest_entry,
+            "discovered font directory",
+        )
+
+    def test_rejects_disk_fallback_font_yy_link(self) -> None:
+        outside_yy = os.path.join(self.outside_dir, "fnt_yy_link.yy")
+        data = dict(MINIMAL_FONT_YY)
+        data["name"] = "fnt_yy_link"
+        with open(outside_yy, "w", encoding="utf-8") as yy_file:
+            json.dump(data, yy_file)
+        font_directory = os.path.join(
+            self.gm_dir,
+            "fonts",
+            "fnt_yy_link",
+        )
+        os.makedirs(font_directory)
+        try:
+            os.symlink(
+                outside_yy,
+                os.path.join(font_directory, "fnt_yy_link.yy"),
+            )
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+        diagnostics = DiagnosticCollector()
+
+        font_files = self._make_converter(diagnostics).find_font_files()
+
+        self.assertEqual(font_files, [])
+        rejected = self._rejections(diagnostics)
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "fonts/fnt_yy_link")
+        self.assertEqual(rejected[0].resource, "fnt_yy_link")
+        self.assertEqual(rejected[0].manifest_entry, "discovered font .yy")
+
+    @patch("src.conversion.fonts._find_system_font", return_value=None)
+    def test_disk_fallback_rejects_contained_cross_family_font_yy_link(
+        self,
+        _find_system_font: Mock,
+    ) -> None:
+        linked_name = "fnt_cross_family_link"
+        wrong_family_yy = self._write_font_at(
+            "sprites/wrong_font/target.yy",
+            linked_name,
+            {"fontName": "WrongFamilyMarker"},
+        )
+        linked_directory = os.path.join(self.gm_dir, "fonts", linked_name)
+        os.makedirs(linked_directory)
+        safe_yy = self._write_font_at(
+            "fonts/fnt_safe_sibling/fnt_safe_sibling.yy",
+            "fnt_safe_sibling",
+            {"fontName": "SafeSiblingMarker"},
+        )
+        try:
+            os.symlink(
+                wrong_family_yy,
+                os.path.join(linked_directory, linked_name + ".yy"),
+            )
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+        diagnostics = DiagnosticCollector()
+        converter = self._make_converter(diagnostics)
+
+        self.assertEqual(converter.find_font_files(), [safe_yy])
+        converter.convert_all()
+
+        safe_output = os.path.join(
+            self.godot_dir,
+            "fonts",
+            "fnt_safe_sibling.tres",
+        )
+        with open(safe_output, "r", encoding="utf-8") as output_file:
+            output = output_file.read()
+        self.assertIn("SafeSiblingMarker", output)
+        self.assertNotIn("WrongFamilyMarker", output)
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(self.godot_dir, "fonts", linked_name + ".tres")
+            )
+        )
+        rejected = self._rejections(diagnostics)
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, f"fonts/{linked_name}")
+        self.assertEqual(rejected[0].resource, linked_name)
+        self.assertEqual(rejected[0].resource_type, "font")
+        self.assertEqual(rejected[0].manifest_entry, "discovered font .yy")
+
+    @patch("src.conversion.fonts._find_system_font", return_value=None)
+    def test_rejects_bundled_font_file_link_outside_project(
+        self,
+        _find_system_font: Mock,
+    ) -> None:
+        yy_path = _make_font_yy(
+            self.gm_dir,
+            "fnt_file_link",
+            {
+                "fontName": "LinkedFamily",
+                "includeTTF": True,
+                "TTFName": "LinkedFont.ttf",
+            },
+        )
+        outside_font = os.path.join(self.outside_dir, "LinkedFont.ttf")
+        with open(outside_font, "wb") as font_file:
+            font_file.write(b"outside project font")
+        try:
+            os.symlink(
+                outside_font,
+                os.path.join(os.path.dirname(yy_path), "LinkedFont.ttf"),
+            )
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+        diagnostics = DiagnosticCollector()
+
+        self._make_converter(diagnostics).convert_all()
+
+        self.assertTrue(
+            os.path.isfile(
+                os.path.join(
+                    self.godot_dir,
+                    "fonts",
+                    "fnt_file_link.tres",
+                )
+            )
+        )
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(self.godot_dir, "fonts", "linked_font.ttf")
+            )
+        )
+        rejected = self._rejections(diagnostics)
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(
+            rejected[0].source_path,
+            "fonts/fnt_file_link/fnt_file_link.yy",
+        )
+        self.assertEqual(rejected[0].resource, "fnt_file_link")
+        self.assertEqual(rejected[0].resource_type, "font")
+        self.assertEqual(rejected[0].manifest_entry, "TTFName")
+
+    @patch("src.conversion.fonts._find_system_font", return_value=None)
+    def test_revalidates_bundled_font_immediately_before_copy(
+        self,
+        _find_system_font: Mock,
+    ) -> None:
+        yy_path = _make_font_yy(
+            self.gm_dir,
+            "fnt_late_swap",
+            {
+                "fontName": "LateSwapFamily",
+                "includeTTF": True,
+                "TTFName": "LateSwap.ttf",
+            },
+        )
+        bundled_path = os.path.join(os.path.dirname(yy_path), "LateSwap.ttf")
+        with open(bundled_path, "wb") as bundled_file:
+            bundled_file.write(b"contained font")
+        outside_font = os.path.join(self.outside_dir, "LateSwap.ttf")
+        with open(outside_font, "wb") as outside_file:
+            outside_file.write(b"outside font")
+        probe_link = os.path.join(self.gm_dir, "font_symlink_probe")
+        try:
+            os.symlink(outside_font, probe_link)
+            os.unlink(probe_link)
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+        diagnostics = DiagnosticCollector()
+        converter = self._make_converter(diagnostics)
+        real_output_destination = converter._font_output_destination
+
+        def swap_before_copy(
+            source_yy_path: str,
+            font_name: str,
+            output_filename: str,
+        ) -> str:
+            destination = real_output_destination(
+                source_yy_path,
+                font_name,
+                output_filename,
+            )
+            os.unlink(bundled_path)
+            os.symlink(outside_font, bundled_path)
+            return destination
+
+        with patch.object(
+            converter,
+            "_font_output_destination",
+            side_effect=swap_before_copy,
+        ):
+            result = converter._process_font(yy_path)
+
+        self.assertIs(result, False)
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(self.godot_dir, "fonts", "late_swap.ttf")
+            )
+        )
+        rejected = self._rejections(diagnostics)
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(
+            rejected[0].source_path,
+            "fonts/fnt_late_swap/fnt_late_swap.yy",
+        )
+        self.assertEqual(rejected[0].manifest_entry, "TTFName")
+
+    @patch("src.conversion.fonts._find_system_font", return_value=None)
+    def test_rejects_malformed_ttf_name_forms_with_owner_diagnostics(
+        self,
+        _find_system_font: Mock,
+    ) -> None:
+        outside_font = os.path.join(self.outside_dir, "Outside.ttf")
+        with open(outside_font, "wb") as font_file:
+            font_file.write(b"outside")
+        malformed_names = {
+            "fnt_traversal": os.path.relpath(
+                outside_font,
+                os.path.join(self.gm_dir, "fonts", "fnt_traversal"),
+            ),
+            "fnt_absolute": outside_font,
+            "fnt_drive_absolute": r"C:\Games\Outside\Font.ttf",
+            "fnt_drive_relative": r"C:Outside\Font.ttf",
+            "fnt_unc": r"\\server\share\Font.ttf",
+            "fnt_nul": "bad\0Font.ttf",
+            "fnt_empty_segment": "nested//Font.ttf",
+            "fnt_parent_segment": "nested/../Font.ttf",
+            "fnt_wrong_extension": "Font.txt",
+        }
+        yy_paths = {
+            font_name: _make_font_yy(
+                self.gm_dir,
+                font_name,
+                {
+                    "fontName": "UnavailableFamily",
+                    "includeTTF": True,
+                    "TTFName": ttf_name,
+                },
+            )
+            for font_name, ttf_name in malformed_names.items()
+        }
+        diagnostics = DiagnosticCollector()
+        converter = self._make_converter(diagnostics)
+
+        for font_name, yy_path in yy_paths.items():
+            with self.subTest(font_name=font_name):
+                self.assertEqual(converter._process_font(yy_path), font_name)
+                self.assertTrue(
+                    os.path.isfile(
+                        os.path.join(
+                            self.godot_dir,
+                            "fonts",
+                            font_name + ".tres",
+                        )
+                    )
+                )
+
+        rejected = self._rejections(diagnostics)
+        self.assertEqual(len(rejected), len(malformed_names), rejected)
+        self.assertEqual(
+            {diagnostic.source_path for diagnostic in rejected},
+            {
+                f"fonts/{font_name}/{font_name}.yy"
+                for font_name in malformed_names
+            },
+        )
+        self.assertEqual(
+            {diagnostic.resource for diagnostic in rejected},
+            set(malformed_names),
+        )
+        self.assertTrue(
+            all(diagnostic.resource_type == "font" for diagnostic in rejected)
+        )
+        self.assertTrue(
+            all(diagnostic.manifest_entry == "TTFName" for diagnostic in rejected)
+        )
+
+
 class TestFontConverterSystemFontLookup(unittest.TestCase):
     """Test that fonts found on the system are copied as font files."""
 
@@ -337,16 +832,22 @@ class TestFontConverterSystemFontLookup(unittest.TestCase):
     @patch('src.conversion.fonts._get_system_font_dirs')
     def test_copies_system_font(self, mock_dirs: Mock) -> None:
         mock_dirs.return_value = [self.fake_font_dir]
+        diagnostics = DiagnosticCollector()
         converter = FontConverter(
             self.gm_dir, self.godot_dir,
             log_callback=lambda msg: self.logs.append(msg),
             progress_callback=lambda v: None,
             conversion_running=lambda: True,
+            diagnostics=diagnostics,
         )
         converter.convert_all()
         expected = os.path.join(self.godot_dir, "fonts", "fnt_sysfont.ttf")
         self.assertTrue(os.path.isfile(expected),
                         f"Expected system font copied to {expected}")
+        self.assertEqual(
+            TestFontConverterSourcePathContainment._rejections(diagnostics),
+            [],
+        )
 
     @patch('src.conversion.fonts._get_system_font_dirs')
     def test_no_tres_when_system_font_found(self, mock_dirs: Mock) -> None:

--- a/tests/test_included_files.py
+++ b/tests/test_included_files.py
@@ -1,14 +1,19 @@
+# pyright: reportPrivateUsage=false
+
 import os
 import sys
 import shutil
 import tempfile
 import unittest
+from unittest.mock import patch
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from src.conversion.included_files import IncludedFilesConverter
+from src.conversion.diagnostics import DiagnosticCollector
+from src.conversion.project_source_paths import ResolvedProjectSourcePath
 
 
 class TestIncludedFilesConverterBasic(unittest.TestCase):
@@ -167,6 +172,285 @@ class TestIncludedFilesConverterMissingFolder(unittest.TestCase):
         converter.convert_all()
         self.assertTrue(len(self.logs) > 0,
                         "Expected at least one log message for missing datafiles folder")
+
+
+class TestIncludedFilesConverterSourceContainment(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.outside_dir = tempfile.mkdtemp()
+        self.datafiles_dir = os.path.join(self.gm_dir, "datafiles")
+        os.makedirs(self.datafiles_dir)
+        self.logs: list[str] = []
+        self.diagnostics = DiagnosticCollector()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+        shutil.rmtree(self.outside_dir)
+
+    def _make_converter(self) -> IncludedFilesConverter:
+        return IncludedFilesConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=self.logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            max_workers=1,
+            diagnostics=self.diagnostics,
+        )
+
+    def _source_path_rejections(self):
+        return [
+            diagnostic
+            for diagnostic in self.diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+
+    def _make_symlink(self, target: str, link_path: str) -> None:
+        try:
+            os.symlink(target, link_path)
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+
+    def test_rejects_datafiles_root_symlink_outside_project(self) -> None:
+        outside_file = os.path.join(self.outside_dir, "outside.txt")
+        with open(outside_file, "w", encoding="utf-8") as source_file:
+            source_file.write("outside project")
+        shutil.rmtree(self.datafiles_dir)
+        self._make_symlink(self.outside_dir, self.datafiles_dir)
+
+        self._make_converter().convert_all()
+
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(self.godot_dir, "included_files", "outside.txt")
+            )
+        )
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].resource, "datafiles")
+        self.assertEqual(rejected[0].resource_type, "included_file")
+        self.assertEqual(rejected[0].manifest_entry, "datafiles directory")
+
+    def test_rejects_nested_directory_symlink_outside_project(self) -> None:
+        with open(
+            os.path.join(self.datafiles_dir, "safe.txt"),
+            "w",
+            encoding="utf-8",
+        ) as source_file:
+            source_file.write("safe")
+        with open(
+            os.path.join(self.outside_dir, "outside.txt"),
+            "w",
+            encoding="utf-8",
+        ) as source_file:
+            source_file.write("outside project")
+        self._make_symlink(
+            self.outside_dir,
+            os.path.join(self.datafiles_dir, "linked_directory"),
+        )
+
+        self._make_converter().convert_all()
+
+        self.assertTrue(
+            os.path.isfile(
+                os.path.join(self.godot_dir, "included_files", "safe.txt")
+            )
+        )
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(
+                    self.godot_dir,
+                    "included_files",
+                    "linked_directory",
+                    "outside.txt",
+                )
+            )
+        )
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "datafiles")
+        self.assertEqual(rejected[0].resource, "linked_directory")
+        self.assertEqual(rejected[0].manifest_entry, "discovered datafiles entry")
+
+    def test_rejects_file_symlink_outside_project(self) -> None:
+        outside_file = os.path.join(self.outside_dir, "outside.txt")
+        with open(outside_file, "w", encoding="utf-8") as source_file:
+            source_file.write("outside project")
+        linked_file = os.path.join(self.datafiles_dir, "linked.txt")
+        self._make_symlink(outside_file, linked_file)
+
+        self._make_converter().convert_all()
+
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(self.godot_dir, "included_files", "linked.txt")
+            )
+        )
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "datafiles")
+        self.assertEqual(rejected[0].resource, "linked.txt")
+        self.assertEqual(rejected[0].manifest_entry, "discovered datafiles entry")
+
+    def test_preserves_contained_file_symlink_copy_semantics(self) -> None:
+        target_file = os.path.join(self.datafiles_dir, "target.txt")
+        with open(target_file, "w", encoding="utf-8") as source_file:
+            source_file.write("contained target")
+        self._make_symlink(
+            target_file,
+            os.path.join(self.datafiles_dir, "alias.txt"),
+        )
+
+        self._make_converter().convert_all()
+
+        alias_output = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "alias.txt",
+        )
+        with open(alias_output, "r", encoding="utf-8") as copied_file:
+            self.assertEqual(copied_file.read(), "contained target")
+
+    def test_direct_copy_boundary_rejects_malformed_source_forms(self) -> None:
+        outside_file = os.path.join(self.outside_dir, "outside.txt")
+        with open(outside_file, "w", encoding="utf-8") as source_file:
+            source_file.write("outside project")
+        unsafe_paths = (
+            os.path.relpath(outside_file, self.gm_dir),
+            outside_file,
+            r"C:\Games\Outside\file.txt",
+            r"C:Outside\file.txt",
+            r"\\server\share\file.txt",
+            "invalid\0file.txt",
+        )
+        output_directory = os.path.join(self.godot_dir, "included_files")
+        os.makedirs(output_directory)
+        converter = self._make_converter()
+
+        for index, source_path in enumerate(unsafe_paths):
+            with self.subTest(source_path=source_path):
+                output_path = os.path.join(output_directory, f"rejected_{index}.txt")
+                result = converter._process_file(
+                    source_path,
+                    output_path,
+                    f"rejected_{index}.txt",
+                )
+                self.assertEqual(result, (f"rejected_{index}.txt", False))
+                self.assertFalse(os.path.exists(output_path))
+
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), len(unsafe_paths), rejected)
+        self.assertTrue(
+            all(
+                diagnostic.source_path == "datafiles"
+                and diagnostic.resource_type == "included_file"
+                and diagnostic.manifest_entry == "discovered datafiles file"
+                for diagnostic in rejected
+            )
+        )
+
+    def test_revalidates_file_after_discovery_before_copy(self) -> None:
+        source_path = os.path.join(self.datafiles_dir, "swapped.txt")
+        with open(source_path, "w", encoding="utf-8") as source_file:
+            source_file.write("original contained file")
+        outside_file = os.path.join(self.outside_dir, "outside.txt")
+        with open(outside_file, "w", encoding="utf-8") as source_file:
+            source_file.write("outside project")
+        converter = self._make_converter()
+        original_process_file = converter._process_file
+        swapped = False
+
+        def swap_then_process(
+            gm_file_path: str,
+            godot_file_path: str,
+            rel_path: str,
+            owner_source_path: str,
+        ) -> tuple[str, bool] | None:
+            nonlocal swapped
+            if not swapped and rel_path == "swapped.txt":
+                os.remove(source_path)
+                self._make_symlink(outside_file, source_path)
+                swapped = True
+            return original_process_file(
+                gm_file_path,
+                godot_file_path,
+                rel_path,
+                owner_source_path,
+            )
+
+        with patch.object(
+            converter,
+            "_process_file",
+            side_effect=swap_then_process,
+        ):
+            converter.convert_all()
+
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(self.godot_dir, "included_files", "swapped.txt")
+            )
+        )
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "datafiles")
+        self.assertEqual(rejected[0].resource, "swapped.txt")
+        self.assertEqual(rejected[0].manifest_entry, "discovered datafiles file")
+
+    def test_revalidates_nested_directory_before_listing(self) -> None:
+        nested_directory = os.path.join(self.datafiles_dir, "nested")
+        os.makedirs(nested_directory)
+        with open(
+            os.path.join(nested_directory, "safe.txt"),
+            "w",
+            encoding="utf-8",
+        ) as source_file:
+            source_file.write("safe")
+        with open(
+            os.path.join(self.outside_dir, "outside.txt"),
+            "w",
+            encoding="utf-8",
+        ) as source_file:
+            source_file.write("outside project")
+        converter = self._make_converter()
+        original_list_directory = converter._list_confined_directory
+        swapped = False
+
+        def swap_then_list(
+            directory: ResolvedProjectSourcePath,
+        ) -> tuple[str, ...] | None:
+            nonlocal swapped
+            if not swapped and directory.source_path == "datafiles/nested":
+                shutil.rmtree(nested_directory)
+                self._make_symlink(self.outside_dir, nested_directory)
+                swapped = True
+            return original_list_directory(directory)
+
+        with patch.object(
+            converter,
+            "_list_confined_directory",
+            side_effect=swap_then_list,
+        ):
+            converter.convert_all()
+
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(
+                    self.godot_dir,
+                    "included_files",
+                    "nested",
+                    "outside.txt",
+                )
+            )
+        )
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].resource, "nested")
+        self.assertEqual(
+            rejected[0].manifest_entry,
+            "discovered datafiles directory",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -9,6 +9,28 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from src.conversion.notes import NoteConverter
+from src.conversion.diagnostics import DiagnosticCollector
+
+
+class TestableNoteConverter(NoteConverter):
+    def discover_notes_for_test(self):
+        notes_root = self._resolve_project_source("notes")
+        assert notes_root is not None
+        return self._discover_notes(notes_root)
+
+    def process_note_for_test(
+        self,
+        src_file: str,
+        dst_file: str,
+        note_name: str,
+        owner_source_path: str,
+    ):
+        return self._process_note(
+            src_file,
+            dst_file,
+            note_name,
+            owner_source_path,
+        )
 
 
 class TestNoteConverterBasic(unittest.TestCase):
@@ -139,6 +161,242 @@ class TestNoteConverterSubfolders(unittest.TestCase):
         expected = os.path.join(self.godot_dir, "notes", "plain_note", "plain_note.txt")
         self.assertTrue(os.path.isfile(expected),
                         "Note without .yy should remain at root level")
+
+
+class TestNoteConverterSourceContainment(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.outside_dir = tempfile.mkdtemp()
+        self.logs: list[str] = []
+        self.diagnostics = DiagnosticCollector()
+        os.makedirs(os.path.join(self.gm_dir, "notes"))
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+        shutil.rmtree(self.outside_dir)
+
+    def _make_converter(self) -> TestableNoteConverter:
+        return TestableNoteConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=self.logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            diagnostics=self.diagnostics,
+        )
+
+    def _source_path_rejections(self):
+        return [
+            diagnostic
+            for diagnostic in self.diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+
+    def _symlink(self, target: str, link_path: str) -> None:
+        try:
+            os.symlink(target, link_path)
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+
+    @staticmethod
+    def _write_text(path: str, content: str) -> None:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as output_file:
+            output_file.write(content)
+
+    def test_rejects_notes_root_symlink_to_external_directory(self) -> None:
+        notes_root = os.path.join(self.gm_dir, "notes")
+        shutil.rmtree(notes_root)
+        external_note = os.path.join(self.outside_dir, "external_note.txt")
+        self._write_text(external_note, "EXTERNAL ROOT NOTE")
+        self._symlink(self.outside_dir, notes_root)
+
+        self._make_converter().convert_all()
+
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(
+                    self.godot_dir,
+                    "notes",
+                    "external_note",
+                    "external_note.txt",
+                )
+            )
+        )
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].resource_type, "note")
+        self.assertEqual(rejected[0].manifest_entry, "notes directory")
+
+    def test_skips_external_nested_directory_but_copies_safe_note(self) -> None:
+        safe_note = os.path.join(self.gm_dir, "notes", "safe.txt")
+        self._write_text(safe_note, "SAFE NOTE")
+        external_note = os.path.join(self.outside_dir, "leak.txt")
+        self._write_text(external_note, "EXTERNAL DIRECTORY NOTE")
+        self._symlink(
+            self.outside_dir,
+            os.path.join(self.gm_dir, "notes", "linked_notes"),
+        )
+
+        self._make_converter().convert_all()
+
+        safe_output = os.path.join(
+            self.godot_dir,
+            "notes",
+            "safe",
+            "safe.txt",
+        )
+        with open(safe_output, "r", encoding="utf-8") as output_file:
+            self.assertEqual(output_file.read(), "SAFE NOTE")
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(self.godot_dir, "notes", "leak", "leak.txt")
+            )
+        )
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "notes")
+        self.assertEqual(rejected[0].resource, "linked_notes")
+        self.assertEqual(rejected[0].resource_type, "note")
+        self.assertEqual(rejected[0].manifest_entry, "discovered note entry")
+
+    def test_rejects_external_note_file_symlink(self) -> None:
+        external_note = os.path.join(self.outside_dir, "outside.txt")
+        self._write_text(external_note, "EXTERNAL FILE NOTE")
+        linked_note = os.path.join(self.gm_dir, "notes", "linked.txt")
+        self._symlink(external_note, linked_note)
+
+        self._make_converter().convert_all()
+
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(self.godot_dir, "notes", "linked", "linked.txt")
+            )
+        )
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "notes")
+        self.assertEqual(rejected[0].resource, "linked")
+        self.assertEqual(rejected[0].resource_type, "note")
+        self.assertEqual(rejected[0].manifest_entry, "note text file")
+
+    def test_rejects_external_companion_yy_without_reading_it(self) -> None:
+        note_directory = os.path.join(self.gm_dir, "notes", "my_note")
+        note_path = os.path.join(note_directory, "my_note.txt")
+        self._write_text(note_path, "SAFE NOTE")
+        outside_yy = os.path.join(self.outside_dir, "my_note.yy")
+        self._write_text(
+            outside_yy,
+            '{"parent":{"path":"folders/Notes/External.yy"}}',
+        )
+        self._symlink(outside_yy, os.path.join(note_directory, "my_note.yy"))
+
+        self._make_converter().convert_all()
+
+        flat_output = os.path.join(
+            self.godot_dir,
+            "notes",
+            "my_note",
+            "my_note.txt",
+        )
+        external_folder_output = os.path.join(
+            self.godot_dir,
+            "notes",
+            "external",
+            "my_note",
+            "my_note.txt",
+        )
+        self.assertTrue(os.path.isfile(flat_output))
+        self.assertFalse(os.path.exists(external_folder_output))
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "notes/my_note")
+        self.assertEqual(rejected[0].resource, "my_note")
+        self.assertEqual(rejected[0].resource_type, "note")
+        self.assertEqual(rejected[0].manifest_entry, "note metadata .yy")
+
+    def test_final_pre_copy_check_rejects_late_note_symlink_swap(self) -> None:
+        note_path = os.path.join(self.gm_dir, "notes", "late.txt")
+        self._write_text(note_path, "ORIGINAL SAFE NOTE")
+        outside_note = os.path.join(self.outside_dir, "late.txt")
+        self._write_text(outside_note, "LATE EXTERNAL NOTE")
+        converter = self._make_converter()
+        assets = converter.discover_notes_for_test()
+        self.assertEqual(len(assets), 1)
+
+        os.unlink(note_path)
+        self._symlink(outside_note, note_path)
+        destination = os.path.join(self.godot_dir, "late.txt")
+        result = converter.process_note_for_test(
+            assets[0].filesystem_path,
+            destination,
+            assets[0].name,
+            assets[0].owner_source_path,
+        )
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertFalse(result.copied)
+        self.assertFalse(os.path.exists(destination))
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "notes")
+        self.assertEqual(rejected[0].resource, "late")
+        self.assertEqual(rejected[0].resource_type, "note")
+        self.assertEqual(
+            rejected[0].manifest_entry,
+            "note text file (pre-copy)",
+        )
+
+    def test_final_pre_copy_check_rejects_malformed_source_candidates(self) -> None:
+        outside_note = os.path.join(self.outside_dir, "outside.txt")
+        self._write_text(outside_note, "OUTSIDE NOTE")
+        traversal_path = os.path.relpath(outside_note, self.gm_dir)
+        unsafe_paths = [
+            traversal_path,
+            outside_note,
+            r"C:\Games\Outside\note.txt",
+            r"C:Outside\note.txt",
+            r"\\server\share\note.txt",
+            "notes/bad\0note.txt",
+        ]
+        converter = self._make_converter()
+
+        for index, unsafe_path in enumerate(unsafe_paths):
+            with self.subTest(unsafe_path=unsafe_path):
+                result = converter.process_note_for_test(
+                    unsafe_path,
+                    os.path.join(self.godot_dir, f"unsafe_{index}.txt"),
+                    f"unsafe_{index}",
+                    "notes",
+                )
+                self.assertIsNotNone(result)
+                assert result is not None
+                self.assertFalse(result.copied)
+
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), len(unsafe_paths), rejected)
+        self.assertEqual(
+            {diagnostic.source_path for diagnostic in rejected},
+            {"notes"},
+        )
+        self.assertTrue(
+            all(diagnostic.resource_type == "note" for diagnostic in rejected)
+        )
+        self.assertTrue(
+            all(
+                diagnostic.manifest_entry == "note text file (pre-copy)"
+                for diagnostic in rejected
+            )
+        )
+        self.assertFalse(
+            any(
+                filenames
+                for _root, _directories, filenames in os.walk(self.godot_dir)
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -6,6 +6,7 @@ import shutil
 import tempfile
 import unittest
 from typing import cast
+from unittest.mock import patch
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
@@ -14,6 +15,7 @@ if PROJECT_ROOT not in sys.path:
 from src.conversion.objects import ObjectConverter
 from src.conversion.asset_registry import AssetRegistryConverter
 from src.conversion.diagnostics import DiagnosticCollector
+from src.conversion.events.base import EventMapping
 from src.conversion.type_defs import JsonDict
 
 
@@ -368,6 +370,701 @@ class TestObjectConverterYYPFiltering(unittest.TestCase):
                         "Object listed in .yyp should be converted")
         self.assertFalse(os.path.isfile(unlisted_path),
                          "Object not listed in .yyp should be skipped")
+
+
+class TestObjectSourceContainment(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.logs: list[str] = []
+        self.diagnostics = DiagnosticCollector()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def _make_converter(self) -> ObjectConverter:
+        return ObjectConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=self.logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            diagnostics=self.diagnostics,
+        )
+
+    def _write_json(self, path: str, value: object) -> None:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as output_file:
+            json.dump(value, output_file)
+
+    def _generated_object_script(self, object_name: str) -> str:
+        for directory, _subdirectories, filenames in os.walk(self.godot_dir):
+            filename = object_name + ".gd"
+            if filename in filenames:
+                with open(
+                    os.path.join(directory, filename),
+                    "r",
+                    encoding="utf-8",
+                ) as source_file:
+                    return source_file.read()
+        self.fail(f"Missing generated object script for {object_name}")
+
+    def _all_generated_text(self) -> str:
+        chunks: list[str] = []
+        for directory, _subdirectories, filenames in os.walk(self.godot_dir):
+            for filename in filenames:
+                path = os.path.join(directory, filename)
+                try:
+                    with open(path, "r", encoding="utf-8") as source_file:
+                        chunks.append(source_file.read())
+                except (OSError, UnicodeDecodeError):
+                    continue
+        return "\n".join(chunks)
+
+    def test_manifest_discovery_reads_selected_yyp_once(self) -> None:
+        yyp_path = os.path.join(self.gm_dir, "ObjectPaths.yyp")
+        self._write_json(yyp_path, {"resources": []})
+
+        with patch("builtins.open", wraps=open) as tracked_open:
+            valid_objects = self._make_converter()._get_valid_object_names()
+
+        self.assertEqual(valid_objects, {})
+        yyp_reads = [
+            call
+            for call in tracked_open.call_args_list
+            if call.args
+            and isinstance(call.args[0], (str, os.PathLike))
+            and os.path.abspath(os.fspath(call.args[0])) == yyp_path
+        ]
+        self.assertEqual(len(yyp_reads), 1, yyp_reads)
+
+    def test_event_filename_cannot_reach_another_project_directory(self) -> None:
+        owner_path = os.path.join(
+            self.gm_dir,
+            "objects",
+            "o_owner",
+            "o_owner.yy",
+        )
+        self._write_json(owner_path, {"resourceType": "GMObject"})
+        mapping = EventMapping(
+            godot_func="_gm_cross_owner",
+            params="",
+            sort_key=1,
+            gml_filename="../shared/Leak.gml",
+        )
+
+        contained = self._make_converter()._event_mapping_paths_are_contained(
+            "objects/o_owner/o_owner.yy",
+            "o_owner",
+            mapping,
+            field="eventList[0].sourceFile",
+        )
+
+        self.assertFalse(contained)
+        rejected = [
+            diagnostic
+            for diagnostic in self.diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertEqual(rejected[0].source_path, "objects/o_owner/o_owner.yy")
+        self.assertEqual(rejected[0].manifest_entry, "eventList[0].sourceFile")
+
+    def test_yyp_declared_object_path_is_used_instead_of_name_reconstruction(self) -> None:
+        declared_dir = os.path.join(self.gm_dir, "objects", "nested", "source")
+        reconstructed_dir = os.path.join(self.gm_dir, "objects", "o_declared")
+        os.makedirs(declared_dir)
+        os.makedirs(reconstructed_dir)
+        self._write_json(
+            os.path.join(declared_dir, "custom_object.yy"),
+            {
+                "name": "o_declared",
+                "resourceType": "GMObject",
+                "eventList": [{"eventType": 0, "eventNum": 0}],
+            },
+        )
+        with open(
+            os.path.join(declared_dir, "Create_0.gml"),
+            "w",
+            encoding="utf-8",
+        ) as source_file:
+            source_file.write("declared_source = 1;")
+        self._write_json(
+            os.path.join(reconstructed_dir, "o_declared.yy"),
+            {
+                "name": "o_declared",
+                "resourceType": "GMObject",
+                "eventList": [{"eventType": 0, "eventNum": 0}],
+            },
+        )
+        with open(
+            os.path.join(reconstructed_dir, "Create_0.gml"),
+            "w",
+            encoding="utf-8",
+        ) as source_file:
+            source_file.write("RECONSTRUCTED_MARKER = 1;")
+        self._write_json(
+            os.path.join(self.gm_dir, "Project.yyp"),
+            {
+                "resources": [
+                    {
+                        "id": {
+                            "name": "o_declared",
+                            "path": "objects/nested/source/custom_object.yy",
+                        }
+                    }
+                ],
+                "resourceType": "GMProject",
+            },
+        )
+
+        self._make_converter().convert_all()
+
+        script = self._generated_object_script("o_declared")
+        self.assertIn("declared_source = 1", script)
+        self.assertNotIn("RECONSTRUCTED_MARKER", script)
+
+    def test_external_first_yyp_cannot_mask_contained_declared_object_path(self) -> None:
+        declared_path = os.path.join(
+            self.gm_dir,
+            "objects",
+            "nested",
+            "custom_object.yy",
+        )
+        self._write_json(
+            declared_path,
+            {
+                "name": "o_inside",
+                "parent": {
+                    "name": "Objects",
+                    "path": "folders/Objects.yy",
+                },
+                "resourceType": "GMObject",
+                "eventList": [],
+            },
+        )
+        self._write_json(
+            os.path.join(self.gm_dir, "BInside.yyp"),
+            {
+                "resources": [
+                    {
+                        "id": {
+                            "name": "o_inside",
+                            "path": "objects/nested/custom_object.yy",
+                        }
+                    }
+                ],
+                "resourceType": "GMProject",
+            },
+        )
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_yyp = os.path.join(outside_dir, "Outside.yyp")
+            self._write_json(
+                outside_yyp,
+                {
+                    "resources": [
+                        {
+                            "id": {
+                                "name": "o_outside",
+                                "path": "objects/o_outside/o_outside.yy",
+                            }
+                        }
+                    ]
+                },
+            )
+            try:
+                os.symlink(
+                    outside_yyp,
+                    os.path.join(self.gm_dir, "AOutside.yyp"),
+                )
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            converter = self._make_converter()
+            valid_objects = converter._get_valid_object_names()
+
+        self.assertEqual(valid_objects, {"o_inside": ""})
+        self.assertEqual(
+            converter._object_source_paths,
+            {"o_inside": "objects/nested/custom_object.yy"},
+        )
+        rejected = [
+            diagnostic
+            for diagnostic in self.diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertIsNone(rejected[0].source_path)
+        self.assertEqual(rejected[0].resource_type, "project")
+        self.assertEqual(rejected[0].manifest_entry, "AOutside.yyp")
+        self.assertIn("AOutside.yyp", rejected[0].message)
+
+    def test_non_file_first_yyp_is_rejected_with_source_link(self) -> None:
+        os.makedirs(os.path.join(self.gm_dir, "ADirectory.yyp"))
+        self._write_json(
+            os.path.join(self.gm_dir, "BInside.yyp"),
+            {"resources": [], "resourceType": "GMProject"},
+        )
+
+        valid_objects = self._make_converter()._get_valid_object_names()
+
+        self.assertEqual(valid_objects, {})
+        rejected = [
+            diagnostic
+            for diagnostic in self.diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertEqual(rejected[0].source_path, "ADirectory.yyp")
+        self.assertEqual(rejected[0].resource_type, "project")
+        self.assertEqual(rejected[0].manifest_entry, "ADirectory.yyp")
+
+    def test_disk_fallback_rejects_object_yy_file_symlink_escape(self) -> None:
+        object_dir = os.path.join(self.gm_dir, "objects", "o_escape")
+        os.makedirs(object_dir)
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_yy = os.path.join(outside_dir, "o_escape.yy")
+            self._write_json(
+                outside_yy,
+                {
+                    "name": "OUTSIDE_OBJECT_MARKER",
+                    "resourceType": "GMObject",
+                    "eventList": [],
+                },
+            )
+            try:
+                os.symlink(outside_yy, os.path.join(object_dir, "o_escape.yy"))
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            self._make_converter().convert_all()
+
+        self.assertNotIn("OUTSIDE_OBJECT_MARKER", self._all_generated_text())
+        rejected = [
+            diagnostic
+            for diagnostic in self.diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+            and diagnostic.resource == "o_escape"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertEqual(rejected[0].source_path, "objects/o_escape")
+        self.assertEqual(rejected[0].manifest_entry, "object.yy")
+
+    def test_disk_fallback_rejects_contained_cross_family_object_yy_link(
+        self,
+    ) -> None:
+        linked_name = "o_cross_family_link"
+        wrong_family_yy = os.path.join(
+            self.gm_dir,
+            "sprites",
+            "wrong_object",
+            "target.yy",
+        )
+        self._write_json(
+            wrong_family_yy,
+            {
+                "name": "WRONG_FAMILY_OBJECT_MARKER",
+                "resourceType": "GMObject",
+                "eventList": [],
+            },
+        )
+        linked_directory = os.path.join(self.gm_dir, "objects", linked_name)
+        os.makedirs(linked_directory)
+        try:
+            os.symlink(
+                wrong_family_yy,
+                os.path.join(linked_directory, linked_name + ".yy"),
+            )
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+
+        safe_name = "o_safe_sibling"
+        self._write_json(
+            os.path.join(self.gm_dir, "objects", safe_name, safe_name + ".yy"),
+            {
+                "name": safe_name,
+                "resourceType": "GMObject",
+                "eventList": [],
+            },
+        )
+
+        self._make_converter().convert_all()
+
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(
+                    self.godot_dir,
+                    "objects",
+                    linked_name,
+                    linked_name + ".tscn",
+                )
+            )
+        )
+        self.assertTrue(
+            os.path.isfile(
+                os.path.join(
+                    self.godot_dir,
+                    "objects",
+                    safe_name,
+                    safe_name + ".tscn",
+                )
+            )
+        )
+        self.assertNotIn("WRONG_FAMILY_OBJECT_MARKER", self._all_generated_text())
+        rejected = [
+            diagnostic
+            for diagnostic in self.diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+            and diagnostic.resource == linked_name
+            and diagnostic.manifest_entry == "object.yy"
+        ]
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, f"objects/{linked_name}")
+        self.assertEqual(rejected[0].resource_type, "object")
+        self.assertEqual(rejected[0].manifest_entry, "object.yy")
+
+    def test_contained_reference_paths_override_untrusted_reference_names(self) -> None:
+        for object_name in ("o_parent", "o_bullet"):
+            self._write_json(
+                os.path.join(
+                    self.gm_dir,
+                    "objects",
+                    object_name,
+                    object_name + ".yy",
+                ),
+                {
+                    "name": object_name,
+                    "resourceType": "GMObject",
+                    "eventList": [],
+                },
+            )
+        self._write_json(
+            os.path.join(self.gm_dir, "sprites", "s_real", "s_real.yy"),
+            {
+                "name": "s_real",
+                "resourceType": "GMSprite",
+                "parent": {"path": "folders/Sprites.yy"},
+            },
+        )
+        _create_fake_sprite_scene(self.godot_dir, "s_real")
+        child_dir = os.path.join(self.gm_dir, "objects", "o_child")
+        self._write_json(
+            os.path.join(child_dir, "o_child.yy"),
+            {
+                "name": "o_child",
+                "resourceType": "GMObject",
+                "spriteId": {
+                    "name": "UNTRUSTED_SPRITE_NAME",
+                    "path": "sprites/s_real/s_real.yy",
+                },
+                "parentObjectId": {
+                    "name": "UNTRUSTED_PARENT_NAME",
+                    "path": "objects/o_parent/o_parent.yy",
+                },
+                "eventList": [
+                    {
+                        "eventType": 4,
+                        "eventNum": 0,
+                        "collisionObjectId": {
+                            "name": "UNTRUSTED_COLLISION_NAME",
+                            "path": "objects/o_bullet/o_bullet.yy",
+                        },
+                    }
+                ],
+            },
+        )
+        with open(
+            os.path.join(child_dir, "Collision_o_bullet.gml"),
+            "w",
+            encoding="utf-8",
+        ) as source_file:
+            source_file.write("safe_collision = true;")
+
+        self._make_converter().convert_all()
+
+        script = self._generated_object_script("o_child")
+        self.assertTrue(script.startswith('extends "res://objects/o_parent/o_parent.gd"'))
+        self.assertIn('"target_object": "o_bullet"', script)
+        self.assertIn("func _on_collision_o_bullet():", script)
+        self.assertIn(
+            'GMRuntime.gml_variable_instance_set(self, "safe_collision", true)',
+            script,
+        )
+        generated = self._all_generated_text()
+        self.assertIn("res://sprites/s_real/s_real.tscn", generated)
+        self.assertNotIn("UNTRUSTED_", generated)
+
+    def test_custom_reference_filenames_preserve_logical_resource_names(self) -> None:
+        references = (
+            (
+                "sprites",
+                "s_logical",
+                "sprites/storage/custom_sprite.yy",
+                "GMSprite",
+            ),
+            (
+                "objects",
+                "o_parent_logical",
+                "objects/storage/custom_parent.yy",
+                "GMObject",
+            ),
+            (
+                "objects",
+                "o_collision_logical",
+                "objects/storage/custom_collision.yy",
+                "GMObject",
+            ),
+        )
+        project_resources: list[dict[str, object]] = []
+        for _kind, logical_name, source_path, resource_type in references:
+            self._write_json(
+                os.path.join(self.gm_dir, *source_path.split("/")),
+                {
+                    "%Name": logical_name,
+                    "name": logical_name,
+                    "resourceType": resource_type,
+                    "eventList": [],
+                },
+            )
+            project_resources.append(
+                {"id": {"name": logical_name, "path": source_path}}
+            )
+        child_source_path = "objects/o_child/o_child.yy"
+        self._write_json(
+            os.path.join(self.gm_dir, *child_source_path.split("/")),
+            {
+                "name": "o_child",
+                "resourceType": "GMObject",
+                "spriteId": {
+                    "name": "UNTRUSTED_SPRITE_NAME",
+                    "path": references[0][2],
+                },
+                "parentObjectId": {
+                    "name": "UNTRUSTED_PARENT_NAME",
+                    "path": references[1][2],
+                },
+                "eventList": [
+                    {
+                        "eventType": 4,
+                        "eventNum": 0,
+                        "collisionObjectId": {
+                            "name": "UNTRUSTED_COLLISION_NAME",
+                            "path": references[2][2],
+                        },
+                    }
+                ],
+            },
+        )
+        project_resources.append(
+            {"id": {"name": "o_child", "path": child_source_path}}
+        )
+        self._write_json(
+            os.path.join(self.gm_dir, "Project.yyp"),
+            {"resources": project_resources, "resourceType": "GMProject"},
+        )
+
+        parsed = self._make_converter()._parse_object_yy(
+            "o_child",
+            child_source_path,
+        )
+
+        self.assertIsNotNone(parsed)
+        assert parsed is not None
+        self.assertEqual(parsed["sprite_name"], "s_logical")
+        self.assertEqual(parsed["sprite_source_path"], references[0][2])
+        self.assertEqual(parsed["parent_object_name"], "o_parent_logical")
+        self.assertEqual(parsed["parent_object_source_path"], references[1][2])
+        collision = parsed["event_list"][0]["collisionObjectId"]
+        self.assertIsInstance(collision, dict)
+        assert isinstance(collision, dict)
+        self.assertEqual(collision["name"], "o_collision_logical")
+        self.assertEqual(collision["path"], references[2][2])
+
+    def test_rejects_malformed_declared_paths_and_unsafe_legacy_names(self) -> None:
+        owner_source_path = "objects/o_owner/o_owner.yy"
+        self._write_json(
+            os.path.join(self.gm_dir, *owner_source_path.split("/")),
+            {"name": "o_owner", "resourceType": "GMObject"},
+        )
+        self._write_json(
+            os.path.join(self.gm_dir, "sprites", "s_safe", "s_safe.yy"),
+            {"name": "s_safe", "resourceType": "GMSprite"},
+        )
+        converter = self._make_converter()
+        malformed_paths: tuple[object, ...] = (7, None, "")
+        unsafe_names = (
+            "../safe",
+            "/tmp/safe",
+            r"C:\Games\safe",
+            r"C:safe",
+            r"\\server\share\safe",
+            "bad\0name",
+            "nested/../safe",
+        )
+
+        for index, raw_path in enumerate(malformed_paths):
+            with self.subTest(path=raw_path):
+                self.assertIsNone(
+                    converter._resolve_resource_reference(
+                        {"path": raw_path, "name": "s_safe"},
+                        owner_source_path=owner_source_path,
+                        owner_name="o_owner",
+                        field=f"badPath[{index}]",
+                        resource_kind="sprites",
+                    )
+                )
+        for index, raw_name in enumerate(unsafe_names):
+            with self.subTest(name=raw_name):
+                self.assertIsNone(
+                    converter._resolve_resource_reference(
+                        {"name": raw_name},
+                        owner_source_path=owner_source_path,
+                        owner_name="o_owner",
+                        field=f"badName[{index}]",
+                        resource_kind="sprites",
+                    )
+                )
+
+        self.assertEqual(
+            converter._resolve_resource_reference(
+                {"name": "s_safe"},
+                owner_source_path=owner_source_path,
+                owner_name="o_owner",
+                field="safeSprite",
+                resource_kind="sprites",
+            ),
+            ("s_safe", "sprites/s_safe/s_safe.yy"),
+        )
+        rejected = [
+            diagnostic
+            for diagnostic in self.diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(
+            len(rejected),
+            len(malformed_paths) + len(unsafe_names),
+            rejected,
+        )
+        self.assertTrue(
+            all(
+                diagnostic.source_path == owner_source_path
+                and diagnostic.resource == "o_owner"
+                and diagnostic.resource_type == "object"
+                for diagnostic in rejected
+            )
+        )
+
+    def test_nested_references_and_event_symlinks_never_enter_output(self) -> None:
+        object_dir = os.path.join(self.gm_dir, "objects", "o_child")
+        os.makedirs(object_dir)
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_parent = os.path.join(outside_dir, "outside_parent.yy")
+            outside_sprite = os.path.join(outside_dir, "outside_sprite.yy")
+            outside_collision = os.path.join(outside_dir, "outside_collision.yy")
+            outside_gml = os.path.join(outside_dir, "outside_event.gml")
+            self._write_json(
+                outside_parent,
+                {"name": "OUTSIDE_PARENT_MARKER", "eventList": []},
+            )
+            self._write_json(
+                outside_sprite,
+                {"name": "OUTSIDE_SPRITE_MARKER", "frames": []},
+            )
+            self._write_json(
+                outside_collision,
+                {"name": "OUTSIDE_COLLISION_MARKER", "eventList": []},
+            )
+            with open(outside_gml, "w", encoding="utf-8") as source_file:
+                source_file.write("OUTSIDE_EVENT_CODE_MARKER = 1;")
+
+            os.makedirs(os.path.join(self.gm_dir, "sprites"))
+            try:
+                os.symlink(
+                    outside_parent,
+                    os.path.join(self.gm_dir, "objects", "parent_link.yy"),
+                )
+                os.symlink(
+                    outside_sprite,
+                    os.path.join(self.gm_dir, "sprites", "sprite_link.yy"),
+                )
+                os.symlink(
+                    outside_collision,
+                    os.path.join(self.gm_dir, "objects", "collision_link.yy"),
+                )
+                os.symlink(outside_gml, os.path.join(object_dir, "Create_0.gml"))
+                os.symlink(outside_gml, os.path.join(object_dir, "Collision_0.gml"))
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            self._write_json(
+                os.path.join(object_dir, "o_child.yy"),
+                {
+                    "name": "o_child",
+                    "resourceType": "GMObject",
+                    "spriteId": {
+                        "name": "s_outside",
+                        "path": "sprites/sprite_link.yy",
+                    },
+                    "parentObjectId": {
+                        "name": "o_outside",
+                        "path": "objects/parent_link.yy",
+                    },
+                    "eventList": [
+                        {"eventType": 0, "eventNum": 0},
+                        {
+                            "eventType": 4,
+                            "eventNum": 0,
+                            "collisionObjectId": {
+                                "name": "o_collision_outside",
+                                "path": "objects/collision_link.yy",
+                            },
+                        },
+                        {
+                            "eventType": 99,
+                            "eventNum": "/../../../../OUTSIDE_EVENT_FILENAME_MARKER",
+                        },
+                    ],
+                },
+            )
+
+            self._make_converter().convert_all()
+
+        generated = self._all_generated_text()
+        for marker in (
+            "OUTSIDE_PARENT_MARKER",
+            "OUTSIDE_SPRITE_MARKER",
+            "OUTSIDE_COLLISION_MARKER",
+            "OUTSIDE_EVENT_CODE_MARKER",
+            "OUTSIDE_EVENT_FILENAME_MARKER",
+            "o_outside",
+            "s_outside",
+            "o_collision_outside",
+        ):
+            with self.subTest(marker=marker):
+                self.assertNotIn(marker, generated)
+
+        rejected = [
+            diagnostic
+            for diagnostic in self.diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+            and diagnostic.resource == "o_child"
+        ]
+        self.assertGreaterEqual(len(rejected), 5)
+        self.assertTrue(
+            all(
+                diagnostic.source_path == "objects/o_child/o_child.yy"
+                and diagnostic.resource == "o_child"
+                and diagnostic.resource_type == "object"
+                for diagnostic in rejected
+            )
+        )
+        rejected_fields = {diagnostic.manifest_entry for diagnostic in rejected}
+        self.assertIn("spriteId.path", rejected_fields)
+        self.assertIn("parentObjectId.path", rejected_fields)
+        self.assertIn("eventList[1].collisionObjectId.path", rejected_fields)
+        self.assertIn("eventList[0].sourceFile", rejected_fields)
+        self.assertIn("eventList[2].sourceFile", rejected_fields)
 
 
 class TestObjectConverterSubfolders(unittest.TestCase):

--- a/tests/test_path_registry.py
+++ b/tests/test_path_registry.py
@@ -101,6 +101,34 @@ class TestPathRegistry(unittest.TestCase):
         self.assertTrue(scene_exists)
         self.assertEqual(render_path_registry_script(()), "extends RefCounted\n\nstatic func entries():\n\treturn []\n")
 
+    def test_skips_uncontained_path_metadata_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as gm_dir, tempfile.TemporaryDirectory() as outside_dir:
+            outside_yy = os.path.join(outside_dir, "path_outside.yy")
+            with open(outside_yy, "w", encoding="utf-8") as source_file:
+                source_file.write('{"name":"path_outside","points":[{"x":99,"y":99}]}')
+            linked_dir = os.path.join(gm_dir, "paths", "path_linked")
+            os.makedirs(linked_dir)
+            linked_yy = os.path.join(linked_dir, "path_linked.yy")
+            try:
+                os.symlink(outside_yy, linked_yy)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            entries = build_path_registry_entries(
+                gm_dir,
+                (
+                    _AssetEntry(1, "path_parent", "paths", "../../../outside.yy"),
+                    _AssetEntry(
+                        2,
+                        "path_linked",
+                        "paths",
+                        "paths/path_linked/path_linked.yy",
+                    ),
+                ),
+            )
+
+        self.assertEqual(entries, ())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_project_manifest.py
+++ b/tests/test_project_manifest.py
@@ -4,6 +4,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
@@ -134,6 +135,363 @@ class TestGameMakerProjectManifest(unittest.TestCase):
         self.assertTrue(
             any(diagnostic.code == "GM2GD-PROJECT-RESOURCE-CONFLICT" for diagnostic in manifest.diagnostics)
         )
+
+    def test_invalid_resource_path_kind_takes_precedence_over_declared_type(
+        self,
+    ) -> None:
+        _write_file(
+            os.path.join(self.gm_dir, "ConflictingKind.yyp"),
+            json.dumps(
+                {
+                    "resources": [
+                        {
+                            "id": {
+                                "name": "s_conflicting",
+                                "path": "sprites/../../outside.yy",
+                            },
+                            "resourceType": "GMObject",
+                        }
+                    ],
+                    "resourceType": "GMProject",
+                }
+            ),
+        )
+
+        manifest = load_gamemaker_project_manifest(self.gm_dir)
+
+        rejected = [
+            diagnostic
+            for diagnostic in manifest.diagnostics
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].resource, "s_conflicting")
+        self.assertEqual(rejected[0].resource_kind, "sprites")
+        self.assertEqual(rejected[0].resource_type, "GMSprite")
+        assert rejected[0].source is not None
+        self.assertEqual(
+            rejected[0].source.field_path,
+            "resources[0].id.path",
+        )
+
+    def test_invalid_resource_paths_report_missing_and_actual_legacy_fields(
+        self,
+    ) -> None:
+        _write_file(
+            os.path.join(self.gm_dir, "MalformedPaths.yyp"),
+            json.dumps(
+                {
+                    "resources": [
+                        {
+                            "id": {"name": "s_missing"},
+                            "resourceType": "GMSprite",
+                        },
+                        {
+                            "Key": "room-null",
+                            "Value": {
+                                "name": "r_null",
+                                "resourcePath": None,
+                                "resourceType": "GMRoom",
+                            },
+                        },
+                        {
+                            "Key": "script-empty",
+                            "Value": {
+                                "name": "scr_empty",
+                                "resource_path": "",
+                                "resourceType": "GMScript",
+                            },
+                        },
+                        {
+                            "name": "snd_numeric",
+                            "path": 7,
+                            "resourceType": "GMSound",
+                        },
+                    ],
+                    "resourceType": "GMProject",
+                }
+            ),
+        )
+
+        manifest = load_gamemaker_project_manifest(self.gm_dir)
+
+        rejected = [
+            diagnostic
+            for diagnostic in manifest.diagnostics
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 4, rejected)
+        self.assertEqual(
+            {
+                diagnostic.source.field_path
+                for diagnostic in rejected
+                if diagnostic.source is not None
+            },
+            {
+                "resources[0].id.path",
+                "resources[1].Value.resourcePath",
+                "resources[2].Value.resource_path",
+                "resources[3].path",
+            },
+        )
+        self.assertIn("<missing>", rejected[0].message)
+        self.assertEqual(manifest.resources, ())
+
+    def test_duplicate_rejected_resource_paths_have_entry_specific_lines(
+        self,
+    ) -> None:
+        _write_file(
+            os.path.join(self.gm_dir, "DuplicateRejectedPaths.yyp"),
+            "{\n"
+            '  "resources": [\n'
+            '    {"id":{"name":"s_first","path":"../../outside.yy"}},\n'
+            '    {"id":{"name":"s_second","path":"../../outside.yy"}}\n'
+            "  ]\n"
+            "}\n",
+        )
+
+        manifest = load_gamemaker_project_manifest(self.gm_dir)
+
+        rejected = [
+            diagnostic
+            for diagnostic in manifest.diagnostics
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 2, rejected)
+        self.assertEqual(
+            [
+                diagnostic.source.line
+                for diagnostic in rejected
+                if diagnostic.source is not None
+            ],
+            [3, 4],
+        )
+
+    def test_skips_project_yyp_symlink_that_resolves_outside_project(self) -> None:
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_yyp = os.path.join(outside_dir, "Outside.yyp")
+            _write_file(
+                outside_yyp,
+                '{"%Name":"Outside","resourceType":"GMProject"}',
+            )
+            try:
+                os.symlink(
+                    outside_yyp,
+                    os.path.join(self.gm_dir, "AOutside.yyp"),
+                )
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+            _write_file(
+                os.path.join(self.gm_dir, "BInside.yyp"),
+                '{"%Name":"Inside","resourceType":"GMProject"}',
+            )
+
+            manifest = load_gamemaker_project_manifest(self.gm_dir)
+
+        self.assertEqual(manifest.project_name, "Inside")
+        self.assertEqual(manifest.yyp_path, os.path.join(self.gm_dir, "BInside.yyp"))
+        rejected = [
+            diagnostic
+            for diagnostic in manifest.diagnostics
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        assert rejected[0].source is not None
+        self.assertEqual(
+            rejected[0].source.path,
+            os.path.join(self.gm_dir, "AOutside.yyp"),
+        )
+        self.assertEqual(rejected[0].source.field_path, "AOutside.yyp")
+
+    def test_skips_non_file_yyp_candidate_with_source_diagnostic(self) -> None:
+        invalid_yyp = os.path.join(self.gm_dir, "AInvalid.yyp")
+        os.makedirs(invalid_yyp)
+        _write_file(
+            os.path.join(self.gm_dir, "BInside.yyp"),
+            '{"%Name":"Inside","resourceType":"GMProject"}',
+        )
+
+        manifest = load_gamemaker_project_manifest(self.gm_dir)
+
+        self.assertEqual(manifest.project_name, "Inside")
+        self.assertEqual(
+            manifest.yyp_path,
+            os.path.join(self.gm_dir, "BInside.yyp"),
+        )
+        rejected = [
+            diagnostic
+            for diagnostic in manifest.diagnostics
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1, rejected)
+        assert rejected[0].source is not None
+        self.assertEqual(rejected[0].source.path, invalid_yyp)
+        self.assertEqual(rejected[0].source.field_path, "AInvalid.yyp")
+        self.assertIn("not a regular .yyp file", rejected[0].message)
+
+    def test_skips_project_option_symlink_that_resolves_outside_project(self) -> None:
+        _write_file(
+            os.path.join(self.gm_dir, "Manifest.yyp"),
+            '{"%Name":"Inside","resourceType":"GMProject"}',
+        )
+        _write_file(
+            os.path.join(self.gm_dir, "options", "main", "options_main.yy"),
+            '{"option_game_speed":60}',
+        )
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_options = os.path.join(outside_dir, "options_windows.yy")
+            _write_file(outside_options, '{"option_windows_version":"outside"}')
+            linked_options = os.path.join(
+                self.gm_dir,
+                "options",
+                "windows",
+                "options_windows.yy",
+            )
+            os.makedirs(os.path.dirname(linked_options))
+            try:
+                os.symlink(outside_options, linked_options)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            manifest = load_gamemaker_project_manifest(self.gm_dir)
+
+        self.assertIsNotNone(manifest.get_option("option_game_speed", "main"))
+        self.assertIsNone(manifest.get_option("option_windows_version", "windows"))
+        rejected = [
+            diagnostic
+            for diagnostic in manifest.diagnostics
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        assert rejected[0].source is not None
+        self.assertEqual(rejected[0].source.path, linked_options)
+        self.assertEqual(
+            rejected[0].source.field_path,
+            "options/windows/options_windows.yy",
+        )
+
+    def test_skips_project_option_symlink_to_contained_wrong_family(self) -> None:
+        _write_file(
+            os.path.join(self.gm_dir, "Manifest.yyp"),
+            '{"%Name":"Inside","resourceType":"GMProject"}',
+        )
+        _write_file(
+            os.path.join(self.gm_dir, "options", "main", "options_main.yy"),
+            '{"option_game_speed":60}',
+        )
+        wrong_family_target = os.path.join(
+            self.gm_dir,
+            "sprites",
+            "s_options_decoy",
+            "s_options_decoy.yy",
+        )
+        _write_file(
+            wrong_family_target,
+            '{"option_windows_version":"wrong-family"}',
+        )
+        linked_options = os.path.join(
+            self.gm_dir,
+            "options",
+            "windows",
+            "options_windows.yy",
+        )
+        os.makedirs(os.path.dirname(linked_options), exist_ok=True)
+        try:
+            os.symlink(wrong_family_target, linked_options)
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+
+        with patch("builtins.open", wraps=open) as tracked_open:
+            manifest = load_gamemaker_project_manifest(self.gm_dir)
+
+        game_speed = manifest.get_option("option_game_speed", "main")
+        self.assertIsNotNone(game_speed)
+        assert game_speed is not None
+        self.assertEqual(game_speed.value, 60)
+        self.assertIsNone(
+            manifest.get_option("option_windows_version", "windows")
+        )
+        opened_paths = {
+            os.path.realpath(call.args[0])
+            for call in tracked_open.call_args_list
+            if call.args and isinstance(call.args[0], str)
+        }
+        self.assertNotIn(os.path.realpath(wrong_family_target), opened_paths)
+        rejected = [
+            diagnostic
+            for diagnostic in manifest.diagnostics
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1, rejected)
+        assert rejected[0].source is not None
+        self.assertEqual(rejected[0].source.path, linked_options)
+        self.assertEqual(
+            rejected[0].source.field_path,
+            "options/windows/options_windows.yy",
+        )
+
+    def test_skips_project_option_directory_symlink_with_source_diagnostic(self) -> None:
+        _write_file(
+            os.path.join(self.gm_dir, "Manifest.yyp"),
+            '{"%Name":"Inside","resourceType":"GMProject"}',
+        )
+        _write_file(
+            os.path.join(self.gm_dir, "options", "main", "options_main.yy"),
+            '{"option_game_speed":60}',
+        )
+        with tempfile.TemporaryDirectory() as outside_dir:
+            _write_file(
+                os.path.join(outside_dir, "options_linux.yy"),
+                '{"option_linux_display_name":"outside"}',
+            )
+            linked_directory = os.path.join(self.gm_dir, "options", "linux")
+            try:
+                os.symlink(outside_dir, linked_directory)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            manifest = load_gamemaker_project_manifest(self.gm_dir)
+
+        self.assertIsNotNone(manifest.get_option("option_game_speed", "main"))
+        self.assertIsNone(manifest.get_option("option_linux_display_name", "linux"))
+        rejected = [
+            diagnostic
+            for diagnostic in manifest.diagnostics
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        assert rejected[0].source is not None
+        self.assertEqual(rejected[0].source.path, linked_directory)
+        self.assertEqual(rejected[0].source.field_path, "options/linux")
+
+    def test_skips_project_option_root_symlink_with_source_diagnostic(self) -> None:
+        _write_file(
+            os.path.join(self.gm_dir, "Manifest.yyp"),
+            '{"%Name":"Inside","resourceType":"GMProject"}',
+        )
+        with tempfile.TemporaryDirectory() as outside_dir:
+            _write_file(
+                os.path.join(outside_dir, "main", "options_main.yy"),
+                '{"option_game_speed":999}',
+            )
+            linked_root = os.path.join(self.gm_dir, "options")
+            try:
+                os.symlink(outside_dir, linked_root)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            manifest = load_gamemaker_project_manifest(self.gm_dir)
+
+        self.assertIsNone(manifest.get_option("option_game_speed", "main"))
+        rejected = [
+            diagnostic
+            for diagnostic in manifest.diagnostics
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        assert rejected[0].source is not None
+        self.assertEqual(rejected[0].source.path, linked_root)
+        self.assertEqual(rejected[0].source.field_path, "options")
 
     def test_ide_version_is_empty_when_metadata_is_absent_or_malformed(self) -> None:
         yyp_path = os.path.join(self.gm_dir, "VersionFallback.yyp")

--- a/tests/test_project_settings.py
+++ b/tests/test_project_settings.py
@@ -13,6 +13,7 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from src.conversion.project_godot import prepare_godot_project_destination
+from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.project_settings import ProjectSettingsConverter
 
 SAMPLE_YYP = """\
@@ -421,13 +422,18 @@ class TestConvertIconFallback(unittest.TestCase):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_converter(self, platform: str = 'linux') -> ProjectSettingsConverter:
+    def _make_converter(
+        self,
+        platform: str = 'linux',
+        diagnostics: DiagnosticCollector | None = None,
+    ) -> ProjectSettingsConverter:
         return ProjectSettingsConverter(
             self.gm_dir, self.godot_dir,
             log_callback=lambda msg: self.logs.append(msg),
             progress_callback=lambda v: None,
             conversion_running=lambda: True,
             gm_platform=platform,
+            diagnostics=diagnostics,
         )
 
     def _create_icon(self, platform: str) -> None:
@@ -471,6 +477,72 @@ class TestConvertIconFallback(unittest.TestCase):
         result = converter.convert_icon()
 
         self.assertFalse(result)
+
+    def test_rejects_selected_icon_file_link_outside_project(self) -> None:
+        from PIL import Image
+
+        diagnostics = DiagnosticCollector()
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_icon = os.path.join(outside_dir, "outside.png")
+            Image.new("RGBA", (16, 16), "red").save(outside_icon, "PNG")
+            icons_dir = os.path.join(self.gm_dir, "options", "linux", "icons")
+            os.makedirs(icons_dir)
+            try:
+                os.symlink(outside_icon, os.path.join(icons_dir, "icon.png"))
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            result = self._make_converter(
+                platform="linux",
+                diagnostics=diagnostics,
+            ).convert_icon()
+
+        self.assertFalse(result)
+        self.assertFalse(os.path.exists(os.path.join(self.godot_dir, "icon.png")))
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertEqual(rejected[0].source_path, "options/linux/icons")
+        self.assertEqual(rejected[0].manifest_entry, "icon file")
+
+    def test_rejects_fallback_icon_directory_link_outside_project(self) -> None:
+        from PIL import Image
+
+        diagnostics = DiagnosticCollector()
+        with tempfile.TemporaryDirectory() as outside_dir:
+            Image.new("RGBA", (16, 16), "red").save(
+                os.path.join(outside_dir, "icon.png"),
+                "PNG",
+            )
+            platform_dir = os.path.join(self.gm_dir, "options", "windows")
+            os.makedirs(platform_dir)
+            try:
+                os.symlink(
+                    outside_dir,
+                    os.path.join(platform_dir, "icons"),
+                    target_is_directory=True,
+                )
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            result = self._make_converter(
+                platform="linux",
+                diagnostics=diagnostics,
+            ).convert_icon()
+
+        self.assertFalse(result)
+        self.assertFalse(os.path.exists(os.path.join(self.godot_dir, "icon.png")))
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertEqual(rejected[0].source_path, "options/windows")
+        self.assertEqual(rejected[0].manifest_entry, "icons directory")
 
     def test_converted_icon_is_wired_into_fresh_minimal_project(self) -> None:
         self._create_yyp()

--- a/tests/test_project_source_paths.py
+++ b/tests/test_project_source_paths.py
@@ -9,7 +9,10 @@ from pathlib import Path
 from src.conversion.project_source_paths import (
     ProjectSourcePathError,
     project_gml_source_paths,
+    resolve_project_filesystem_source_path,
+    resolve_project_sidecar_source_path,
     resolve_project_source_path,
+    validate_project_resource_source_path,
 )
 
 
@@ -32,6 +35,80 @@ class TestProjectSourcePaths(unittest.TestCase):
             )
             self.assertEqual(resolved.filesystem_path, os.path.abspath(yy_path))
 
+    def test_resource_metadata_guard_preserves_only_same_kind_yy_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            same_kind = resolve_project_source_path(
+                root,
+                "scripts/legacy/../scr_live/scr_live.yy",
+            )
+            cross_kind = resolve_project_source_path(
+                root,
+                "scripts/../objects/o_cross/o_cross.yy",
+            )
+            wrong_extension = resolve_project_source_path(
+                root,
+                "scripts/scr_live/scr_live.gml",
+            )
+
+            self.assertIs(
+                validate_project_resource_source_path(same_kind, "scripts"),
+                same_kind,
+            )
+            self.assertEqual(
+                same_kind.source_path,
+                "scripts/scr_live/scr_live.yy",
+            )
+            with self.assertRaisesRegex(ProjectSourcePathError, "declared 'scripts'"):
+                validate_project_resource_source_path(cross_kind, "scripts")
+            with self.assertRaisesRegex(ProjectSourcePathError, ".yy metadata file"):
+                validate_project_resource_source_path(wrong_extension, "scripts")
+
+    def test_resource_metadata_guard_checks_contained_symlink_target_family(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as root_text:
+            root = Path(root_text)
+            same_family_target = root / "sprites" / "target" / "target.yy"
+            cross_family_target = root / "objects" / "target" / "target.yy"
+            same_family_target.parent.mkdir(parents=True)
+            cross_family_target.parent.mkdir(parents=True)
+            same_family_target.write_text("{}", encoding="utf-8")
+            cross_family_target.write_text("{}", encoding="utf-8")
+            same_family_link = root / "sprites" / "same" / "same.yy"
+            cross_family_link = root / "sprites" / "cross" / "cross.yy"
+            same_family_link.parent.mkdir()
+            cross_family_link.parent.mkdir()
+            try:
+                same_family_link.symlink_to(same_family_target)
+                cross_family_link.symlink_to(cross_family_target)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            same_family = resolve_project_source_path(
+                root,
+                "sprites/same/same.yy",
+            )
+            cross_family = resolve_project_source_path(
+                root,
+                "sprites/cross/cross.yy",
+            )
+
+            self.assertIs(
+                validate_project_resource_source_path(
+                    same_family,
+                    "sprites",
+                ),
+                same_family,
+            )
+            with self.assertRaisesRegex(
+                ProjectSourcePathError,
+                "after symbolic-link resolution",
+            ):
+                validate_project_resource_source_path(
+                    cross_family,
+                    "sprites",
+                )
+
     def test_rejects_parent_traversal_outside_project(self) -> None:
         with tempfile.TemporaryDirectory() as parent_text:
             parent = Path(parent_text)
@@ -45,6 +122,25 @@ class TestProjectSourcePaths(unittest.TestCase):
                 "escapes the selected GameMaker project root",
             ):
                 resolve_project_source_path(root, "sprites/../../outside.yy")
+
+    def test_rejects_leading_traversal_that_reenters_project_lexically(self) -> None:
+        with tempfile.TemporaryDirectory() as parent_text:
+            parent = Path(parent_text)
+            root = parent / "project"
+            source = root / "scripts" / "inside.gml"
+            source.parent.mkdir(parents=True)
+            source.write_text("return 1;", encoding="utf-8")
+
+            for source_path in (
+                "../project/scripts/inside.gml",
+                "sprites/../../project/scripts/inside.gml",
+            ):
+                with self.subTest(source_path=source_path):
+                    with self.assertRaisesRegex(
+                        ProjectSourcePathError,
+                        "escapes the selected GameMaker project root through traversal",
+                    ):
+                        resolve_project_source_path(root, source_path)
 
     def test_rejects_posix_windows_drive_and_unc_absolute_paths(self) -> None:
         with tempfile.TemporaryDirectory() as root:
@@ -113,6 +209,145 @@ class TestProjectSourcePaths(unittest.TestCase):
                 resolved.source_path,
                 "sprite_alias/s_inside/s_inside.yy",
             )
+
+    def test_resolves_owner_relative_and_project_relative_sidecars(self) -> None:
+        with tempfile.TemporaryDirectory() as root_text:
+            root = Path(root_text)
+            owner = root / "rooms" / "r_test" / "r_test.yy"
+            owner.parent.mkdir(parents=True)
+            owner.write_text("{}", encoding="utf-8")
+            room_code = owner.parent / "RoomCreationCode.gml"
+            room_code.write_text("show_debug_message('room')", encoding="utf-8")
+            script = root / "scripts" / "scr_test" / "scr_test.gml"
+            script.parent.mkdir(parents=True)
+            script.write_text("return 1;", encoding="utf-8")
+
+            owner_relative = resolve_project_sidecar_source_path(
+                root,
+                "rooms/r_test/r_test.yy",
+                "RoomCreationCode.gml",
+            )
+            rooted = resolve_project_sidecar_source_path(
+                root,
+                owner,
+                "scripts/scr_test/scr_test.gml",
+            )
+            placeholder = resolve_project_sidecar_source_path(
+                root,
+                owner,
+                "${project_dir}/scripts/scr_test/scr_test.gml",
+            )
+            other_resource_root = resolve_project_sidecar_source_path(
+                root,
+                owner,
+                "materials/m_world/m_world.yy",
+            )
+            config_root = resolve_project_sidecar_source_path(
+                root,
+                owner,
+                "configs/Default/config.yy",
+            )
+
+            self.assertEqual(owner_relative.source_path, "rooms/r_test/RoomCreationCode.gml")
+            self.assertEqual(rooted.filesystem_path, os.path.abspath(script))
+            self.assertEqual(placeholder.filesystem_path, os.path.abspath(script))
+            self.assertEqual(
+                other_resource_root.source_path,
+                "materials/m_world/m_world.yy",
+            )
+            self.assertEqual(
+                config_root.source_path,
+                "configs/Default/config.yy",
+            )
+
+    def test_rejects_unsafe_sidecar_forms_before_owner_composition(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            unsafe_paths = (
+                "../../../outside.gml",
+                "/tmp/outside.gml",
+                r"C:\Games\Outside\outside.gml",
+                r"C:Outside\outside.gml",
+                r"\\server\share\outside.gml",
+                "bad\0path.gml",
+            )
+            for sidecar_path in unsafe_paths:
+                with self.subTest(sidecar_path=sidecar_path):
+                    with self.assertRaises(ProjectSourcePathError):
+                        resolve_project_sidecar_source_path(
+                            root,
+                            "rooms/r_test/r_test.yy",
+                            sidecar_path,
+                        )
+
+    def test_revalidates_discovered_file_symlinks(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as parent_text,
+            tempfile.TemporaryDirectory() as outside_text,
+        ):
+            parent = Path(parent_text)
+            root = parent / "project"
+            root.mkdir()
+            inside = root / "scripts" / "inside.gml"
+            inside.parent.mkdir()
+            inside.write_text("return 1;", encoding="utf-8")
+            outside = Path(outside_text) / "outside.gml"
+            outside.write_text("return 2;", encoding="utf-8")
+            try:
+                inside_link = root / "inside_link.gml"
+                inside_link.symlink_to(inside)
+                outside_link = root / "outside_link.gml"
+                outside_link.symlink_to(outside)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            resolved_inside = resolve_project_filesystem_source_path(root, inside_link)
+            self.assertEqual(
+                os.path.realpath(resolved_inside.filesystem_path),
+                os.path.realpath(inside),
+            )
+            with self.assertRaisesRegex(ProjectSourcePathError, "symbolic link"):
+                resolve_project_filesystem_source_path(root, outside_link)
+
+    def test_revalidates_canonical_candidate_under_symlinked_project_root(self) -> None:
+        with tempfile.TemporaryDirectory() as parent_text:
+            parent = Path(parent_text)
+            canonical_root = parent / "canonical_project"
+            source = canonical_root / "scripts" / "inside.gml"
+            source.parent.mkdir(parents=True)
+            source.write_text("return 1;", encoding="utf-8")
+            selected_root = parent / "selected_project"
+            try:
+                selected_root.symlink_to(canonical_root, target_is_directory=True)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            resolved = resolve_project_filesystem_source_path(
+                selected_root,
+                source,
+            )
+
+            self.assertEqual(resolved.source_path, "scripts/inside.gml")
+            self.assertEqual(
+                os.path.realpath(resolved.filesystem_path),
+                os.path.realpath(source),
+            )
+
+    @unittest.skipIf(os.sep == "\\", "Backslash is a native separator on Windows")
+    def test_rejects_discovered_literal_backslash_instead_of_redirecting(self) -> None:
+        with tempfile.TemporaryDirectory() as root_text:
+            root = Path(root_text)
+            listed_path = root / "extensions" / "evil\\name.yy"
+            redirected_path = root / "extensions" / "evil" / "name.yy"
+            listed_path.parent.mkdir(parents=True)
+            redirected_path.parent.mkdir(parents=True)
+            listed_path.write_text('{"name":"listed"}', encoding="utf-8")
+            redirected_path.write_text('{"name":"redirected"}', encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                ProjectSourcePathError,
+                "host-literal backslash",
+            ):
+                resolve_project_filesystem_source_path(root, listed_path)
 
     def test_enumerates_only_yyp_owned_gml_in_resource_and_metadata_order(self) -> None:
         with tempfile.TemporaryDirectory() as root_text:
@@ -215,6 +450,135 @@ class TestProjectSourcePaths(unittest.TestCase):
                     "rooms/r_live/InstanceCreationCode_inst_live.gml",
                 ),
             )
+
+    def test_gml_enumeration_rejects_cross_kind_normalization(self) -> None:
+        with tempfile.TemporaryDirectory() as root_text:
+            root = Path(root_text)
+            (root / "Project.yyp").write_text(
+                json.dumps(
+                    {
+                        "resources": [
+                            {
+                                "id": {
+                                    "name": "scr_live",
+                                    "path": (
+                                        "scripts/legacy/../scr_live/scr_live.yy"
+                                    ),
+                                }
+                            },
+                            {
+                                "id": {
+                                    "name": "scr_cross",
+                                    "path": (
+                                        "scripts/../objects/scr_cross/scr_cross.yy"
+                                    ),
+                                }
+                            },
+                        ],
+                        "RoomOrderNodes": [],
+                        "resourceType": "GMProject",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            live_dir = root / "scripts" / "scr_live"
+            live_dir.mkdir(parents=True)
+            (live_dir / "scr_live.yy").write_text(
+                json.dumps({"name": "scr_live", "resourceType": "GMScript"}),
+                encoding="utf-8",
+            )
+            (live_dir / "scr_live.gml").write_text("return 1;\n", encoding="utf-8")
+            cross_dir = root / "objects" / "scr_cross"
+            cross_dir.mkdir(parents=True)
+            (cross_dir / "scr_cross.yy").write_text(
+                json.dumps({"name": "scr_cross", "resourceType": "GMScript"}),
+                encoding="utf-8",
+            )
+            (cross_dir / "scr_cross.gml").write_text(
+                "return 2;\n",
+                encoding="utf-8",
+            )
+
+            source_paths = tuple(
+                source.source_path for source in project_gml_source_paths(root)
+            )
+
+        self.assertEqual(source_paths, ("scripts/scr_live/scr_live.gml",))
+
+    def test_derived_sidecar_names_cannot_leave_their_owner_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as root_text:
+            root = Path(root_text)
+            (root / "Project.yyp").write_text(
+                json.dumps(
+                    {
+                        "resources": [
+                            {
+                                "id": {
+                                    "name": "../leaked",
+                                    "path": "scripts/owner/custom.yy",
+                                }
+                            },
+                            {
+                                "id": {
+                                    "name": "r_owner",
+                                    "path": "rooms/r_owner/r_owner.yy",
+                                }
+                            },
+                        ],
+                        "RoomOrderNodes": [],
+                        "resourceType": "GMProject",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            script_dir = root / "scripts" / "owner"
+            script_dir.mkdir(parents=True)
+            (script_dir / "custom.yy").write_text(
+                json.dumps(
+                    {
+                        "name": "../leaked",
+                        "resourceType": "GMScript",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (root / "scripts" / "leaked.gml").write_text(
+                "#macro LEAKED_SCRIPT 1\n",
+                encoding="utf-8",
+            )
+            room_dir = root / "rooms" / "r_owner"
+            room_dir.mkdir(parents=True)
+            (room_dir / "r_owner.yy").write_text(
+                json.dumps(
+                    {
+                        "name": "r_owner",
+                        "resourceType": "GMRoom",
+                        "layers": [
+                            {
+                                "instances": [
+                                    {
+                                        "name": "/../../shared/Leak",
+                                        "hasCreationCode": True,
+                                    }
+                                ]
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            leaked_room_code = root / "rooms" / "shared" / "Leak.gml"
+            leaked_room_code.parent.mkdir(parents=True)
+            leaked_room_code.write_text(
+                "#macro LEAKED_ROOM 1\n",
+                encoding="utf-8",
+            )
+
+            source_paths = tuple(
+                source.source_path for source in project_gml_source_paths(root)
+            )
+
+        self.assertEqual(source_paths, ())
 
 
 if __name__ == "__main__":

--- a/tests/test_resource_index.py
+++ b/tests/test_resource_index.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import sys
@@ -10,6 +11,7 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from src.conversion.resource_index import GameMakerResourceIndex
+from src.conversion.diagnostics import DiagnosticCollector
 
 
 def _write_file(path: str, content: str) -> None:
@@ -120,13 +122,17 @@ class TestGameMakerResourceIndex(unittest.TestCase):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _build_index(self) -> GameMakerResourceIndex:
+    def _build_index(
+        self,
+        diagnostics: DiagnosticCollector | None = None,
+    ) -> GameMakerResourceIndex:
         index = GameMakerResourceIndex(
             self.gm_dir,
             self.godot_dir,
             log_callback=lambda msg: self.logs.append(str(msg)),
             progress_callback=lambda v: None,
             conversion_running=lambda: True,
+            diagnostics=diagnostics,
         )
         return index.build()
 
@@ -160,6 +166,31 @@ class TestGameMakerResourceIndex(unittest.TestCase):
             os.path.join(self.gm_dir, "extensions", name, name + ".yy"),
             _make_extension_yy(name),
         )
+
+    def _write_inherited_room_pair(
+        self,
+        parent_name: str,
+        child_name: str,
+        creation_code_file: str,
+    ) -> None:
+        parent_content = _make_room_yy(parent_name).replace(
+            '"creationCodeFile":"",',
+            f'"creationCodeFile":{json.dumps(creation_code_file)},',
+        )
+        parent_reference = json.dumps(
+            {
+                "name": parent_name,
+                "path": f"rooms/{parent_name}/{parent_name}.yy",
+            },
+            separators=(",", ":"),
+        )
+        child_content = (
+            _make_room_yy(child_name)
+            .replace('"inheritCode":false,', '"inheritCode":true,')
+            .replace('"parentRoom":null,', f'"parentRoom":{parent_reference},')
+        )
+        self._write_room(parent_name, content=parent_content)
+        self._write_room(child_name, content=child_content)
 
     def test_indexes_yyp_resources_and_preserves_room_order(self) -> None:
         self._write_yyp(
@@ -252,7 +283,8 @@ class TestGameMakerResourceIndex(unittest.TestCase):
                 "}\n",
             )
 
-            index = self._build_index()
+            diagnostics = DiagnosticCollector()
+            index = self._build_index(diagnostics)
 
         self.assertIsNone(index.get_resource("sprites", "s_escape"))
         self.assertTrue(
@@ -262,6 +294,85 @@ class TestGameMakerResourceIndex(unittest.TestCase):
             ),
             self.logs,
         )
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertEqual(rejected[0].source_path, "TestProject.yyp")
+        self.assertEqual(rejected[0].resource, "s_escape")
+        self.assertEqual(rejected[0].resource_type, "GMSprite")
+        self.assertEqual(rejected[0].manifest_entry, "resources[0].id.path")
+
+    def test_rejects_yyp_resource_normalized_into_another_kind(self) -> None:
+        _write_file(
+            os.path.join(self.gm_dir, "TestProject.yyp"),
+            "{\n"
+            '  "resources":[\n'
+            '    {"id":{"name":"s_cross",'
+            '"path":"sprites/../objects/o_cross/o_cross.yy"}}\n'
+            "  ],\n"
+            '  "RoomOrderNodes":[],\n'
+            '  "resourceType":"GMProject"\n'
+            "}\n",
+        )
+        self._write_resource(
+            "objects",
+            "o_cross",
+            "folders/Objects.yy",
+            "GMObject",
+        )
+        diagnostics = DiagnosticCollector()
+
+        index = self._build_index(diagnostics)
+
+        self.assertIsNone(index.get_resource("sprites", "s_cross"))
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertEqual(rejected[0].source_path, "TestProject.yyp")
+        self.assertEqual(rejected[0].resource, "s_cross")
+        self.assertEqual(rejected[0].resource_type, "GMSprite")
+        self.assertEqual(rejected[0].manifest_entry, "resources[0].id.path")
+
+    def test_rejects_yyp_resource_that_is_not_yy_metadata(self) -> None:
+        _write_file(
+            os.path.join(self.gm_dir, "TestProject.yyp"),
+            "{\n"
+            '  "resources":[\n'
+            '    {"id":{"name":"s_json",'
+            '"path":"sprites/s_json/s_json.json"}}\n'
+            "  ],\n"
+            '  "RoomOrderNodes":[],\n'
+            '  "resourceType":"GMProject"\n'
+            "}\n",
+        )
+        _write_file(
+            os.path.join(self.gm_dir, "sprites", "s_json", "s_json.json"),
+            _make_minimal_yy(
+                "s_json",
+                "GMSprite",
+                "Sprites",
+                "folders/Sprites.yy",
+            ),
+        )
+        diagnostics = DiagnosticCollector()
+
+        index = self._build_index(diagnostics)
+
+        self.assertIsNone(index.get_resource("sprites", "s_json"))
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertIn(".yy metadata file", rejected[0].message)
+        self.assertEqual(rejected[0].source_path, "TestProject.yyp")
 
     def test_preserves_manifest_resource_metadata_and_resolves_by_graph_fields(self) -> None:
         _write_file(
@@ -319,6 +430,224 @@ class TestGameMakerResourceIndex(unittest.TestCase):
         index = self._build_index()
 
         self.assertIn("ads_show_rewarded", index.get_extension_functions())
+
+    def test_disk_fallback_skips_resource_directory_symlink_escape(self) -> None:
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_resource = os.path.join(outside_dir, "s_escape")
+            _write_file(
+                os.path.join(outside_resource, "s_escape.yy"),
+                _make_minimal_yy(
+                    "s_escape",
+                    "GMSprite",
+                    "Sprites",
+                    "folders/Sprites.yy",
+                ),
+            )
+            sprites_dir = os.path.join(self.gm_dir, "sprites")
+            os.makedirs(sprites_dir)
+            try:
+                os.symlink(
+                    outside_resource,
+                    os.path.join(sprites_dir, "s_escape"),
+                    target_is_directory=True,
+                )
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            index = self._build_index()
+
+        self.assertIsNone(index.get_resource("sprites", "s_escape"))
+        self.assertTrue(
+            any(
+                "s_escape" in message and "symbolic link" in message
+                for message in self.logs
+            ),
+            self.logs,
+        )
+
+    def test_disk_fallback_skips_extension_metadata_symlink_escape(self) -> None:
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_yy = os.path.join(outside_dir, "AdSDK.yy")
+            _write_file(outside_yy, _make_extension_yy("AdSDK"))
+            extension_dir = os.path.join(self.gm_dir, "extensions", "AdSDK")
+            os.makedirs(extension_dir)
+            try:
+                os.symlink(outside_yy, os.path.join(extension_dir, "AdSDK.yy"))
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            diagnostics = DiagnosticCollector()
+            index = self._build_index(diagnostics)
+
+        self.assertNotIn("ads_show_rewarded", index.get_extension_functions())
+        self.assertTrue(
+            any(
+                "AdSDK.yy" in message and "symbolic link" in message
+                for message in self.logs
+            ),
+            self.logs,
+        )
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertEqual(rejected[0].source_path, "extensions/AdSDK")
+        self.assertEqual(
+            rejected[0].manifest_entry,
+            "disk fallback resource metadata",
+        )
+
+    def test_disk_fallback_validates_canonical_resource_family(self) -> None:
+        self._write_resource(
+            "sprites",
+            "s_local",
+            "folders/Sprites.yy",
+            "GMSprite",
+        )
+        same_family_target = os.path.join(
+            self.gm_dir,
+            "sprites",
+            "targets",
+            "shared.yy",
+        )
+        cross_family_target = os.path.join(
+            self.gm_dir,
+            "objects",
+            "targets",
+            "shared.yy",
+        )
+        _write_file(
+            same_family_target,
+            _make_minimal_yy(
+                "s_alias_target",
+                "GMSprite",
+                "Sprites",
+                "folders/Sprites.yy",
+            ),
+        )
+        _write_file(
+            cross_family_target,
+            _make_minimal_yy(
+                "o_cross_target",
+                "GMObject",
+                "Objects",
+                "folders/Objects.yy",
+            ),
+        )
+        same_family_alias = os.path.join(
+            self.gm_dir,
+            "sprites",
+            "s_alias",
+            "s_alias.yy",
+        )
+        cross_family_alias = os.path.join(
+            self.gm_dir,
+            "sprites",
+            "s_cross",
+            "s_cross.yy",
+        )
+        os.makedirs(os.path.dirname(same_family_alias))
+        os.makedirs(os.path.dirname(cross_family_alias))
+        try:
+            os.symlink(same_family_target, same_family_alias)
+            os.symlink(cross_family_target, cross_family_alias)
+        except (NotImplementedError, OSError) as exc:
+            self.skipTest(f"Symbolic links are unavailable: {exc}")
+        diagnostics = DiagnosticCollector()
+
+        index = self._build_index(diagnostics)
+
+        self.assertIsNotNone(index.get_resource("sprites", "s_local"))
+        alias = index.get_resource("sprites", "s_alias")
+        self.assertIsNotNone(alias)
+        self.assertIsNone(index.get_resource("sprites", "s_cross"))
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "sprites/s_cross")
+        self.assertEqual(rejected[0].resource, "s_cross")
+        self.assertEqual(rejected[0].resource_type, "sprites")
+        self.assertEqual(
+            rejected[0].manifest_entry,
+            "disk fallback resource metadata",
+        )
+
+    def test_extension_disk_fallback_validates_canonical_resource_family(
+        self,
+    ) -> None:
+        same_family_target = os.path.join(
+            self.gm_dir,
+            "extensions",
+            "targets",
+            "shared.yy",
+        )
+        cross_family_target = os.path.join(
+            self.gm_dir,
+            "objects",
+            "targets",
+            "extension.yy",
+        )
+        _write_file(
+            same_family_target,
+            _make_extension_yy("SameSDK").replace(
+                "ads_show_rewarded",
+                "same_family_function",
+            ),
+        )
+        _write_file(
+            cross_family_target,
+            _make_extension_yy("CrossSDK").replace(
+                "ads_show_rewarded",
+                "cross_family_function",
+            ),
+        )
+        same_family_alias = os.path.join(
+            self.gm_dir,
+            "extensions",
+            "SameSDK",
+            "SameSDK.yy",
+        )
+        cross_family_alias = os.path.join(
+            self.gm_dir,
+            "extensions",
+            "CrossSDK",
+            "CrossSDK.yy",
+        )
+        os.makedirs(os.path.dirname(same_family_alias))
+        os.makedirs(os.path.dirname(cross_family_alias))
+        try:
+            os.symlink(same_family_target, same_family_alias)
+            os.symlink(cross_family_target, cross_family_alias)
+        except (NotImplementedError, OSError) as exc:
+            self.skipTest(f"Symbolic links are unavailable: {exc}")
+        diagnostics = DiagnosticCollector()
+
+        index = self._build_index(diagnostics)
+
+        self.assertIsNotNone(
+            index.get_extension_function("same_family_function")
+        )
+        self.assertIsNone(
+            index.get_extension_function("cross_family_function")
+        )
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "extensions/CrossSDK")
+        self.assertEqual(rejected[0].resource, "CrossSDK")
+        self.assertEqual(rejected[0].resource_type, "extensions")
+        self.assertEqual(
+            rejected[0].manifest_entry,
+            "disk fallback resource metadata",
+        )
 
     def test_computes_godot_paths_with_subfolders(self) -> None:
         self._write_yyp([
@@ -389,6 +718,249 @@ class TestGameMakerResourceIndex(unittest.TestCase):
         self.assertEqual(room.creation_code_file, "rooms/r_code/RoomCreationCode.gml")
         self.assertTrue(room.inherit_code)
         self.assertTrue(room.is_dnd)
+
+    def test_rejects_non_string_room_creation_code_without_blocking_siblings(
+        self,
+    ) -> None:
+        malformed_values: dict[str, object] = {
+            "r_object": {"path": "RoomCreationCode.gml"},
+            "r_list": ["RoomCreationCode.gml"],
+            "r_number": 7,
+            "r_boolean": True,
+        }
+        resources = [("rooms", name) for name in malformed_values]
+        resources.append(("rooms", "r_safe"))
+        self._write_yyp(resources, room_order=[name for _kind, name in resources])
+        for room_name, value in malformed_values.items():
+            content = _make_room_yy(room_name).replace(
+                '"creationCodeFile":"",',
+                f'"creationCodeFile":{json.dumps(value)},',
+            )
+            self._write_room(room_name, content=content)
+        safe_content = _make_room_yy("r_safe").replace(
+            '"creationCodeFile":"",',
+            '"creationCodeFile":"RoomCreationCode.gml",',
+        )
+        self._write_room("r_safe", content=safe_content)
+        diagnostics = DiagnosticCollector()
+
+        index = self._build_index(diagnostics)
+
+        for room_name in malformed_values:
+            room = index.get_room(room_name)
+            assert room is not None
+            self.assertEqual(room.creation_code_file, "")
+        safe_room = index.get_room("r_safe")
+        assert safe_room is not None
+        self.assertEqual(safe_room.creation_code_file, "RoomCreationCode.gml")
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), len(malformed_values), rejected)
+        self.assertEqual(
+            {diagnostic.resource for diagnostic in rejected},
+            set(malformed_values),
+        )
+        self.assertEqual(
+            {diagnostic.source_path for diagnostic in rejected},
+            {
+                f"rooms/{room_name}/{room_name}.yy"
+                for room_name in malformed_values
+            },
+        )
+        self.assertTrue(
+            all(
+                diagnostic.resource_type == "room"
+                and diagnostic.manifest_entry == "creationCodeFile"
+                for diagnostic in rejected
+            )
+        )
+
+    def test_inherited_room_creation_code_resolves_from_parent_owner(self) -> None:
+        cases = (
+            (
+                "owner_relative",
+                "RoomCreationCode.gml",
+                "rooms/r_parent_owner_relative/RoomCreationCode.gml",
+            ),
+            (
+                "project_placeholder",
+                "${project_dir}/rooms/r_parent_project_placeholder/RoomCode.gml",
+                "rooms/r_parent_project_placeholder/RoomCode.gml",
+            ),
+            (
+                "rooms_root",
+                "rooms/r_parent_rooms_root/RoomCode.gml",
+                "rooms/r_parent_rooms_root/RoomCode.gml",
+            ),
+            (
+                "scripts_root",
+                "scripts/shared/RoomCode.gml",
+                "scripts/shared/RoomCode.gml",
+            ),
+        )
+        resources: list[tuple[str, str]] = []
+        expected_by_child: dict[str, str] = {}
+        for suffix, source_path, expected_path in cases:
+            parent_name = "r_parent_" + suffix
+            child_name = "r_child_" + suffix
+            resources.extend((("rooms", parent_name), ("rooms", child_name)))
+            expected_by_child[child_name] = expected_path
+            self._write_inherited_room_pair(
+                parent_name,
+                child_name,
+                source_path,
+            )
+            _write_file(
+                os.path.join(self.gm_dir, *expected_path.split("/")),
+                f"global.{suffix} = true;\n",
+            )
+        self._write_yyp(resources)
+        diagnostics = DiagnosticCollector()
+
+        index = self._build_index(diagnostics)
+
+        self.assertFalse(
+            any(
+                diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+                for diagnostic in diagnostics.diagnostics()
+            ),
+            diagnostics.diagnostics(),
+        )
+        for child_name, expected_path in expected_by_child.items():
+            with self.subTest(child=child_name):
+                child = index.get_room(child_name)
+                assert child is not None
+                self.assertEqual(child.creation_code_file, expected_path)
+
+    def test_rejects_unsafe_inherited_room_creation_code_paths(self) -> None:
+        outside_path = os.path.join(
+            os.path.dirname(self.gm_dir),
+            f"{os.path.basename(self.gm_dir)}_outside_room_code.gml",
+        )
+        _write_file(outside_path, "global.outside_code = true;\n")
+        self.addCleanup(
+            lambda: os.path.isfile(outside_path) and os.unlink(outside_path)
+        )
+        cases = {
+            "traversal": "../outside.gml",
+            "posix_absolute": outside_path,
+            "drive_absolute": r"C:\Outside\Leak.gml",
+            "drive_relative": r"C:Outside\Leak.gml",
+            "unc": r"\\server\share\Leak.gml",
+            "nul": "RoomCode\0.gml",
+        }
+        resources: list[tuple[str, str]] = []
+        expected_parents: set[str] = set()
+        child_names: list[str] = []
+        for suffix, source_path in cases.items():
+            parent_name = "r_parent_" + suffix
+            child_name = "r_child_" + suffix
+            resources.extend((("rooms", parent_name), ("rooms", child_name)))
+            expected_parents.add(parent_name)
+            child_names.append(child_name)
+            self._write_inherited_room_pair(
+                parent_name,
+                child_name,
+                source_path,
+            )
+
+        old_windows_rewrite_decoy = os.path.join(
+            self.gm_dir,
+            "rooms",
+            "r_parent_drive_absolute",
+            "C:",
+            "Outside",
+            "Leak.gml",
+        )
+        _write_file(
+            old_windows_rewrite_decoy,
+            "global.old_windows_rewrite_decoy = true;\n",
+        )
+        self._write_yyp(resources)
+        diagnostics = DiagnosticCollector()
+
+        index = self._build_index(diagnostics)
+
+        self.assertTrue(os.path.isfile(old_windows_rewrite_decoy))
+        for child_name in child_names:
+            with self.subTest(child=child_name):
+                child = index.get_room(child_name)
+                assert child is not None
+                self.assertEqual(child.creation_code_file, "")
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), len(cases), rejected)
+        self.assertEqual(
+            {diagnostic.resource for diagnostic in rejected},
+            expected_parents,
+        )
+        self.assertEqual(
+            {diagnostic.source_path for diagnostic in rejected},
+            {
+                f"rooms/{parent_name}/{parent_name}.yy"
+                for parent_name in expected_parents
+            },
+        )
+        self.assertTrue(
+            all(diagnostic.resource_type == "room" for diagnostic in rejected)
+        )
+        self.assertTrue(
+            all(
+                diagnostic.manifest_entry == "creationCodeFile"
+                for diagnostic in rejected
+            )
+        )
+
+    def test_rejects_inherited_room_creation_code_symlink_escape(self) -> None:
+        parent_name = "r_parent_symlink"
+        child_name = "r_child_symlink"
+        self._write_yyp(
+            (("rooms", parent_name), ("rooms", child_name)),
+        )
+        self._write_inherited_room_pair(
+            parent_name,
+            child_name,
+            "LinkedRoomCode.gml",
+        )
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_path = os.path.join(outside_dir, "RoomCode.gml")
+            _write_file(outside_path, "global.outside_code = true;\n")
+            linked_path = os.path.join(
+                self.gm_dir,
+                "rooms",
+                parent_name,
+                "LinkedRoomCode.gml",
+            )
+            try:
+                os.symlink(outside_path, linked_path)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+            diagnostics = DiagnosticCollector()
+
+            index = self._build_index(diagnostics)
+
+        child = index.get_room(child_name)
+        assert child is not None
+        self.assertEqual(child.creation_code_file, "")
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(
+            rejected[0].source_path,
+            f"rooms/{parent_name}/{parent_name}.yy",
+        )
+        self.assertEqual(rejected[0].resource, parent_name)
+        self.assertEqual(rejected[0].resource_type, "room")
+        self.assertEqual(rejected[0].manifest_entry, "creationCodeFile")
 
     def test_missing_yyp_falls_back_to_disk_scan(self) -> None:
         self._write_room("r_disk")

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -14,6 +14,8 @@ if PROJECT_ROOT not in sys.path:
 
 from src.conversion.rooms import ROOM_RUNTIME_SCRIPT_RELATIVE_PATH, RoomConverter
 from src.conversion.diagnostics import DiagnosticCollector
+from src.conversion.resource_index import IndexedRoom
+from src.conversion.room_creation_code import resolve_instance_creation_code
 from src.conversion.room_layers import (
     GAMEMAKER_EMPTY_TILE_SENTINEL,
     GAMEMAKER_TILE_FLIP_BIT,
@@ -185,7 +187,9 @@ class TestRoomConverter(unittest.TestCase):
         shutil.rmtree(self.godot_dir)
 
     def _make_converter(
-        self, conversion_running: Callable[[], bool] = lambda: True
+        self,
+        conversion_running: Callable[[], bool] = lambda: True,
+        diagnostics: DiagnosticCollector | None = None,
     ) -> RoomConverter:
         return RoomConverter(
             self.gm_dir,
@@ -194,6 +198,7 @@ class TestRoomConverter(unittest.TestCase):
             progress_callback=lambda value: self.progress.append(value),
             conversion_running=conversion_running,
             max_workers=1,
+            diagnostics=diagnostics,
         )
 
     def _write_yyp(
@@ -1219,6 +1224,400 @@ class TestRoomConverter(unittest.TestCase):
         ]
         self.assertTrue(missing_logs)
         self.assertTrue(all(log.startswith("Info:") for log in missing_logs))
+
+    def test_rejects_unsafe_room_creation_code_paths_with_owner_diagnostics(self):
+        room_names = [
+            "r_traversal",
+            "r_absolute",
+            "r_drive_absolute",
+            "r_drive_relative",
+            "r_unc",
+            "r_nul",
+            "r_symlink",
+        ]
+        self._write_yyp(room_names)
+
+        outside_directory = os.path.dirname(self.gm_dir)
+        outside_path = os.path.join(
+            outside_directory,
+            f"{os.path.basename(self.gm_dir)}_outside_room_code.gml",
+        )
+        _write_file(outside_path, "global.outside_room_code_was_read = true;\n")
+        self.addCleanup(
+            lambda: os.path.isfile(outside_path) and os.unlink(outside_path)
+        )
+
+        traversal_room_directory = os.path.join(
+            self.gm_dir,
+            "rooms",
+            "r_traversal",
+        )
+        traversal_path = os.path.relpath(outside_path, traversal_room_directory)
+        unsafe_paths = {
+            "r_traversal": traversal_path,
+            "r_absolute": outside_path,
+            "r_drive_absolute": r"C:\Games\Outside\RoomCreationCode.gml",
+            "r_drive_relative": r"C:Outside\RoomCreationCode.gml",
+            "r_unc": r"\\server\share\RoomCreationCode.gml",
+            "r_nul": "RoomCreationCode\0.gml",
+        }
+        for room_name, source_path in unsafe_paths.items():
+            self._write_room(room_name, creation_code_file=source_path)
+
+        self._write_room("r_symlink", creation_code_file="LinkedRoomCode.gml")
+        linked_path = os.path.join(
+            self.gm_dir,
+            "rooms",
+            "r_symlink",
+            "LinkedRoomCode.gml",
+        )
+        try:
+            os.symlink(outside_path, linked_path)
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+
+        diagnostics = DiagnosticCollector()
+        self._make_converter(diagnostics=diagnostics).convert_all()
+
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), len(room_names), rejected)
+        self.assertEqual(
+            {diagnostic.source_path for diagnostic in rejected},
+            {
+                f"rooms/{room_name}/{room_name}.yy"
+                for room_name in room_names
+            },
+        )
+        self.assertTrue(
+            all(diagnostic.resource_type == "room" for diagnostic in rejected)
+        )
+        self.assertTrue(
+            all(
+                diagnostic.manifest_entry == "creationCodeFile"
+                for diagnostic in rejected
+            )
+        )
+        for room_name in room_names:
+            self.assertFalse(
+                os.path.exists(
+                    os.path.join(
+                        self.godot_dir,
+                        "rooms",
+                        room_name,
+                        room_name + ".gd",
+                    )
+                ),
+                room_name,
+            )
+            scene = self._read_scene(room_name)
+            self.assertIn(
+                'metadata/gamemaker_creation_code_source_path = ""',
+                scene,
+            )
+            self.assertIn(
+                "metadata/gamemaker_creation_code_file_exists = false",
+                scene,
+            )
+
+    def test_accepts_project_relative_room_creation_code_forms(self):
+        room_names = ["r_rooted", "r_placeholder", "r_backslash"]
+        self._write_yyp(room_names)
+        source_paths = {
+            "r_rooted": "rooms/r_rooted/RoomCreationCode.gml",
+            "r_placeholder": (
+                "${project_dir}/rooms/r_placeholder/RoomCreationCode.gml"
+            ),
+            "r_backslash": r"rooms\r_backslash\RoomCreationCode.gml",
+        }
+        for room_name, source_path in source_paths.items():
+            _write_file(
+                os.path.join(
+                    self.gm_dir,
+                    "rooms",
+                    room_name,
+                    "RoomCreationCode.gml",
+                ),
+                f'global.{room_name}_code = "converted";\n',
+            )
+            self._write_room(room_name, creation_code_file=source_path)
+
+        self._make_converter().convert_all()
+
+        for room_name in room_names:
+            script = self._read_room_script(room_name)
+            self.assertIn(f'"{room_name}_code"', script)
+            self.assertIn('"converted"', script)
+
+    def test_inherited_room_creation_code_stays_parent_relative(self):
+        self._write_yyp(["r_parent", "r_child"])
+        _write_file(
+            os.path.join(
+                self.gm_dir,
+                "rooms",
+                "r_parent",
+                "RoomCreationCode.gml",
+            ),
+            'global.inherited_room_code = "parent";\n',
+        )
+        self._write_room(
+            "r_parent",
+            creation_code_file="RoomCreationCode.gml",
+        )
+        self._write_room(
+            "r_child",
+            inherit_code=True,
+            parent_room={
+                "name": "r_parent",
+                "path": "rooms/r_parent/r_parent.yy",
+            },
+        )
+
+        self._make_converter().convert_all()
+
+        child_script = self._read_room_script("r_child")
+        self.assertIn('"inherited_room_code"', child_script)
+        self.assertIn('"parent"', child_script)
+
+    def test_rejects_instance_name_sidecar_traversal(self):
+        self._write_yyp(["r_instance_escape"])
+        room_directory = os.path.join(
+            self.gm_dir,
+            "rooms",
+            "r_instance_escape",
+        )
+        bridge_directory = os.path.join(
+            room_directory,
+            "InstanceCreationCode_bridge",
+        )
+        outside_stem = os.path.join(
+            os.path.dirname(self.gm_dir),
+            f"{os.path.basename(self.gm_dir)}_outside_instance_code",
+        )
+        outside_path = outside_stem + ".gml"
+        _write_file(outside_path, "outside_instance_code_was_read = true;\n")
+        self.addCleanup(
+            lambda: os.path.isfile(outside_path) and os.unlink(outside_path)
+        )
+        instance_name = "bridge/" + os.path.relpath(
+            outside_stem,
+            bridge_directory,
+        ).replace(os.sep, "/")
+        self._write_room(
+            "r_instance_escape",
+            layers=[
+                {
+                    "%Name": "Instances",
+                    "resourceType": "GMRInstanceLayer",
+                    "instances": [
+                        {
+                            "name": instance_name,
+                            "hasCreationCode": True,
+                        }
+                    ],
+                }
+            ],
+        )
+        os.makedirs(bridge_directory)
+
+        diagnostics = DiagnosticCollector()
+        self._make_converter(diagnostics=diagnostics).convert_all()
+
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(
+                    self.godot_dir,
+                    "rooms",
+                    "r_instance_escape",
+                    "r_instance_escape.gd",
+                )
+            )
+        )
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(
+            rejected[0].source_path,
+            "rooms/r_instance_escape/r_instance_escape.yy",
+        )
+        self.assertEqual(
+            rejected[0].manifest_entry,
+            "layers[].instances[].name",
+        )
+
+    def test_rejects_instance_name_that_reaches_another_project_directory(self):
+        self._write_yyp(["r_instance_cross_owner"])
+        self._write_room(
+            "r_instance_cross_owner",
+            layers=[
+                {
+                    "%Name": "Instances",
+                    "resourceType": "GMRInstanceLayer",
+                    "instances": [
+                        {
+                            "name": "bridge/../../shared/Leak",
+                            "hasCreationCode": True,
+                        }
+                    ],
+                }
+            ],
+        )
+        _write_file(
+            os.path.join(self.gm_dir, "rooms", "shared", "Leak.gml"),
+            "cross_owner_instance_code_was_read = true;\n",
+        )
+        diagnostics = DiagnosticCollector()
+
+        self._make_converter(diagnostics=diagnostics).convert_all()
+
+        room_script = os.path.join(
+            self.godot_dir,
+            "rooms",
+            "r_instance_cross_owner",
+            "r_instance_cross_owner.gd",
+        )
+        self.assertFalse(os.path.exists(room_script))
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(
+            rejected[0].source_path,
+            "rooms/r_instance_cross_owner/r_instance_cross_owner.yy",
+        )
+        self.assertEqual(
+            rejected[0].manifest_entry,
+            "layers[].instances[].name",
+        )
+
+    def test_instance_name_aliases_are_rejected_but_safe_name_is_transpiled(self):
+        room_name = "r_instance_components"
+        self._write_yyp([room_name])
+        instances = [
+            {"name": "bridge/../alias", "hasCreationCode": True},
+            {"name": r"bridge\..\alias", "hasCreationCode": True},
+            {"name": ".", "hasCreationCode": True},
+            {"name": "..", "hasCreationCode": True},
+            {"name": "inst_safe", "hasCreationCode": True},
+        ]
+        room_path = self._write_room(
+            room_name,
+            layers=[
+                {
+                    "%Name": "Instances",
+                    "resourceType": "GMRInstanceLayer",
+                    "instances": instances,
+                }
+            ],
+        )
+        room_directory = os.path.dirname(room_path)
+        unsafe_sources = {
+            "alias.gml": "unsafe_component_alias = 1;\n",
+            "InstanceCreationCode_..gml": "unsafe_component_dot = 1;\n",
+            "InstanceCreationCode_...gml": "unsafe_component_dotdot = 1;\n",
+        }
+        for filename, source in unsafe_sources.items():
+            _write_file(os.path.join(room_directory, filename), source)
+        _write_file(
+            os.path.join(
+                room_directory,
+                "InstanceCreationCode_inst_safe.gml",
+            ),
+            "safe_instance_component = 1;\n",
+        )
+        diagnostics = DiagnosticCollector()
+
+        self._make_converter(diagnostics=diagnostics).convert_all()
+
+        script = self._read_room_script(room_name)
+        self.assertIn("safe_instance_component", script)
+        self.assertNotIn("unsafe_component_alias", script)
+        self.assertNotIn("unsafe_component_dot", script)
+        self.assertNotIn("unsafe_component_dotdot", script)
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 4, rejected)
+        self.assertTrue(
+            all(
+                diagnostic.source_path
+                == f"rooms/{room_name}/{room_name}.yy"
+                for diagnostic in rejected
+            )
+        )
+        self.assertTrue(
+            all(
+                diagnostic.manifest_entry == "layers[].instances[].name"
+                for diagnostic in rejected
+            )
+        )
+
+    def test_two_argument_instance_creation_code_infers_confined_project_root(self):
+        room_name = "r_direct_helper"
+        room_path = self._write_room(room_name)
+        source_path = os.path.join(
+            os.path.dirname(room_path),
+            "InstanceCreationCode_inst_safe.gml",
+        )
+        _write_file(source_path, "safe_direct_helper = true;\n")
+        room = IndexedRoom(
+            name=room_name,
+            yy_path=room_path,
+            yyp_path=f"rooms/{room_name}/{room_name}.yy",
+            godot_path=f"res://rooms/{room_name}/{room_name}.tscn",
+        )
+
+        metadata = resolve_instance_creation_code(
+            room,
+            {"name": "inst_safe", "hasCreationCode": True},
+        )
+
+        self.assertEqual(metadata.source_path, source_path)
+        self.assertTrue(metadata.exists)
+        self.assertFalse(metadata.path_rejected)
+
+    def test_two_argument_instance_creation_code_rejects_unsafe_root_inference(self):
+        absolute_owner = os.path.join(
+            self.gm_dir,
+            "room_resources",
+            "r_direct_helper.yy",
+        )
+        cases = (
+            ("relative", "rooms/r_direct_helper/r_direct_helper.yy"),
+            ("missing_rooms_component", absolute_owner),
+        )
+        for label, owner_path in cases:
+            with self.subTest(case=label):
+                warnings: list[str] = []
+                room = IndexedRoom(
+                    name="r_direct_helper",
+                    yy_path=owner_path,
+                    yyp_path="rooms/r_direct_helper/r_direct_helper.yy",
+                    godot_path="res://rooms/r_direct_helper/r_direct_helper.tscn",
+                )
+
+                metadata = resolve_instance_creation_code(
+                    room,
+                    {"name": "inst_safe", "hasCreationCode": True},
+                    warn_callback=warnings.append,
+                )
+
+                self.assertEqual(metadata.source_path, "")
+                self.assertFalse(metadata.exists)
+                self.assertTrue(metadata.path_rejected)
+                self.assertEqual(len(warnings), 1, warnings)
+                self.assertIn(owner_path, warnings[0])
+                self.assertIn("layers[].instances[].name", warnings[0])
 
     def test_instance_emits_creation_code_metadata(self):
         self._write_yyp(["r_instance_code"], extra_resources=[("objects", "o_player")])

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import tempfile
 import unittest
 from pathlib import Path
 from typing import cast
 
+from src.conversion.asset_registry import AssetRegistryEntry
 from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.scripts import (
     SCRIPT_REGISTRY_RELATIVE_PATH,
@@ -66,6 +68,11 @@ def _extension_yy(name: str) -> dict[str, object]:
     }
 
 
+class ScriptSourceProbe(ScriptConverter):
+    def source_gml_path(self, entry: AssetRegistryEntry) -> str | None:
+        return self._source_gml_path(entry)
+
+
 class TestScriptConverter(unittest.TestCase):
     def setUp(self) -> None:
         self.gm_dir = Path(tempfile.mkdtemp())
@@ -107,7 +114,12 @@ class TestScriptConverter(unittest.TestCase):
             "function scr_modern(a, b = 4) { return a + b; }",
         )
 
-    def _converter(self, macro_configuration: str | None = None) -> ScriptConverter:
+    def _converter(
+        self,
+        macro_configuration: str | None = None,
+        *,
+        diagnostics: DiagnosticCollector | None = None,
+    ) -> ScriptConverter:
         return ScriptConverter(
             self.gm_dir,
             self.godot_dir,
@@ -115,6 +127,33 @@ class TestScriptConverter(unittest.TestCase):
             progress_callback=lambda _value: None,
             conversion_running=lambda: True,
             macro_configuration=macro_configuration,
+            diagnostics=diagnostics,
+        )
+
+    def _source_probe(
+        self,
+        diagnostics: DiagnosticCollector,
+    ) -> ScriptSourceProbe:
+        return ScriptSourceProbe(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=lambda message: self.logs.append(str(message)),
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            diagnostics=diagnostics,
+        )
+
+    @staticmethod
+    def _script_entry(name: str, source_path: str) -> AssetRegistryEntry:
+        return AssetRegistryEntry(
+            id=1,
+            name=name,
+            kind="scripts",
+            asset_type="script",
+            type_name="Script",
+            source_path=source_path,
+            godot_path="res://scripts/probe.gd",
+            legacy_id=source_path,
         )
 
     def test_converts_scripts_and_generated_registry(self) -> None:
@@ -156,6 +195,224 @@ class TestScriptConverter(unittest.TestCase):
         self.assertIn('preload("res://scripts/game/scr_modern.gd").new().gm2godot_callable()', registry)
         self.assertIn('preload("res://scripts/game/scr_modern.gd").new().gm2godot_scoped_callable()', registry)
         self.assertIn('"legacy_arguments": false', registry)
+
+    def test_declared_manifest_script_path_owns_selected_sidecar(self) -> None:
+        _write_json(
+            self.gm_dir / "ScriptTest.yyp",
+            {
+                "resources": [
+                    {
+                        "id": {
+                            "name": "scr_declared",
+                            "path": "scripts/nested/source/custom_script.yy",
+                        }
+                    }
+                ],
+                "RoomOrderNodes": [],
+                "resourceType": "GMProject",
+            },
+        )
+        script_metadata: dict[str, object] = {
+            "%Name": "scr_declared",
+            "name": "scr_declared",
+            "parent": {
+                "name": "Declared",
+                "path": "folders/Scripts/Declared.yy",
+            },
+            "resourceType": "GMScript",
+        }
+        _write_json(
+            self.gm_dir / "scripts" / "nested" / "source" / "custom_script.yy",
+            script_metadata,
+        )
+        _write_text(
+            self.gm_dir / "scripts" / "nested" / "source" / "scr_declared.gml",
+            "function scr_declared() { return 41; }",
+        )
+        _write_json(
+            self.gm_dir / "scripts" / "scr_declared" / "scr_declared.yy",
+            script_metadata,
+        )
+        _write_text(
+            self.gm_dir / "scripts" / "scr_declared" / "scr_declared.gml",
+            "function scr_declared() { return 99; }",
+        )
+
+        self._converter().convert_all()
+
+        generated = (
+            self.godot_dir / "scripts" / "declared" / "scr_declared.gd"
+        ).read_text(encoding="utf-8")
+        self.assertIn("return 41", generated)
+        self.assertNotIn("return 99", generated)
+        self.assertIn("func gm2godot_callable():", generated)
+
+    def test_unusual_script_name_cannot_move_preferred_source_from_owner(self) -> None:
+        owner_path = self.gm_dir / "scripts" / "owner" / "custom.yy"
+        _write_json(owner_path, {"resourceType": "GMScript"})
+        escaped_source = self.gm_dir / "scripts" / "escaped.gml"
+        fallback_source = self.gm_dir / "scripts" / "owner" / "safe.gml"
+        _write_text(escaped_source, "return 99;")
+        _write_text(fallback_source, "return 7;")
+        diagnostics = DiagnosticCollector()
+
+        selected = self._source_probe(diagnostics).source_gml_path(
+            self._script_entry("../escaped", "scripts/owner/custom.yy")
+        )
+
+        self.assertEqual(selected, str(fallback_source))
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertEqual(rejected[0].source_path, "scripts/owner/custom.yy")
+        self.assertEqual(rejected[0].manifest_entry, "preferred script source")
+
+    def test_script_name_aliases_do_not_select_derived_source(self) -> None:
+        aliases = (
+            ("slash", "bridge/../a_alias", "a_alias.gml"),
+            ("backslash", r"bridge\..\a_alias", "a_alias.gml"),
+            ("dot", ".", "..gml"),
+            ("dotdot", "..", "...gml"),
+        )
+        for label, script_name, aliased_filename in aliases:
+            with self.subTest(alias=label):
+                owner_relative = f"scripts/owner_{label}/custom.yy"
+                owner_directory = self.gm_dir / "scripts" / f"owner_{label}"
+                fallback_source = owner_directory / "z_fallback.gml"
+                _write_json(
+                    owner_directory / "custom.yy",
+                    {"resourceType": "GMScript"},
+                )
+                _write_text(fallback_source, "return 7;")
+                _write_text(owner_directory / aliased_filename, "return 99;")
+                diagnostics = DiagnosticCollector()
+
+                selected = self._source_probe(diagnostics).source_gml_path(
+                    self._script_entry(script_name, owner_relative)
+                )
+
+                self.assertEqual(selected, str(fallback_source))
+                rejected = [
+                    diagnostic
+                    for diagnostic in diagnostics.diagnostics()
+                    if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+                ]
+                self.assertEqual(len(rejected), 1, rejected)
+                self.assertEqual(rejected[0].source_path, owner_relative)
+                self.assertEqual(
+                    rejected[0].manifest_entry,
+                    "preferred script source",
+                )
+
+    def test_safe_script_name_still_prefers_matching_source(self) -> None:
+        owner_directory = self.gm_dir / "scripts" / "owner_safe"
+        preferred_source = owner_directory / "scr_safe.gml"
+        _write_json(
+            owner_directory / "custom.yy",
+            {"resourceType": "GMScript"},
+        )
+        _write_text(owner_directory / "a_fallback.gml", "return 7;")
+        _write_text(preferred_source, "return 99;")
+        diagnostics = DiagnosticCollector()
+
+        selected = self._source_probe(diagnostics).source_gml_path(
+            self._script_entry("scr_safe", "scripts/owner_safe/custom.yy")
+        )
+
+        self.assertEqual(selected, str(preferred_source))
+        self.assertFalse(
+            any(
+                diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+                for diagnostic in diagnostics.diagnostics()
+            )
+        )
+
+    def test_fallback_discovery_skips_source_symlink_outside_project(self) -> None:
+        owner_path = self.gm_dir / "scripts" / "owner" / "custom.yy"
+        fallback_source = self.gm_dir / "scripts" / "owner" / "b_valid.gml"
+        _write_json(owner_path, {"resourceType": "GMScript"})
+        _write_text(fallback_source, "return 7;")
+        diagnostics = DiagnosticCollector()
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_source = Path(outside_dir) / "a_external.gml"
+            outside_source.write_text("return 99;", encoding="utf-8")
+            linked_source = self.gm_dir / "scripts" / "owner" / "a_external.gml"
+            try:
+                os.symlink(outside_source, linked_source)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            selected = self._source_probe(diagnostics).source_gml_path(
+                self._script_entry("missing", "scripts/owner/custom.yy")
+            )
+
+        self.assertEqual(selected, str(fallback_source))
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertEqual(rejected[0].source_path, "scripts/owner/custom.yy")
+        self.assertEqual(rejected[0].manifest_entry, "discovered script source")
+
+    def test_preferred_sidecar_symlink_outside_project_uses_valid_fallback(self) -> None:
+        owner_path = self.gm_dir / "scripts" / "owner" / "custom.yy"
+        fallback_source = self.gm_dir / "scripts" / "owner" / "z_valid.gml"
+        _write_json(owner_path, {"resourceType": "GMScript"})
+        _write_text(fallback_source, "return 7;")
+        diagnostics = DiagnosticCollector()
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_source = Path(outside_dir) / "outside.gml"
+            outside_source.write_text("return 99;", encoding="utf-8")
+            preferred_source = self.gm_dir / "scripts" / "owner" / "scr_owner.gml"
+            try:
+                os.symlink(outside_source, preferred_source)
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            selected = self._source_probe(diagnostics).source_gml_path(
+                self._script_entry("scr_owner", "scripts/owner/custom.yy")
+            )
+
+        self.assertEqual(selected, str(fallback_source))
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertEqual(rejected[0].source_path, "scripts/owner/custom.yy")
+        self.assertEqual(rejected[0].manifest_entry, "preferred script source")
+
+    def test_script_yy_symlink_outside_project_is_not_used_as_an_owner(self) -> None:
+        script_directory = self.gm_dir / "scripts" / "owner"
+        fallback_source = script_directory / "safe.gml"
+        _write_text(fallback_source, "return 7;")
+        diagnostics = DiagnosticCollector()
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_yy = Path(outside_dir) / "custom.yy"
+            _write_json(outside_yy, {"resourceType": "GMScript"})
+            try:
+                os.symlink(outside_yy, script_directory / "custom.yy")
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            selected = self._source_probe(diagnostics).source_gml_path(
+                self._script_entry("safe", "scripts/owner/custom.yy")
+            )
+
+        self.assertIsNone(selected)
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1)
+        self.assertEqual(rejected[0].manifest_entry, "script .yy")
 
     def test_script_body_uses_caller_instance_scope(self) -> None:
         self._write_project()

--- a/tests/test_shaders.py
+++ b/tests/test_shaders.py
@@ -1,7 +1,7 @@
 import json
 import os
-import sys
 import shutil
+import sys
 import tempfile
 import unittest
 
@@ -11,6 +11,7 @@ if PROJECT_ROOT not in sys.path:
 
 from src.conversion.shaders import ShaderConverter
 from src.conversion.asset_output_paths import build_asset_output_paths
+from src.conversion.diagnostics import DiagnosticCollector
 
 SAMPLE_FSH = """\
 precision highp float;
@@ -343,6 +344,489 @@ void main()
             if filename.endswith(".gdshader")
         ]
         self.assertEqual(generated_shaders, [output_path])
+
+
+class TestShaderSourcePathContainment(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.outside_dir = tempfile.mkdtemp()
+        os.makedirs(os.path.join(self.gm_dir, "shaders"))
+        self.diagnostics = DiagnosticCollector()
+        self.logs: list[str] = []
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+        shutil.rmtree(self.outside_dir)
+
+    @staticmethod
+    def _write_json(path: str, value: object) -> None:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as output_file:
+            json.dump(value, output_file)
+
+    @staticmethod
+    def _write_fragment(path: str, marker: str) -> None:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as fragment_file:
+            fragment_file.write(SAMPLE_FSH + f"\n// {marker}\n")
+
+    def _write_yyp(self, resources: list[tuple[str, str]]) -> str:
+        yyp_path = os.path.join(self.gm_dir, "ShaderContainment.yyp")
+        self._write_json(
+            yyp_path,
+            {
+                "%Name": "Shader Containment",
+                "resources": [
+                    {
+                        "id": {"name": name, "path": path},
+                        "resourceType": "GMShader",
+                    }
+                    for name, path in resources
+                ],
+            },
+        )
+        return yyp_path
+
+    def _make_converter(self) -> ShaderConverter:
+        return ShaderConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=self.logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            diagnostics=self.diagnostics,
+        )
+
+    def _source_path_rejections(self):
+        return [
+            diagnostic
+            for diagnostic in self.diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+
+    def _generated_shaders(self) -> list[str]:
+        return [
+            os.path.join(root, filename)
+            for root, _directories, filenames in os.walk(self.godot_dir)
+            for filename in filenames
+            if filename.endswith(".gdshader")
+        ]
+
+    def test_rejects_malformed_manifest_shader_paths_with_yyp_diagnostics(
+        self,
+    ) -> None:
+        outside_yy = os.path.join(self.outside_dir, "outside.yy")
+        self._write_json(
+            outside_yy,
+            {"name": "outside", "resourceType": "GMShader"},
+        )
+        self._write_fragment(
+            os.path.splitext(outside_yy)[0] + ".fsh",
+            "OUTSIDE_MANIFEST_STAGE",
+        )
+        relative_outside = os.path.relpath(outside_yy, self.gm_dir).replace(
+            os.sep,
+            "/",
+        )
+        unsafe_paths = [
+            f"shaders/../{relative_outside}",
+            outside_yy,
+            r"C:\Games\Outside\shader.yy",
+            r"C:Outside\shader.yy",
+            r"\\server\share\shader.yy",
+            "shaders/bad\0shader.yy",
+        ]
+        self._write_yyp(
+            [
+                (f"shd_unsafe_{index}", path)
+                for index, path in enumerate(unsafe_paths)
+            ]
+        )
+
+        self._make_converter().convert_all()
+
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), len(unsafe_paths), rejected)
+        self.assertEqual(
+            {diagnostic.resource for diagnostic in rejected},
+            {f"shd_unsafe_{index}" for index in range(len(unsafe_paths))},
+        )
+        self.assertEqual(
+            {diagnostic.source_path for diagnostic in rejected},
+            {"ShaderContainment.yyp"},
+        )
+        self.assertEqual(
+            {diagnostic.manifest_entry for diagnostic in rejected},
+            {
+                f"resources[{index}].id.path"
+                for index in range(len(unsafe_paths))
+            },
+        )
+        self.assertTrue(
+            all(diagnostic.resource_type == "shader" for diagnostic in rejected)
+        )
+        self.assertEqual(self._generated_shaders(), [])
+
+    def test_rejects_manifest_yy_and_stage_symlink_escapes(self) -> None:
+        outside_yy = os.path.join(self.outside_dir, "outside.yy")
+        outside_fragment = os.path.join(self.outside_dir, "outside.fsh")
+        self._write_json(
+            outside_yy,
+            {"name": "outside", "resourceType": "GMShader"},
+        )
+        self._write_fragment(outside_fragment, "OUTSIDE_FILE_LINK")
+
+        yy_link_directory = os.path.join(
+            self.gm_dir,
+            "shaders",
+            "shd_yy_link",
+        )
+        os.makedirs(yy_link_directory)
+        stage_link_directory = os.path.join(
+            self.gm_dir,
+            "shaders",
+            "shd_stage_link",
+        )
+        os.makedirs(stage_link_directory)
+        self._write_json(
+            os.path.join(stage_link_directory, "shd_stage_link.yy"),
+            {"name": "shd_stage_link", "resourceType": "GMShader"},
+        )
+
+        outside_asset_directory = os.path.join(
+            self.outside_dir,
+            "outside_asset",
+        )
+        self._write_json(
+            os.path.join(outside_asset_directory, "shd_directory_link.yy"),
+            {"name": "shd_directory_link", "resourceType": "GMShader"},
+        )
+        self._write_fragment(
+            os.path.join(outside_asset_directory, "shd_directory_link.fsh"),
+            "OUTSIDE_DIRECTORY_LINK",
+        )
+        try:
+            os.symlink(
+                outside_yy,
+                os.path.join(yy_link_directory, "shd_yy_link.yy"),
+            )
+            os.symlink(
+                outside_fragment,
+                os.path.join(stage_link_directory, "shd_stage_link.fsh"),
+            )
+            os.symlink(
+                outside_asset_directory,
+                os.path.join(
+                    self.gm_dir,
+                    "shaders",
+                    "shd_directory_link",
+                ),
+            )
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+
+        self._write_yyp(
+            [
+                ("shd_yy_link", "shaders/shd_yy_link/shd_yy_link.yy"),
+                (
+                    "shd_stage_link",
+                    "shaders/shd_stage_link/shd_stage_link.yy",
+                ),
+                (
+                    "shd_directory_link",
+                    "shaders/shd_directory_link/shd_directory_link.yy",
+                ),
+            ]
+        )
+
+        self._make_converter().convert_all()
+
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), 3, rejected)
+        self.assertEqual(
+            {diagnostic.resource for diagnostic in rejected},
+            {"shd_yy_link", "shd_stage_link", "shd_directory_link"},
+        )
+        stage_rejection = next(
+            diagnostic
+            for diagnostic in rejected
+            if diagnostic.resource == "shd_stage_link"
+        )
+        self.assertEqual(
+            stage_rejection.source_path,
+            "shaders/shd_stage_link/shd_stage_link.yy",
+        )
+        self.assertEqual(stage_rejection.manifest_entry, "derived .fsh stage")
+        self.assertEqual(self._generated_shaders(), [])
+
+    def test_manifest_requires_shader_yy_family_and_suffix(self) -> None:
+        cross_family_yy = os.path.join(
+            self.gm_dir,
+            "objects",
+            "shd_cross_family",
+            "shd_cross_family.yy",
+        )
+        self._write_json(
+            cross_family_yy,
+            {"name": "shd_cross_family", "resourceType": "GMShader"},
+        )
+        self._write_fragment(
+            os.path.splitext(cross_family_yy)[0] + ".fsh",
+            "CROSS_FAMILY_STAGE",
+        )
+        non_yy_path = os.path.join(
+            self.gm_dir,
+            "shaders",
+            "shd_non_yy",
+            "shd_non_yy.fsh",
+        )
+        self._write_fragment(non_yy_path, "NON_YY_MANIFEST_STAGE")
+        safe_yy = os.path.join(
+            self.gm_dir,
+            "shaders",
+            "shd_safe",
+            "shd_safe.yy",
+        )
+        self._write_json(
+            safe_yy,
+            {"name": "shd_safe", "resourceType": "GMShader"},
+        )
+        self._write_fragment(
+            os.path.splitext(safe_yy)[0] + ".fsh",
+            "SAFE_MANIFEST_STAGE",
+        )
+        self._write_yyp(
+            [
+                (
+                    "shd_cross_family",
+                    "shaders/../objects/shd_cross_family/shd_cross_family.yy",
+                ),
+                ("shd_non_yy", "shaders/shd_non_yy/shd_non_yy.fsh"),
+                ("shd_safe", "shaders/shd_safe/shd_safe.yy"),
+            ]
+        )
+
+        self._make_converter().convert_all()
+
+        rejected = self._source_path_rejections()
+        self.assertEqual(
+            [
+                (
+                    diagnostic.resource,
+                    diagnostic.source_path,
+                    diagnostic.manifest_entry,
+                )
+                for diagnostic in rejected
+            ],
+            [
+                (
+                    "shd_cross_family",
+                    "ShaderContainment.yyp",
+                    "resources[0].id.path",
+                ),
+                (
+                    "shd_non_yy",
+                    "ShaderContainment.yyp",
+                    "resources[1].id.path",
+                ),
+            ],
+        )
+        generated = self._generated_shaders()
+        self.assertEqual(len(generated), 1, generated)
+        with open(generated[0], encoding="utf-8") as shader_file:
+            contents = shader_file.read()
+        self.assertIn("SAFE_MANIFEST_STAGE", contents)
+        self.assertNotIn("CROSS_FAMILY_STAGE", contents)
+        self.assertNotIn("NON_YY_MANIFEST_STAGE", contents)
+
+    def test_disk_fallback_rejects_file_and_directory_symlink_escapes(
+        self,
+    ) -> None:
+        outside_fragment = os.path.join(self.outside_dir, "outside.fsh")
+        self._write_fragment(outside_fragment, "OUTSIDE_DISK_FILE")
+        outside_shader_directory = os.path.join(
+            self.outside_dir,
+            "outside_shader_directory",
+        )
+        self._write_fragment(
+            os.path.join(outside_shader_directory, "outside_dir.fsh"),
+            "OUTSIDE_DISK_DIRECTORY",
+        )
+        containing_directory = os.path.join(
+            self.gm_dir,
+            "shaders",
+            "contained",
+        )
+        self._write_fragment(
+            os.path.join(containing_directory, "shd_safe_sibling.fsh"),
+            "SAFE_DISK_SIBLING",
+        )
+        try:
+            os.symlink(
+                outside_fragment,
+                os.path.join(containing_directory, "shd_file_link.fsh"),
+            )
+            os.symlink(
+                outside_shader_directory,
+                os.path.join(containing_directory, "linked_directory"),
+            )
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+
+        self._make_converter().convert_all()
+
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), 2, rejected)
+        self.assertEqual(
+            {
+                (
+                    diagnostic.resource,
+                    diagnostic.source_path,
+                    diagnostic.manifest_entry,
+                )
+                for diagnostic in rejected
+            },
+            {
+                (
+                    "shd_file_link",
+                    "shaders/contained",
+                    "discovered .fsh stage",
+                ),
+                (
+                    "linked_directory",
+                    "shaders/contained",
+                    "discovered shader directory",
+                ),
+            },
+        )
+        generated = self._generated_shaders()
+        self.assertEqual(len(generated), 1, generated)
+        with open(generated[0], encoding="utf-8") as shader_file:
+            contents = shader_file.read()
+        self.assertIn("SAFE_DISK_SIBLING", contents)
+        self.assertNotIn("OUTSIDE_DISK_FILE", contents)
+        self.assertNotIn("OUTSIDE_DISK_DIRECTORY", contents)
+
+    def test_disk_fallback_rejects_yy_symlink_but_converts_safe_stage(
+        self,
+    ) -> None:
+        shader_directory = os.path.join(
+            self.gm_dir,
+            "shaders",
+            "shd_safe_stage",
+        )
+        self._write_fragment(
+            os.path.join(shader_directory, "shd_safe_stage.fsh"),
+            "SAFE_STAGE",
+        )
+        outside_yy = os.path.join(self.outside_dir, "outside.yy")
+        self._write_json(
+            outside_yy,
+            {"name": "outside_name", "resourceType": "GMShader"},
+        )
+        try:
+            os.symlink(
+                outside_yy,
+                os.path.join(shader_directory, "shd_safe_stage.yy"),
+            )
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+
+        self._make_converter().convert_all()
+
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].resource, "shd_safe_stage")
+        self.assertEqual(rejected[0].manifest_entry, "discovered .yy")
+        self.assertEqual(
+            rejected[0].source_path,
+            "shaders/shd_safe_stage",
+        )
+        generated = self._generated_shaders()
+        self.assertEqual(len(generated), 1, generated)
+        with open(generated[0], encoding="utf-8") as shader_file:
+            self.assertIn("SAFE_STAGE", shader_file.read())
+
+    def test_disk_fallback_rejects_contained_cross_family_shader_yy_link(
+        self,
+    ) -> None:
+        linked_name = "shd_cross_family_link"
+        wrong_family_yy = os.path.join(
+            self.gm_dir,
+            "objects",
+            "wrong_shader",
+            "target.yy",
+        )
+        self._write_json(
+            wrong_family_yy,
+            {
+                "name": "WRONG_FAMILY_SHADER_NAME",
+                "resourceType": "GMShader",
+            },
+        )
+        linked_directory = os.path.join(self.gm_dir, "shaders", linked_name)
+        os.makedirs(linked_directory)
+        try:
+            os.symlink(
+                wrong_family_yy,
+                os.path.join(linked_directory, linked_name + ".yy"),
+            )
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+        self._write_fragment(
+            os.path.join(linked_directory, linked_name + ".fsh"),
+            "LINKED_DIRECTORY_SAFE_STAGE",
+        )
+
+        safe_name = "shd_safe_sibling"
+        safe_directory = os.path.join(self.gm_dir, "shaders", safe_name)
+        self._write_json(
+            os.path.join(safe_directory, safe_name + ".yy"),
+            {"name": safe_name, "resourceType": "GMShader"},
+        )
+        self._write_fragment(
+            os.path.join(safe_directory, safe_name + ".fsh"),
+            "SAFE_SIBLING_STAGE",
+        )
+
+        self._make_converter().convert_all()
+
+        generated = self._generated_shaders()
+        self.assertEqual(len(generated), 2, generated)
+        generated_by_name = {os.path.basename(path): path for path in generated}
+        self.assertNotIn("wrong_family_shader_name.gdshader", generated_by_name)
+        with open(
+            generated_by_name[linked_name + ".gdshader"],
+            encoding="utf-8",
+        ) as shader_file:
+            self.assertIn("LINKED_DIRECTORY_SAFE_STAGE", shader_file.read())
+        with open(
+            generated_by_name[safe_name + ".gdshader"],
+            encoding="utf-8",
+        ) as shader_file:
+            self.assertIn("SAFE_SIBLING_STAGE", shader_file.read())
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, f"shaders/{linked_name}")
+        self.assertEqual(rejected[0].resource, linked_name)
+        self.assertEqual(rejected[0].resource_type, "shader")
+        self.assertEqual(rejected[0].manifest_entry, "discovered .yy")
+
+    def test_convert_shader_rejects_direct_source_outside_project(self) -> None:
+        outside_fragment = os.path.join(self.outside_dir, "outside.fsh")
+        output_path = os.path.join(self.godot_dir, "outside.gdshader")
+        self._write_fragment(outside_fragment, "DIRECT_OUTSIDE")
+
+        self._make_converter().convert_shader(outside_fragment, output_path)
+
+        self.assertFalse(os.path.exists(output_path))
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].resource, "outside")
+        self.assertEqual(rejected[0].resource_type, "shader")
+        self.assertEqual(rejected[0].manifest_entry, "shader stage")
 
 
 class TestShaderConverterSubfolders(unittest.TestCase):

--- a/tests/test_sounds.py
+++ b/tests/test_sounds.py
@@ -13,7 +13,12 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from src.conversion.sounds import SoundConverter
-from src.conversion.asset_output_paths import build_asset_output_paths
+from src.conversion.asset_registry import AssetRegistryConverter
+from src.conversion.asset_output_paths import (
+    build_asset_output_paths,
+    resource_filesystem_path,
+)
+from src.conversion.diagnostics import DiagnosticCollector
 from src.conversion.type_defs import ConversionRunning, LogCallback, ProgressCallback
 
 
@@ -25,6 +30,7 @@ class SoundConverterKwargs(TypedDict, total=False):
     progress_callback: ProgressCallback
     conversion_running: ConversionRunning
     organize_by_audio_group: NotRequired[bool]
+    diagnostics: NotRequired[DiagnosticCollector]
 
 
 MINIMAL_SOUND_YY: SoundYY = {
@@ -119,6 +125,24 @@ class TestSoundConverterBasic(unittest.TestCase):
         self.assertIn('type="AudioStreamWAV"', content)
         self.assertIn('source_file="res://sounds/jump/jump.wav"', content)
         self.assertIn('edit/loop_mode=0', content)
+
+    def test_import_source_path_uses_escaped_godot_string_literal(self) -> None:
+        converter = self._make_converter()
+        sound_file = 'clip"\\\n[remap]\nimporter=\t\x01evil.wav'
+        expected_path = f"res://sounds/injected/{sound_file}"
+
+        content = converter._generate_import_file(sound_file, "injected")
+
+        self.assertIsNotNone(content)
+        assert content is not None
+        source_line = next(
+            line for line in content.splitlines() if line.startswith("source_file=")
+        )
+        self.assertEqual(
+            source_line,
+            "source_file=" + json.dumps(expected_path, ensure_ascii=False),
+        )
+        self.assertNotIn('\n[remap]\nimporter=', content)
 
 
 class TestSoundGeneratedPathCollisions(unittest.TestCase):
@@ -523,6 +547,452 @@ class TestSoundConverterSubfolders(unittest.TestCase):
             'source_file="res://sounds/audiogroup_music/sfx/theme/theme.wav"',
             content,
         )
+
+
+class TestSoundConverterSourcePathContainment(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.outside_dir = tempfile.mkdtemp()
+        self.logs: list[str] = []
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+        shutil.rmtree(self.outside_dir)
+
+    def _make_converter(
+        self,
+        diagnostics: DiagnosticCollector | None = None,
+    ) -> SoundConverter:
+        return SoundConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=self.logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            max_workers=1,
+            diagnostics=diagnostics,
+        )
+
+    def _write_yyp(self, resources: list[tuple[str, str]]) -> None:
+        with open(
+            os.path.join(self.gm_dir, "SoundPaths.yyp"),
+            "w",
+            encoding="utf-8",
+        ) as project_file:
+            json.dump(
+                {
+                    "resources": [
+                        {"id": {"name": name, "path": path}}
+                        for name, path in resources
+                    ]
+                },
+                project_file,
+            )
+
+    def _write_sound_yy(self, sound_name: str, sound_file: object) -> str:
+        sound_dir = os.path.join(self.gm_dir, "sounds", sound_name)
+        os.makedirs(sound_dir, exist_ok=True)
+        data = dict(MINIMAL_SOUND_YY)
+        data["name"] = sound_name
+        data["%Name"] = sound_name
+        data["soundFile"] = sound_file
+        yy_path = os.path.join(sound_dir, f"{sound_name}.yy")
+        with open(yy_path, "w", encoding="utf-8") as yy_file:
+            json.dump(data, yy_file)
+        return yy_path
+
+    def test_accepts_contained_manifest_and_disk_discovered_sound_yy(self) -> None:
+        referenced_yy = _make_sound_yy(self.gm_dir, "snd_referenced")
+        orphan_yy = _make_sound_yy(self.gm_dir, "snd_orphan")
+        converter = self._make_converter()
+
+        self.assertEqual(
+            set(converter.find_sound_files()),
+            {referenced_yy, orphan_yy},
+        )
+
+        self._write_yyp(
+            [("snd_referenced", r"sounds\snd_referenced\snd_referenced.yy")]
+        )
+
+        self.assertEqual(converter.find_sound_files(), [referenced_yy])
+
+    def test_rejects_cross_family_manifest_resource_after_normalization(
+        self,
+    ) -> None:
+        cross_family_yy = os.path.join(
+            self.gm_dir,
+            "objects",
+            "snd_cross_family",
+            "snd_cross_family.yy",
+        )
+        os.makedirs(os.path.dirname(cross_family_yy))
+        with open(cross_family_yy, "w", encoding="utf-8") as yy_file:
+            json.dump(MINIMAL_SOUND_YY, yy_file)
+        self._write_yyp(
+            [
+                (
+                    "snd_cross_family",
+                    "sounds/../objects/snd_cross_family/snd_cross_family.yy",
+                )
+            ]
+        )
+        diagnostics = DiagnosticCollector()
+
+        sound_files = self._make_converter(diagnostics).find_sound_files()
+
+        self.assertEqual(sound_files, [])
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "SoundPaths.yyp")
+        self.assertEqual(rejected[0].resource, "snd_cross_family")
+        self.assertEqual(rejected[0].resource_type, "sound")
+        self.assertEqual(rejected[0].manifest_entry, "resources[0].id.path")
+
+    def test_accepts_owner_and_project_relative_sound_file_forms(self) -> None:
+        references = {
+            "snd_owner": "snd_owner.wav",
+            "snd_project": "sounds/shared/snd_project.wav",
+            "snd_placeholder": (
+                "${project_dir}/sounds/shared/snd_placeholder.wav"
+            ),
+            "snd_backslash": r"sounds\shared\snd_backslash.wav",
+        }
+        shared_dir = os.path.join(self.gm_dir, "sounds", "shared")
+        os.makedirs(shared_dir)
+        yy_paths: dict[str, str] = {}
+        expected_payloads: dict[str, bytes] = {}
+        for index, (sound_name, sound_file) in enumerate(
+            references.items(),
+            start=1,
+        ):
+            yy_path = self._write_sound_yy(sound_name, sound_file)
+            yy_paths[sound_name] = yy_path
+            payload = bytes([index]) * 16
+            expected_payloads[sound_name] = payload
+            audio_path = (
+                os.path.join(os.path.dirname(yy_path), sound_file)
+                if sound_name == "snd_owner"
+                else os.path.join(shared_dir, f"{sound_name}.wav")
+            )
+            with open(audio_path, "wb") as audio_file:
+                audio_file.write(payload)
+
+        converter = self._make_converter()
+        self._write_yyp(
+            [
+                (sound_name, f"sounds/{sound_name}/{sound_name}.yy")
+                for sound_name in references
+            ]
+        )
+        converter.convert_all()
+
+        for sound_name in yy_paths:
+            with self.subTest(sound_name=sound_name):
+                output_path = resource_filesystem_path(
+                    self.godot_dir,
+                    converter._sound_output_paths[sound_name],
+                )
+                with open(output_path, "rb") as output_file:
+                    self.assertEqual(
+                        output_file.read(),
+                        expected_payloads[sound_name],
+                    )
+
+    def test_rejects_unsafe_sound_file_paths_with_owner_diagnostics(self) -> None:
+        outside_path = os.path.join(self.outside_dir, "outside.wav")
+        with open(outside_path, "wb") as outside_file:
+            outside_file.write(b"outside project audio")
+
+        traversal_directory = os.path.join(
+            self.gm_dir,
+            "sounds",
+            "snd_traversal",
+        )
+        unsafe_paths = {
+            "snd_traversal": os.path.relpath(
+                outside_path,
+                traversal_directory,
+            ),
+            "snd_absolute": outside_path,
+            "snd_drive_absolute": r"C:\Games\Outside\sound.wav",
+            "snd_drive_relative": r"C:Outside\sound.wav",
+            "snd_unc": r"\\server\share\sound.wav",
+            "snd_nul": "sound\0.wav",
+            "snd_symlink": "linked.wav",
+        }
+        yy_paths = {
+            sound_name: self._write_sound_yy(sound_name, sound_file)
+            for sound_name, sound_file in unsafe_paths.items()
+        }
+        try:
+            os.symlink(
+                outside_path,
+                os.path.join(
+                    self.gm_dir,
+                    "sounds",
+                    "snd_symlink",
+                    "linked.wav",
+                ),
+            )
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+
+        diagnostics = DiagnosticCollector()
+        converter = self._make_converter(diagnostics)
+        for sound_name, yy_path in yy_paths.items():
+            with self.subTest(sound_name=sound_name):
+                result = converter._process_sound(yy_path)
+                self.assertIsNotNone(result)
+                assert result is not None
+                self.assertFalse(result["success"])
+
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), len(unsafe_paths), rejected)
+        self.assertEqual(
+            {diagnostic.source_path for diagnostic in rejected},
+            {
+                f"sounds/{sound_name}/{sound_name}.yy"
+                for sound_name in unsafe_paths
+            },
+        )
+        self.assertTrue(
+            all(diagnostic.resource_type == "sound" for diagnostic in rejected)
+        )
+        self.assertTrue(
+            all(diagnostic.manifest_entry == "soundFile" for diagnostic in rejected)
+        )
+        self.assertFalse(
+            any(
+                files
+                for _root, _directories, files in os.walk(self.godot_dir)
+            )
+        )
+
+    def test_rejects_non_string_and_empty_sound_file_without_coercion(
+        self,
+    ) -> None:
+        malformed_values: dict[str, object] = {
+            "snd_number": 7,
+            "snd_boolean": True,
+            "snd_null": None,
+            "snd_list": ["list.wav"],
+            "snd_object": {"path": "object.wav"},
+            "snd_empty": "",
+        }
+        yy_paths = {
+            sound_name: self._write_sound_yy(sound_name, sound_file)
+            for sound_name, sound_file in malformed_values.items()
+        }
+        for sound_name in ("snd_number", "snd_boolean", "snd_null"):
+            coerced_name = str(malformed_values[sound_name])
+            with open(
+                os.path.join(os.path.dirname(yy_paths[sound_name]), coerced_name),
+                "wb",
+            ) as audio_file:
+                audio_file.write(b"must not be copied")
+
+        safe_yy = self._write_sound_yy("snd_safe", "snd_safe.wav")
+        with open(
+            os.path.join(os.path.dirname(safe_yy), "snd_safe.wav"),
+            "wb",
+        ) as safe_audio:
+            safe_audio.write(b"safe sibling")
+        diagnostics = DiagnosticCollector()
+        converter = self._make_converter(diagnostics)
+
+        converter.convert_all()
+
+        safe_output = resource_filesystem_path(
+            self.godot_dir,
+            converter._sound_output_paths["snd_safe"],
+        )
+        with open(safe_output, "rb") as safe_audio:
+            self.assertEqual(safe_audio.read(), b"safe sibling")
+        for sound_name in malformed_values:
+            self.assertFalse(
+                os.path.exists(os.path.join(self.godot_dir, "sounds", sound_name))
+            )
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), len(malformed_values), rejected)
+        self.assertEqual(
+            {diagnostic.resource for diagnostic in rejected},
+            set(malformed_values),
+        )
+        self.assertEqual(
+            {diagnostic.source_path for diagnostic in rejected},
+            {
+                f"sounds/{sound_name}/{sound_name}.yy"
+                for sound_name in malformed_values
+            },
+        )
+        self.assertTrue(
+            all(
+                diagnostic.resource_type == "sound"
+                and diagnostic.manifest_entry == "soundFile"
+                for diagnostic in rejected
+            )
+        )
+
+    def test_shared_pipeline_dedupes_identical_unsafe_sound_file_rejection(
+        self,
+    ) -> None:
+        outside_audio = os.path.join(self.outside_dir, "outside.wav")
+        with open(outside_audio, "wb") as audio_file:
+            audio_file.write(b"outside")
+        sound_name = "snd_shared_diagnostic"
+        sound_directory = os.path.join(self.gm_dir, "sounds", sound_name)
+        unsafe_reference = os.path.relpath(outside_audio, sound_directory)
+        self._write_sound_yy(sound_name, unsafe_reference)
+        diagnostics = DiagnosticCollector()
+        rejection_logs: list[str] = []
+        sound_converter = SoundConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=rejection_logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            max_workers=1,
+            diagnostics=diagnostics,
+        )
+
+        sound_converter.convert_all()
+        AssetRegistryConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=rejection_logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            diagnostics=diagnostics,
+        ).build_entries()
+
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1, rejected)
+        emitted_rejections = [
+            message
+            for message in rejection_logs
+            if "Rejected GameMaker source path" in message
+        ]
+        self.assertEqual(len(emitted_rejections), 2, emitted_rejections)
+        self.assertEqual(emitted_rejections[0], emitted_rejections[1])
+
+    def test_disk_fallback_rejects_external_directory_and_keeps_safe_sibling(
+        self,
+    ) -> None:
+        safe_yy = _make_sound_yy(self.gm_dir, "snd_safe")
+        outside_sound_directory = os.path.join(
+            self.outside_dir,
+            "snd_directory_link",
+        )
+        os.makedirs(outside_sound_directory)
+        with open(
+            os.path.join(outside_sound_directory, "snd_directory_link.yy"),
+            "w",
+            encoding="utf-8",
+        ) as yy_file:
+            json.dump(MINIMAL_SOUND_YY, yy_file)
+        try:
+            os.symlink(
+                outside_sound_directory,
+                os.path.join(
+                    self.gm_dir,
+                    "sounds",
+                    "snd_directory_link",
+                ),
+            )
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+        diagnostics = DiagnosticCollector()
+
+        sound_files = self._make_converter(diagnostics).find_sound_files()
+
+        self.assertEqual(sound_files, [safe_yy])
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "sounds")
+        self.assertEqual(rejected[0].resource, "snd_directory_link")
+        self.assertEqual(rejected[0].resource_type, "sound")
+        self.assertEqual(
+            rejected[0].manifest_entry,
+            "discovered sound entry",
+        )
+
+    def test_rejects_manifest_sound_yy_path_outside_project(self) -> None:
+        outside_yy = os.path.join(self.outside_dir, "snd_escape.yy")
+        with open(outside_yy, "w", encoding="utf-8") as yy_file:
+            json.dump(MINIMAL_SOUND_YY, yy_file)
+        unsafe_path = os.path.relpath(outside_yy, self.gm_dir).replace(
+            os.sep,
+            "/",
+        )
+        self._write_yyp(
+            [("snd_escape", f"sounds/../{unsafe_path}")]
+        )
+        diagnostics = DiagnosticCollector()
+
+        sound_files = self._make_converter(diagnostics).find_sound_files()
+
+        self.assertEqual(sound_files, [])
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "SoundPaths.yyp")
+        self.assertEqual(rejected[0].resource, "snd_escape")
+        self.assertEqual(rejected[0].resource_type, "sound")
+        self.assertEqual(rejected[0].manifest_entry, "resources[0].id.path")
+
+    def test_rejects_disk_discovered_yy_symlink_to_outside_project(self) -> None:
+        outside_yy = os.path.join(self.outside_dir, "snd_link.yy")
+        with open(outside_yy, "w", encoding="utf-8") as yy_file:
+            json.dump(MINIMAL_SOUND_YY, yy_file)
+        sound_dir = os.path.join(self.gm_dir, "sounds", "snd_link")
+        os.makedirs(sound_dir)
+        linked_yy = os.path.join(sound_dir, "snd_link.yy")
+        try:
+            os.symlink(outside_yy, linked_yy)
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+        diagnostics = DiagnosticCollector()
+
+        sound_files = self._make_converter(diagnostics).find_sound_files()
+
+        self.assertEqual(sound_files, [])
+        rejected = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "sounds/snd_link")
+        self.assertEqual(rejected[0].resource, "snd_link")
+        self.assertEqual(rejected[0].resource_type, "sound")
+        self.assertEqual(rejected[0].manifest_entry, "discovered .yy")
+        self.assertIn(linked_yy, rejected[0].message)
 
 
 class TestSoundConverterEdgeCases(unittest.TestCase):

--- a/tests/test_sprites.py
+++ b/tests/test_sprites.py
@@ -1,11 +1,13 @@
 # pyright: reportPrivateUsage=false
 
+import json
 import os
 import sys
 import shutil
 import tempfile
 import unittest
 from typing import cast
+from unittest.mock import patch
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
@@ -13,6 +15,7 @@ if PROJECT_ROOT not in sys.path:
 
 from PIL import Image
 from src.conversion.asset_registry import AssetRegistryConverter
+from src.conversion.diagnostics import ConversionDiagnostic, DiagnosticCollector
 from src.conversion.resource_index import GameMakerResourceIndex
 from src.conversion.sprites import AnimationData, CollisionData, SpriteConverter, SpriteParseResult
 
@@ -510,6 +513,29 @@ class TestGetValidSpriteNames(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(result, {})
 
+    def test_skips_external_yyp_link_before_contained_project_file(self) -> None:
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_yyp = os.path.join(outside_dir, "Outside.yyp")
+            with open(outside_yyp, "w", encoding="utf-8") as project_file:
+                project_file.write(_make_yyp_content(["s_outside"]))
+            try:
+                os.symlink(
+                    outside_yyp,
+                    os.path.join(self.gm_dir, "AOutside.yyp"),
+                )
+            except (NotImplementedError, OSError) as error:
+                self.skipTest(f"Symbolic links are unavailable: {error}")
+            with open(
+                os.path.join(self.gm_dir, "BInside.yyp"),
+                "w",
+                encoding="utf-8",
+            ) as project_file:
+                project_file.write(_make_yyp_content(["s_inside"]))
+
+            result = self._make_converter()._get_valid_sprite_names()
+
+        self.assertEqual(result, {"s_inside": ""})
+
 
 class TestSpriteConverterFiltering(unittest.TestCase):
     """Test that orphaned sprites are filtered out based on .yyp."""
@@ -862,6 +888,623 @@ def _make_yy_content_with_sequence(sprite_name: str, frame_guids: list[str], lay
         pbs=playback_speed, pbst=playback_speed_type, pb=playback,
         kf=keyframes_json,
     )
+
+
+class TestSpriteConverterSourcePathContainment(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.outside_dir = tempfile.mkdtemp()
+        self.logs: list[str] = []
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+        shutil.rmtree(self.outside_dir)
+
+    def _make_converter(
+        self,
+        diagnostics: DiagnosticCollector | None = None,
+    ) -> SpriteConverter:
+        return SpriteConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=self.logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            max_workers=1,
+            diagnostics=diagnostics,
+        )
+
+    def _write_yyp(self, resources: list[dict[str, object]]) -> str:
+        yyp_path = os.path.join(self.gm_dir, "SpritePaths.yyp")
+        with open(yyp_path, "w", encoding="utf-8") as yyp_file:
+            json.dump({"resources": resources}, yyp_file)
+        return yyp_path
+
+    def _write_yy(self, relative_path: str, content: str) -> str:
+        yy_path = os.path.join(self.gm_dir, *relative_path.split("/"))
+        os.makedirs(os.path.dirname(yy_path), exist_ok=True)
+        with open(yy_path, "w", encoding="utf-8") as yy_file:
+            yy_file.write(content)
+        return yy_path
+
+    @staticmethod
+    def _write_png(path: str, color: str = "red") -> None:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        Image.new("RGBA", (2, 2), color).save(path, "PNG")
+
+    @staticmethod
+    def _rejections(
+        diagnostics: DiagnosticCollector,
+    ) -> list[ConversionDiagnostic]:
+        return [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+
+    def test_manifest_discovery_reads_selected_yyp_once(self) -> None:
+        yyp_path = self._write_yyp([])
+
+        with patch("builtins.open", wraps=open) as tracked_open:
+            valid_sprites = self._make_converter()._get_valid_sprite_names()
+
+        self.assertEqual(valid_sprites, {})
+        yyp_reads = [
+            call
+            for call in tracked_open.call_args_list
+            if call.args
+            and isinstance(call.args[0], (str, os.PathLike))
+            and os.path.abspath(os.fspath(call.args[0])) == yyp_path
+        ]
+        self.assertEqual(len(yyp_reads), 1, yyp_reads)
+
+    def test_declared_yy_path_drives_lts_order_metadata_and_subfolder(self) -> None:
+        sprite_name = "s_declared"
+        yy_relative_path = "sprites/source_folder/metadata.yy"
+        frame_guids = ["frame-z", "frame-a"]
+        layer_guids = ["layer-z", "layer-a"]
+        yy_content = _make_yy_content_with_sequence(
+            sprite_name,
+            frame_guids,
+            layer_guids,
+            width=8,
+            height=6,
+            bbox_right=7,
+            bbox_bottom=5,
+            playback_speed=12.0,
+            frame_lengths=[1.0, 2.0],
+        ).replace(
+            f'"name":"{sprite_name}",',
+            (
+                f'"name":"{sprite_name}",\n'
+                '  "parent":{"path":"folders/Sprites/Characters/Heroes.yy"},'
+            ),
+        )
+        yy_path = self._write_yy(yy_relative_path, yy_content)
+        sprite_directory = os.path.dirname(yy_path)
+        frame_colors = [("red", "blue"), ("green", "yellow")]
+        for frame_guid, colors in zip(frame_guids, frame_colors):
+            for layer_guid, color in zip(layer_guids, colors):
+                self._write_png(
+                    os.path.join(
+                        sprite_directory,
+                        "layers",
+                        frame_guid,
+                        layer_guid + ".png",
+                    ),
+                    color,
+                )
+        self._write_yyp(
+            [
+                {
+                    "id": {"name": sprite_name, "path": yy_relative_path},
+                    "resourceType": "GMSprite",
+                }
+            ]
+        )
+
+        self._make_converter().convert_all()
+
+        output_directory = os.path.join(
+            self.godot_dir,
+            "sprites",
+            "characters",
+            "heroes",
+            sprite_name,
+        )
+        expected_colors = ["blue", "yellow"]
+        for index, expected_color in enumerate(expected_colors, start=1):
+            with Image.open(
+                os.path.join(output_directory, f"{sprite_name}_{index}.png")
+            ) as image:
+                self.assertEqual(
+                    image.convert("RGBA").getpixel((0, 0)),
+                    Image.new("RGBA", (1, 1), expected_color).getpixel((0, 0)),
+                )
+        with open(
+            os.path.join(output_directory, f"{sprite_name}.tscn"),
+            "r",
+            encoding="utf-8",
+        ) as scene_file:
+            scene = scene_file.read()
+        self.assertIn('"speed": 12.0', scene)
+        self.assertIn('"duration": 2.0', scene)
+        self.assertIn("metadata/gamemaker_width = 8", scene)
+        self.assertIn("metadata/gamemaker_height = 6", scene)
+
+    def test_normal_direct_sprite_path_still_converts(self) -> None:
+        sprite_name = "s_direct"
+        yy_relative_path = f"sprites/{sprite_name}/{sprite_name}.yy"
+        self._write_yy(
+            yy_relative_path,
+            _make_yy_content(sprite_name, ["frame"], ["layer"]),
+        )
+        self._write_png(
+            os.path.join(
+                self.gm_dir,
+                "sprites",
+                sprite_name,
+                "layers",
+                "frame",
+                "layer.png",
+            )
+        )
+        self._write_yyp(
+            [{"id": {"name": sprite_name, "path": yy_relative_path}}]
+        )
+
+        self._make_converter().convert_all()
+
+        self.assertTrue(
+            os.path.isfile(
+                os.path.join(
+                    self.godot_dir,
+                    "sprites",
+                    sprite_name,
+                    sprite_name + ".png",
+                )
+            )
+        )
+
+    def test_normal_disk_fallback_sprite_still_converts(self) -> None:
+        sprite_name = "s_fallback"
+        self._write_yy(
+            f"sprites/{sprite_name}/{sprite_name}.yy",
+            _make_yy_content(sprite_name, ["frame"], ["layer"]),
+        )
+        self._write_png(
+            os.path.join(
+                self.gm_dir,
+                "sprites",
+                sprite_name,
+                "layers",
+                "frame",
+                "layer.png",
+            )
+        )
+
+        self._make_converter().convert_all()
+
+        self.assertTrue(
+            os.path.isfile(
+                os.path.join(
+                    self.godot_dir,
+                    "sprites",
+                    sprite_name,
+                    sprite_name + ".png",
+                )
+            )
+        )
+
+    def test_rejects_unsafe_declared_sprite_yy_path_forms(self) -> None:
+        outside_yy = os.path.join(self.outside_dir, "outside.yy")
+        with open(outside_yy, "w", encoding="utf-8") as yy_file:
+            yy_file.write(_make_yy_content("outside", ["frame"], ["layer"]))
+        unsafe_paths = [
+            os.path.relpath(outside_yy, self.gm_dir).replace(os.sep, "/"),
+            outside_yy,
+            r"C:\Games\Outside\sprite.yy",
+            r"C:Outside\sprite.yy",
+            r"\\server\share\sprite.yy",
+            "sprites/s_bad/s_bad\0.yy",
+        ]
+        self._write_yyp(
+            [
+                {
+                    "id": {"name": f"s_bad_{index}", "path": path},
+                    "resourceType": "GMSprite",
+                }
+                for index, path in enumerate(unsafe_paths)
+            ]
+        )
+        diagnostics = DiagnosticCollector()
+
+        valid_names = self._make_converter(diagnostics)._get_valid_sprite_names()
+
+        self.assertEqual(valid_names, {})
+        rejected = self._rejections(diagnostics)
+        self.assertEqual(len(rejected), len(unsafe_paths), rejected)
+        self.assertEqual(
+            {diagnostic.source_path for diagnostic in rejected},
+            {"SpritePaths.yyp"},
+        )
+        self.assertEqual(
+            {diagnostic.manifest_entry for diagnostic in rejected},
+            {
+                f"resources[{index}].id.path"
+                for index in range(len(unsafe_paths))
+            },
+        )
+        self.assertTrue(
+            all(diagnostic.resource_type == "sprite" for diagnostic in rejected)
+        )
+
+    def test_rejects_normalized_cross_family_manifest_path_and_keeps_safe_sibling(
+        self,
+    ) -> None:
+        sprite_name = "s_cross_family"
+        self._write_yy(
+            "sounds/s_cross_family/decoy.yy",
+            _make_yy_content(sprite_name, ["frame"], ["layer"]),
+        )
+        safe_yy_relative = "sprites/s_cross_family/safe.yy"
+        safe_yy = self._write_yy(
+            safe_yy_relative,
+            _make_yy_content(sprite_name, ["frame"], ["layer"]),
+        )
+        self._write_yyp(
+            [
+                {
+                    "id": {
+                        "name": sprite_name,
+                        "path": "sprites/../sounds/s_cross_family/decoy.yy",
+                    },
+                    "resourceType": "GMSprite",
+                },
+                {
+                    "id": {"name": sprite_name, "path": safe_yy_relative},
+                    "resourceType": "GMSprite",
+                },
+            ]
+        )
+        diagnostics = DiagnosticCollector()
+        converter = self._make_converter(diagnostics)
+
+        valid_names = converter._get_valid_sprite_names()
+
+        self.assertEqual(valid_names, {sprite_name: ""})
+        self.assertEqual(converter._yyp_sprite_yy_paths, {sprite_name: safe_yy})
+        rejected = self._rejections(diagnostics)
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "SpritePaths.yyp")
+        self.assertEqual(rejected[0].resource, sprite_name)
+        self.assertEqual(rejected[0].resource_type, "sprite")
+        self.assertEqual(
+            rejected[0].manifest_entry,
+            "resources[0].id.path",
+        )
+
+    def test_rejects_declared_yy_file_link_to_outside_project(self) -> None:
+        sprite_name = "s_direct_link"
+        outside_yy = os.path.join(self.outside_dir, "outside.yy")
+        with open(outside_yy, "w", encoding="utf-8") as yy_file:
+            yy_file.write(_make_yy_content(sprite_name, ["frame"], ["layer"]))
+        yy_relative_path = f"sprites/{sprite_name}/{sprite_name}.yy"
+        linked_yy = os.path.join(self.gm_dir, *yy_relative_path.split("/"))
+        os.makedirs(os.path.dirname(linked_yy))
+        try:
+            os.symlink(outside_yy, linked_yy)
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+        self._write_yyp(
+            [{"id": {"name": sprite_name, "path": yy_relative_path}}]
+        )
+        diagnostics = DiagnosticCollector()
+
+        valid_names = self._make_converter(diagnostics)._get_valid_sprite_names()
+
+        self.assertEqual(valid_names, {})
+        rejected = self._rejections(diagnostics)
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "SpritePaths.yyp")
+        self.assertEqual(rejected[0].resource, sprite_name)
+        self.assertEqual(rejected[0].manifest_entry, "resources[0].id.path")
+
+    def test_rejects_disk_fallback_resource_directory_link(self) -> None:
+        sprite_name = "s_directory_link"
+        outside_sprite_directory = os.path.join(
+            self.outside_dir,
+            sprite_name,
+        )
+        os.makedirs(outside_sprite_directory)
+        with open(
+            os.path.join(outside_sprite_directory, sprite_name + ".yy"),
+            "w",
+            encoding="utf-8",
+        ) as yy_file:
+            yy_file.write(_make_yy_content(sprite_name, ["frame"], ["layer"]))
+        self._write_png(
+            os.path.join(
+                outside_sprite_directory,
+                "layers",
+                "frame",
+                "layer.png",
+            )
+        )
+        sprite_root = os.path.join(self.gm_dir, "sprites")
+        os.makedirs(sprite_root)
+        try:
+            os.symlink(
+                outside_sprite_directory,
+                os.path.join(sprite_root, sprite_name),
+            )
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+        diagnostics = DiagnosticCollector()
+
+        self._make_converter(diagnostics).convert_all()
+
+        self.assertFalse(
+            os.path.exists(os.path.join(self.godot_dir, "sprites", sprite_name))
+        )
+        rejected = self._rejections(diagnostics)
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, "sprites")
+        self.assertEqual(rejected[0].resource, sprite_name)
+        self.assertEqual(
+            rejected[0].manifest_entry,
+            "discovered sprite directory",
+        )
+
+    def test_rejects_disk_fallback_yy_file_link_but_keeps_legacy_images(self) -> None:
+        sprite_name = "s_yy_link"
+        sprite_directory = os.path.join(self.gm_dir, "sprites", sprite_name)
+        os.makedirs(sprite_directory)
+        outside_yy = os.path.join(self.outside_dir, sprite_name + ".yy")
+        with open(outside_yy, "w", encoding="utf-8") as yy_file:
+            yy_file.write(
+                _make_yy_content_with_collision(
+                    sprite_name,
+                    ["frame"],
+                    ["layer"],
+                    width=99,
+                )
+            )
+        try:
+            os.symlink(
+                outside_yy,
+                os.path.join(sprite_directory, sprite_name + ".yy"),
+            )
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+        self._write_png(
+            os.path.join(
+                sprite_directory,
+                "layers",
+                "frame",
+                "layer.png",
+            )
+        )
+        diagnostics = DiagnosticCollector()
+
+        self._make_converter(diagnostics).convert_all()
+
+        output_directory = os.path.join(
+            self.godot_dir,
+            "sprites",
+            sprite_name,
+        )
+        self.assertTrue(os.path.isfile(os.path.join(output_directory, sprite_name + ".png")))
+        with open(
+            os.path.join(output_directory, sprite_name + ".tscn"),
+            "r",
+            encoding="utf-8",
+        ) as scene_file:
+            self.assertNotIn("gamemaker_width = 99", scene_file.read())
+        rejected = self._rejections(diagnostics)
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, f"sprites/{sprite_name}")
+        self.assertEqual(rejected[0].resource, sprite_name)
+        self.assertEqual(rejected[0].manifest_entry, "discovered sprite .yy")
+
+    def test_disk_fallback_rejects_contained_cross_family_sprite_yy_link(
+        self,
+    ) -> None:
+        linked_name = "s_cross_family_link"
+        wrong_family_yy = self._write_yy(
+            "sounds/wrong_sprite/target.yy",
+            _make_yy_content_with_collision(
+                linked_name,
+                ["frame"],
+                ["layer"],
+                width=99,
+            ),
+        )
+        linked_directory = os.path.join(self.gm_dir, "sprites", linked_name)
+        os.makedirs(linked_directory)
+        try:
+            os.symlink(
+                wrong_family_yy,
+                os.path.join(linked_directory, linked_name + ".yy"),
+            )
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+        self._write_png(
+            os.path.join(
+                linked_directory,
+                "layers",
+                "frame",
+                "layer.png",
+            )
+        )
+
+        safe_name = "s_safe_sibling"
+        self._write_yy(
+            f"sprites/{safe_name}/{safe_name}.yy",
+            _make_yy_content(safe_name, ["frame"], ["layer"]),
+        )
+        self._write_png(
+            os.path.join(
+                self.gm_dir,
+                "sprites",
+                safe_name,
+                "layers",
+                "frame",
+                "layer.png",
+            )
+        )
+        diagnostics = DiagnosticCollector()
+
+        self._make_converter(diagnostics).convert_all()
+
+        linked_scene = os.path.join(
+            self.godot_dir,
+            "sprites",
+            linked_name,
+            linked_name + ".tscn",
+        )
+        with open(linked_scene, "r", encoding="utf-8") as scene_file:
+            self.assertNotIn("gamemaker_width = 99", scene_file.read())
+        self.assertTrue(
+            os.path.isfile(
+                os.path.join(
+                    self.godot_dir,
+                    "sprites",
+                    safe_name,
+                    safe_name + ".tscn",
+                )
+            )
+        )
+        rejected = self._rejections(diagnostics)
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, f"sprites/{linked_name}")
+        self.assertEqual(rejected[0].resource, linked_name)
+        self.assertEqual(rejected[0].resource_type, "sprite")
+        self.assertEqual(rejected[0].manifest_entry, "discovered sprite .yy")
+
+    def test_rejects_layers_and_frame_directory_links(self) -> None:
+        resources: list[dict[str, object]] = []
+        outside_layers = os.path.join(self.outside_dir, "layers")
+        self._write_png(
+            os.path.join(outside_layers, "frame", "layer.png")
+        )
+
+        layers_sprite = "s_layers_link"
+        layers_yy_relative = f"sprites/{layers_sprite}/{layers_sprite}.yy"
+        layers_yy = self._write_yy(
+            layers_yy_relative,
+            _make_yy_content(layers_sprite, ["frame"], ["layer"]),
+        )
+        try:
+            os.symlink(
+                outside_layers,
+                os.path.join(os.path.dirname(layers_yy), "layers"),
+            )
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+        resources.append(
+            {"id": {"name": layers_sprite, "path": layers_yy_relative}}
+        )
+
+        frame_sprite = "s_frame_link"
+        frame_yy_relative = f"sprites/{frame_sprite}/{frame_sprite}.yy"
+        frame_yy = self._write_yy(
+            frame_yy_relative,
+            _make_yy_content(frame_sprite, ["frame"], ["layer"]),
+        )
+        frame_layers = os.path.join(os.path.dirname(frame_yy), "layers")
+        os.makedirs(frame_layers)
+        try:
+            os.symlink(
+                os.path.join(outside_layers, "frame"),
+                os.path.join(frame_layers, "frame"),
+            )
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+        resources.append(
+            {"id": {"name": frame_sprite, "path": frame_yy_relative}}
+        )
+        self._write_yyp(resources)
+        diagnostics = DiagnosticCollector()
+
+        self._make_converter(diagnostics).convert_all()
+
+        rejected = self._rejections(diagnostics)
+        self.assertEqual(len(rejected), 2, rejected)
+        self.assertEqual(
+            {diagnostic.source_path for diagnostic in rejected},
+            {
+                layers_yy_relative,
+                frame_yy_relative,
+            },
+        )
+        self.assertEqual(
+            {diagnostic.manifest_entry for diagnostic in rejected},
+            {"layers directory", "frames[].name"},
+        )
+
+    def test_revalidates_png_after_discovery_before_copy(self) -> None:
+        sprite_name = "s_png_link"
+        yy_relative_path = f"sprites/{sprite_name}/{sprite_name}.yy"
+        yy_path = self._write_yy(
+            yy_relative_path,
+            _make_yy_content(sprite_name, ["frame"], ["layer"]),
+        )
+        sprite_directory = os.path.dirname(yy_path)
+        png_path = os.path.join(
+            sprite_directory,
+            "layers",
+            "frame",
+            "layer.png",
+        )
+        self._write_png(png_path)
+        diagnostics = DiagnosticCollector()
+        converter = self._make_converter(diagnostics)
+        discovered = converter._find_all_sprite_images(
+            {sprite_name: sprite_directory},
+            {sprite_name: yy_path},
+        )
+        outside_png = os.path.join(self.outside_dir, "outside.png")
+        self._write_png(outside_png, "blue")
+        os.unlink(png_path)
+        try:
+            os.symlink(outside_png, png_path)
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+        os.makedirs(
+            os.path.join(self.godot_dir, "sprites", sprite_name),
+            exist_ok=True,
+        )
+
+        result = converter._process_sprite(
+            sprite_name,
+            1,
+            discovered[sprite_name],
+            1,
+        )
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result[-1], "")
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(
+                    self.godot_dir,
+                    "sprites",
+                    sprite_name,
+                    sprite_name + ".png",
+                )
+            )
+        )
+        rejected = self._rejections(diagnostics)
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].source_path, yy_relative_path)
+        self.assertEqual(
+            rejected[0].manifest_entry,
+            "frames[].name/layers[].name",
+        )
 
 
 class TestParseCollisionData(unittest.TestCase):

--- a/tests/test_tilesets.py
+++ b/tests/test_tilesets.py
@@ -7,14 +7,16 @@ import shutil
 import tempfile
 import unittest
 from typing import cast
+from unittest.mock import patch
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from PIL import Image
-from src.conversion.tilesets import TileSetConverter, TilesetData
 from src.conversion.asset_registry import AssetRegistryConverter
+from src.conversion.diagnostics import DiagnosticCollector
+from src.conversion.tilesets import TileSetConverter, TilesetData
 
 
 def _make_tileset_yy_content(name: str, sprite_name: str, tile_width: int = 16, tile_height: int = 16,
@@ -327,6 +329,964 @@ class TestParseTilesetYY(unittest.TestCase):
         self.assertIn('metadata/gamemaker_tileset_animation_frames = [{"frames": [0, 1], "duration": 2}]', tres)
         self.assertIn('metadata/gamemaker_tileset_auto_tile_sets = [{"name": "terrain"}]', tres)
         self.assertIn('metadata/gamemaker_tileset_collisions = [{"tileId": 1', tres)
+
+
+class TestTileSetSourceContainment(unittest.TestCase):
+    FRAME_GUID = "aaaaaaaa-0000-0000-0000-000000000001"
+    LAYER_GUID = "bbbbbbbb-0000-0000-0000-000000000001"
+
+    def setUp(self) -> None:
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.outside_dir = tempfile.mkdtemp()
+        self.logs: list[str] = []
+        self.diagnostics = DiagnosticCollector()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+        shutil.rmtree(self.outside_dir)
+
+    def _make_converter(self) -> TileSetConverter:
+        return TileSetConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=self.logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            max_workers=1,
+            diagnostics=self.diagnostics,
+        )
+
+    def _write_json(self, path: str, value: object) -> None:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as output_file:
+            json.dump(value, output_file)
+
+    def _write_tileset(
+        self,
+        path: str,
+        name: str,
+        sprite_id: object,
+        *,
+        tile_width: int = 16,
+        tile_height: int = 16,
+    ) -> None:
+        self._write_json(
+            path,
+            {
+                "$GMTileSet": "v1",
+                "%Name": name,
+                "spriteId": sprite_id,
+                "tileWidth": tile_width,
+                "tileHeight": tile_height,
+                "tile_count": 4,
+                "out_columns": 2,
+                "parent": {
+                    "name": "Tilesets",
+                    "path": "folders/Tilesets.yy",
+                },
+                "resourceType": "GMTileSet",
+                "resourceVersion": "2.0",
+            },
+        )
+
+    def _write_sprite(
+        self,
+        yy_path: str,
+        *,
+        color: str,
+        width: int = 48,
+        height: int = 40,
+    ) -> str:
+        self._write_json(
+            yy_path,
+            {
+                "frames": [{"name": self.FRAME_GUID}],
+                "layers": [{"name": self.LAYER_GUID, "visible": True}],
+                "resourceType": "GMSprite",
+                "resourceVersion": "2.0",
+            },
+        )
+        image_path = os.path.join(
+            os.path.dirname(yy_path),
+            "layers",
+            self.FRAME_GUID,
+            self.LAYER_GUID + ".png",
+        )
+        os.makedirs(os.path.dirname(image_path), exist_ok=True)
+        Image.new("RGBA", (width, height), color).save(image_path, "PNG")
+        return image_path
+
+    def test_manifest_discovery_reads_selected_yyp_once(self) -> None:
+        yyp_path = os.path.join(self.gm_dir, "TileSetPaths.yyp")
+        self._write_json(yyp_path, {"resources": []})
+
+        with patch("builtins.open", wraps=open) as tracked_open:
+            valid_tilesets = self._make_converter()._get_valid_tileset_names()
+
+        self.assertEqual(valid_tilesets, {})
+        yyp_reads = [
+            call
+            for call in tracked_open.call_args_list
+            if call.args
+            and isinstance(call.args[0], (str, os.PathLike))
+            and os.path.abspath(os.fspath(call.args[0])) == yyp_path
+        ]
+        self.assertEqual(len(yyp_reads), 1, yyp_reads)
+
+    def _source_path_rejections(self):
+        return [
+            diagnostic
+            for diagnostic in self.diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+        ]
+
+    def test_declared_tileset_and_sprite_paths_override_name_reconstruction(self) -> None:
+        declared_tileset = os.path.join(
+            self.gm_dir,
+            "tilesets",
+            "declared",
+            "custom_tileset.yy",
+        )
+        declared_sprite = os.path.join(
+            self.gm_dir,
+            "sprites",
+            "declared",
+            "custom_sprite.yy",
+        )
+        self._write_tileset(
+            declared_tileset,
+            "ts_declared",
+            {
+                "name": "s_decoy",
+                "path": "sprites/declared/custom_sprite.yy",
+            },
+            tile_width=24,
+            tile_height=20,
+        )
+        self._write_sprite(declared_sprite, color="red")
+
+        reconstructed_tileset = os.path.join(
+            self.gm_dir,
+            "tilesets",
+            "ts_declared",
+            "ts_declared.yy",
+        )
+        self._write_tileset(
+            reconstructed_tileset,
+            "ts_declared",
+            {"name": "s_decoy", "path": "sprites/s_decoy/s_decoy.yy"},
+            tile_width=8,
+            tile_height=8,
+        )
+        decoy_sprite = os.path.join(
+            self.gm_dir,
+            "sprites",
+            "s_decoy",
+            "s_decoy.yy",
+        )
+        self._write_sprite(decoy_sprite, color="blue")
+        self._write_json(
+            os.path.join(self.gm_dir, "DeclaredPaths.yyp"),
+            {
+                "resources": [
+                    {
+                        "id": {
+                            "name": "ts_declared",
+                            "path": "tilesets/declared/custom_tileset.yy",
+                        }
+                    }
+                ],
+                "resourceType": "GMProject",
+            },
+        )
+
+        self._make_converter().convert_all()
+
+        output_dir = os.path.join(self.godot_dir, "tilesets", "ts_declared")
+        with open(
+            os.path.join(output_dir, "ts_declared.tres"),
+            "r",
+            encoding="utf-8",
+        ) as tres_file:
+            tres = tres_file.read()
+        self.assertIn("texture_region_size = Vector2i(24, 20)", tres)
+        self.assertIn("tile_size = Vector2i(24, 20)", tres)
+        with Image.open(os.path.join(output_dir, "ts_declared.png")) as image:
+            self.assertEqual(image.getpixel((0, 0)), (255, 0, 0, 255))
+
+    def test_external_first_yyp_cannot_mask_contained_declared_tileset_path(self) -> None:
+        declared_path = os.path.join(
+            self.gm_dir,
+            "tilesets",
+            "nested",
+            "custom_tileset.yy",
+        )
+        self._write_tileset(
+            declared_path,
+            "ts_inside",
+            {"name": "s_inside", "path": "sprites/s_inside/s_inside.yy"},
+        )
+        self._write_json(
+            os.path.join(self.gm_dir, "BInside.yyp"),
+            {
+                "resources": [
+                    {
+                        "id": {
+                            "name": "ts_inside",
+                            "path": "tilesets/nested/custom_tileset.yy",
+                        }
+                    }
+                ],
+                "resourceType": "GMProject",
+            },
+        )
+        with tempfile.TemporaryDirectory() as outside_dir:
+            outside_yyp = os.path.join(outside_dir, "Outside.yyp")
+            self._write_json(
+                outside_yyp,
+                {
+                    "resources": [
+                        {
+                            "id": {
+                                "name": "ts_outside",
+                                "path": "tilesets/ts_outside/ts_outside.yy",
+                            }
+                        }
+                    ]
+                },
+            )
+            try:
+                os.symlink(
+                    outside_yyp,
+                    os.path.join(self.gm_dir, "AOutside.yyp"),
+                )
+            except (NotImplementedError, OSError) as exc:
+                self.skipTest(f"Symbolic links are unavailable: {exc}")
+
+            converter = self._make_converter()
+            valid_tilesets = converter._get_valid_tileset_names()
+
+        self.assertEqual(valid_tilesets, {"ts_inside": ""})
+        self.assertEqual(
+            converter._tileset_source_paths,
+            {"ts_inside": "tilesets/nested/custom_tileset.yy"},
+        )
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), 1)
+        self.assertIsNone(rejected[0].source_path)
+        self.assertEqual(rejected[0].resource_type, "project")
+        self.assertEqual(rejected[0].manifest_entry, "AOutside.yyp")
+        self.assertIn("AOutside.yyp", rejected[0].message)
+
+    def test_non_file_first_yyp_is_rejected_with_source_link(self) -> None:
+        os.makedirs(os.path.join(self.gm_dir, "ADirectory.yyp"))
+        self._write_json(
+            os.path.join(self.gm_dir, "BInside.yyp"),
+            {"resources": [], "resourceType": "GMProject"},
+        )
+
+        valid_tilesets = self._make_converter()._get_valid_tileset_names()
+
+        self.assertEqual(valid_tilesets, {})
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), 1)
+        self.assertEqual(rejected[0].source_path, "ADirectory.yyp")
+        self.assertEqual(rejected[0].resource_type, "project")
+        self.assertEqual(rejected[0].manifest_entry, "ADirectory.yyp")
+
+    def test_validates_and_preserves_legacy_sprite_name_fallback(self) -> None:
+        tileset_path = os.path.join(
+            self.gm_dir,
+            "tilesets",
+            "ts_legacy",
+            "ts_legacy.yy",
+        )
+        self._write_tileset(
+            tileset_path,
+            "ts_legacy",
+            {"name": "s_legacy"},
+        )
+        _make_sprite_for_tileset(self.gm_dir, "s_legacy", width=32, height=16)
+
+        self._make_converter().convert_all()
+
+        self.assertTrue(
+            os.path.isfile(
+                os.path.join(
+                    self.godot_dir,
+                    "tilesets",
+                    "ts_legacy",
+                    "ts_legacy.tres",
+                )
+            )
+        )
+        self.assertEqual(self._source_path_rejections(), [])
+
+    def test_rejects_malformed_sprite_reference_forms_with_owner_diagnostics(
+        self,
+    ) -> None:
+        outside_sprite = os.path.join(self.outside_dir, "outside.yy")
+        self._write_json(outside_sprite, {"frames": [], "layers": []})
+        traversal_path = os.path.relpath(
+            outside_sprite,
+            os.path.join(self.gm_dir, "tilesets", "ts_traversal"),
+        )
+        cross_family_path = "objects/o_decoy/o_decoy.yy"
+        self._write_json(
+            os.path.join(self.gm_dir, *cross_family_path.split("/")),
+            {"resourceType": "GMObject"},
+        )
+        cases: list[tuple[str, object, str]] = [
+            ("ts_absolute", {"path": outside_sprite}, "spriteId.path"),
+            ("ts_traversal", {"path": traversal_path}, "spriteId.path"),
+            (
+                "ts_drive_absolute",
+                {"path": r"C:\Games\Outside\sprite.yy"},
+                "spriteId.path",
+            ),
+            (
+                "ts_drive_relative",
+                {"path": r"C:Outside\sprite.yy"},
+                "spriteId.path",
+            ),
+            (
+                "ts_unc",
+                {"path": r"\\server\share\sprite.yy"},
+                "spriteId.path",
+            ),
+            ("ts_nul", {"path": "bad\0sprite.yy"}, "spriteId.path"),
+            ("ts_non_string", {"path": 7}, "spriteId.path"),
+            (
+                "ts_cross_family",
+                {"path": cross_family_path},
+                "spriteId.path",
+            ),
+            ("ts_bad_legacy", {"name": "../outside"}, "spriteId.name"),
+            ("ts_not_object", ["sprites/s_safe/s_safe.yy"], "spriteId"),
+        ]
+        for name, sprite_id, _field in cases:
+            tileset_path = os.path.join(
+                self.gm_dir,
+                "tilesets",
+                name,
+                name + ".yy",
+            )
+            self._write_tileset(tileset_path, name, sprite_id)
+
+        converter = self._make_converter()
+        for name, _sprite_id, _field in cases:
+            result = converter._process_tileset(name)
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertFalse(result["success"])
+
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), len(cases), rejected)
+        self.assertEqual(
+            {diagnostic.resource for diagnostic in rejected},
+            {name for name, _sprite_id, _field in cases},
+        )
+        self.assertTrue(
+            all(
+                diagnostic.source_path
+                == f"tilesets/{diagnostic.resource}/{diagnostic.resource}.yy"
+                and diagnostic.resource_type == "tileset"
+                for diagnostic in rejected
+            )
+        )
+        expected_fields = {
+            name: field for name, _sprite_id, field in cases
+        }
+        self.assertTrue(
+            all(
+                diagnostic.manifest_entry
+                == expected_fields[cast(str, diagnostic.resource)]
+                for diagnostic in rejected
+            )
+        )
+
+    def test_rejects_referenced_sprite_metadata_symlink_escape(self) -> None:
+        outside_sprite = os.path.join(self.outside_dir, "outside_sprite.yy")
+        self._write_json(
+            outside_sprite,
+            {
+                "frames": [{"name": self.FRAME_GUID}],
+                "layers": [{"name": self.LAYER_GUID, "visible": True}],
+                "resourceType": "GMSprite",
+            },
+        )
+        sprite_name = "s_linked_metadata"
+        linked_sprite = os.path.join(
+            self.gm_dir,
+            "sprites",
+            sprite_name,
+            sprite_name + ".yy",
+        )
+        os.makedirs(os.path.dirname(linked_sprite), exist_ok=True)
+        try:
+            os.symlink(outside_sprite, linked_sprite)
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+
+        tileset_name = "ts_linked_sprite_metadata"
+        self._write_tileset(
+            os.path.join(
+                self.gm_dir,
+                "tilesets",
+                tileset_name,
+                tileset_name + ".yy",
+            ),
+            tileset_name,
+            {
+                "name": sprite_name,
+                "path": f"sprites/{sprite_name}/{sprite_name}.yy",
+            },
+        )
+
+        converter = self._make_converter()
+        with patch("builtins.open", wraps=open) as tracked_open:
+            result = converter._process_tileset(tileset_name)
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertFalse(result["success"])
+        self.assertNotIn(
+            os.path.realpath(outside_sprite),
+            {
+                os.path.realpath(call.args[0])
+                for call in tracked_open.call_args_list
+                if call.args and isinstance(call.args[0], str)
+            },
+        )
+        rejected = self._source_path_rejections()
+        self.assertEqual(len(rejected), 1, rejected)
+        self.assertEqual(rejected[0].resource, tileset_name)
+        self.assertEqual(
+            rejected[0].source_path,
+            f"tilesets/{tileset_name}/{tileset_name}.yy",
+        )
+        self.assertEqual(rejected[0].manifest_entry, "spriteId.path")
+
+    def test_rejects_normalized_cross_family_and_non_yy_sprite_paths(
+        self,
+    ) -> None:
+        rejected_targets = {
+            "ts_cross_family": os.path.join(
+                self.gm_dir,
+                "tilesets",
+                "decoy",
+                "decoy.yy",
+            ),
+            "ts_non_yy": os.path.join(
+                self.gm_dir,
+                "sprites",
+                "decoy",
+                "decoy.json",
+            ),
+        }
+        for target in rejected_targets.values():
+            self._write_json(
+                target,
+                {
+                    "frames": [{"name": self.FRAME_GUID}],
+                    "layers": [{"name": self.LAYER_GUID, "visible": True}],
+                },
+            )
+
+        sprite_paths = {
+            "ts_cross_family": (
+                "sprites/placeholder/../../tilesets/decoy/decoy.yy"
+            ),
+            "ts_non_yy": "sprites/decoy/decoy.json",
+        }
+        for tileset_name, sprite_path in sprite_paths.items():
+            self._write_tileset(
+                os.path.join(
+                    self.gm_dir,
+                    "tilesets",
+                    tileset_name,
+                    tileset_name + ".yy",
+                ),
+                tileset_name,
+                {"name": "s_decoy", "path": sprite_path},
+            )
+
+        safe_tileset = "ts_safe_reference"
+        safe_sprite = "s_safe_reference"
+        self._write_tileset(
+            os.path.join(
+                self.gm_dir,
+                "tilesets",
+                safe_tileset,
+                safe_tileset + ".yy",
+            ),
+            safe_tileset,
+            {
+                "name": safe_sprite,
+                "path": f"sprites/{safe_sprite}/{safe_sprite}.yy",
+            },
+        )
+        self._write_sprite(
+            os.path.join(
+                self.gm_dir,
+                "sprites",
+                safe_sprite,
+                safe_sprite + ".yy",
+            ),
+            color="green",
+        )
+
+        converter = self._make_converter()
+        with patch("builtins.open", wraps=open) as tracked_open:
+            rejected_results = {
+                tileset_name: converter._process_tileset(tileset_name)
+                for tileset_name in sprite_paths
+            }
+            safe_result = converter._process_tileset(safe_tileset)
+
+        self.assertTrue(
+            all(
+                result is not None and not result["success"]
+                for result in rejected_results.values()
+            )
+        )
+        self.assertIsNotNone(safe_result)
+        assert safe_result is not None
+        self.assertTrue(safe_result["success"])
+
+        opened_paths = {
+            os.path.realpath(call.args[0])
+            for call in tracked_open.call_args_list
+            if call.args and isinstance(call.args[0], str)
+        }
+        self.assertTrue(
+            opened_paths.isdisjoint(
+                os.path.realpath(path) for path in rejected_targets.values()
+            )
+        )
+        rejected = [
+            diagnostic
+            for diagnostic in self._source_path_rejections()
+            if diagnostic.resource in sprite_paths
+        ]
+        self.assertEqual(len(rejected), len(sprite_paths), rejected)
+        self.assertTrue(
+            all(
+                diagnostic.source_path
+                == f"tilesets/{diagnostic.resource}/{diagnostic.resource}.yy"
+                and diagnostic.manifest_entry == "spriteId.path"
+                for diagnostic in rejected
+            )
+        )
+        self.assertTrue(
+            os.path.isfile(
+                os.path.join(
+                    self.godot_dir,
+                    "tilesets",
+                    safe_tileset,
+                    safe_tileset + ".png",
+                )
+            )
+        )
+
+    def test_sprite_frame_and_layer_rejections_are_linked_to_sprite_metadata(
+        self,
+    ) -> None:
+        cases: list[tuple[str, str, str, object]] = [
+            ("ts_frame_slash", "s_frame_slash", "frames[0].name", "nested/frame"),
+            ("ts_frame_dot", "s_frame_dot", "frames[0].name", ".."),
+            (
+                "ts_frame_drive",
+                "s_frame_drive",
+                "frames[0].name",
+                r"C:\Outside\frame",
+            ),
+            ("ts_frame_nul", "s_frame_nul", "frames[0].name", "bad\0frame"),
+            ("ts_frame_non_string", "s_frame_non_string", "frames[0].name", 7),
+            (
+                "ts_layer_backslash",
+                "s_layer_backslash",
+                "layers[0].name",
+                r"nested\layer",
+            ),
+            ("ts_layer_dot", "s_layer_dot", "layers[0].name", "."),
+            (
+                "ts_layer_unc",
+                "s_layer_unc",
+                "layers[0].name",
+                r"\\server\share\layer",
+            ),
+            (
+                "ts_layer_non_string",
+                "s_layer_non_string",
+                "layers[0].name",
+                ["layer"],
+            ),
+        ]
+        for tileset_name, sprite_name, field, invalid_value in cases:
+            frames: list[dict[str, object]] = [{"name": self.FRAME_GUID}]
+            layers: list[dict[str, object]] = [
+                {"name": self.LAYER_GUID, "visible": True}
+            ]
+            if field == "frames[0].name":
+                frames[0]["name"] = invalid_value
+            else:
+                layers[0]["name"] = invalid_value
+            self._write_tileset(
+                os.path.join(
+                    self.gm_dir,
+                    "tilesets",
+                    tileset_name,
+                    tileset_name + ".yy",
+                ),
+                tileset_name,
+                {
+                    "name": sprite_name,
+                    "path": f"sprites/{sprite_name}/{sprite_name}.yy",
+                },
+            )
+            self._write_json(
+                os.path.join(
+                    self.gm_dir,
+                    "sprites",
+                    sprite_name,
+                    sprite_name + ".yy",
+                ),
+                {
+                    "frames": frames,
+                    "layers": layers,
+                    "resourceType": "GMSprite",
+                },
+            )
+
+        safe_tileset = "ts_safe_sidecar"
+        safe_sprite = "s_safe_sidecar"
+        self._write_tileset(
+            os.path.join(
+                self.gm_dir,
+                "tilesets",
+                safe_tileset,
+                safe_tileset + ".yy",
+            ),
+            safe_tileset,
+            {
+                "name": safe_sprite,
+                "path": f"sprites/{safe_sprite}/{safe_sprite}.yy",
+            },
+        )
+        self._write_sprite(
+            os.path.join(
+                self.gm_dir,
+                "sprites",
+                safe_sprite,
+                safe_sprite + ".yy",
+            ),
+            color="green",
+        )
+
+        self._make_converter().convert_all()
+
+        expected = {
+            tileset_name: (f"sprites/{sprite_name}/{sprite_name}.yy", field)
+            for tileset_name, sprite_name, field, _invalid_value in cases
+        }
+        rejected = [
+            diagnostic
+            for diagnostic in self._source_path_rejections()
+            if diagnostic.resource in expected
+        ]
+        self.assertEqual(len(rejected), len(cases), rejected)
+        self.assertEqual(
+            {
+                diagnostic.resource: (
+                    diagnostic.source_path,
+                    diagnostic.manifest_entry,
+                )
+                for diagnostic in rejected
+            },
+            expected,
+        )
+        for tileset_name in expected:
+            self.assertFalse(
+                os.path.exists(
+                    os.path.join(
+                        self.godot_dir,
+                        "tilesets",
+                        tileset_name,
+                        tileset_name + ".png",
+                    )
+                )
+            )
+        self.assertTrue(
+            os.path.isfile(
+                os.path.join(
+                    self.godot_dir,
+                    "tilesets",
+                    safe_tileset,
+                    safe_tileset + ".png",
+                )
+            )
+        )
+
+    def test_disk_fallback_rejects_tileset_file_and_directory_symlink_escapes(
+        self,
+    ) -> None:
+        tilesets_root = os.path.join(self.gm_dir, "tilesets")
+        linked_file_dir = os.path.join(tilesets_root, "ts_file_link")
+        os.makedirs(linked_file_dir)
+        outside_file = os.path.join(self.outside_dir, "ts_file_link.yy")
+        self._write_tileset(
+            outside_file,
+            "ts_file_link",
+            {"name": "s_outside"},
+        )
+        outside_directory = os.path.join(self.outside_dir, "ts_directory_link")
+        self._write_tileset(
+            os.path.join(outside_directory, "ts_directory_link.yy"),
+            "ts_directory_link",
+            {"name": "s_outside"},
+        )
+        try:
+            os.symlink(
+                outside_file,
+                os.path.join(linked_file_dir, "ts_file_link.yy"),
+            )
+            os.symlink(
+                outside_directory,
+                os.path.join(tilesets_root, "ts_directory_link"),
+            )
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+
+        self._make_converter().convert_all()
+
+        for name in ("ts_file_link", "ts_directory_link"):
+            self.assertFalse(
+                os.path.isfile(
+                    os.path.join(
+                        self.godot_dir,
+                        "tilesets",
+                        name,
+                        name + ".tres",
+                    )
+                )
+            )
+        rejected = self._source_path_rejections()
+        self.assertEqual(
+            {(item.resource, item.manifest_entry) for item in rejected},
+            {
+                ("ts_file_link", "tileset .yy"),
+                ("ts_directory_link", "tileset directory"),
+            },
+        )
+
+    def test_rejects_sprite_image_symlink_escapes_with_sprite_provenance(
+        self,
+    ) -> None:
+        outside_file_image = os.path.join(self.outside_dir, "outside_file.png")
+        Image.new("RGBA", (16, 16), "magenta").save(
+            outside_file_image,
+            "PNG",
+        )
+
+        for name, sprite_name in (
+            ("ts_layer_file", "s_layer_file"),
+            ("ts_layer_directory", "s_layer_directory"),
+            ("ts_frame_directory", "s_frame_directory"),
+            ("ts_layer_fallback", "s_layer_fallback"),
+            ("ts_layer_safe", "s_layer_safe"),
+        ):
+            self._write_tileset(
+                os.path.join(self.gm_dir, "tilesets", name, name + ".yy"),
+                name,
+                {
+                    "name": sprite_name,
+                    "path": f"sprites/{sprite_name}/{sprite_name}.yy",
+                },
+            )
+            self._write_sprite(
+                os.path.join(
+                    self.gm_dir,
+                    "sprites",
+                    sprite_name,
+                    sprite_name + ".yy",
+                ),
+                color="green",
+            )
+
+        file_sprite_dir = os.path.join(
+            self.gm_dir,
+            "sprites",
+            "s_layer_file",
+        )
+        file_image = os.path.join(
+            file_sprite_dir,
+            "layers",
+            self.FRAME_GUID,
+            self.LAYER_GUID + ".png",
+        )
+        os.remove(file_image)
+
+        directory_sprite_dir = os.path.join(
+            self.gm_dir,
+            "sprites",
+            "s_layer_directory",
+        )
+        shutil.rmtree(os.path.join(directory_sprite_dir, "layers"))
+        frame_sprite_dir = os.path.join(
+            self.gm_dir,
+            "sprites",
+            "s_frame_directory",
+        )
+        shutil.rmtree(
+            os.path.join(frame_sprite_dir, "layers", self.FRAME_GUID)
+        )
+        fallback_sprite_dir = os.path.join(
+            self.gm_dir,
+            "sprites",
+            "s_layer_fallback",
+        )
+        os.remove(
+            os.path.join(
+                fallback_sprite_dir,
+                "layers",
+                self.FRAME_GUID,
+                self.LAYER_GUID + ".png",
+            )
+        )
+        outside_layers = os.path.join(self.outside_dir, "outside_layers")
+        outside_directory_image = os.path.join(
+            outside_layers,
+            self.FRAME_GUID,
+            self.LAYER_GUID + ".png",
+        )
+        os.makedirs(os.path.dirname(outside_directory_image))
+        Image.new("RGBA", (16, 16), "cyan").save(
+            outside_directory_image,
+            "PNG",
+        )
+        outside_frame = os.path.join(self.outside_dir, "outside_frame")
+        os.makedirs(outside_frame)
+        Image.new("RGBA", (16, 16), "yellow").save(
+            os.path.join(outside_frame, self.LAYER_GUID + ".png"),
+            "PNG",
+        )
+        try:
+            os.symlink(outside_file_image, file_image)
+            os.symlink(
+                outside_layers,
+                os.path.join(directory_sprite_dir, "layers"),
+            )
+            os.symlink(
+                outside_frame,
+                os.path.join(
+                    frame_sprite_dir,
+                    "layers",
+                    self.FRAME_GUID,
+                ),
+            )
+            os.symlink(
+                outside_file_image,
+                os.path.join(fallback_sprite_dir, "layers", "fallback.png"),
+            )
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+
+        real_copy2 = shutil.copy2
+        with (
+            patch("builtins.open", wraps=open) as tracked_open,
+            patch(
+                "src.conversion.tilesets.shutil.copy2",
+                wraps=real_copy2,
+            ) as tracked_copy,
+        ):
+            self._make_converter().convert_all()
+
+        outside_root = os.path.realpath(self.outside_dir)
+        opened_paths = {
+            os.path.realpath(call.args[0])
+            for call in tracked_open.call_args_list
+            if call.args and isinstance(call.args[0], str)
+        }
+        copied_sources = {
+            os.path.realpath(call.args[0])
+            for call in tracked_copy.call_args_list
+            if call.args and isinstance(call.args[0], str)
+        }
+        self.assertFalse(
+            any(
+                path == outside_root or path.startswith(outside_root + os.sep)
+                for path in opened_paths | copied_sources
+            )
+        )
+
+        rejected = [
+            diagnostic
+            for diagnostic in self._source_path_rejections()
+            if diagnostic.resource
+            in {
+                "ts_layer_file",
+                "ts_layer_directory",
+                "ts_frame_directory",
+                "ts_layer_fallback",
+            }
+        ]
+        self.assertEqual(len(rejected), 4, rejected)
+        self.assertEqual(
+            {
+                diagnostic.resource: (
+                    diagnostic.source_path,
+                    diagnostic.manifest_entry,
+                )
+                for diagnostic in rejected
+            },
+            {
+                "ts_layer_file": (
+                    "sprites/s_layer_file/s_layer_file.yy",
+                    "layers[0].name",
+                ),
+                "ts_layer_directory": (
+                    "sprites/s_layer_directory/s_layer_directory.yy",
+                    "layers",
+                ),
+                "ts_frame_directory": (
+                    "sprites/s_frame_directory/s_frame_directory.yy",
+                    "frames[0].name",
+                ),
+                "ts_layer_fallback": (
+                    "sprites/s_layer_fallback/s_layer_fallback.yy",
+                    "layers",
+                ),
+            },
+        )
+        for name in (
+            "ts_layer_file",
+            "ts_layer_directory",
+            "ts_frame_directory",
+            "ts_layer_fallback",
+        ):
+            self.assertFalse(
+                os.path.isfile(
+                    os.path.join(
+                        self.godot_dir,
+                        "tilesets",
+                        name,
+                        name + ".png",
+                    )
+                )
+            )
+        self.assertTrue(
+            os.path.isfile(
+                os.path.join(
+                    self.godot_dir,
+                    "tilesets",
+                    "ts_layer_safe",
+                    "ts_layer_safe.png",
+                )
+            )
+        )
 
 
 class TestTileSetConverterSubfolders(unittest.TestCase):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,19 +10,20 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_1(self) -> None:
-        self.assertEqual(get_version(), "0.7.1")
+    def test_release_version_is_0_7_2(self) -> None:
+        self.assertEqual(get_version(), "0.7.2")
 
-    def test_release_docs_reference_0_7_1(self) -> None:
+    def test_release_docs_reference_0_7_2(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
         readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
         issue_template = (
             PROJECT_ROOT / ".github" / "ISSUE_TEMPLATE" / "unsupported_gml_api.yml"
         ).read_text(encoding="utf-8")
 
+        self.assertIn("## 0.7.2 - 2026-07-17", changelog)
+        self.assertIn("Current source version: `0.7.2`.", readme)
+        self.assertIn("GM2Godot 0.7.2, GameMaker LTS 2026", issue_template)
         self.assertIn("## 0.7.1 - 2026-07-17", changelog)
-        self.assertIn("Current source version: `0.7.1`.", readme)
-        self.assertIn("GM2Godot 0.7.1, GameMaker LTS 2026", issue_template)
         self.assertIn("immutable GameMaker LTS 2026 SNAP and Adding fixtures", changelog)
         self.assertIn("## 0.7.0 - 2026-07-17", changelog)
         self.assertIn("GameMaker LTS 2026", changelog)


### PR DESCRIPTION
## Summary

- route nested `.yy` sidecars, manifest resources, and disk fallbacks through one project-root resolver
- reject traversal, absolute/drive/UNC/NUL paths, symlink escapes, and cross-family `.yy` targets with source-linked diagnostics
- preserve declared paths, safe sibling continuation, logical resource identity, and single-read manifest discovery
- bump the source release to 0.7.2

## Validation

- `./venv/bin/python -m unittest` (1,420 passed, 37 skipped)
- `./venv/bin/ruff check .`
- `./venv/bin/pyright --warnings` (0 errors, 0 warnings)
- pinned SNAP + Adding GameMaker LTS 2026 fixtures under exact Godot `4.7.1.stable.official.a13da4feb`

Closes #704