### PR TITLE
Populate the GitHub Wiki documentation source

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.4, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.5, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.5 - 2026-07-18
+
+- Added reviewable GitHub Wiki sources with installation, conversion, compatibility, diagnostics, generated-runtime, contributor, and maintainer guidance for GameMaker LTS 2026 and Godot 4.7.1.
+- Corrected stale destination, localization, UI, support, code-of-conduct, and license documentation, and added a versioned release/Wiki review checklist with local link coverage.
+
 ## 0.7.4 - 2026-07-18
 
 - Added format-v2 trusted conversion manifests with terminal outcomes and plan-ordered requested, executed, completed, skipped, and failed step names for successful and partial conversions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,8 @@ Thank you for your interest in contributing to GM2Godot! We aim to make GameMake
 
 ### UI Development
 - Maintain consistency with the existing dark theme
-- Use the modern widget classes in `src/gui/modern_widgets.py`
-- Follow the existing pattern for styling and layout
+- Follow the existing panel, dialog, icon, and theme patterns under `src/gui/`
+- Keep user-facing controls in the owning `src/gui/panels/` or `src/gui/dialogs/` module
 - Test UI changes at different window sizes
 
 ### Asset Conversion
@@ -120,7 +120,7 @@ Fixture contributions should include:
    - Go to the [GM2Godot repository](https://github.com/Infiland/GM2Godot)
    - Click "New Pull Request"
    - Select your fork and branch
-   - Fill out the PR template
+   - Describe the focused scope and validation evidence
    - Add screenshots for UI changes
 
 ## Testing
@@ -134,6 +134,18 @@ Before submitting a PR:
 - Check that existing features still work
 - Test on different platforms if possible
 
+## Maintainer Release Checklist
+
+For every versioned pull request:
+
+- Update `src/version.py`, `CHANGELOG.md`, the current source version in `README.md`, version examples in issue templates, and `tests/test_version.py`.
+- Review the version banners and user workflows under `docs/wiki/`; include any required Wiki changes in the same reviewable branch.
+- Confirm all required pull-request checks pass, including exact Godot 4.7.1 smoke and the current GameMaker LTS conversion gates.
+- After merge, confirm the new tag points to the intended `main` commit and that the Linux, macOS zip/DMG, and Windows release assets are present and non-empty.
+- If Wiki sources changed, reference the documentation issue without an auto-closing keyword, publish the exact merged `docs/wiki/` pages, and verify live navigation before closing the issue.
+
+The full Wiki publication and rollback procedure is in [`docs/WIKI_MAINTENANCE.md`](docs/WIKI_MAINTENANCE.md).
+
 ## Areas for Contribution
 
 We particularly welcome contributions in these areas:
@@ -146,22 +158,22 @@ We particularly welcome contributions in these areas:
 
 ## Localization
 
-To localize GM2Godot into other languages, create a copy of the Template.json file found in the Languages folder in GM2Godot's root directory. Rename the file to the chosen language's ISO-639 (Set 3) code (for example, eng for English). Refer to [Wikipedia](https://en.wikipedia.org/wiki/List_of_ISO_639-3_codes) for a list of languages and their corresponding ISO-639 codes.
-More information regarding localization can be found in the README section of the Template.json file ([GitHub copy](https://raw.githubusercontent.com/Infiland/GM2Godot/refs/heads/main/Languages/template.json))
+To localize GM2Godot into another language, copy `Languages/template/template.json` to the `Languages/` directory and rename the copy to the language's ISO 639-3 code (for example, `eng.json` for English). Refer to [Wikipedia](https://en.wikipedia.org/wiki/List_of_ISO_639-3_codes) for the code list.
+
+The template's embedded `README` field explains the required keys ([GitHub copy](https://raw.githubusercontent.com/Infiland/GM2Godot/refs/heads/main/Languages/template/template.json)).
 
 ## Questions or Issues?
 
 - Check existing [issues](https://github.com/Infiland/GM2Godot/issues)
 - Create a new issue for bugs or feature requests
-- Join our community discussions (Add community links)
 
 ## Code of Conduct
 
 - Be respectful and inclusive
 - Help others learn and grow
 - Focus on constructive feedback
-- Follow the project's code of conduct (Add link if available)
+- Follow the project's [Code of Conduct](CODE_OF_CONDUCT.md)
 
 ## License
 
-By contributing to GM2Godot, you agree that your contributions will be licensed under the same license as the project (Add license information).
+By contributing to GM2Godot, you agree that your contributions will be licensed under the project's [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 GM2Godot targets GameMaker LTS 2026 source projects and Godot 4.7.1 output. It converts supported project data and GML through a GUI or headless CLI, with generated Godot runtime helpers, deterministic asset registries, diagnostics, compatibility reports, and fixture-backed regression tests.
 
+[Documentation](https://github.com/Infiland/GM2Godot/wiki) · [Latest release](https://github.com/Infiland/GM2Godot/releases/latest) · [Issues](https://github.com/Infiland/GM2Godot/issues)
+
 ## Features
 
 - **Modern Dark Theme UI**: Clean project selection, settings, progress, and logs
@@ -43,7 +45,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.4`.
+Current source version: `0.7.5`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 
@@ -94,8 +96,9 @@ python main.py
 
 2. **Configure Project Paths**
 - Set your GameMaker project directory
-- Set an empty Godot project directory
-  - **Important**: Godot directory must be empty to prevent data loss
+- Set a separate Godot project destination
+  - The destination may be missing, empty, or an existing valid Godot project containing `project.godot`.
+  - GM2Godot rejects a non-empty non-project directory. Back up existing projects because managed output paths may be replaced by a later conversion.
 
 3. **Configure Settings**
 - Click the "Settings" button to open the configuration window
@@ -127,7 +130,7 @@ python main.py validate --godot-project path/to/GodotProject --fail-on-unsupport
 
 You can also invoke the same headless interface directly with `python -m src.cli`.
 
-CLI reports are written under `gm2godot/` inside the selected report or Godot project directory. The diagnostic outputs are `conversion_diagnostics.json` and `conversion_diagnostics.md`; static compatibility outputs include `gml_manual_scope.md` and `gml_api_compatibility.md`.
+CLI reports are written under `gm2godot/` inside the selected report or Godot project directory. The diagnostic outputs are `conversion_diagnostics.json` and `conversion_diagnostics.md`; static compatibility outputs include `gml_manual_scope.md`, `gml_api_compatibility.md`, and the JSON/Markdown platform capability reports.
 
 Every valid `convert` invocation prints exactly one terminal outcome summary after its buffered conversion logs. The diagnostic JSON report also includes a top-level `outcome` object with:
 
@@ -186,7 +189,6 @@ To contribute:
 
 - Report issues on our [GitHub Issues](https://github.com/Infiland/GM2Godot/issues) page
 - Check our [Documentation](https://github.com/Infiland/GM2Godot/wiki) for detailed guides
-- Join our community (Add community links if available)
 
 ---
 

--- a/docs/WIKI_MAINTENANCE.md
+++ b/docs/WIKI_MAINTENANCE.md
@@ -1,0 +1,17 @@
+# Wiki source and publication
+
+The reviewed GitHub Wiki source lives in [`docs/wiki/`](wiki/). The live Wiki is a separate Git repository and must be published only from a merged main-repository revision. A source pull request must reference—but must not auto-close—the documentation issue; close it only after the merged pages are published and verified live.
+
+The canonical page set is:
+
+- `Home.md`
+- `Installation.md`
+- `Quick-Start-Conversion.md`
+- `Compatibility-and-Limitations.md`
+- `Diagnostics-and-Troubleshooting.md`
+- `Generated-Project-and-Runtime.md`
+- `Contributing-and-Testing.md`
+- `Maintainer-Release-and-Wiki.md`
+- `_Sidebar.md`
+
+Follow the complete, user-visible procedure in [`Maintainer-Release-and-Wiki.md`](wiki/Maintainer-Release-and-Wiki.md). Record both the merged main-repository SHA and the pre-publication Wiki SHA before pushing so the publication is traceable and can be reverted without rewriting Wiki history.

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,0 +1,79 @@
+# Compatibility and Limitations
+
+> **Applies to:** GM2Godot 0.7.5 · GameMaker LTS 2026 · Godot 4.7.1
+>
+> **Last reviewed:** 2026-07-18
+
+[Home](Home) · [Quick Start Conversion](Quick-Start-Conversion) · [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting)
+
+GM2Godot converts supported GameMaker source projects into an editable Godot project. It is a migration tool, not a byte-for-byte runtime replacement: a conversion that completes still needs review and gameplay testing in Godot.
+
+## What the compatibility labels mean
+
+| Status | Meaning |
+| --- | --- |
+| **Implemented** | GM2Godot has a working parser, emitter, converter, or runtime path for the documented surface, as applicable. Check the entry's parser, emitter, runtime, and smoke-coverage fields separately: an implemented status does not promise smoke coverage or perfect behavior in every composition or project. |
+| **Partial** | A useful conversion path exists, but known GameMaker semantics, target behavior, resource variants, or regression coverage are incomplete. Read the entry notes and conversion diagnostics before relying on it. |
+| **Unsupported** | GM2Godot does not have a safe equivalent. The feature should be reported explicitly instead of being treated as working output. It needs a project change, manual Godot implementation, or reviewed plugin/extension bridge. |
+| **Planned** | The feature is tracked but does not yet have a supported implementation. A roadmap entry is not a compatibility promise or release date. |
+
+Generated reports also use **out of scope** for behavior that GM2Godot intentionally does not plan to translate. In particular, GM2Godot converts source projects; it does not recover projects from compiled GameMaker games.
+
+## Get the current answer from generated reports
+
+Do not rely on a hand-copied API count in this Wiki. The manifest and report generators change with the implementation and are the current source of truth for a checkout or release.
+
+```bash
+python main.py report --report-dir reports
+python main.py analyze \
+  --gm-project path/to/GameMakerProject \
+  --report-dir reports \
+  --target-platform windows
+```
+
+Look under `reports/gm2godot/`:
+
+- `gml_manual_scope.md` summarizes modern GML language and manual-section coverage.
+- `gml_api_compatibility.md` summarizes runtime API coverage by category and links categories to their tracking issues.
+- `platform_capability_report.md` and `.json` identify target-specific export presets, permissions, plugins, hooks, and unsupported capabilities.
+- `conversion_diagnostics.md` and `.json` contain the command's diagnostics. `analyze` currently reports target selection and project-directory/`.yyp` findings; conversion adds converter, resource, API, and outcome diagnostics under the generated project's `gm2godot/` directory.
+- A converted project's `gm2godot/conversion_manifest.json` records the exact enabled converters, source metadata, resources, generated-file hashes, and canonical `success` or `partial` outcome. It is project evidence, not a global support table; verify it through the latest attempt ledger as described in [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting). The schema and publication contract live in the canonical [`conversion_manifest.py`](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/conversion_manifest.py).
+
+For work that is missing or not yet proven, the repository [compatibility roadmap](https://github.com/Infiland/GM2Godot/tree/main/todo-list) provides planning and historical context. It can lag the implementation, so use generated reports—not roadmap checkboxes or copied totals—for current support claims. See [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting) for project-specific outcomes and report trust rules.
+
+## Host, source filter, and export target are different
+
+Three separate platform questions are easy to confuse:
+
+| Question | Current contract |
+| --- | --- |
+| **Where can GM2Godot run?** | Release artifacts and source execution are supported on Windows, macOS, and Linux. This is the **conversion host**. |
+| **What does `--target-platform` select?** | The CLI accepts `windows`, `macos`, or `linux`. This is a **GameMaker source/configuration filter** used for target-specific project options, conditional GML and macros, and capability-report context. It does not filter the project's resource inventory. It defaults from the conversion host. |
+| **Where can the generated game be exported?** | The generated project targets Godot 4.7.1, but GM2Godot does not certify a complete export for a platform. Godot export templates and presets, signing, permissions, SDKs, native extensions, store services, and target-device tests remain separate work. |
+
+Selecting `--target-platform windows`, for example, does **not** create or validate a production Windows export and does not make Steam, Xbox, native DLL, or other platform APIs available. Use the generated platform capability report and configure the required Godot plugins and export settings explicitly.
+
+## Compatibility baseline
+
+- The source compatibility target is **[GameMaker LTS 2026](https://releases.gamemaker.io/release-notes/2026/0)** and its [version-specific manual](https://manual.gamemaker.io/lts/en/). Projects from newer monthly or beta releases may contain schema, syntax, APIs, or resource variants outside this baseline.
+- The output and automated smoke-test target is the official **[Godot 4.7.1](https://godotengine.org/article/maintenance-release-godot-4-7-1/)** build at commit `a13da4feb`. Other Godot versions may parse the project, but they are not the compatibility target for this release.
+- GM2Godot expects an editable GameMaker project with a `.yyp` and its `.yy`, GML, and asset files. Compiled executables are not supported input.
+- A generated project is a migration starting point. Keep the original GameMaker project, convert into a separate destination, and compare behavior before replacing any production workflow.
+
+## Known limitation areas
+
+The following areas require especially careful manual review. This list is intentionally high level; the generated reports and roadmap hold the detailed, current status.
+
+- Exact GameMaker value, coercion, lookup, lifecycle, and event-order edge cases can differ from GDScript and Godot callbacks.
+- Precise sprite masks, pixel-perfect collisions, collision dispatch, and GameMaker physics behavior are not guaranteed to match Godot physics.
+- Shader translation, surfaces, GPU/draw state, cameras, the application surface, GUI scaling, and render ordering can need manual Godot work.
+- Advanced room/layer mutation, tilemaps, texture groups, sequences, timelines, particles, animation curves, and dynamic asset APIs have partial or metadata-only areas.
+- Audio groups, streaming/compression, positional audio, async payload timing, networking, and filesystem sandbox behavior can vary by target.
+- Native extensions, marketplace SDKs, Steam, IAP, cloud, push, console, browser, and mobile services require explicit Godot plugins, permissions, or project-specific bridges; metadata and stubs are not working SDK integrations.
+- Importing a resource does not prove exact runtime semantics, visual parity, performance, or export readiness. Large and renderer-sensitive projects need representative target-device tests.
+
+An **implemented** label therefore means “the documented GM2Godot contract exists,” not “the whole converted game is guaranteed identical.” Treat warnings and unsupported diagnostics as migration tasks, and validate the generated project with the exact Godot target described in [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).
+
+## When you find a gap
+
+Use the project's [issue chooser](https://github.com/Infiland/GM2Godot/issues/new/choose) so the report reaches the right workflow. Include a minimal source example, the relevant generated diagnostic/report entry, GM2Godot version or commit, GameMaker version, Godot version, conversion host, and selected target-platform filter. The troubleshooting page explains which report files are safe to trust and attach.

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,0 +1,83 @@
+# Contributing and Testing
+
+> **Applies to:** GM2Godot 0.7.5 · GameMaker LTS 2026 · Godot 4.7.1
+>
+> **Last reviewed:** 2026-07-18
+
+This page is the short contributor route map. The repository's [CONTRIBUTING.md](https://github.com/Infiland/GM2Godot/blob/main/CONTRIBUTING.md) and `AGENTS.md` remain authoritative for development rules.
+
+## Set up a development checkout
+
+```bash
+git clone https://github.com/YOUR_USERNAME/GM2Godot.git
+cd GM2Godot
+python3 -m venv venv
+source venv/bin/activate  # Windows: venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+GM2Godot requires Python 3.12 or later. Install Godot 4.7.1 and set `GODOT_BIN` when a change needs generated-resource or runtime validation.
+
+## Choose the right extension point
+
+- **GML syntax or lowering:** work under `src/conversion/gml_transpiler_parts/` and add focused parser/lowering tests.
+- **GML API or generated runtime behavior:** update the API manifest/dispatch metadata and the owning segment under `src/conversion/gml_runtime_parts/segments/`. Add Python coverage and a `*_godot.py` test when behavior depends on Godot.
+- **GameMaker resource conversion:** add parse-only models and fixtures before renderer/writer behavior. Keep generated paths deterministic and route compatibility gaps through diagnostics.
+- **Object events:** update the event mapping registry and add scheduler/runtime coverage for ordering-sensitive behavior.
+- **Conversion orchestration:** use `conversion_plan.py` and `conversion_context.py`; do not add a parallel execution path around the plan.
+- **Documentation:** update the canonical repository source. Wiki pages are reviewed under `docs/wiki/` and published after merge.
+
+The deeper architecture references are:
+
+- [Conversion architecture](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/conversion_architecture.md)
+- [Runtime segment ownership](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/gml_runtime_parts/README.md)
+- [Generated runtime managers](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/runtime_managers.md)
+- [Godot architecture policy](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/godot_architecture_policy.md)
+
+## Fixtures
+
+A useful fixture is the smallest legal or intentionally malformed GameMaker project that proves one behavior. Include the `.yyp`, required `.yy` resources, and a short coverage note. Avoid adding third-party projects without a reviewed license and immutable source reference.
+
+Use the repository's fixture manifests and existing test families as the pattern:
+
+- focused parser/converter fixtures under `tests/fixtures/`;
+- deterministic golden snapshots for generated output;
+- exact Godot 4.7.1 tests for parse/load/runtime behavior; and
+- pinned external-project CI only when the source revision, license, runtime cost, and failure artifacts are bounded.
+
+## Required checks
+
+For Python or generated-code logic changes:
+
+```bash
+./venv/bin/pyright --warnings
+./venv/bin/ruff check .
+./venv/bin/python -m unittest
+```
+
+Fix every Pyright error and warning in changed code. Run the relevant focused test while iterating; use the full suite for broad behavior changes. For Godot-dependent changes, run with the exact binary:
+
+```bash
+GODOT_BIN=/path/to/Godot-4.7.1 \
+  ./venv/bin/python -m unittest discover -s tests -p 'test_*_godot.py'
+```
+
+Documentation-only changes do not require Pyright or the Python suite unless the change also touches tests/code or verification was explicitly requested. Link and page-source checks should still pass.
+
+## Pull requests and issues
+
+Keep each branch and pull request focused on one issue. Describe the behavior, validation evidence, user-visible limitations, and any follow-up that was deliberately left out. Do not make a compatibility claim solely because conversion completed; include diagnostics and exact-Godot evidence where relevant.
+
+Use the issue templates for unsupported APIs, invalid generated GDScript, resource mismatches, and fixture contributions. Minimal source projects and complete version details make regressions much easier to reproduce.
+
+## Documentation changes
+
+When changing a version-sensitive page:
+
+1. Update its **Applies to** and **Last reviewed** banner.
+2. Prefer links to generated reports or canonical source over copied compatibility totals.
+3. Update `_Sidebar.md` when adding or renaming a page.
+4. Include Wiki review in the release checklist.
+5. After the main-repository change merges, publish the exact merged `docs/wiki/` files to the Wiki and verify the live links.
+
+See [Release and Wiki Maintenance](Maintainer-Release-and-Wiki) for the publication procedure.

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,0 +1,135 @@
+# Diagnostics and Troubleshooting
+
+> **Applies to:** GM2Godot 0.7.5 · GameMaker LTS 2026 · Godot 4.7.1
+>
+> **Last reviewed:** 2026-07-18
+
+[Home](Home) · [Quick Start Conversion](Quick-Start-Conversion) · [Compatibility and Limitations](Compatibility-and-Limitations)
+
+When a conversion surprises you, preserve the console output and inspect the latest attempt ledger before opening the generated project. Then read the structured diagnostics and run Godot validation. These files distinguish a usable partial migration from a failed or stale output directory.
+
+## Report files
+
+Paths below are relative to the generated Godot project unless a report directory is stated.
+
+| File | What it tells you | When it is written |
+| --- | --- | --- |
+| `gm2godot/conversion_attempt.json` | The terminal state of the latest conversion attempt and whether that publication updated, preserved, or found no canonical manifest. | After destination preflight, for every terminal conversion attempt. A rejected preflight does not write into the destination. |
+| `gm2godot/conversion_manifest.json` | Format-v2 canonical record of a trustworthy successful or partial conversion, including enabled converters, source metadata, resources, generated-file hashes, source maps, architecture policy, and path diagnostics. | Only when GM2Godot has a trustworthy completed-output candidate. Failed or cancelled work can preserve an older file. |
+| `gm2godot/conversion_diagnostics.json` | Machine-readable diagnostic summary, sorted diagnostic entries, and the terminal `outcome` object. | During conversion; also under an explicit report directory for `report`, `analyze`, or `convert --report-dir`. |
+| `gm2godot/conversion_diagnostics.md` | Human-readable view of the same diagnostics and outcome. | Published as a pair with the JSON report. |
+| `gm2godot/godot_validation_report.json` | Godot binary used, resources checked, import/boot return codes and output, detected warnings/errors, and `passed`, `failed`, or `skipped` status. | By `validate` when headless Godot validation runs or is attempted. |
+| `gm2godot/architecture_policy.json` | Generated runtime-manager, room, layer/depth, renderer, collision, audio, file/buffer/network, and signal-queue policy choices. | As part of a conversion. |
+| `gm2godot/gml_manual_scope.md`, `gml_api_compatibility.md`, `platform_capability_report.md`, `platform_capability_report.json` | Current global compatibility and target-capability inventory. | Under `--report-dir` for static reporting, analysis, or conversion. |
+| `gm2godot/extension_compatibility_report.json` and `group_compatibility_report.json` | Project extension/native-binding findings and texture/audio group compatibility details. | When the corresponding converters inspect those resources. |
+
+The JSON diagnostic entries can include `source_path`, line and column, resource and event/API context, a manifest entry, tracking issue, and workaround. Start with the first `error`, then unsupported warnings, then other warnings.
+
+## Terminal outcomes
+
+Every valid `convert` command prints exactly one terminal line beginning `GM2Godot conversion outcome:`. When the current JSON diagnostic report is published successfully, it carries the same state and ledgers.
+
+| State | Meaning |
+| --- | --- |
+| `success` | Every requested converter step and every tracked resource completed. This is not a claim of perfect GameMaker behavior; review compatibility diagnostics and validate in Godot. |
+| `partial` | Every requested converter step completed, but at least one tracked resource was skipped or failed. The output can be useful, but the missing work must be understood. |
+| `failed` | The latest invocation terminated as a failure, so its filesystem output must not be assumed usable. `failed_step` and `failure_phase` identify preflight, runtime, report, or finalizer context when available. A separately digest-verified canonical candidate can still exist from an earlier phase or attempt. |
+| `cancelled` | A user stop request or `SIGINT` was observed before the CLI's terminal-summary commit point. Generated output may be incomplete, although a late cancellation can coexist with a separately digest-verified canonical candidate. |
+
+For converters and resources, `requested = completed + skipped + failed`. Completed and failed work was executed. A resource or converter interrupted after it started can be recorded as both executed and skipped, so `executed` and `skipped` are intentionally not disjoint. The named `steps` ledger follows conversion-plan order and is usually the clearest place to find where work stopped.
+
+## Exit codes and CI thresholds
+
+| Result | Exit code |
+| --- | ---: |
+| Success, with thresholds passing | `0` |
+| Partial output | `2` |
+| Partial output with `--allow-partial`, with thresholds passing | `0` |
+| Any diagnostic threshold violation, including with `--allow-partial` | `2` |
+| Destination preflight rejection | `2` |
+| Failed conversion or runtime/report/finalizer exception | `1` |
+| Cancelled conversion | `130` |
+
+`--allow-partial` applies only to `convert`. It changes the exit-code treatment of a usable `partial` outcome; it does not turn the state into `success` and does not override any diagnostic threshold.
+
+Available thresholds are:
+
+- `--fail-on-unsupported`: fail when any diagnostic is identified as unsupported.
+- `--max-unsupported N`: fail when unsupported diagnostics exceed `N`.
+- `--max-warnings N`: fail when warnings exceed `N`.
+- `--max-errors N`: fail when errors exceed `N`; the default is `0`.
+
+Use `--allow-partial` in CI only after the skipped/failed resources are intentional and covered by an explicit migration plan. A zero exit code with that flag still represents a `partial` artifact.
+
+## Attempt ledger versus trusted manifest
+
+`conversion_attempt.json` is format v1 and answers “what happened in the latest invocation?” `conversion_manifest.json` is format v2 and answers “what trustworthy successful/partial output was canonically recorded?” These are independent questions: a late report failure or cancellation can happen after a valid canonical candidate was committed, while another failed attempt can leave an older canonical file in place.
+
+Read `canonical_manifest` in the attempt ledger:
+
+| `status` | `updated` | `current_output` | How to interpret it |
+| --- | ---: | --- | --- |
+| `updated` | `true` | `verified` | This publication committed a canonical manifest last. Verify the file's raw-byte SHA-256 against the ledger before consuming it. |
+| `preserved` | `false` | `unverified` | A regular canonical file already existed and was left untouched. Its recorded digest identifies those bytes, but preservation does not prove that its schema or contents describe the current destination or latest attempt. |
+| `absent` | `false` | `unavailable` | No canonical manifest exists; `sha256` is `null`. |
+
+The digest string is `sha256:` followed by the lowercase hash of the raw `conversion_manifest.json` bytes. The attempt and canonical files are each atomically replaced, but they are not one multi-file atomic unit: publication is attempt-first and canonical-last. A missing canonical file or digest mismatch can therefore identify an interrupted pair publication. Do not trust the canonical manifest until the digest matches.
+
+Even when the digest matches, inspect both records:
+
+1. Read the latest attempt's `attempt.state`, `failed_step`, and `failure_phase`.
+2. Require `canonical_manifest.current_output` to be `verified` when treating this attempt as a fresh canonical publication.
+3. Compare the recorded digest with the canonical file bytes.
+4. Read the canonical manifest's own `conversion.state`; only `success` and `partial` are canonical states.
+5. For `partial`, inspect resource counts and diagnostics before using the output.
+
+After `failed` or `cancelled`, never assume that an existing manifest describes the latest filesystem merely because the file is present. Keep the attempt ledger with any diagnostic bundle you attach to an issue.
+
+## Validate with Godot 4.7.1
+
+Run validation after conversion:
+
+```bash
+python main.py validate \
+  --godot-project path/to/GodotProject \
+  --godot-bin path/to/Godot-4.7.1 \
+  --fail-on-unsupported
+```
+
+Godot binary discovery uses the first existing file in this order:
+
+1. `--godot-bin`
+2. the `GODOT_BIN` environment variable
+3. `godot` on `PATH`
+4. `/Applications/Godot.app/Contents/MacOS/Godot` on macOS
+
+An explicit or environment path that is not a file is skipped and discovery continues. The selected file must still be executable. Check it directly with `path/to/godot --version`; the pinned CI baseline is the official `4.7.1.stable.official.a13da4feb` build.
+
+If no Godot binary is found, validation records `status: "skipped"` and an informational diagnostic. It does **not** prove the project is valid and is not a hard failure by itself. Set `GODOT_BIN` or pass `--godot-bin` to get real parser/resource validation.
+
+With a binary available, validation asks Godot to import supported asset types and loads every `.gd`, `.gdshader`, `.tscn`, and `.tres` resource under the destination project (excluding `.godot/`), not only GM2Godot-managed files. It records Godot warning/error output as validation issues. `--godot-boot-frames N` additionally boots the configured main scene headlessly for `N` frames after resource validation; it is disabled by default. Use `--skip-godot-validation` only when intentionally limiting `validate` to existing reports and project-presence checks.
+
+## Common failures
+
+| Symptom | What to check |
+| --- | --- |
+| Preflight exits `2` and the destination is unchanged | Use a missing or empty destination, or a valid existing Godot project with a regular `project.godot`. GM2Godot refuses a non-empty non-project directory and unsafe redirected or conflicting managed-output paths. Read the structured stderr diagnostic; a rejected preflight intentionally writes no attempt ledger into that destination. |
+| “No `.yyp` found” or the wrong project is analyzed | Pass the GameMaker project root that directly contains the `.yyp`. The GUI rejects multiple `.yyp` files; `analyze` warns about them, while headless project readers select the sorted first valid candidate. Separating projects is safer. |
+| Outcome is `partial` | Read `outcome.resources`, the ordered `steps` ledger, and warning/error rows in `conversion_diagnostics.json`. Search the generated compatibility reports for the affected API or resource family before choosing `--allow-partial`. |
+| Unsupported GML call or extension | Use the diagnostic's `api`, `manifest_entry`, `issue_number`, and `workaround`. Native extensions and service SDKs need a reviewed Godot addon/GDExtension or explicit local mapping; a generated stub is not a working native integration. |
+| Godot validation is `skipped` | Fix `--godot-bin`/`GODOT_BIN`, check executable permissions, and confirm `--version` reports the official 4.7.1 build. |
+| Godot reports a parse, load, import, or boot error | Open `godot_validation_report.json` and fix the first retained Godot issue. Correlate generated scripts with adjacent `.gmlmap.json` source maps when present, then rerun validation. Boot warnings also fail boot validation. |
+| Converted output runs but differs from GameMaker | Check [Compatibility and Limitations](Compatibility-and-Limitations), `architecture_policy.json`, platform capabilities, and the affected resource/API report. Create the smallest fixture that preserves the mismatch. |
+| An old manifest is still present after failure or cancellation | This can be deliberate preservation. Trust the latest attempt ledger's status and digest rules, not the manifest filename alone. |
+| Report or artifact publication fails | Preserve stderr and exception detail, do not treat old reports as current, and retry in a writable local destination after checking permissions and filesystem redirection. Attach both ledgers if they exist. |
+
+## Report the right kind of issue
+
+Use the [GitHub issue chooser](https://github.com/Infiland/GM2Godot/issues/new/choose) or its focused templates:
+
+- [Unsupported GML API](https://github.com/Infiland/GM2Godot/issues/new?template=unsupported_gml_api.yml) for a missing function, variable, constant, or language feature.
+- [Invalid Generated GDScript](https://github.com/Infiland/GM2Godot/issues/new?template=invalid_generated_gdscript.yml) when Godot cannot parse or load generated code/resources.
+- [Resource Conversion Mismatch](https://github.com/Infiland/GM2Godot/issues/new?template=resource_conversion_mismatch.yml) for sprite, sound, room, object, tileset, shader, path, sequence, extension, option, or other resource differences.
+- [Fixture Contribution](https://github.com/Infiland/GM2Godot/issues/new?template=fixture_contribution.yml) for a minimal reproducible project or regression case.
+
+Include the smallest legal source/fixture, exact reproduction command, terminal output, `conversion_diagnostics.json`, `conversion_attempt.json`, the digest-matching manifest when applicable, `godot_validation_report.json`, and the GM2Godot/GameMaker/Godot/host/target-platform versions. Remove proprietary assets and secrets before uploading. Contributor expectations and test commands are documented in [Contributing and Testing](Contributing-and-Testing) and the repository's canonical [CONTRIBUTING.md](https://github.com/Infiland/GM2Godot/blob/main/CONTRIBUTING.md).

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,0 +1,243 @@
+# Generated Project and Runtime
+
+> **Applies to:** GM2Godot 0.7.5 · GameMaker LTS 2026 · Godot 4.7.1
+>
+> **Last reviewed:** 2026-07-18
+
+[Home](Home) · [Installation](Installation) · [Quick start](Quick-Start-Conversion) · [Compatibility](Compatibility-and-Limitations) · [Diagnostics](Diagnostics-and-Troubleshooting) · [Contributing](Contributing-and-Testing)
+
+This page is the advanced-user map of a converted project: what GM2Godot owns, how the generated runtime coordinates GameMaker semantics, and which reports are authoritative. The implementation-facing documents in the main repository remain canonical for details that can change between releases.
+
+## Generated layout and ownership
+
+A full conversion can produce a tree like this. The exact files depend on the enabled converter keys and the source project.
+
+```text
+GodotProject/
+├── project.godot
+├── default_bus_layout.tres
+├── icon.ico / icon.png
+├── addons/gm2godot_extensions/
+├── gm2godot/
+│   ├── gml_runtime.gd
+│   ├── gml_room_node.gd
+│   ├── managers/
+│   ├── conversion_attempt.json
+│   ├── conversion_manifest.json
+│   ├── conversion_diagnostics.json / .md
+│   ├── architecture_policy.json
+│   └── other registries and compatibility reports
+├── fonts/
+├── included_files/
+├── notes/
+├── objects/
+├── rooms/
+├── scripts/
+├── shaders/
+├── sounds/
+├── sprites/
+└── tilesets/
+```
+
+GM2Godot treats these directories as managed output roots:
+
+- `addons/gm2godot_extensions/`
+- `fonts/`, `gm2godot/`, `included_files/`, `notes/`, `objects/`, `rooms/`, `scripts/`, `shaders/`, `sounds/`, `sprites/`, and `tilesets/`
+
+The top-level `default_bus_layout.tres`, `icon.ico`, and `icon.png` are managed files. `project.godot` is jointly managed: GM2Godot can update the generated `GM*` autoload entries and, when a room is generated, set `run/main_scene` from the first GameMaker `RoomOrderNodes` entry. Existing unrelated project settings and unrelated autoloads are preserved.
+
+Treat every generated file under a managed root as reproducible output. A later conversion can replace it even if the converter does not delete the entire directory. For repeatable migrations:
+
+1. Keep the GameMaker project and `gm2godot_extension_functions.json` as source-controlled inputs.
+2. Put hand-authored Godot code outside the managed roots—for example, `res://game/` or `res://addons/my_bridge/`.
+3. Point extension mappings or custom autoloads at that hand-authored code.
+4. Review `conversion_attempt.json`, diagnostics, and the manifest diff after every regeneration.
+
+Editing generated GDScript is useful for investigation, but it is not a durable fix. Make durable changes in the GameMaker source, the extension mapping/bridge, or GM2Godot itself. The managed-path safety rules are implemented in [`project_godot.py`](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/project_godot.py).
+
+## Room and rendering architecture
+
+The generated room policy translates GameMaker’s flat resource model into a Godot scene tree:
+
+- Each room is a `Node2D` root using `res://gm2godot/gml_room_node.gd`.
+- The first ordered GameMaker room becomes the Godot main scene when it was converted successfully.
+- GameMaker layers become `Node2D` children. The depth mapping is `z_index = -GameMaker depth`, because lower GameMaker depth and higher Godot `z_index` both draw later.
+- Every room reserves a `GMGUI` `CanvasLayer` at layer `1000` for Draw GUI phases.
+- Decodable tile data uses Godot 4 `TileMapLayer` output.
+- Native Godot callbacks do not define GameMaker event order; the runtime managers coordinate the generated phases.
+
+`gm2godot/architecture_policy.json` records the feature-detected backend choices for the particular conversion:
+
+| Domain | Possible policy modes | What selects the mode |
+| --- | --- | --- |
+| Rendering | `godot_node_scene`, `central_canvas_draw_manager`, `surface_viewport` | Detected `draw_`, `shader_`, `gpu_`, `font_`, or `sprite_` API usage, effect layers, and surface/application-surface usage |
+| Collision | `generated_bounds_idle`, `generated_bounds_direct_queries`, `godot_physics_world_bridge` | Collision-query code and GameMaker physics-room settings |
+| Audio | pooled `AudioStreamPlayer` / `AudioStreamPlayer2D`, or an idle runtime manager | Sound assets and audio API usage |
+| File, buffer, HTTP, network | `FileAccess`, `DirAccess`, `PackedByteArray`, HTTP and socket wrappers | Detected file/buffer/network APIs |
+
+The policy is a conversion-time description, not proof of gameplay parity. Inspect its `project_features`, `renderer`, `collision`, `audio`, `file_buffer_network`, `runtime_managers`, and `signal_queue_policy` fields together with diagnostics. The canonical, implementation-facing policy is [`godot_architecture_policy.md`](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/godot_architecture_policy.md).
+
+## Runtime facade and autoload managers
+
+Generated scripts continue to preload `res://gm2godot/gml_runtime.gd` and call `GMRuntime.gml_*`. That static compatibility facade is the stable call-site boundary. The generated autoloads under `res://gm2godot/managers/` divide lifecycle ownership into explicit domains and register in this order:
+
+| Order | Autoload | Primary responsibility |
+| ---: | --- | --- |
+| 0 | `GMRuntime` | Root registry, compatibility lifecycle, startup and shutdown |
+| 10 | `GMAssets` | Assets, texture groups, audio groups and dynamic assets |
+| 20 | `GMRooms` | Room order, current room, transitions and layers |
+| 30 | `GMInstances` | Live instances, handles, object indices and creation order |
+| 40 | `GMEvents` | Input dispatch, Step scheduler, alarms, timelines, sequences and collision window |
+| 50 | `GMDraw` | Ordered Draw phases, draw state, surfaces, shaders and texture-group state |
+| 60 | `GMInput` | Godot input capture and GameMaker keyboard, mouse, gamepad and gesture state |
+| 70 | `GMAudio` | Audio instances, groups, emitters and listeners |
+| 80 | `GMAsync` | FIFO async delivery, `async_load`, HTTP, buffer and networking queues |
+| 90 | `GMPlatform` | Platform hooks, extension callback schemas, OS/debug and GC state |
+
+Godot loads the autoload nodes before the main scene and the generated `project.godot` lists them deterministically. `GMRuntime.manager_order()` exposes the observed registration order, while `manager_registry_snapshot()` exposes domains, dependencies, state keys, and initialization indices.
+
+Each manager also exposes named `state_bucket()` dictionaries. These are ownership and migration seams; they do **not** mean that every compatibility variable has already moved out of `gml_runtime.gd`. Existing generated call sites should keep using the facade unless a runtime change deliberately moves a domain behind a manager.
+
+See [`runtime_managers.md`](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/runtime_managers.md), [`runtime_managers.py`](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/runtime_managers.py), and the executable expectations in [`test_runtime_managers.py`](https://github.com/Infiland/GM2Godot/blob/main/tests/test_runtime_managers.py).
+
+## Lifecycle and event order
+
+### Room entry and transitions
+
+Generated object `_ready()` methods register the instance, initialize motion state, and run converted Create behavior when present. The generated room root then performs the room-entry sequence:
+
+1. Register layer and view metadata.
+2. Update the current room and room globals.
+3. Run instance creation code in declared GameMaker creation order.
+4. Dispatch Game Start once for the running game.
+5. Run room creation code.
+6. Dispatch Room Start.
+
+For `room_goto*()` and `room_restart()`, the compatibility runtime dispatches Room End on the old scene, moves persistent instances to a root-level holding node, replaces the room scene, restores those instances, and runs the entry sequence for the new scene.
+
+### Per-frame scheduler
+
+`GMInput._input(event)` captures native input as it arrives. On the generated `GMEvents` frame pump, input event bindings are dispatched first, followed by the central scheduler:
+
+```text
+Begin Step
+→ time sources
+→ alarms
+→ Step
+→ motion/path update
+→ collision dispatch
+→ End Step
+→ clear one-frame input edges
+```
+
+Collision is therefore evaluated after motion/path updates and before End Step. Do not attach correctness to the incidental `_process()` order of individual object nodes.
+
+`GMDraw` independently dispatches the ordered drawing phases:
+
+```text
+Pre Draw → Draw Begin → Draw → Draw End → Post Draw
+→ Draw GUI Begin → Draw GUI → Draw GUI End
+```
+
+`GMAsync` owns FIFO delivery for queued HTTP, networking, audio, platform, and extension callbacks. It scopes `async_load` to each delivered Async event. Godot signals that affect GameMaker ordering—such as supported collision, timer, animation, HTTP-completion, and audio-finished signals—must be queued through the manager identified by `architecture_policy.json`; user-authored native callbacks are outside this ordering contract unless they use the same queue.
+
+The current GameMaker-facing phase contract and known deviations live in [`runtime_managers.md`](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/runtime_managers.md). GameMaker’s reference order is linked from that canonical document.
+
+## State and persistence boundaries
+
+Runtime state has three practical ownership levels:
+
+| Scope | Examples | Expected lifetime |
+| --- | --- | --- |
+| Static compatibility facade | Globals, handles, registries and compatibility helper state still owned by `gml_runtime.gd` | Across generated room scene changes |
+| Autoload manager buckets | Domain registries, queue metadata and future migrated runtime state | Across generated room scene changes |
+| Room/object scene state | Layer nodes, object instances, transient draw/collision data | Normally one room or frame unless explicitly preserved |
+
+Persistent **instances** are reparented across generated room transitions. Their instance creation code is not rerun after restoration. Full persistent **room** state is not preserved: the generated scene enters again and lifecycle/room creation behavior runs, with a runtime warning. This is a deliberate, reported deviation rather than silent parity.
+
+One-frame input edges, collision pairs, transient draw state, room-local layers, and non-persistent instances should be reset at their documented frame or room boundary. Add a regression test whenever custom runtime work moves state between ownership levels.
+
+## Conversion evidence and trust model
+
+The `gm2godot/` directory is also the evidence bundle for a conversion:
+
+| Artifact | When it exists | Use it for |
+| --- | --- | --- |
+| `conversion_attempt.json` (format 1) | Every terminal attempt after destination preflight | Latest terminal state, named step ledger, failure/cancellation context, and the canonical-manifest digest relationship |
+| `conversion_manifest.json` (format 2) | Trustworthy success or usable partial conversion | Source metadata, enabled converters, resources, generated paths, source maps, generated-file hashes, architecture policy and path-collision diagnostics |
+| `conversion_diagnostics.json` / `.md` | Conversion/report pipeline | Structured warnings, errors, unsupported APIs, source locations, workarounds and outcome |
+| `architecture_policy.json` (format 1) | Conversion policy publication | Project feature scan and selected runtime/backend policies |
+| `platform_capability_report.json` / `.md` | Static report generation | Target permissions, export presets, optional plugins and platform-service gaps |
+| `extension_compatibility_report.json` | Extension metadata conversion | Native files, discovered functions, mappings, generated stubs and extension diagnostics |
+| `godot_validation_report.json` (format 1) | `validate` with Godot validation enabled | Destination-project import, loadable-resource scan and optional main-scene boot results |
+| `*.gd.gmlmap.json` | GML source-map emission | Mapping generated GDScript lines back to GameMaker source/event context |
+
+Important trust rules:
+
+- Unsafe destinations rejected during preflight are not modified and do not receive an attempt ledger.
+- A partial canonical manifest is written only when every requested converter step completed; its partiality comes from skipped or failed resources.
+- `conversion_attempt.json` is committed before `conversion_manifest.json`. Each file replacement is atomic, but the pair is not one multi-file atomic transaction.
+- Consumers must compare `conversion_attempt.json` → `canonical_manifest.sha256` with the actual canonical manifest. A mismatch means publication was interrupted.
+- `canonical_manifest.status = preserved` is transaction-relative. It does not prove that an older manifest describes the destination after a failed or cancelled attempt.
+- `generated_files` describes files changed from the conversion’s initial output snapshot; it intentionally does not claim ownership of every unchanged pre-existing file.
+
+The exact schemas and transaction rules are defined by [`conversion_manifest.py`](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/conversion_manifest.py), [`conversion_outcome.py`](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/conversion_outcome.py), and their [manifest tests](https://github.com/Infiland/GM2Godot/blob/main/tests/test_conversion_manifest.py).
+
+## Extension mappings and platform bridges
+
+GM2Godot does not guess how a native GameMaker extension, SDK, storefront, ad network, or analytics library should behave in Godot. Unmapped extension calls are not emitted as raw GDScript.
+
+Put an explicit mapping file at the GameMaker project root:
+
+```json
+{
+  "functions": {
+    "ads_show_rewarded": {
+      "target": "AdBridge.show_rewarded",
+      "min_args": 1,
+      "max_args": 1
+    },
+    "analytics_event": "AnalyticsBridge.event"
+  }
+}
+```
+
+The target becomes the emitted Godot call target. Back it with a reviewed script, addon, autoload, or GDExtension that handles platform permissions and SDK setup. For repeat conversion, keep that implementation outside `res://addons/gm2godot_extensions/`, because that subtree is generated.
+
+GM2Godot emits disabled-by-default stubs under `res://addons/gm2godot_extensions/<extension>/`. Their methods call `push_error()` until a project-specific implementation replaces the behavior. Platform-service hooks and extension async schemas can route results through the generated `GMAsync` queue, preserving callback payload context and `async_load` scoping.
+
+Use the full mapping, platform-hook, and callback-schema contract in [`extension_compatibility.md`](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/extension_compatibility.md). Always inspect `extension_compatibility_report.json` before enabling an extension on an export target.
+
+## Known deviations to review before shipping
+
+| Area | Current behavior |
+| --- | --- |
+| Precise collision masks | Precise requests are reported, but runtime collision uses generated shape bounds; pixel-perfect mask parity is not implemented. |
+| Persistent rooms | Persistent instances are carried across room changes, but full persistent room state is not retained. |
+| Shaders and GPU state | GameMaker GLSL ES and Godot shader language/state do not map one-to-one; generated output needs visual review. |
+| Native extensions and platform services | Closed binaries, entitlements, permissions and SDK initialization require explicit reviewed Godot integrations. |
+| `game_end` | Maps to `SceneTree.quit()`; platform-specific close prompts and window behavior are not emulated. |
+| Custom Godot callbacks/signals | Only generated manager queues participate in the GameMaker ordering contract. Direct custom callbacks can observe a different order. |
+| Architecture feature detection | Policy selection is based on indexed project metadata and GML feature scanning. It guides review; it is not a runtime-equivalence proof. |
+
+The complete and frequently changing coverage matrix belongs on [Compatibility and Limitations](Compatibility-and-Limitations) and in the repository’s [`todo-list/`](https://github.com/Infiland/GM2Godot/tree/main/todo-list). Do not infer support merely because a function transpiles or a resource loads.
+
+## Validate a generated project
+
+Use the exact pinned Godot build for resource and runtime validation:
+
+```bash
+python main.py validate \
+  --godot-project /path/to/GodotProject \
+  --godot-bin /path/to/Godot-4.7.1 \
+  --godot-boot-frames 120 \
+  --fail-on-unsupported
+```
+
+Validation imports supported asset types, loads every `.gd`, `.tscn`, `.tres`, and `.gdshader` resource under the destination project except `.godot/`, and can boot the configured main scene for the requested frame count. Read the first warning/error in `gm2godot/godot_validation_report.json`, then correlate it with conversion diagnostics and any `.gmlmap.json` source map.
+
+For report interpretation and failure recovery, continue to [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting). For implementation changes, use [Contributing and Testing](Contributing-and-Testing) and preserve the runtime/architecture contracts covered by the Godot-backed tests.
+
+---
+
+[Home](Home) · [Quick start](Quick-Start-Conversion) · [Compatibility](Compatibility-and-Limitations) · [Diagnostics](Diagnostics-and-Troubleshooting)

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,58 @@
+# GM2Godot Documentation
+
+> **Applies to:** GM2Godot 0.7.5 · GameMaker LTS 2026 · Godot 4.7.1
+>
+> **Last reviewed:** 2026-07-18
+
+GM2Godot converts supported GameMaker source projects and GML into editable Godot projects. It combines asset conversion, a GML-to-GDScript transpiler, generated runtime helpers, compatibility diagnostics, and headless Godot validation. It is a migration aid, not a promise of automatic one-to-one gameplay parity.
+
+## Start here
+
+- [Installation](Installation) — download a release build or run GM2Godot from source on Windows, macOS, or Linux.
+- [Quick Start Conversion](Quick-Start-Conversion) — convert a project through the GUI or CLI and validate the result.
+- [Compatibility and Limitations](Compatibility-and-Limitations) — understand the current target, support levels, platform scope, and known gaps.
+- [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting) — interpret outcomes, reports, exit codes, and common failures.
+- [Generated Project and Runtime](Generated-Project-and-Runtime) — learn what GM2Godot generates and where manual Godot work belongs.
+- [Contributing and Testing](Contributing-and-Testing) — extend the transpiler, runtime, converters, fixtures, or documentation.
+
+Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-and-Wiki).
+
+## Compatibility target
+
+This documentation set describes:
+
+- GM2Godot 0.7.5;
+- GameMaker LTS 2026 source projects in the GMS2 runtime family; and
+- Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
+
+GameMaker beta/GMRT releases and later Godot releases are not implied by that target. GM2Godot can continue after unsupported or malformed resources and may produce a usable `partial` conversion; always inspect the generated diagnostics and run Godot validation before treating a migration as complete.
+
+## Typical workflow
+
+1. Preserve the GameMaker project and choose a separate Godot destination.
+2. Run conversion from the GUI or CLI.
+3. Read `conversion_diagnostics.md` and the terminal outcome.
+4. Validate the destination project, including generated resources, with the exact supported Godot version.
+5. Review unsupported or partial behavior, then continue the migration in Godot.
+6. Keep authored Godot work outside paths that GM2Godot owns and may replace on a later conversion.
+
+## Current sources of truth
+
+The Wiki explains how to use the project. Details that change frequently remain canonical in the repository:
+
+- [README and CLI outcome contract](https://github.com/Infiland/GM2Godot/blob/main/README.md)
+- [Compatibility roadmap](https://github.com/Infiland/GM2Godot/tree/main/todo-list) — planning context, not a live support table
+- [Generated-runtime documentation](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/runtime_managers.md)
+- [Godot architecture policy](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/godot_architecture_policy.md)
+- [Contributing guide](https://github.com/Infiland/GM2Godot/blob/main/CONTRIBUTING.md)
+- [Changelog](https://github.com/Infiland/GM2Godot/blob/main/CHANGELOG.md)
+
+Generate current compatibility reports from the version of GM2Godot you are actually running instead of relying on copied API totals.
+
+## Downloads and support
+
+- [Latest release](https://github.com/Infiland/GM2Godot/releases/latest)
+- [Open issues](https://github.com/Infiland/GM2Godot/issues)
+- [Report an unsupported GML API](https://github.com/Infiland/GM2Godot/issues/new?template=unsupported_gml_api.yml)
+- [Report invalid generated GDScript](https://github.com/Infiland/GM2Godot/issues/new?template=invalid_generated_gdscript.yml)
+- [Report a resource conversion mismatch](https://github.com/Infiland/GM2Godot/issues/new?template=resource_conversion_mismatch.yml)

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,0 +1,75 @@
+# Installation
+
+> **Applies to:** GM2Godot 0.7.5 · GameMaker LTS 2026 · Godot 4.7.1
+>
+> **Last reviewed:** 2026-07-18
+
+Use a packaged release for the desktop interface, or run from source when you also need the headless CLI. The current packaging and dependency details live in the repository's [release workflow](https://github.com/Infiland/GM2Godot/blob/main/.github/workflows/release.yml) and [`requirements.txt`](https://github.com/Infiland/GM2Godot/blob/main/requirements.txt).
+
+Godot is not required merely to launch GM2Godot. Install the exact [Godot 4.7.1 release](https://github.com/godotengine/godot/releases/tag/4.7.1-stable) separately to open or headlessly validate converted output.
+
+## Install a packaged release
+
+Download the asset for your operating system from [GitHub Releases](https://github.com/Infiland/GM2Godot/releases). Extract downloaded archives before launching the application.
+
+| Operating system | Release asset | Launch |
+| --- | --- | --- |
+| Windows | `GM2Godot-windows.zip` | Extract the archive, then run `GM2Godot.exe`. |
+| macOS | `GM2Godot-macos.dmg` or `GM2Godot-macos.zip` | Open the DMG and copy `GM2Godot.app` to Applications, or extract the ZIP and launch the app. |
+| Linux | `GM2Godot-linux.zip` | Extract the archive and run `./GM2Godot`. If the executable bit was lost during download or extraction, run `chmod +x GM2Godot` once. |
+
+The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
+
+After launch, confirm that the title bar, footer, or **Help → About GM2Godot** shows version `0.7.5`.
+
+## Run from source
+
+GM2Godot requires Python 3.12 or later. The automated builds and tests use Python 3.12, so that is the most predictable choice. Git is required for the clone commands below.
+
+### Windows (PowerShell)
+
+```powershell
+git clone https://github.com/Infiland/GM2Godot.git
+Set-Location GM2Godot
+py -3.12 -m venv venv
+.\venv\Scripts\Activate.ps1
+python -m pip install -r requirements.txt
+python main.py
+```
+
+If the `py` launcher is unavailable, use a Python 3.12-or-later executable in its place. Activate the same environment again before running GM2Godot in a new terminal.
+
+### macOS
+
+```bash
+git clone https://github.com/Infiland/GM2Godot.git
+cd GM2Godot
+python3 -m venv venv
+source venv/bin/activate
+python -m pip install -r requirements.txt
+python main.py
+```
+
+### Linux
+
+```bash
+git clone https://github.com/Infiland/GM2Godot.git
+cd GM2Godot
+python3 -m venv venv
+source venv/bin/activate
+python -m pip install -r requirements.txt
+python main.py
+```
+
+## Verify the source installation
+
+With the virtual environment active, check the installed checkout without starting the GUI:
+
+```bash
+python main.py --version
+python main.py list-converters
+```
+
+The first command should print `GM2Godot 0.7.5`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+
+Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,0 +1,84 @@
+# Release and Wiki Maintenance
+
+> **Applies to:** GM2Godot 0.7.5 · GameMaker LTS 2026 · Godot 4.7.1
+>
+> **Last reviewed:** 2026-07-18
+
+This page documents the current maintainer path for a versioned release and for publishing the reviewed Wiki sources. It does not replace branch protection or repository settings.
+
+## Release model
+
+`src/version.py` is the release trigger and source version. A pull request that changes it starts cross-platform artifact builds; the merged change starts the `Build and Release` workflow on `main`. The workflow builds Linux, macOS, and Windows archives, creates the macOS DMG, and publishes the GitHub release/tag. Every release must use a new version: do not reuse a tag or treat a workflow rerun as a no-op.
+
+The release workflow is canonical at [`.github/workflows/release.yml`](https://github.com/Infiland/GM2Godot/blob/main/.github/workflows/release.yml).
+
+## Versioned-change checklist
+
+Before opening the pull request:
+
+- [ ] Update `src/version.py`.
+- [ ] Add the dated version entry to `CHANGELOG.md`.
+- [ ] Update the current source version in `README.md`.
+- [ ] Update version examples in issue templates and version tests.
+- [ ] Review all `docs/wiki/` **Applies to** banners and change those whose claims were revalidated.
+- [ ] Review Wiki links, navigation, target-version wording, and any user-facing workflow changed by the release.
+- [ ] Run the validation required by the changed code and keep Pyright/Ruff clean when Python or generated-code logic changed.
+- [ ] If the pull request is preparing the first live Wiki publication, use `Refs #712` (or equivalent prose), not `Closes #712`/`Fixes #712`.
+
+Before merging:
+
+- [ ] Confirm `refs/tags/v<version>` does not already exist on the GitHub remote; do not rely only on a local checkout's tag list.
+- [ ] Confirm all pull-request checks pass, including exact Godot 4.7.1 smoke and current GameMaker LTS conversion gates.
+- [ ] Confirm Linux, macOS, and Windows build jobs produce non-empty artifacts.
+- [ ] Confirm the pull request references the intended issue, uses the correct closure timing, and does not absorb unrelated work.
+
+After merging:
+
+- [ ] Confirm the tag points to the intended `main` commit.
+- [ ] Confirm the release is neither draft nor prerelease and all expected assets are present.
+- [ ] Confirm post-merge tests, exact-LTS conversions, Godot smoke, and release jobs pass.
+- [ ] If `docs/wiki/` changed, publish the exact merged pages and verify the live Wiki before closing the documentation issue. Record the merged source SHA and published Wiki SHA on the issue before closing it.
+
+## Canonical Wiki sources
+
+The reviewable source is [`docs/wiki/`](https://github.com/Infiland/GM2Godot/tree/main/docs/wiki) in the main repository. The rendered GitHub Wiki is a separate Git repository at:
+
+```text
+https://github.com/Infiland/GM2Godot.wiki.git
+```
+
+Do not edit version-sensitive Wiki prose only in the browser. A browser-only correction will drift from the reviewed source and can be overwritten by the next publication.
+
+## First publication
+
+GitHub requires the first Wiki page to be created through the repository Wiki interface before the Wiki Git repository can be cloned.
+
+1. Merge the reviewed main-repository pull request.
+2. Resolve and record the exact merged `main` SHA. Publish from that revision, not from an unmerged branch or a dirty working tree.
+3. Create the initial `Home` page in the GitHub Wiki using the exact merged `docs/wiki/Home.md` content. Keep issue #712 open.
+4. Clone `https://github.com/Infiland/GM2Godot.wiki.git` into a new temporary directory and confirm the checkout is clean.
+5. Record the checked-out branch and `git rev-parse HEAD` as the pre-publication Wiki SHA; do not assume the branch is named `main` or `master`.
+6. Copy only the canonical Markdown inventory from the merged `docs/wiki/`, including `_Sidebar.md`. Stop if the Wiki has an extra or browser-only page: reconcile it into the canonical source through review before deleting or overwriting it.
+7. Stage the Markdown changes and inspect `git diff --cached --check`, `git diff --cached --name-status`, and the full staged diff. The staged inventory and content must match the merged source exactly.
+8. Commit with the merged main-repository SHA in the message.
+9. Fetch the Wiki branch again and confirm its remote tip still equals the recorded pre-publication Wiki SHA. If it changed, stop and reconcile the concurrent update; never force-push.
+10. Push `HEAD` to the explicitly recorded Wiki branch.
+
+For later publications, begin by pulling the live Wiki and confirming it has no unreviewed browser-only changes. Reconcile any such changes into `docs/wiki/` through a normal pull request before overwriting them.
+
+## Post-publication verification
+
+Check more than an HTTP success code: an uninitialized Wiki redirects to the repository root.
+
+- Open `https://github.com/Infiland/GM2Godot/wiki` and confirm the final page remains under `/GM2Godot/wiki`.
+- Open every sidebar page and confirm headings, code blocks, and local navigation render.
+- Verify release, issue-template, manual, and versioned Godot-documentation links.
+- Confirm `git ls-remote https://github.com/Infiland/GM2Godot.wiki.git HEAD` succeeds.
+- Clone the Wiki into a second clean temporary directory and compare its Markdown inventory and bytes with `docs/wiki/` at the recorded merged source SHA.
+- Record the merged source SHA, published Wiki SHA, and verification result on the documentation issue; only then close it.
+
+## Rollback and ownership
+
+Repository maintainers own the Wiki source and publication check. Wiki changes are Git commits, so revert the offending publication commit on the recorded Wiki branch and push the revert normally when a publication is wrong. Do not reset or force-push. Verify the restored live pages, then fix the canonical source through a main-repository pull request so the next sync does not reintroduce the problem.
+
+Never place credentials, private fixture data, or generated failure artifacts in Wiki history.

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,0 +1,77 @@
+# Quick Start Conversion
+
+> **Applies to:** GM2Godot 0.7.5 · GameMaker LTS 2026 · Godot 4.7.1
+>
+> **Last reviewed:** 2026-07-18
+
+This guide covers a first conversion through either the desktop interface or the source CLI. GM2Godot converts source projects, so select the GameMaker project root that contains the `.yyp` file—not an exported or compiled game.
+
+Before converting into an existing Godot project, commit it to version control or make a backup. Conversion writes the selected generated resources and settings into that project.
+
+## Choose a safe Godot destination
+
+GM2Godot classifies the destination before writing output. The current rules are implemented in [`project_godot.py`](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/project_godot.py).
+
+| Destination state | GUI | CLI | Result |
+| --- | --- | --- | --- |
+| Path does not exist | Not accepted; create an empty directory first. | Accepted. | The CLI creates the directory and initializes `project.godot` when conversion starts. |
+| Existing empty directory | Accepted. | Accepted. | Conversion initializes a minimal `project.godot`. |
+| Existing Godot project with a valid regular `project.godot` | Accepted. | Accepted. | Selected converters may update `project.godot` and GM2Godot-managed paths. Back up or commit the project first. |
+| Non-empty directory without `project.godot` | Rejected. | Rejected. | Preflight refuses conversion instead of treating the directory as a new project. |
+
+Redirected destinations such as symbolic links or junctions, invalid `project.godot` files, and unsafe managed output paths are also rejected. Choose the real project directory and resolve the reported preflight error before retrying.
+
+## Convert with the GUI
+
+1. Launch the packaged application, or run `python main.py` from an activated source environment.
+2. For **GameMaker Directory**, choose the project root containing one `.yyp` file.
+3. For **Godot Directory**, choose an empty directory or an existing valid Godot project. The GUI requires this directory to exist already.
+4. Open **Settings** and review the conversion checkboxes. Most start enabled; notes and sound-group folders start off.
+5. Choose the target platform: `windows`, `macos`, or `linux`. This selects target-specific GameMaker project options and conditional GML/macros; it does not filter the project's resources and does not have to match the computer running the converter.
+6. Click **Convert** and follow the console and progress display. The stop button requests cancellation.
+
+A completed progress bar means the conversion worker finished; it is not proof of full GameMaker semantic compatibility. Use the report checks below before treating the output as ready.
+
+## Convert with the CLI
+
+The CLI is available from a source installation through `python main.py` or `python -m src.cli`. A complete first conversion can be run as one command:
+
+```bash
+python main.py convert --gm-project "/path/to/GameMakerProject" --godot-project "/path/to/GodotProject" --groups assets,project,wip --target-platform windows
+```
+
+Replace both paths and choose `windows`, `macos`, or `linux` for the GameMaker options and conditional GML/macros you want selected. This does not filter the project's resources. If `--target-platform` is omitted, GM2Godot defaults to the current host platform.
+
+The three conversion groups are defined by the current [`CONVERSION_CATEGORIES`](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/converter.py):
+
+- `assets` converts the supported asset, script, object, room, and registry outputs.
+- `project` converts the supported icon, project metadata/settings, audio buses, and notes.
+- `wip` enables the shader and tileset converters.
+
+To run only specific converters, first print the accepted keys:
+
+```bash
+python main.py list-converters --format json
+python main.py convert --gm-project "/path/to/GameMakerProject" --godot-project "/path/to/GodotProject" --only sprites,scripts,objects,rooms --target-platform windows
+```
+
+When `--only` contains at least one key, it takes precedence over `--groups`. Unknown group names and converter keys are rejected before conversion.
+
+## Verify the first conversion
+
+1. Read the terminal outcome (CLI). A terminal state can be `success`, `partial`, `failed`, or `cancelled`.
+2. After destination preflight succeeds, read `<GodotProject>/gm2godot/conversion_attempt.json` and `<GodotProject>/gm2godot/conversion_diagnostics.md`. Address errors, unsupported APIs, and relevant warnings. A pre-existing `conversion_manifest.json` may describe an earlier trustworthy run, so inspect the newest attempt ledger first. A rejected preflight intentionally writes no conversion artifacts inside the destination.
+3. Validate the destination project, including the generated resources, with the exact Godot 4.7.1 executable:
+
+   ```bash
+   python main.py validate --godot-project "/path/to/GodotProject" --godot-bin "/absolute/path/to/Godot-4.7.1" --fail-on-unsupported
+   ```
+
+   If `--godot-bin` is omitted, validation checks `GODOT_BIN`, then a `godot` executable on `PATH`, then the standard macOS application path. If Godot cannot be found, project/resource validation is reported as skipped rather than passed.
+
+4. For an additional bounded boot check of the configured main scene, add `--godot-boot-frames 60`. The validation details are written to `<GodotProject>/gm2godot/godot_validation_report.json`.
+5. Open `project.godot` in Godot 4.7.1, inspect the generated scenes and scripts, and test the game paths that matter to your project. Conversion and parser validation do not guarantee one-to-one runtime behavior.
+
+The repository CI pins the full Godot build used for smoke tests in [`godot-smoke.yml`](https://github.com/Infiland/GM2Godot/blob/main/.github/workflows/godot-smoke.yml). For interpreting partial output and unsupported features, continue with [Compatibility and Limitations](Compatibility-and-Limitations); for report details and failures, use [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting). Generated file layout and runtime helpers are covered in [Generated Project and Runtime](Generated-Project-and-Runtime).
+
+If GM2Godot is not installed yet, start with [Installation](Installation).

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,16 @@
+**GM2Godot Documentation**
+
+- [Home](Home)
+- [Installation](Installation)
+- [Quick Start Conversion](Quick-Start-Conversion)
+- [Compatibility and Limitations](Compatibility-and-Limitations)
+- [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting)
+- [Generated Project and Runtime](Generated-Project-and-Runtime)
+
+**Contributors**
+
+- [Contributing and Testing](Contributing-and-Testing)
+- [Release and Wiki Maintenance](Maintainer-Release-and-Wiki)
+- [Repository](https://github.com/Infiland/GM2Godot)
+- [Issues](https://github.com/Infiland/GM2Godot/issues)
+- [Releases](https://github.com/Infiland/GM2Godot/releases)

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.4"
+VERSION = "0.7.5"
 
 
 def get_version():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,7 @@ from src.conversion.diagnostics import (
 )
 from src.conversion.godot_validation import GodotValidationReport
 from src.conversion.project_godot import ConversionPreflightError
+from src.version import get_version
 
 
 class _OutcomeConverterStub:
@@ -662,7 +663,7 @@ class TestCLIReports(unittest.TestCase):
             exit_code = cli.main(["--version"])
 
         self.assertEqual(exit_code, 0)
-        self.assertEqual(output.getvalue().strip(), "GM2Godot 0.7.4")
+        self.assertEqual(output.getvalue().strip(), f"GM2Godot {get_version()}")
 
     def test_list_converters_writes_text_inventory(self) -> None:
         output = io.StringIO()
@@ -731,7 +732,7 @@ class TestCLIReports(unittest.TestCase):
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.strip(), "GM2Godot 0.7.4")
+        self.assertEqual(result.stdout.strip(), f"GM2Godot {get_version()}")
 
     def test_app_entrypoint_routes_global_cli_flags(self) -> None:
         app_entrypoint = importlib.import_module("main")

--- a/tests/test_documentation_health.py
+++ b/tests/test_documentation_health.py
@@ -1,10 +1,24 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 import unittest
+
+from src.version import get_version
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+WIKI_SOURCE_DIR = PROJECT_ROOT / "docs" / "wiki"
+WIKI_PAGES = {
+    "Home.md",
+    "Installation.md",
+    "Quick-Start-Conversion.md",
+    "Compatibility-and-Limitations.md",
+    "Diagnostics-and-Troubleshooting.md",
+    "Generated-Project-and-Runtime.md",
+    "Contributing-and-Testing.md",
+    "Maintainer-Release-and-Wiki.md",
+}
 
 
 class TestDocumentationHealth(unittest.TestCase):
@@ -37,6 +51,82 @@ class TestDocumentationHealth(unittest.TestCase):
         for heading in required_headings:
             with self.subTest(heading=heading):
                 self.assertIn(heading, contributing)
+
+    def test_reviewable_wiki_source_is_complete_and_versioned(self) -> None:
+        self.assertEqual(
+            {path.name for path in WIKI_SOURCE_DIR.glob("*.md")},
+            WIKI_PAGES | {"_Sidebar.md"},
+        )
+
+        current_version = get_version()
+        applies_to_pattern = re.compile(
+            rf"^> \*\*Applies to:\*\* GM2Godot {re.escape(current_version)} · "
+            r"GameMaker LTS 2026 · Godot 4\.7\.1\s*$",
+            re.MULTILINE,
+        )
+        reviewed_pattern = re.compile(
+            r"^> \*\*Last reviewed:\*\* \d{4}-\d{2}-\d{2}\s*$",
+            re.MULTILINE,
+        )
+
+        for filename in sorted(WIKI_PAGES):
+            with self.subTest(page=filename):
+                content = (WIKI_SOURCE_DIR / filename).read_text(encoding="utf-8")
+                self.assertRegex(content, applies_to_pattern)
+                self.assertRegex(content, reviewed_pattern)
+                self.assertEqual(
+                    set(re.findall(r"\bGM2Godot (\d+\.\d+\.\d+)\b", content)),
+                    {current_version},
+                )
+
+    def test_wiki_sidebar_and_local_page_links_resolve(self) -> None:
+        sidebar = (WIKI_SOURCE_DIR / "_Sidebar.md").read_text(encoding="utf-8")
+        for filename in sorted(WIKI_PAGES):
+            with self.subTest(sidebar_page=filename):
+                self.assertIn(f"]({filename.removesuffix('.md')})", sidebar)
+
+        markdown_link_pattern = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+        for source in sorted(WIKI_SOURCE_DIR.glob("*.md")):
+            content = source.read_text(encoding="utf-8")
+            for target in markdown_link_pattern.findall(content):
+                target_without_fragment = target.split("#", 1)[0]
+                if (
+                    not target_without_fragment
+                    or "://" in target_without_fragment
+                    or target_without_fragment.startswith("mailto:")
+                ):
+                    continue
+                target_filename = (
+                    target_without_fragment
+                    if target_without_fragment.endswith(".md")
+                    else f"{target_without_fragment}.md"
+                )
+                with self.subTest(source=source.name, target=target):
+                    self.assertIn(target_filename, WIKI_PAGES | {"_Sidebar.md"})
+                    self.assertTrue((WIKI_SOURCE_DIR / target_filename).is_file())
+
+    def test_user_documentation_links_and_guidance_are_current(self) -> None:
+        readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
+        contributing = (PROJECT_ROOT / "CONTRIBUTING.md").read_text(
+            encoding="utf-8"
+        )
+        maintenance = (PROJECT_ROOT / "docs" / "WIKI_MAINTENANCE.md").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn(
+            "[Documentation](https://github.com/Infiland/GM2Godot/wiki) ·",
+            readme,
+        )
+        self.assertIn("missing, empty, or an existing valid Godot project", readme)
+        self.assertIn("Languages/template/template.json", contributing)
+        self.assertNotIn("Languages/template.json", contributing)
+        self.assertNotIn("modern_widgets.py", contributing)
+        self.assertNotIn("Add community links", readme + contributing)
+        self.assertNotIn("Add link if available", readme + contributing)
+        self.assertIn("docs/wiki/", maintenance)
+        self.assertIn("merged main-repository SHA", maintenance)
+        self.assertIn("must not auto-close", maintenance)
 
     def test_runtime_docs_cover_ownership_event_order_and_state(self) -> None:
         segment_readme = (PROJECT_ROOT / "src" / "conversion" / "gml_runtime_parts" / "README.md").read_text(
@@ -76,4 +166,3 @@ class TestDocumentationHealth(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 import unittest
 
 from src.version import get_version
@@ -10,19 +11,27 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_4(self) -> None:
-        self.assertEqual(get_version(), "0.7.4")
+    def test_release_version_is_0_7_5(self) -> None:
+        self.assertEqual(get_version(), "0.7.5")
 
-    def test_release_docs_reference_0_7_4(self) -> None:
+    def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
         readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
         issue_template = (
             PROJECT_ROOT / ".github" / "ISSUE_TEMPLATE" / "unsupported_gml_api.yml"
         ).read_text(encoding="utf-8")
 
+        current_version = get_version()
+        self.assertRegex(
+            changelog,
+            rf"(?m)^## {re.escape(current_version)} - \d{{4}}-\d{{2}}-\d{{2}}$",
+        )
+        self.assertIn(f"Current source version: `{current_version}`.", readme)
+        self.assertIn(
+            f"GM2Godot {current_version}, GameMaker LTS 2026",
+            issue_template,
+        )
         self.assertIn("## 0.7.4 - 2026-07-18", changelog)
-        self.assertIn("Current source version: `0.7.4`.", readme)
-        self.assertIn("GM2Godot 0.7.4, GameMaker LTS 2026", issue_template)
         self.assertIn("## 0.7.1 - 2026-07-17", changelog)
         self.assertIn("immutable GameMaker LTS 2026 SNAP and Adding fixtures", changelog)
         self.assertIn("## 0.7.0 - 2026-07-17", changelog)


### PR DESCRIPTION
## Summary

- add a canonical, reviewed GitHub Wiki source set for installation, conversion, compatibility, diagnostics, generated runtime architecture, contributing, and maintenance
- document the GameMaker LTS 2026 / Godot 4.7.1 target and strengthen Wiki navigation, version-drift, and local-link checks
- correct stale README and contributor guidance, and increment the release version to 0.7.5

## User impact

The existing Documentation link will have a complete, maintainable destination once these merged pages are published to the live Wiki. Compatibility claims now point users toward generated evidence and clearly distinguish conversion host, GameMaker target filtering, and Godot export work.

## Validation

- `./venv/bin/python -m unittest` — 1,806 passed, 39 skipped
- `./venv/bin/pyright --warnings` — 0 errors, 0 warnings
- `./venv/bin/ruff check .` — clean
- `git diff --cached --check` — clean

## Publication

Refs #712.

This PR intentionally does not auto-close #712. After merge, the exact merged pages will be published to the currently uninitialized Wiki, live navigation and source parity will be verified, and only then will the issue be closed.
