### PR TITLE
Upgrade GitHub Actions to native Node.js 24 runtimes

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.5, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.6, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -10,10 +10,10 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/godot-smoke.yml
+++ b/.github/workflows/godot-smoke.yml
@@ -18,10 +18,10 @@ jobs:
     timeout-minutes: 25
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
@@ -29,7 +29,7 @@ jobs:
         run: pip install Pillow
 
       - name: Cache pinned Godot
-        uses: actions/cache@v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/gm2godot/godot-${{ env.GODOT_VERSION }}
           key: godot-${{ runner.os }}-${{ env.GODOT_VERSION }}-${{ env.GODOT_ARCHIVE_SHA256 }}

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -10,10 +10,10 @@ jobs:
   pyright:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       tag_exists: ${{ steps.check_tag.outputs.exists }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Extract version
         id: version
@@ -58,10 +58,10 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
@@ -122,14 +122,14 @@ jobs:
 
       - name: Upload artifact
         if: matrix.name != 'macos'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: GM2Godot-${{ matrix.name }}
           path: GM2Godot-${{ matrix.name }}.zip
 
       - name: Upload macOS artifacts
         if: matrix.name == 'macos'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: GM2Godot-${{ matrix.name }}
           path: |
@@ -143,15 +143,15 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           path: artifacts
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: v${{ needs.get-version.outputs.version }}
           name: GM2Godot v${{ needs.get-version.outputs.version }}

--- a/.github/workflows/tcc-conversion-test.yml
+++ b/.github/workflows/tcc-conversion-test.yml
@@ -23,10 +23,10 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
@@ -34,7 +34,7 @@ jobs:
         run: pip install Pillow
 
       - name: Cache pinned Godot
-        uses: actions/cache@v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/gm2godot/godot-${{ env.GODOT_VERSION }}
           key: godot-${{ runner.os }}-${{ env.GODOT_VERSION }}-${{ env.GODOT_ARCHIVE_SHA256 }}
@@ -106,10 +106,10 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
@@ -117,7 +117,7 @@ jobs:
         run: pip install Pillow
 
       - name: Cache pinned Godot
-        uses: actions/cache@v4
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/gm2godot/godot-${{ env.GODOT_VERSION }}
           key: godot-${{ runner.os }}-${{ env.GODOT_VERSION }}-${{ env.GODOT_ARCHIVE_SHA256 }}
@@ -181,7 +181,7 @@ jobs:
 
       - name: Upload bounded current-LTS failure reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: lts-2026-fixture-reports
           path: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
@@ -32,10 +32,10 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.6 - 2026-07-18
+
+- Pinned every GitHub Actions dependency to an immutable commit backed by a Node 24-native release, eliminating mutable tag drift and deprecated Node runtime warnings.
+- Added repository policy checks that reject unpinned or non-Node-24-native action references before workflow changes can merge.
+
 ## 0.7.5 - 2026-07-18
 
 - Added reviewable GitHub Wiki sources with installation, conversion, compatibility, diagnostics, generated-runtime, contributor, and maintainer guidance for GameMaker LTS 2026 and Godot 4.7.1.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.5`.
+Current source version: `0.7.6`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.5 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.6 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.5 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.6 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.5 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.6 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.5 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.6 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.5 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.6 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.5;
+- GM2Godot 0.7.6;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.5 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.6 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -20,7 +20,7 @@ Download the asset for your operating system from [GitHub Releases](https://gith
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar, footer, or **Help → About GM2Godot** shows version `0.7.5`.
+After launch, confirm that the title bar, footer, or **Help → About GM2Godot** shows version `0.7.6`.
 
 ## Run from source
 
@@ -70,6 +70,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.5`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.6`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.5 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.6 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.5 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.6 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.5"
+VERSION = "0.7.6"
 
 
 def get_version():

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -135,7 +135,7 @@ class TestCIWorkflows(unittest.TestCase):
         godot_test_files = tuple((PROJECT_ROOT / "tests").glob("test_*_godot.py"))
 
         self.assertIn("GODOT_BIN=$godot_bin", content)
-        self.assertIn("actions/cache@v4", content)
+        self.assertIn("uses: actions/cache@", content)
         self.assertGreater(len(godot_test_files), 13)
         self.assertIn(
             "python -m unittest discover -s tests -p 'test_*_godot.py' -v",
@@ -265,7 +265,7 @@ class TestCIWorkflows(unittest.TestCase):
         upload_step = content[upload_index:]
 
         self.assertIn("if: failure()", upload_step)
-        self.assertIn("uses: actions/upload-artifact@v4", upload_step)
+        self.assertIn("uses: actions/upload-artifact@", upload_step)
         self.assertIn("if-no-files-found: ignore", upload_step)
         self.assertIn("retention-days: 7", upload_step)
         for report_name in (

--- a/tests/test_documentation_health.py
+++ b/tests/test_documentation_health.py
@@ -9,6 +9,7 @@ from src.version import get_version
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 WIKI_SOURCE_DIR = PROJECT_ROOT / "docs" / "wiki"
+WORKFLOW_DIR = PROJECT_ROOT / ".github" / "workflows"
 WIKI_PAGES = {
     "Home.md",
     "Installation.md",
@@ -18,6 +19,38 @@ WIKI_PAGES = {
     "Generated-Project-and-Runtime.md",
     "Contributing-and-Testing.md",
     "Maintainer-Release-and-Wiki.md",
+}
+WORKFLOW_USES_PATTERN = re.compile(
+    r"^\s*(?:-\s*)?(?P<key_quote>['\"]?)uses(?P=key_quote)\s*:"
+    r"\s*(?P<value>.*?)\s*$"
+)
+YAML_BLOCK_SCALAR_PATTERN = re.compile(
+    r"^(?P<indent> *)(?:-\s*)?[^#\n]+:\s*[>|][1-9+-]*"
+    r"\s*(?:#.*)?$"
+)
+FLOW_STYLE_USES_PATTERN = re.compile(
+    r"\{[^{}]*?(?:['\"]uses['\"]|uses)\s*:"
+    r"\s*(?P<value>[^,}]+)"
+)
+PINNED_EXTERNAL_ACTION_PATTERN = re.compile(
+    r"^(?P<quote>['\"]?)"
+    r"(?P<action>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+"
+    r"(?:/[A-Za-z0-9_.-]+)*)"
+    r"@(?P<sha>[0-9a-fA-F]{40})(?P=quote)"
+    r"\s+#\s*"
+    r"(?P<version>v(?P<major>0|[1-9]\d*)"
+    r"\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?)"
+    r"\s*$"
+)
+APPROVED_NODE24_ACTION_MAJORS = {
+    "actions/checkout": 5,
+    "actions/setup-python": 6,
+    "actions/cache": 5,
+    "actions/upload-artifact": 6,
+    "actions/download-artifact": 7,
+    "softprops/action-gh-release": 3,
 }
 
 
@@ -162,6 +195,130 @@ class TestDocumentationHealth(unittest.TestCase):
         self.assertIn("ruff check .", workflow)
         self.assertIn("[tool.ruff.lint]", pyproject)
         self.assertIn('"F82"', pyproject)
+
+    def test_external_workflow_actions_are_immutable_and_node24_native(
+        self,
+    ) -> None:
+        workflows = sorted(
+            [
+                *WORKFLOW_DIR.glob("*.yml"),
+                *WORKFLOW_DIR.glob("*.yaml"),
+            ]
+        )
+        self.assertTrue(workflows)
+
+        pins: dict[str, tuple[str, str, str]] = {}
+        external_count = 0
+
+        for workflow in workflows:
+            lines = workflow.read_text(encoding="utf-8").splitlines()
+            block_scalar_indent: int | None = None
+            for line_number, line in enumerate(lines, start=1):
+                stripped_line = line.strip()
+                indentation = len(line) - len(line.lstrip(" "))
+                if block_scalar_indent is not None:
+                    if (
+                        not stripped_line
+                        or stripped_line.startswith("#")
+                        or indentation > block_scalar_indent
+                    ):
+                        continue
+                    block_scalar_indent = None
+
+                location = (
+                    f"{workflow.relative_to(PROJECT_ROOT)}:{line_number}"
+                )
+                uses_match = WORKFLOW_USES_PATTERN.match(line)
+                if uses_match is None:
+                    block_scalar_match = YAML_BLOCK_SCALAR_PATTERN.match(line)
+                    if block_scalar_match is not None:
+                        block_scalar_indent = len(
+                            block_scalar_match.group("indent")
+                        )
+                        continue
+
+                    flow_uses_match = FLOW_STYLE_USES_PATTERN.search(line)
+                    if flow_uses_match is None:
+                        continue
+
+                    flow_value = flow_uses_match.group("value").strip()
+                    unquoted_flow_value = (
+                        flow_value[1:]
+                        if flow_value[:1] in {'"', "'"}
+                        else flow_value
+                    )
+                    if unquoted_flow_value.startswith(("./", "docker://")):
+                        continue
+
+                    external_count += 1
+                    with self.subTest(location=location):
+                        self.fail(
+                            f"{location}: external uses must be on its own "
+                            "line so its immutable pin can be verified"
+                        )
+                    continue
+
+                raw_value = uses_match.group("value").strip()
+                unquoted_value = (
+                    raw_value[1:]
+                    if raw_value[:1] in {'"', "'"}
+                    else raw_value
+                )
+                if unquoted_value.startswith(("./", "docker://")):
+                    continue
+
+                external_count += 1
+                pin_match = PINNED_EXTERNAL_ACTION_PATTERN.fullmatch(raw_value)
+
+                with self.subTest(location=location):
+                    self.assertIsNotNone(
+                        pin_match,
+                        f"{location}: external uses must be "
+                        "<action>@<40-character SHA> # vMAJOR.MINOR.PATCH",
+                    )
+                if pin_match is None:
+                    continue
+
+                action = pin_match.group("action")
+                sha = pin_match.group("sha").lower()
+                version = pin_match.group("version")
+                repository = "/".join(action.split("/")[:2]).casefold()
+                approved_major = APPROVED_NODE24_ACTION_MAJORS.get(repository)
+
+                with self.subTest(location=location, action=action):
+                    self.assertIsNotNone(
+                        approved_major,
+                        f"{location}: review this action's runtime and add "
+                        "its smallest Node-24-native major to "
+                        "APPROVED_NODE24_ACTION_MAJORS",
+                    )
+                if approved_major is None:
+                    continue
+
+                with self.subTest(location=location, action=action):
+                    self.assertEqual(
+                        int(pin_match.group("major")),
+                        approved_major,
+                        f"{location}: use the approved smallest "
+                        f"Node-24-native major v{approved_major}",
+                    )
+
+                action_key = action.casefold()
+                observed_pin = (sha, version)
+                previous_pin = pins.get(action_key)
+                if previous_pin is None:
+                    pins[action_key] = (sha, version, location)
+                    continue
+
+                with self.subTest(location=location, action=action):
+                    self.assertEqual(
+                        observed_pin,
+                        previous_pin[:2],
+                        f"{location}: {action} differs from "
+                        f"{previous_pin[2]}",
+                    )
+
+        self.assertGreater(external_count, 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_5(self) -> None:
-        self.assertEqual(get_version(), "0.7.5")
+    def test_release_version_is_0_7_6(self) -> None:
+        self.assertEqual(get_version(), "0.7.6")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
@@ -31,6 +31,7 @@ class TestVersion(unittest.TestCase):
             f"GM2Godot {current_version}, GameMaker LTS 2026",
             issue_template,
         )
+        self.assertIn("## 0.7.5 - 2026-07-18", changelog)
         self.assertIn("## 0.7.4 - 2026-07-18", changelog)
         self.assertIn("## 0.7.1 - 2026-07-17", changelog)
         self.assertIn("immutable GameMaker LTS 2026 SNAP and Adding fixtures", changelog)


### PR DESCRIPTION
## Summary

- replace all 26 external action references across six workflows with reviewed, immutable SHAs for the smallest Node 24-native majors
- add a repository policy test for full-SHA pins, adjacent semantic-version comments, explicit Node 24 allowlisting, consistent pins, and flow/block-scalar edge cases
- update stale workflow tests and synchronize release/documentation surfaces for version 0.7.6

## Why

GitHub-hosted runners were forcing the existing Node 20 action builds onto Node 24 and emitting deprecation warnings. Immutable Node 24-native releases remove that compatibility risk and prevent mutable action-tag drift.

## Validation

- every pin resolves to its claimed official tag and each upstream `action.yml` declares `node24`
- `actionlint 1.7.12 .github/workflows/*.yml` — clean (official checksum verified)
- `./venv/bin/python -m unittest` — 1,807 passed, 39 skipped
- `./venv/bin/pyright --warnings` — 0 errors, 0 warnings
- `./venv/bin/ruff check .` — clean
- `git diff --cached --check` — clean

## Follow-through

Refs #717.

This PR intentionally does not auto-close #717. After merge, the v0.7.6 release, all platform assets, and workflow logs will be verified for the deprecated/forced Node runtime warning patterns before the issue is closed. The separate remote-tag idempotency bug remains tracked in #722.
