### PR TITLE
Preserve verified release downloads without deprecated extraction

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.6, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.7, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,10 +145,26 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - name: Download all artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      - name: Download verified artifact archives
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          path: artifacts
+          path: raw-artifacts
+          skip-decompress: true
+          digest-mismatch: error
+
+      - name: Extract verified artifact archives
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          for name in GM2Godot-windows GM2Godot-macos GM2Godot-linux; do
+            archive="raw-artifacts/$name/$name.zip"
+            if [[ ! -s "$archive" ]]; then
+              echo "::error::Missing or empty verified archive: $archive" >&2
+              exit 1
+            fi
+            mkdir -p "artifacts/$name"
+            unzip -q "$archive" -d "artifacts/$name"
+          done
 
       - name: Create release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 0.7.7 - 2026-07-18
+
+- Upgraded the release-only artifact download action to immutable v8.0.1, retained fail-closed SHA-256 digest verification, and bypassed its deprecated Node extraction dependency before native archive extraction.
+- Added regression coverage for the verified-archive download mode and the exact Linux, macOS, and Windows extraction layout consumed by the release publisher.
+
 ## 0.7.6 - 2026-07-18
 
-- Pinned every GitHub Actions dependency to an immutable commit backed by a Node 24-native release, eliminating mutable tag drift and deprecated Node runtime warnings.
+- Pinned every GitHub Actions dependency to an immutable commit backed by a Node 24-native release, eliminating mutable tag drift and retired Node 20 runtime warnings.
 - Added repository policy checks that reject unpinned or non-Node-24-native action references before workflow changes can merge.
 
 ## 0.7.5 - 2026-07-18

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.6`.
+Current source version: `0.7.7`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.6 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.7 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.6 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.7 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.6 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.7 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.6 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.7 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.6 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.7 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.6;
+- GM2Godot 0.7.7;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.6 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.7 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -20,7 +20,7 @@ Download the asset for your operating system from [GitHub Releases](https://gith
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar, footer, or **Help → About GM2Godot** shows version `0.7.6`.
+After launch, confirm that the title bar, footer, or **Help → About GM2Godot** shows version `0.7.7`.
 
 ## Run from source
 
@@ -70,6 +70,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.6`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.7`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.6 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.7 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.6 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.7 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.6"
+VERSION = "0.7.7"
 
 
 def get_version():

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import re
+import subprocess
+import tempfile
+import textwrap
 import unittest
+import zipfile
 from pathlib import Path
 
 
@@ -61,7 +65,120 @@ def _godot_env_lines(content: str) -> tuple[str, ...]:
     )
 
 
+def _workflow_run_script(content: str, step_name: str) -> str:
+    marker = f"      - name: {step_name}\n        run: |\n"
+    _, separator, remainder = content.partition(marker)
+    if not separator:
+        raise AssertionError(f"Workflow step not found: {step_name}")
+
+    script_lines: list[str] = []
+    for line in remainder.splitlines():
+        if line.startswith("      - name: "):
+            break
+        script_lines.append(line)
+    return textwrap.dedent("\n".join(script_lines)).strip() + "\n"
+
+
+def _write_raw_artifact_archive(
+    root: Path,
+    artifact_name: str,
+    members: dict[str, bytes],
+) -> None:
+    artifact_dir = root / "raw-artifacts" / artifact_name
+    artifact_dir.mkdir(parents=True)
+    with zipfile.ZipFile(
+        artifact_dir / f"{artifact_name}.zip",
+        "w",
+        compression=zipfile.ZIP_DEFLATED,
+    ) as archive:
+        for member_name, payload in members.items():
+            archive.writestr(member_name, payload)
+
+
 class TestCIWorkflows(unittest.TestCase):
+    def test_release_preserves_digest_checks_without_deprecated_extraction(
+        self,
+    ) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        content = workflow.read_text(encoding="utf-8")
+
+        self.assertIn("contents: write", content)
+        self.assertIn("uses: actions/download-artifact@", content)
+        self.assertIn("path: raw-artifacts", content)
+        self.assertIn("skip-decompress: true", content)
+        self.assertIn("digest-mismatch: error", content)
+        self.assertIn("Extract verified artifact archives", content)
+        self.assertIn(
+            "for name in GM2Godot-windows GM2Godot-macos GM2Godot-linux",
+            content,
+        )
+        self.assertIn('archive="raw-artifacts/$name/$name.zip"', content)
+        self.assertIn('[[ ! -s "$archive" ]]', content)
+        self.assertIn('unzip -q "$archive" -d "artifacts/$name"', content)
+
+        expected_members = {
+            "GM2Godot-windows": {"GM2Godot-windows.zip": b"windows"},
+            "GM2Godot-macos": {
+                "GM2Godot-macos.zip": b"macos-zip",
+                "GM2Godot-macos.dmg": b"macos-dmg",
+            },
+            "GM2Godot-linux": {"GM2Godot-linux.zip": b"linux"},
+        }
+        for artifact_name, members in expected_members.items():
+            for member_name in members:
+                with self.subTest(release_file=member_name):
+                    self.assertIn(
+                        f"artifacts/{artifact_name}/{member_name}",
+                        content,
+                    )
+
+        script = _workflow_run_script(content, "Extract verified artifact archives")
+        with tempfile.TemporaryDirectory() as temp_directory:
+            root = Path(temp_directory)
+            for artifact_name, members in expected_members.items():
+                _write_raw_artifact_archive(root, artifact_name, members)
+
+            result = subprocess.run(
+                ["bash", "-c", script],
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            for artifact_name, members in expected_members.items():
+                for member_name, payload in members.items():
+                    with self.subTest(artifact=artifact_name, member=member_name):
+                        extracted = root / "artifacts" / artifact_name / member_name
+                        self.assertEqual(extracted.read_bytes(), payload)
+
+    def test_release_extraction_fails_when_verified_archive_is_missing(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        content = workflow.read_text(encoding="utf-8")
+        script = _workflow_run_script(content, "Extract verified artifact archives")
+
+        with tempfile.TemporaryDirectory() as temp_directory:
+            root = Path(temp_directory)
+            _write_raw_artifact_archive(
+                root,
+                "GM2Godot-windows",
+                {"GM2Godot-windows.zip": b"windows"},
+            )
+            result = subprocess.run(
+                ["bash", "-c", script],
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "Missing or empty verified archive: "
+            "raw-artifacts/GM2Godot-macos/GM2Godot-macos.zip",
+            result.stderr,
+        )
+
     def test_unit_workflow_runs_discovery_for_golden_and_threshold_gates(self) -> None:
         workflow = PROJECT_ROOT / ".github" / "workflows" / "tests.yml"
         content = workflow.read_text(encoding="utf-8")

--- a/tests/test_documentation_health.py
+++ b/tests/test_documentation_health.py
@@ -49,7 +49,7 @@ APPROVED_NODE24_ACTION_MAJORS = {
     "actions/setup-python": 6,
     "actions/cache": 5,
     "actions/upload-artifact": 6,
-    "actions/download-artifact": 7,
+    "actions/download-artifact": 8,
     "softprops/action-gh-release": 3,
 }
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_6(self) -> None:
-        self.assertEqual(get_version(), "0.7.6")
+    def test_release_version_is_0_7_7(self) -> None:
+        self.assertEqual(get_version(), "0.7.7")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- upgrade the release-only artifact downloader to immutable `actions/download-artifact` v8.0.1
- retain fail-closed SHA-256 digest checks while using supported raw-download mode to bypass the upstream deprecated unzip dependency
- extract the three verified outer archives into the existing release layout with explicit missing/empty checks
- add dynamic success and failure coverage for the exact workflow shell block
- bump all release and Wiki surfaces to 0.7.7

## Why

The v0.7.6 release succeeded, but its release-only download step emitted Node `DEP0005` from `unzip-stream`. The same dependency remains in upstream v8.0.1. `skip-decompress: true` prevents that code path from executing without weakening artifact digest verification; native extraction then recreates the four paths consumed by the release publisher.

This intentionally leaves issue 717 open until the merged v0.7.7 release publishes all four assets and its complete logs contain none of the requested warning signatures.

## Validation

- `./venv/bin/python -m unittest` — 1,809 passed, 39 skipped
- `./venv/bin/pyright --warnings` — 0 errors, 0 warnings
- `./venv/bin/ruff check .` — clean
- `actionlint 1.7.12 .github/workflows/*.yml` — clean; official archive checksum verified
- v8.0.1 pin resolves to the official tag and declares `node24`
- independent focused review — clean
