### PR TITLE
Fix Included Files runtime parity

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.7, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.8, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,5 +51,6 @@ jobs:
           tests.test_architecture_policy
           tests.test_converter
           tests.test_cli
+          tests.test_asset_registry
           tests.test_included_files.TestIncludedFilesManagedRootTransaction
           tests.test_included_files.TestIncludedFilesConverterOutputContainment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,3 +51,5 @@ jobs:
           tests.test_architecture_policy
           tests.test_converter
           tests.test_cli
+          tests.test_included_files.TestIncludedFilesManagedRootTransaction
+          tests.test_included_files.TestIncludedFilesConverterOutputContainment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Aligned Included File emission, asset registry and conversion-manifest paths, and generated GML file APIs on `res://included_files/`, using GameMaker packaged-name normalization (ASCII `A`–`Z` to lowercase and spaces to underscores) with deterministic collision-safe suffixes and diagnostics.
 - Preserved `user://gm2godot/`-first relative read precedence over packaged defaults and added exact Godot 4.7.1 end-to-end coverage for nested `file_exists()`, text-file reads, and `buffer_load()`.
 - Confined Included File publication against redirected or non-regular destination paths, hardlink referent mutation, and tested late path swaps while preserving binary bytes and source metadata.
+- Made Included File integrity checks portable across Windows path and handle metadata while retaining exact same-handle and SHA-256 source/output mutation detection, and expanded the native Windows transaction regression job.
 - Made `res://included_files/` and its generated runtime registry one converter-owned output set whose previous pair survives ordinary conversion failures and cancellation. Its separate publication steps are not process-crash-atomic, so conversion must not run alongside a live game or another converter until [#727](https://github.com/Infiland/GM2Godot/issues/727) is implemented.
 
 ## 0.7.7 - 2026-07-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.7.8 - 2026-07-18
+
+- Aligned Included File emission, asset registry and conversion-manifest paths, and generated GML file APIs on `res://included_files/`, using GameMaker packaged-name normalization (ASCII `A`–`Z` to lowercase and spaces to underscores) with deterministic collision-safe suffixes and diagnostics.
+- Preserved `user://gm2godot/`-first relative read precedence over packaged defaults and added exact Godot 4.7.1 end-to-end coverage for nested `file_exists()`, text-file reads, and `buffer_load()`.
+- Confined Included File publication against redirected or non-regular destination paths, hardlink referent mutation, and tested late path swaps while preserving binary bytes and source metadata.
+- Made `res://included_files/` and its generated runtime registry one converter-owned output set whose previous pair survives ordinary conversion failures and cancellation. Its separate publication steps are not process-crash-atomic, so conversion must not run alongside a live game or another converter until [#727](https://github.com/Infiland/GM2Godot/issues/727) is implemented.
+
 ## 0.7.7 - 2026-07-18
 
 - Upgraded the release-only artifact download action to immutable v8.0.1, retained fail-closed SHA-256 digest verification, and bypassed its deprecated Node extraction dependency before native archive extraction.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ GM2Godot targets GameMaker LTS 2026 source projects and Godot 4.7.1 output. It c
 - **Asset Conversion**: Converts GameMaker project resources to Godot format:
   - Sprites, collision masks, animation metadata, and generated scenes
   - Sound effects, audio groups, bus layouts, and runtime playback metadata
-  - Fonts, notes, included files, scripts, objects, rooms, tilesets, shaders, paths, timelines, sequences, particles, extensions, texture groups, and options metadata where supported
+  - Fonts, notes, scripts, objects, rooms, tilesets, shaders, paths, timelines, sequences, particles, extensions, texture groups, and options metadata where supported
+  - Included Files under `res://included_files/`, with GameMaker packaged-path normalization, `user://gm2godot/`-first read precedence, and deterministic collision-safe suffixes and diagnostics
   - Project settings, game icons, platform options, and validation reports
 - **Platform Support**: Converts settings for multiple platforms:
   - Windows
@@ -24,6 +25,8 @@ GM2Godot targets GameMaker LTS 2026 source projects and Godot 4.7.1 output. It c
 - **Diagnostics and Reports**: Writes structured warnings/errors, compatibility Markdown/JSON, trusted conversion manifests, per-attempt outcome ledgers, architecture-policy reports, and optional headless Godot validation reports
 - **Customizable Conversion**: Choose conversion groups or specific converter keys
 - **Compatibility Roadmap**: Tracks current and missing GameMaker-to-Godot coverage in [`todo-list/`](todo-list/README.md)
+
+`res://included_files/` and `res://gm2godot/gml_included_file_registry.gd` are one converter-owned output set. Ordinary conversion failures and cancellation preserve the previous pair, but the two publication steps are not process-crash-atomic. Until [#727](https://github.com/Infiland/GM2Godot/issues/727) is implemented, do not convert a project while a live game or another converter is accessing that output.
 
 ## What GM2Godot Is and Isn't
 
@@ -45,7 +48,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.7`.
+Current source version: `0.7.8`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.7 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.8 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.7 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.8 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.7 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.8 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.7 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.8 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -45,6 +45,18 @@ GM2Godot treats these directories as managed output roots:
 - `fonts/`, `gm2godot/`, `included_files/`, `notes/`, `objects/`, `rooms/`, `scripts/`, `shaders/`, `sounds/`, `sprites/`, and `tilesets/`
 
 The top-level `default_bus_layout.tres`, `icon.ico`, and `icon.png` are managed files. `project.godot` is jointly managed: GM2Godot can update the generated `GM*` autoload entries and, when a room is generated, set `run/main_scene` from the first GameMaker `RoomOrderNodes` entry. Existing unrelated project settings and unrelated autoloads are preserved.
+
+### Included Files and file reads
+
+GameMaker Included Files from `datafiles/` are emitted under `res://included_files/`. Each relative path uses GameMaker's packaged lookup form: ASCII `A`–`Z` is lowercased and spaces become underscores, including nested directory components; other characters are preserved.
+
+For relative file and buffer reads, the generated runtime checks the exact `user://gm2godot/<path>` first and then the normalized `res://included_files/<path>`. Writes target user storage. A saved user file therefore overrides its packaged default, and deleting the saved copy reveals the packaged file again. `file_exists()`, text-file reads, and `buffer_load()` share this precedence.
+
+When source paths collapse to the same packaged name, or when one normalized file path would block another file's directory, GM2Godot reserves natural names and deterministically assigns `_2`, `_3`, and later suffixes before the extension. The emitted files, asset registry, and conversion manifest use the same assignments. `GM2GD-INCLUDED-FILE-PATH-COLLISION` reports the mapping; rename these conflicts in GameMaker because normalized lookup cannot distinguish every original alias. Publication also rejects redirected or non-regular paths in the managed `included_files/` output tree instead of writing through them.
+
+`res://included_files/` and `res://gm2godot/gml_included_file_registry.gd` form one converter-owned output set. Ordinary conversion failures and cancellation preserve the previous pair, but the root and registry are published in separate steps and are not process-crash-atomic. Until [#727](https://github.com/Infiland/GM2Godot/issues/727) is implemented, do not run conversion while a live game or another converter is accessing the same output project.
+
+This emission and runtime-read contract is covered by an end-to-end smoke test using the exact supported Godot 4.7.1 build.
 
 Treat every generated file under a managed root as reproducible output. A later conversion can replace it even if the converter does not delete the entire directory. For repeatable migrations:
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.7 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.8 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.7;
+- GM2Godot 0.7.8;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.7 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.8 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -20,7 +20,7 @@ Download the asset for your operating system from [GitHub Releases](https://gith
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar, footer, or **Help → About GM2Godot** shows version `0.7.7`.
+After launch, confirm that the title bar, footer, or **Help → About GM2Godot** shows version `0.7.8`.
 
 ## Run from source
 
@@ -70,6 +70,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.7`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.8`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.7 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.8 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.7 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.8 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/src/conversion/asset_registry.py
+++ b/src/conversion/asset_registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import posixpath
@@ -561,17 +562,79 @@ def _included_file_content_fingerprint(
     )
 
 
+def _included_file_path_handle_fingerprints_match(
+    path_fingerprint: tuple[int, int, int, int, int],
+    handle_fingerprint: tuple[int, int, int, int, int],
+) -> bool:
+    """Compare stable content metadata across Windows path and handle stat."""
+
+    if _uses_windows_included_file_path_handle_semantics():
+        return path_fingerprint[:4] == handle_fingerprint[:4]
+    return path_fingerprint == handle_fingerprint
+
+
+def _uses_windows_included_file_path_handle_semantics() -> bool:
+    return os.name == "nt"
+
+
 def _included_file_streams_match(
     source_file: BinaryIO,
     output_file: BinaryIO,
-) -> bool:
+) -> tuple[bool, str, str]:
+    source_digest = hashlib.sha256()
+    output_digest = hashlib.sha256()
     while True:
         source_chunk = source_file.read(1024 * 1024)
         output_chunk = output_file.read(1024 * 1024)
+        source_digest.update(source_chunk)
+        output_digest.update(output_chunk)
         if source_chunk != output_chunk:
-            return False
+            return (
+                False,
+                source_digest.hexdigest(),
+                output_digest.hexdigest(),
+            )
         if not source_chunk:
-            return True
+            return (
+                True,
+                source_digest.hexdigest(),
+                output_digest.hexdigest(),
+            )
+
+
+def _included_file_stream_sha256(opened_file: BinaryIO) -> str:
+    digest = hashlib.sha256()
+    while True:
+        chunk = opened_file.read(1024 * 1024)
+        if not chunk:
+            return digest.hexdigest()
+        digest.update(chunk)
+
+
+def _included_file_streams_match_stably(
+    source_file: BinaryIO,
+    output_file: BinaryIO,
+    output_path: str,
+) -> bool:
+    matches, source_sha256, output_sha256 = _included_file_streams_match(
+        source_file,
+        output_file,
+    )
+    if not matches:
+        return False
+
+    source_file.seek(0)
+    if _included_file_stream_sha256(source_file) != source_sha256:
+        raise OSError(
+            "Asset-registry Included File source changed during validation"
+        )
+    output_file.seek(0)
+    if _included_file_stream_sha256(output_file) != output_sha256:
+        raise OSError(
+            "Asset-registry Included File output changed during validation: "
+            f"{output_path}"
+        )
+    return True
 
 
 @dataclass(frozen=True)
@@ -1050,9 +1113,10 @@ class AssetRegistryConverter(BaseConverter):
                 )
             with os.fdopen(output_fd, "rb") as output_file:
                 output_fd = -1
-                matches = _included_file_streams_match(
+                matches = _included_file_streams_match_stably(
                     source_file,
                     output_file,
+                    output_path,
                 )
                 final_open_stat = os.fstat(output_file.fileno())
             _verify_open_asset_output_directory(
@@ -1145,6 +1209,9 @@ class AssetRegistryConverter(BaseConverter):
         expected_fingerprint = _included_file_content_fingerprint(output_stat)
         with open(output_path, "rb") as output_file:
             opened_stat = os.fstat(output_file.fileno())
+            opened_fingerprint = _included_file_content_fingerprint(
+                opened_stat
+            )
             if (
                 not stat.S_ISREG(opened_stat.st_mode)
                 or not os.path.samestat(opened_stat, output_stat)
@@ -1158,9 +1225,10 @@ class AssetRegistryConverter(BaseConverter):
                 output_path,
                 expected_fingerprint,
             )
-            matches = _included_file_streams_match(
+            matches = _included_file_streams_match_stably(
                 source_file,
                 output_file,
+                output_path,
             )
             final_open_stat = os.fstat(output_file.fileno())
         self._verify_included_file_output_fallback(
@@ -1170,7 +1238,11 @@ class AssetRegistryConverter(BaseConverter):
         )
         if (
             _included_file_content_fingerprint(final_open_stat)
-            != expected_fingerprint
+            != opened_fingerprint
+            or not _included_file_path_handle_fingerprints_match(
+                expected_fingerprint,
+                _included_file_content_fingerprint(final_open_stat),
+            )
         ):
             raise OSError(
                 "Asset-registry Included File output changed during "

--- a/src/conversion/asset_registry.py
+++ b/src/conversion/asset_registry.py
@@ -7,7 +7,7 @@ import secrets
 import stat
 import tempfile
 from dataclasses import dataclass, field
-from typing import Callable, ClassVar, Iterable, cast
+from typing import BinaryIO, Callable, ClassVar, Iterable, cast
 
 from src.conversion.base_converter import BaseConverter
 from src.conversion.diagnostics import DiagnosticCollector
@@ -28,9 +28,14 @@ from src.conversion.generated_paths import (
     generated_path_segment,
     generated_resource_stem,
 )
+from src.conversion.included_file_paths import (
+    canonical_included_file_lookup_path,
+    plan_included_file_paths,
+)
 from src.conversion.project_source_paths import (
     ProjectSourcePathError,
     is_safe_project_source_component,
+    resolve_project_source_path,
     validate_project_resource_source_path,
 )
 from src.conversion.script_functions import modern_script_function_names
@@ -119,6 +124,7 @@ def _atomic_write_asset_text_at(
     root: str,
     components: tuple[str, ...],
     content: str,
+    publication_validator: Callable[[], None] | None = None,
 ) -> None:
     directory_flags = os.O_RDONLY
     directory_flags |= getattr(os, "O_DIRECTORY", 0)
@@ -143,6 +149,7 @@ def _atomic_write_asset_text_at(
             current_fd,
             components[-1],
             content,
+            publication_validator,
         )
         _verify_open_asset_output_directory(root, output_directory, current_fd)
     finally:
@@ -234,6 +241,7 @@ def _atomic_write_asset_text_in_directory(
     directory_fd: int,
     filename: str,
     content: str,
+    publication_validator: Callable[[], None] | None = None,
 ) -> None:
     output_identity, output_mode = _asset_output_state_at(directory_fd, filename)
     temporary_name = ""
@@ -282,6 +290,8 @@ def _atomic_write_asset_text_in_directory(
             or (staged_stat.st_dev, staged_stat.st_ino) != temporary_identity
         ):
             raise OSError(f"Generated asset staging file changed: {filename}")
+        if publication_validator is not None:
+            publication_validator()
         _verify_asset_output_state_at(directory_fd, filename, output_identity)
         os.replace(
             temporary_name,
@@ -290,6 +300,28 @@ def _atomic_write_asset_text_in_directory(
             dst_dir_fd=directory_fd,
         )
         temporary_pending = False
+        if publication_validator is not None:
+            try:
+                publication_validator()
+            except BaseException as validation_error:
+                try:
+                    published_stat = os.stat(
+                        filename,
+                        dir_fd=directory_fd,
+                        follow_symlinks=False,
+                    )
+                    if (
+                        stat.S_ISREG(published_stat.st_mode)
+                        and (published_stat.st_dev, published_stat.st_ino)
+                        == temporary_identity
+                    ):
+                        os.unlink(filename, dir_fd=directory_fd)
+                except BaseException as cleanup_error:
+                    validation_error.add_note(
+                        "Failed to remove invalid generated asset registry: "
+                        f"{cleanup_error}"
+                    )
+                raise
     finally:
         if file_descriptor >= 0:
             os.close(file_descriptor)
@@ -304,6 +336,7 @@ def _atomic_write_asset_text_fallback(
     root: str,
     components: tuple[str, ...],
     content: str,
+    publication_validator: Callable[[], None] | None = None,
 ) -> None:
     directory_identities = _prepare_asset_output_directories_fallback(
         root,
@@ -342,9 +375,48 @@ def _atomic_write_asset_text_fallback(
             raise OSError(
                 f"Generated asset staging file changed: {components[-1]}"
             )
+        if publication_validator is not None:
+            publication_validator()
         _verify_asset_output_state(output_path, output_identity)
         os.replace(staged_path, output_path)
         staged_pending = False
+        if publication_validator is not None:
+            try:
+                publication_validator()
+            except BaseException as validation_error:
+                try:
+                    published_stat = os.lstat(output_path)
+                    if (
+                        stat.S_ISREG(published_stat.st_mode)
+                        and (published_stat.st_dev, published_stat.st_ino)
+                        == temporary_identity
+                    ):
+                        try:
+                            os.unlink(output_path)
+                        except PermissionError:
+                            if os.name != "nt":
+                                raise
+                            os.chmod(output_path, stat.S_IWRITE)
+                            writable_stat = os.lstat(output_path)
+                            if (
+                                not stat.S_ISREG(writable_stat.st_mode)
+                                or (
+                                    writable_stat.st_dev,
+                                    writable_stat.st_ino,
+                                )
+                                != temporary_identity
+                            ):
+                                raise OSError(
+                                    "Generated asset registry changed before "
+                                    f"cleanup: {output_path}"
+                                )
+                            os.unlink(output_path)
+                except BaseException as cleanup_error:
+                    validation_error.add_note(
+                        "Failed to remove invalid generated asset registry: "
+                        f"{cleanup_error}"
+                    )
+                raise
     finally:
         if file_descriptor >= 0:
             os.close(file_descriptor)
@@ -448,6 +520,60 @@ def _verify_asset_output_state(
         raise OSError(f"Asset registry changed during publication: {output_path}")
 
 
+def atomic_write_confined_generated_text(
+    output_path: str,
+    content: str,
+    *,
+    confinement_root: str,
+    publication_validator: Callable[[], None] | None = None,
+) -> None:
+    """Publish UTF-8 generated text through a confined, no-follow path."""
+
+    output_absolute = os.path.abspath(output_path)
+    root = os.path.abspath(confinement_root)
+    components = _asset_output_components(root, output_absolute)
+    _ensure_asset_output_root(root)
+    if _confined_asset_output_supported():
+        _atomic_write_asset_text_at(
+            root,
+            components,
+            content,
+            publication_validator,
+        )
+        return
+    _atomic_write_asset_text_fallback(
+        root,
+        components,
+        content,
+        publication_validator,
+    )
+
+
+def _included_file_content_fingerprint(
+    file_stat: os.stat_result,
+) -> tuple[int, int, int, int, int]:
+    return (
+        file_stat.st_dev,
+        file_stat.st_ino,
+        file_stat.st_size,
+        file_stat.st_mtime_ns,
+        file_stat.st_ctime_ns,
+    )
+
+
+def _included_file_streams_match(
+    source_file: BinaryIO,
+    output_file: BinaryIO,
+) -> bool:
+    while True:
+        source_chunk = source_file.read(1024 * 1024)
+        output_chunk = output_file.read(1024 * 1024)
+        if source_chunk != output_chunk:
+            return False
+        if not source_chunk:
+            return True
+
+
 @dataclass(frozen=True)
 class AssetRegistryEntry:
     id: int
@@ -479,6 +605,12 @@ class AssetRegistryEntry:
 
 
 @dataclass(frozen=True)
+class _UnavailablePublishedIncludedFile:
+    entry: AssetRegistryEntry
+    reason: str
+
+
+@dataclass(frozen=True)
 class _ProjectResource:
     kind: str
     name: str
@@ -494,6 +626,7 @@ class _DeclaredRegistryResource:
     source_path: str | None
     owner_source_path: str | None
     manifest_field: str | None
+    included_file_logical_path: str | None = None
 
 
 @dataclass(frozen=True)
@@ -509,6 +642,7 @@ class _AssetRegistryConversionPlan:
     resource_keys: tuple[str, ...]
     requested_keys: tuple[str, ...]
     unavailable: tuple[_UnavailableRegistryResource, ...]
+    included_file_logical_paths: tuple[str, ...]
 
 
 @dataclass
@@ -662,6 +796,418 @@ class AssetRegistryConverter(BaseConverter):
         entries, _processed_count = self._build_entries_from_resources(resources)
         return entries
 
+    def build_published_entries(self) -> tuple[AssetRegistryEntry, ...]:
+        """Return entries whose Included File outputs match current sources.
+
+        ``build_entries()`` remains the source-planning API used by converters
+        that need the complete deterministic asset namespace before outputs
+        exist. Artifact publishers use this method so they never advertise an
+        absent, redirected, stale, or otherwise mismatched Included File.
+        """
+
+        plan = self._conversion_plan()
+        entries, _processed_count = self._build_entries_from_resources(
+            plan.resources,
+            included_file_logical_paths=plan.included_file_logical_paths,
+        )
+        published, _unavailable = self._filter_published_included_file_entries(
+            entries
+        )
+        return published
+
+    def revalidate_published_entries(
+        self,
+        expected_entries: tuple[AssetRegistryEntry, ...],
+    ) -> None:
+        """Fail if current published Included Files differ from the plan."""
+
+        expected_included_files = tuple(
+            entry
+            for entry in expected_entries
+            if entry.kind == "included_files"
+        )
+        current_included_files = tuple(
+            entry
+            for entry in self.build_published_entries()
+            if entry.kind == "included_files"
+        )
+        if current_included_files != expected_included_files:
+            raise OSError(
+                "Asset-registry Included File publication inputs changed after "
+                "planning."
+            )
+
+    def _filter_published_included_file_entries(
+        self,
+        entries: tuple[AssetRegistryEntry, ...],
+    ) -> tuple[
+        tuple[AssetRegistryEntry, ...],
+        tuple[_UnavailablePublishedIncludedFile, ...],
+    ]:
+        published: list[AssetRegistryEntry] = []
+        unavailable: list[_UnavailablePublishedIncludedFile] = []
+        for entry in entries:
+            if entry.kind != "included_files":
+                published.append(entry)
+                continue
+            matches, reason = self._included_file_output_matches_source(entry)
+            if matches:
+                published.append(entry)
+            else:
+                unavailable.append(
+                    _UnavailablePublishedIncludedFile(
+                        entry=entry,
+                        reason=reason,
+                    )
+                )
+        return tuple(published), tuple(unavailable)
+
+    def _included_file_output_matches_source(
+        self,
+        entry: AssetRegistryEntry,
+    ) -> tuple[bool, str]:
+        source_file: BinaryIO | None = None
+        try:
+            source_file, source_stat = self._open_pinned_included_file_source(
+                entry
+            )
+            output_path, components = self._included_file_output_path(entry)
+            with source_file:
+                self._verify_pinned_included_file_source(
+                    entry,
+                    source_file,
+                    source_stat,
+                )
+                if _confined_asset_output_supported():
+                    matches = self._included_file_output_matches_at(
+                        output_path,
+                        components,
+                        source_file,
+                    )
+                else:
+                    matches = self._included_file_output_matches_fallback(
+                        output_path,
+                        components,
+                        source_file,
+                    )
+                self._verify_pinned_included_file_source(
+                    entry,
+                    source_file,
+                    source_stat,
+                )
+        except (OSError, ProjectSourcePathError, ValueError) as error:
+            if source_file is not None and not source_file.closed:
+                source_file.close()
+            return False, str(error)
+        if not matches:
+            return False, "the generated output bytes differ from the source file"
+        return True, ""
+
+    def _open_pinned_included_file_source(
+        self,
+        entry: AssetRegistryEntry,
+    ) -> tuple[BinaryIO, os.stat_result]:
+        resolved = resolve_project_source_path(
+            self.gm_project_path,
+            entry.source_path,
+        )
+        source_file = open(resolved.filesystem_path, "rb")
+        try:
+            source_stat = os.fstat(source_file.fileno())
+            if not stat.S_ISREG(source_stat.st_mode):
+                raise OSError(
+                    "Asset-registry Included File source is not regular: "
+                    f"{entry.source_path}"
+                )
+            self._verify_pinned_included_file_source(
+                entry,
+                source_file,
+                source_stat,
+            )
+        except Exception:
+            source_file.close()
+            raise
+        return source_file, source_stat
+
+    def _verify_pinned_included_file_source(
+        self,
+        entry: AssetRegistryEntry,
+        source_file: BinaryIO,
+        expected_stat: os.stat_result,
+    ) -> None:
+        resolved = resolve_project_source_path(
+            self.gm_project_path,
+            entry.source_path,
+        )
+        current_path_stat = os.stat(resolved.filesystem_path)
+        current_open_stat = os.fstat(source_file.fileno())
+        if (
+            not stat.S_ISREG(current_open_stat.st_mode)
+            or not os.path.samestat(expected_stat, current_path_stat)
+            or _included_file_content_fingerprint(current_open_stat)
+            != _included_file_content_fingerprint(expected_stat)
+        ):
+            raise OSError(
+                "Asset-registry Included File source changed during validation: "
+                f"{entry.source_path}"
+            )
+
+    def _included_file_output_path(
+        self,
+        entry: AssetRegistryEntry,
+    ) -> tuple[str, tuple[str, ...]]:
+        prefix = "res://included_files/"
+        if not entry.godot_path.startswith(prefix):
+            raise ValueError(
+                "Asset-registry Included File output is outside its managed root: "
+                f"{entry.godot_path}"
+            )
+        relative_path = entry.godot_path.removeprefix(prefix)
+        normalized_relative = posixpath.normpath(relative_path)
+        relative_components = tuple(normalized_relative.split("/"))
+        if (
+            not relative_path
+            or "\\" in relative_path
+            or normalized_relative != relative_path
+            or any(
+                component in {"", ".", ".."}
+                for component in relative_components
+            )
+        ):
+            raise ValueError(
+                "Asset-registry Included File output path is invalid: "
+                f"{entry.godot_path}"
+            )
+        project_root = os.path.abspath(self.godot_project_path)
+        components = ("included_files", *relative_components)
+        output_path = os.path.join(project_root, *components)
+        if _asset_output_components(project_root, output_path) != components:
+            raise ValueError(
+                "Asset-registry Included File output escapes the Godot project: "
+                f"{entry.godot_path}"
+            )
+        return output_path, components
+
+    def _included_file_output_matches_at(
+        self,
+        output_path: str,
+        components: tuple[str, ...],
+        source_file: BinaryIO,
+    ) -> bool:
+        project_root = os.path.abspath(self.godot_project_path)
+        directory_flags = os.O_RDONLY
+        directory_flags |= getattr(os, "O_DIRECTORY", 0)
+        directory_flags |= getattr(os, "O_NOFOLLOW", 0)
+        file_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        project_fd = os.open(project_root, directory_flags)
+        current_fd = project_fd
+        output_fd = -1
+        try:
+            _verify_open_asset_output_directory(
+                project_root,
+                project_root,
+                project_fd,
+            )
+            for component in components[:-1]:
+                child_fd = os.open(
+                    component,
+                    directory_flags,
+                    dir_fd=current_fd,
+                )
+                if current_fd != project_fd:
+                    os.close(current_fd)
+                current_fd = child_fd
+
+            output_directory = os.path.dirname(output_path)
+            _verify_open_asset_output_directory(
+                project_root,
+                output_directory,
+                current_fd,
+            )
+            output_fd = os.open(
+                components[-1],
+                file_flags,
+                dir_fd=current_fd,
+            )
+            opened_stat = os.fstat(output_fd)
+            path_stat = os.stat(
+                components[-1],
+                dir_fd=current_fd,
+                follow_symlinks=False,
+            )
+            expected_fingerprint = _included_file_content_fingerprint(
+                opened_stat
+            )
+            if (
+                _path_is_redirected(output_path, path_stat)
+                or not stat.S_ISREG(opened_stat.st_mode)
+                or not stat.S_ISREG(path_stat.st_mode)
+                or not os.path.samestat(opened_stat, path_stat)
+            ):
+                raise OSError(
+                    "Asset-registry Included File output is redirected or "
+                    f"non-regular: {output_path}"
+                )
+            with os.fdopen(output_fd, "rb") as output_file:
+                output_fd = -1
+                matches = _included_file_streams_match(
+                    source_file,
+                    output_file,
+                )
+                final_open_stat = os.fstat(output_file.fileno())
+            _verify_open_asset_output_directory(
+                project_root,
+                output_directory,
+                current_fd,
+            )
+            final_path_stat = os.stat(
+                components[-1],
+                dir_fd=current_fd,
+                follow_symlinks=False,
+            )
+            if (
+                _path_is_redirected(output_path, final_path_stat)
+                or not stat.S_ISREG(final_path_stat.st_mode)
+                or not os.path.samestat(opened_stat, final_path_stat)
+                or _included_file_content_fingerprint(final_open_stat)
+                != expected_fingerprint
+                or _included_file_content_fingerprint(final_path_stat)
+                != expected_fingerprint
+            ):
+                raise OSError(
+                    "Asset-registry Included File output changed during "
+                    f"validation: {output_path}"
+                )
+            return matches
+        finally:
+            if output_fd >= 0:
+                os.close(output_fd)
+            if current_fd != project_fd:
+                os.close(current_fd)
+            os.close(project_fd)
+
+    def _included_file_output_matches_fallback(
+        self,
+        output_path: str,
+        components: tuple[str, ...],
+        source_file: BinaryIO,
+    ) -> bool:
+        project_root = os.path.abspath(self.godot_project_path)
+        project_real = os.path.normcase(os.path.realpath(project_root))
+        directory_path = project_root
+        directory_identities: list[tuple[str, tuple[int, int]]] = []
+        for component in (None, *components[:-1]):
+            if component is not None:
+                directory_path = os.path.join(directory_path, component)
+            directory_stat = os.lstat(directory_path)
+            directory_real = os.path.normcase(os.path.realpath(directory_path))
+            try:
+                contained = (
+                    os.path.commonpath((project_real, directory_real))
+                    == project_real
+                )
+            except ValueError:
+                contained = False
+            if (
+                _path_is_redirected(directory_path, directory_stat)
+                or not stat.S_ISDIR(directory_stat.st_mode)
+                or not contained
+            ):
+                raise OSError(
+                    "Asset-registry Included File output directory is "
+                    f"redirected or invalid: {directory_path}"
+                )
+            directory_identities.append(
+                (
+                    directory_path,
+                    (directory_stat.st_dev, directory_stat.st_ino),
+                )
+            )
+
+        output_stat = os.lstat(output_path)
+        output_real = os.path.normcase(os.path.realpath(output_path))
+        try:
+            output_contained = (
+                os.path.commonpath((project_real, output_real))
+                == project_real
+            )
+        except ValueError:
+            output_contained = False
+        if (
+            _path_is_redirected(output_path, output_stat)
+            or not stat.S_ISREG(output_stat.st_mode)
+            or not output_contained
+        ):
+            raise OSError(
+                "Asset-registry Included File output is redirected or "
+                f"non-regular: {output_path}"
+            )
+        expected_fingerprint = _included_file_content_fingerprint(output_stat)
+        with open(output_path, "rb") as output_file:
+            opened_stat = os.fstat(output_file.fileno())
+            if (
+                not stat.S_ISREG(opened_stat.st_mode)
+                or not os.path.samestat(opened_stat, output_stat)
+            ):
+                raise OSError(
+                    "Asset-registry Included File output changed before "
+                    f"validation: {output_path}"
+                )
+            self._verify_included_file_output_fallback(
+                directory_identities,
+                output_path,
+                expected_fingerprint,
+            )
+            matches = _included_file_streams_match(
+                source_file,
+                output_file,
+            )
+            final_open_stat = os.fstat(output_file.fileno())
+        self._verify_included_file_output_fallback(
+            directory_identities,
+            output_path,
+            expected_fingerprint,
+        )
+        if (
+            _included_file_content_fingerprint(final_open_stat)
+            != expected_fingerprint
+        ):
+            raise OSError(
+                "Asset-registry Included File output changed during "
+                f"validation: {output_path}"
+            )
+        return matches
+
+    @staticmethod
+    def _verify_included_file_output_fallback(
+        directory_identities: list[tuple[str, tuple[int, int]]],
+        output_path: str,
+        expected_fingerprint: tuple[int, int, int, int, int],
+    ) -> None:
+        for directory_path, expected_identity in directory_identities:
+            directory_stat = os.lstat(directory_path)
+            if (
+                _path_is_redirected(directory_path, directory_stat)
+                or not stat.S_ISDIR(directory_stat.st_mode)
+                or (directory_stat.st_dev, directory_stat.st_ino)
+                != expected_identity
+            ):
+                raise OSError(
+                    "Asset-registry Included File output directory changed: "
+                    f"{directory_path}"
+                )
+        output_stat = os.lstat(output_path)
+        if (
+            _path_is_redirected(output_path, output_stat)
+            or not stat.S_ISREG(output_stat.st_mode)
+            or _included_file_content_fingerprint(output_stat)
+            != expected_fingerprint
+        ):
+            raise OSError(
+                "Asset-registry Included File output changed during "
+                f"validation: {output_path}"
+            )
+
     def _ordered_project_resources(self) -> tuple[_ProjectResource, ...]:
         """Return every discoverable base resource in stable registry order."""
         return tuple(
@@ -695,6 +1241,11 @@ class AssetRegistryConverter(BaseConverter):
                 resource_keys=resource_keys,
                 requested_keys=resource_keys,
                 unavailable=(),
+                included_file_logical_paths=self._valid_included_file_logical_paths(
+                    resource.name
+                    for resource in resources
+                    if resource.kind == "included_files"
+                ),
             )
 
         declaration_groups = self._declared_registry_resources()
@@ -706,12 +1257,17 @@ class AssetRegistryConverter(BaseConverter):
         declared_identities: set[tuple[str, str]] = set()
         requested_keys: list[str] = []
         unavailable: list[_UnavailableRegistryResource] = []
+        requested_included_file_paths: list[str] = []
 
         for declarations in declaration_groups:
             declaration = declarations[0]
+            declaration_name = (
+                declaration.included_file_logical_path
+                or declaration.name
+            )
             identity = self._resource_identity(
                 declaration.kind,
-                declaration.name,
+                declaration_name,
             )
             declared_identities.add(identity)
             available = available_by_identity.get(identity)
@@ -725,8 +1281,13 @@ class AssetRegistryConverter(BaseConverter):
                 allowed_sources: set[str] = set()
                 reasons: list[str] = []
                 for item in declarations:
-                    source_path, reason = self._declared_included_file_source(
-                        item
+                    (
+                        source_path,
+                        requested_logical_path,
+                        reason,
+                    ) = self._declared_included_file_source(item)
+                    requested_included_file_paths.append(
+                        requested_logical_path
                     )
                     if source_path is not None:
                         allowed_sources.add(source_path)
@@ -784,7 +1345,30 @@ class AssetRegistryConverter(BaseConverter):
             resource_keys=resource_keys,
             requested_keys=tuple(requested_keys),
             unavailable=tuple(unavailable),
+            included_file_logical_paths=self._valid_included_file_logical_paths(
+                (
+                    *requested_included_file_paths,
+                    *(
+                        resource.name
+                        for resource in resources
+                        if resource.kind == "included_files"
+                    ),
+                )
+            ),
         )
+
+    @staticmethod
+    def _valid_included_file_logical_paths(
+        logical_paths: Iterable[str],
+    ) -> tuple[str, ...]:
+        valid_paths: list[str] = []
+        for logical_path in logical_paths:
+            try:
+                canonical_included_file_lookup_path(logical_path)
+            except ProjectSourcePathError:
+                continue
+            valid_paths.append(logical_path)
+        return tuple(valid_paths)
 
     def _declared_registry_resources(
         self,
@@ -797,7 +1381,10 @@ class AssetRegistryConverter(BaseConverter):
         seen_declarations: set[tuple[str, str, str | None]] = set()
 
         def add(resource: _DeclaredRegistryResource) -> None:
-            identity = self._resource_identity(resource.kind, resource.name)
+            identity = self._resource_identity(
+                resource.kind,
+                resource.included_file_logical_path or resource.name,
+            )
             declaration_key = (*identity, resource.source_path)
             if (
                 not resource.name
@@ -828,6 +1415,14 @@ class AssetRegistryConverter(BaseConverter):
                     source_path=resource.path,
                     owner_source_path=self.project_manifest.yyp_path,
                     manifest_field=manifest_field,
+                    included_file_logical_path=(
+                        self._included_file_logical_name(
+                            resource.path,
+                            resource.name,
+                        )
+                        if kind == "included_files"
+                        else None
+                    ),
                 )
             )
 
@@ -893,6 +1488,7 @@ class AssetRegistryConverter(BaseConverter):
                     source_path=source_path or None,
                     owner_source_path=self.project_manifest.yyp_path,
                     manifest_field=manifest_field,
+                    included_file_logical_path=logical_name,
                 )
             )
 
@@ -932,19 +1528,38 @@ class AssetRegistryConverter(BaseConverter):
 
     @staticmethod
     def _included_file_logical_name(path: str, name: str) -> str:
-        normalized = posixpath.normpath(path.replace("\\", "/"))
-        if normalized.startswith("datafiles/"):
-            relative_path = normalized.removeprefix("datafiles/")
-            if relative_path and relative_path != ".":
-                return relative_path
-        return name or posixpath.basename(normalized)
+        normalized = posixpath.normpath(
+            (path or name).replace("\\", "/").strip()
+        )
+        project_prefix = "${project_dir}/"
+        if normalized.startswith(project_prefix):
+            normalized = normalized.removeprefix(project_prefix)
+        source_root, separator, source_relative = normalized.partition("/")
+        if (
+            separator
+            and source_root.casefold() == "datafiles"
+            and source_relative
+        ):
+            return source_relative
+        return name if normalized in {"", "."} else normalized
 
     def _declared_included_file_source(
         self,
         resource: _DeclaredRegistryResource,
-    ) -> tuple[str | None, str]:
+    ) -> tuple[str | None, str, str]:
+        requested_logical_path = (
+            resource.included_file_logical_path
+            or self._included_file_logical_name(
+                resource.source_path or "",
+                resource.name,
+            )
+        )
         if resource.source_path is None:
-            return None, "its manifest source path was rejected"
+            return (
+                None,
+                requested_logical_path,
+                "its manifest source path was rejected",
+            )
         resolved = self._resolve_project_source(
             resource.source_path,
             owner_source_path=resource.owner_source_path,
@@ -953,7 +1568,15 @@ class AssetRegistryConverter(BaseConverter):
             field=resource.manifest_field,
         )
         if resolved is None:
-            return None, "its manifest source path was rejected"
+            return (
+                None,
+                requested_logical_path,
+                "its manifest source path was rejected",
+            )
+        requested_logical_path = self._included_file_logical_name(
+            resolved.source_path,
+            resource.name,
+        )
         try:
             source_kind, separator, _remainder = (
                 resolved.source_path.partition("/")
@@ -987,7 +1610,11 @@ class AssetRegistryConverter(BaseConverter):
                 resource_type="included_file",
                 field=resource.manifest_field,
             )
-            return None, "its manifest source path was rejected"
+            return (
+                None,
+                requested_logical_path,
+                "its manifest source path was rejected",
+            )
         except ValueError as exc:
             self._report_source_path_rejection(
                 resource.source_path,
@@ -997,23 +1624,29 @@ class AssetRegistryConverter(BaseConverter):
                 resource_type="included_file",
                 field=resource.manifest_field,
             )
-            return None, "its manifest source path was rejected"
+            return (
+                None,
+                requested_logical_path,
+                "its manifest source path was rejected",
+            )
         if (
             resolved.source_path.endswith(".yy")
             or not os.path.isfile(resolved.filesystem_path)
         ):
             return (
                 None,
+                requested_logical_path,
                 f"the declared file is missing at {resolved.source_path!r}",
             )
-        return resolved.source_path, ""
+        return resolved.source_path, requested_logical_path, ""
 
     @staticmethod
     def _unavailable_outcome_resource_key(
         resource: _DeclaredRegistryResource,
     ) -> str:
         source_label = resource.source_path or resource.manifest_field or ""
-        return f"{resource.kind}:{resource.name}:{source_label}"
+        resource_name = resource.included_file_logical_path or resource.name
+        return f"{resource.kind}:{resource_name}:{source_label}"
 
     def _report_unavailable_registry_resource(
         self,
@@ -1043,16 +1676,45 @@ class AssetRegistryConverter(BaseConverter):
             )
         self._safe_log(message)
 
+    def _report_unavailable_published_included_file(
+        self,
+        unavailable: _UnavailablePublishedIncludedFile,
+    ) -> None:
+        entry = unavailable.entry
+        message = (
+            "Warning: Omitting GameMaker asset-registry Included File "
+            f"{entry.name!r} because {unavailable.reason}."
+        )
+        if self.diagnostics is not None:
+            self.diagnostics.add(
+                "warning",
+                "GM2GD-ASSET-REGISTRY-OUTPUT-UNAVAILABLE",
+                message,
+                source_path=self._diagnostic_source_path(entry.source_path),
+                resource=entry.name,
+                resource_type="included_file",
+                manifest_entry="generated Included File output",
+                workaround=(
+                    "Run the Included Files converter successfully, then retry "
+                    "asset-registry publication."
+                ),
+            )
+        self._safe_log(message)
+
     def _build_entries_from_resources(
         self,
         resources: tuple[_ProjectResource, ...],
         *,
         track_outcomes: bool = False,
+        included_file_logical_paths: tuple[str, ...] = (),
     ) -> tuple[tuple[AssetRegistryEntry, ...], int]:
         """Build entries and report how many base resources began processing."""
         self._timeline_action_source_failures.clear()
         room_order_indices = self._room_order_indices(resources)
-        godot_paths = self._stable_godot_paths(resources)
+        godot_paths = self._stable_godot_paths(
+            resources,
+            included_file_logical_paths=included_file_logical_paths,
+        )
         timeline_script_stems = self._stable_timeline_script_stems(resources)
         used_ids: set[int] = set()
         entries: list[AssetRegistryEntry] = []
@@ -1123,10 +1785,23 @@ class AssetRegistryConverter(BaseConverter):
         entries, processed_count = self._build_entries_from_resources(
             resources,
             track_outcomes=True,
+            included_file_logical_paths=plan.included_file_logical_paths,
         )
         registry_path = os.path.join(self.godot_project_path, ASSET_REGISTRY_RELATIVE_PATH)
         if processed_count < len(resources) or not self.conversion_running():
             return registry_path
+
+        entries, unavailable_outputs = self._filter_published_included_file_entries(
+            entries
+        )
+        unavailable_output_keys = {
+            self._entry_outcome_resource_key(unavailable.entry)
+            for unavailable in unavailable_outputs
+        }
+        for unavailable in unavailable_outputs:
+            resource_key = self._entry_outcome_resource_key(unavailable.entry)
+            self._resource_skipped(resource_key)
+            self._report_unavailable_published_included_file(unavailable)
 
         try:
             texture_groups, audio_groups = self.build_group_registries(entries)
@@ -1162,14 +1837,20 @@ class AssetRegistryConverter(BaseConverter):
                 registry_path,
                 registry_script,
                 confinement_root=self.godot_project_path,
+                publication_validator=lambda: self.revalidate_published_entries(
+                    entries
+                ),
             )
         except Exception:
             for resource_key in plan.resource_keys:
-                self._resource_failed(resource_key)
+                if resource_key not in unavailable_output_keys:
+                    self._resource_failed(resource_key)
             raise
 
         for resource in resources:
             resource_key = self._outcome_resource_key(resource)
+            if resource_key in unavailable_output_keys:
+                continue
             timeline_key = (resource.name, resource.source_path)
             if (
                 resource.kind == "timelines"
@@ -1193,22 +1874,26 @@ class AssetRegistryConverter(BaseConverter):
         content: str,
         *,
         confinement_root: str | None = None,
+        publication_validator: Callable[[], None] | None = None,
     ) -> None:
         """Publish generated UTF-8 text through a confined, no-follow path."""
-        output_absolute = os.path.abspath(output_path)
-        output_directory = os.path.dirname(output_absolute) or os.curdir
-        root = os.path.abspath(confinement_root or output_directory)
-        components = _asset_output_components(root, output_absolute)
-        _ensure_asset_output_root(root)
-        if _confined_asset_output_supported():
-            _atomic_write_asset_text_at(root, components, content)
-            return
-        _atomic_write_asset_text_fallback(root, components, content)
+        output_directory = os.path.dirname(os.path.abspath(output_path)) or os.curdir
+        atomic_write_confined_generated_text(
+            output_path,
+            content,
+            confinement_root=confinement_root or output_directory,
+            publication_validator=publication_validator,
+        )
 
     @staticmethod
     def _outcome_resource_key(resource: _ProjectResource) -> str:
         """Return an opaque lifecycle key for one deduplicated base resource."""
         return f"{resource.kind}:{resource.name}:{resource.source_path}"
+
+    @staticmethod
+    def _entry_outcome_resource_key(entry: AssetRegistryEntry) -> str:
+        """Return the lifecycle key for one planned base registry entry."""
+        return f"{entry.kind}:{entry.name}:{entry.source_path}"
 
     def build_group_registries(
         self,
@@ -1619,8 +2304,25 @@ class AssetRegistryConverter(BaseConverter):
     def _stable_godot_paths(
         self,
         resources: Iterable[_ProjectResource],
+        *,
+        included_file_logical_paths: Iterable[str] = (),
     ) -> dict[tuple[str, str, str], str]:
         ordered_resources = tuple(resources)
+        included_file_paths = {
+            assignment.original_logical_path: (
+                "res://included_files/" + assignment.assigned_output_path
+            )
+            for assignment in plan_included_file_paths(
+                (
+                    *included_file_logical_paths,
+                    *(
+                        resource.name
+                        for resource in ordered_resources
+                        if resource.kind == "included_files"
+                    ),
+                )
+            )
+        }
         extension_paths = collision_safe_extension_stub_resource_paths(
             (resource.name, resource.source_path)
             for resource in ordered_resources
@@ -1629,6 +2331,13 @@ class AssetRegistryConverter(BaseConverter):
         paths: dict[tuple[str, str, str], str] = {}
         used_paths: set[str] = set()
         for resource in ordered_resources:
+            if resource.kind == "included_files":
+                path = included_file_paths[
+                    posixpath.normpath(resource.name.replace("\\", "/"))
+                ]
+                used_paths.add(path.casefold())
+                paths[self._resource_key(resource)] = path
+                continue
             if resource.kind == "extensions":
                 path = extension_paths[(resource.name, resource.source_path)]
                 used_paths.add(path.casefold())
@@ -1716,7 +2425,10 @@ class AssetRegistryConverter(BaseConverter):
         if resource.kind == "shaders":
             return self._flat_resource_path("shaders", self._get_subfolder_from_resource(resource), resource.name, ".gdshader", suffix=suffix)
         if resource.kind == "included_files":
-            return "res://included_files/" + resource.name
+            return (
+                "res://included_files/"
+                + canonical_included_file_lookup_path(resource.name)
+            )
         if resource.kind == "extensions":
             return extension_stub_resource_path(
                 resource.name,
@@ -2642,5 +3354,6 @@ __all__ = [
     "GROUP_COMPATIBILITY_REPORT_RELATIVE_PATH",
     "AssetRegistryConverter",
     "AssetRegistryEntry",
+    "atomic_write_confined_generated_text",
     "render_asset_registry_script",
 ]

--- a/src/conversion/conversion_manifest.py
+++ b/src/conversion/conversion_manifest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import posixpath
 import stat
 import tempfile
 from collections.abc import Callable, Iterable, Mapping
@@ -20,6 +21,10 @@ from src.conversion.generated_paths import (
     is_snake_case_path_segment,
     res_path_segments,
     snake_case_res_path,
+)
+from src.conversion.included_file_paths import (
+    canonical_included_file_lookup_path,
+    plan_included_file_paths,
 )
 from src.conversion.project_manifest import load_gamemaker_project_manifest
 from src.conversion.type_defs import JsonDict
@@ -146,14 +151,25 @@ def write_conversion_artifacts(
     )
 
     manifest_content: bytes | None = None
+    manifest_asset_converter: AssetRegistryConverter | None = None
+    manifest_asset_entries: tuple[AssetRegistryEntry, ...] = ()
     if manifest_outcome is not None:
-        manifest_payload = build_conversion_manifest(
+        manifest_asset_converter = _asset_registry_converter(
+            gm_project_path,
+            godot_project_path,
+            macro_configuration=target_platform,
+        )
+        manifest_asset_entries = (
+            manifest_asset_converter.build_published_entries()
+        )
+        manifest_payload = _build_conversion_manifest(
             gm_project_path,
             godot_project_path,
             target_platform=target_platform,
-            enabled_converters=enabled_converter_keys,
+            enabled_converter_keys=enabled_converter_keys,
             output_snapshot=output_snapshot,
             conversion_outcome=manifest_outcome,
+            asset_entries=manifest_asset_entries,
         )
         manifest_content = _serialize_json(manifest_payload)
         manifest_status = "updated"
@@ -267,6 +283,13 @@ def write_conversion_artifacts(
                 )
                 verify_preserved_manifest()
                 _verify_artifact_target_state(target_path, target_state)
+                if (
+                    target_path == manifest_path
+                    and manifest_asset_converter is not None
+                ):
+                    manifest_asset_converter.revalidate_published_entries(
+                        manifest_asset_entries
+                    )
                 staged_artifact = staged[target_path]
                 backup = backups[target_path]
                 _publish_staged_artifact(
@@ -288,6 +311,13 @@ def write_conversion_artifacts(
                     path=target_path,
                 )
                 verify_preserved_manifest()
+                if (
+                    target_path == manifest_path
+                    and manifest_asset_converter is not None
+                ):
+                    manifest_asset_converter.revalidate_published_entries(
+                        manifest_asset_entries
+                    )
             _verify_artifact_directory(
                 godot_project_path,
                 root_identity,
@@ -383,12 +413,33 @@ def build_conversion_manifest(
         conversion_outcome,
         _planned_step_names(enabled_converter_keys),
     )
-    project_manifest = load_gamemaker_project_manifest(gm_project_path, target_platform=target_platform)
     asset_entries = _asset_registry_entries(
         gm_project_path,
         godot_project_path,
         macro_configuration=target_platform,
     )
+    return _build_conversion_manifest(
+        gm_project_path,
+        godot_project_path,
+        target_platform=target_platform,
+        enabled_converter_keys=enabled_converter_keys,
+        output_snapshot=output_snapshot,
+        conversion_outcome=conversion_outcome,
+        asset_entries=asset_entries,
+    )
+
+
+def _build_conversion_manifest(
+    gm_project_path: str,
+    godot_project_path: str,
+    *,
+    target_platform: str,
+    enabled_converter_keys: tuple[str, ...],
+    output_snapshot: ConversionOutputSnapshot,
+    conversion_outcome: ConversionOutcome,
+    asset_entries: tuple[AssetRegistryEntry, ...],
+) -> JsonDict:
+    project_manifest = load_gamemaker_project_manifest(gm_project_path, target_platform=target_platform)
     generated_files = _generated_files(godot_project_path, output_snapshot)
     return {
         "format_version": 2,
@@ -1469,7 +1520,21 @@ def _asset_registry_entries(
     *,
     macro_configuration: str | None = None,
 ) -> tuple[AssetRegistryEntry, ...]:
-    converter = AssetRegistryConverter(
+    converter = _asset_registry_converter(
+        gm_project_path,
+        godot_project_path,
+        macro_configuration=macro_configuration,
+    )
+    return converter.build_published_entries()
+
+
+def _asset_registry_converter(
+    gm_project_path: str,
+    godot_project_path: str,
+    *,
+    macro_configuration: str | None = None,
+) -> AssetRegistryConverter:
+    return AssetRegistryConverter(
         gm_project_path,
         godot_project_path,
         log_callback=lambda _message: None,
@@ -1477,7 +1542,6 @@ def _asset_registry_entries(
         conversion_running=lambda: True,
         macro_configuration=macro_configuration,
     )
-    return converter.build_entries()
 
 
 def capture_conversion_output_snapshot(godot_project_path: str) -> ConversionOutputSnapshot:
@@ -1623,13 +1687,23 @@ def _path_diagnostics(entries: tuple[AssetRegistryEntry, ...]) -> list[JsonDict]
     diagnostics: list[JsonDict] = []
     paths_by_casefold: dict[str, list[AssetRegistryEntry]] = {}
     base_paths_by_casefold: dict[str, list[tuple[AssetRegistryEntry, str]]] = {}
+    included_collision_components = _included_file_collision_components(entries)
     for entry in entries:
         if not entry.godot_path:
             continue
         paths_by_casefold.setdefault(entry.godot_path.casefold(), []).append(entry)
         base_path = _base_generated_path(entry)
         if base_path:
-            base_paths_by_casefold.setdefault(base_path.casefold(), []).append((entry, base_path))
+            collision_key = base_path.casefold()
+            if entry.kind == "included_files":
+                logical_path = posixpath.normpath(
+                    entry.name.replace("\\", "/")
+                )
+                collision_key = included_collision_components.get(
+                    logical_path,
+                    collision_key,
+                )
+            base_paths_by_casefold.setdefault(collision_key, []).append((entry, base_path))
         unsafe_segments = _unsafe_segments(entry.godot_path)
         if unsafe_segments:
             diagnostics.append({
@@ -1691,6 +1765,33 @@ def _path_diagnostics(entries: tuple[AssetRegistryEntry, ...]) -> list[JsonDict]
     return diagnostics
 
 
+def _included_file_collision_components(
+    entries: tuple[AssetRegistryEntry, ...],
+) -> dict[str, str]:
+    assignments = plan_included_file_paths(
+        entry.name
+        for entry in entries
+        if entry.kind == "included_files"
+    )
+    component_roots: dict[tuple[str, ...], str] = {}
+    for assignment in assignments:
+        if not assignment.has_collision:
+            continue
+        component_roots.setdefault(
+            assignment.collision_group,
+            (
+                "res://included_files/"
+                + assignment.canonical_lookup_path
+            ).casefold(),
+        )
+
+    return {
+        logical_path: component_root
+        for collision_group, component_root in component_roots.items()
+        for logical_path in collision_group
+    }
+
+
 def _base_generated_path(entry: AssetRegistryEntry) -> str:
     segments = res_path_segments(entry.godot_path)
     if len(segments) < 2:
@@ -1708,6 +1809,11 @@ def _base_generated_path(entry: AssetRegistryEntry) -> str:
         base_segments = list(segments)
         base_segments[-2] = generated_resource_stem(entry.name)
         return "res://" + "/".join(base_segments)
+    if kind == "included_files":
+        return (
+            "res://included_files/"
+            + canonical_included_file_lookup_path(entry.name)
+        )
     return entry.godot_path
 
 

--- a/src/conversion/gml_runtime_parts/segments/65_files_ini_json.gd
+++ b/src/conversion/gml_runtime_parts/segments/65_files_ini_json.gd
@@ -1,7 +1,8 @@
 const GML_FILE_TEXT_HANDLE_KIND = "file_text"
 const GML_FILE_BINARY_HANDLE_KIND = "file_binary"
 const GML_FILE_USER_ROOT = "user://gm2godot"
-const GML_FILE_DATAFILES_ROOT = "res://datafiles"
+const GML_FILE_INCLUDED_FILES_ROOT = "res://included_files"
+const GML_INCLUDED_FILE_REGISTRY_PATH = "res://gm2godot/gml_included_file_registry.gd"
 const GML_FILE_BIN_READ = 0
 const GML_FILE_BIN_WRITE = 1
 const GML_FILE_BIN_READ_WRITE = 2
@@ -9,6 +10,11 @@ const GML_FILE_BIN_READ_WRITE = 2
 static var _gml_ini_config = ConfigFile.new()
 static var _gml_ini_path = ""
 static var _gml_ini_open = false
+static var _gml_included_file_registry_loaded = false
+static var _gml_included_file_registry_available = false
+static var _gml_included_file_exact_paths = {}
+static var _gml_included_file_canonical_paths = {}
+static var _gml_included_file_ambiguous_paths = {}
 
 
 static func gml_file_resolve_path(path, write = false):
@@ -39,7 +45,7 @@ static func gml_file_delete(path):
 
 
 static func gml_directory_exists(path):
-	return DirAccess.dir_exists_absolute(_gml_file_resolve_path(path, false))
+	return DirAccess.dir_exists_absolute(_gml_file_resolve_path(path, false, true))
 
 
 static func gml_directory_create(path):
@@ -400,7 +406,7 @@ static func _gml_file_bin_file(file_id):
 	return null
 
 
-static func _gml_file_resolve_path(path, write = false):
+static func _gml_file_resolve_path(path, write = false, expect_directory = false):
 	var text = _gml_file_plain_path(path)
 	if text.begins_with("user://"):
 		return text
@@ -412,20 +418,144 @@ static func _gml_file_resolve_path(path, write = false):
 	var user_path = GML_FILE_USER_ROOT + "/" + relative
 	if write:
 		return user_path
-	if FileAccess.file_exists(user_path) or DirAccess.dir_exists_absolute(user_path):
+	if expect_directory and DirAccess.dir_exists_absolute(user_path):
 		return user_path
-	var data_path = GML_FILE_DATAFILES_ROOT + "/" + relative
-	if FileAccess.file_exists(data_path) or DirAccess.dir_exists_absolute(data_path):
-		return data_path
+	if not expect_directory and FileAccess.file_exists(user_path):
+		return user_path
+	var logical_path = _gml_file_registry_logical_path(relative)
+	var packaged_relative = _gml_file_packaged_relative_path(
+		logical_path if logical_path != "" else relative
+	)
+	var packaged_path = GML_FILE_INCLUDED_FILES_ROOT + "/" + packaged_relative
+	if expect_directory:
+		if DirAccess.dir_exists_absolute(packaged_path):
+			return packaged_path
+		return user_path
+
+	_gml_included_file_registry_ensure_loaded()
+	if _gml_included_file_registry_available and logical_path != "":
+		if _gml_included_file_exact_paths.has(logical_path):
+			var exact_path = _gml_included_file_registry_output_path(
+				_gml_included_file_exact_paths[logical_path]
+			)
+			if exact_path != "" and FileAccess.file_exists(exact_path):
+				return exact_path
+			return user_path
+		if _gml_included_file_ambiguous_paths.has(packaged_relative):
+			return user_path
+		if _gml_included_file_canonical_paths.has(packaged_relative):
+			var canonical_path = _gml_included_file_registry_output_path(
+				_gml_included_file_canonical_paths[packaged_relative]
+			)
+			if canonical_path != "" and FileAccess.file_exists(canonical_path):
+				return canonical_path
+			return user_path
+
+	if FileAccess.file_exists(packaged_path):
+		return packaged_path
 	return user_path
 
 
+static func _gml_included_file_registry_ensure_loaded():
+	if _gml_included_file_registry_loaded:
+		return
+	_gml_included_file_registry_loaded = true
+	_gml_included_file_registry_available = false
+	_gml_included_file_exact_paths = {}
+	_gml_included_file_canonical_paths = {}
+	_gml_included_file_ambiguous_paths = {}
+	if not ResourceLoader.exists(GML_INCLUDED_FILE_REGISTRY_PATH):
+		return
+	var registry_script = load(GML_INCLUDED_FILE_REGISTRY_PATH)
+	if registry_script == null or not registry_script.has_method("gml_included_file_registry_entries"):
+		return
+	var entries = registry_script.gml_included_file_registry_entries()
+	if not (entries is Array):
+		return
+	_gml_included_file_registry_available = true
+	var canonical_candidates = {}
+	for entry in entries:
+		if typeof(entry) != TYPE_DICTIONARY:
+			continue
+		var logical_path = _gml_file_registry_logical_path(
+			str(entry.get("logical_path", ""))
+		)
+		var canonical_path = str(entry.get("canonical_path", ""))
+		var assigned_path = str(entry.get("assigned_path", ""))
+		if (
+			logical_path == ""
+			or canonical_path == ""
+			or assigned_path == ""
+			or canonical_path != _gml_file_packaged_relative_path(logical_path)
+		):
+			continue
+		var normalized_entry = {
+			"assigned_path": assigned_path,
+			"emitted": bool(entry.get("emitted", true))
+		}
+		_gml_included_file_exact_paths[logical_path] = normalized_entry
+		if not canonical_candidates.has(canonical_path):
+			canonical_candidates[canonical_path] = []
+		canonical_candidates[canonical_path].append(normalized_entry)
+	for candidate_key in canonical_candidates:
+		var candidates = canonical_candidates[candidate_key]
+		if candidates.size() == 1:
+			_gml_included_file_canonical_paths[candidate_key] = candidates[0]
+		else:
+			_gml_included_file_ambiguous_paths[candidate_key] = true
+
+
+static func _gml_included_file_registry_output_path(entry):
+	if typeof(entry) != TYPE_DICTIONARY or not bool(entry.get("emitted", false)):
+		return ""
+	var assigned_path = str(entry.get("assigned_path", ""))
+	if (
+		assigned_path == ""
+		or _gml_file_registry_logical_path(assigned_path) != assigned_path
+	):
+		return ""
+	return GML_FILE_INCLUDED_FILES_ROOT + "/" + assigned_path
+
+
+static func _gml_file_registry_logical_path(path):
+	var components = []
+	for component in str(path).replace("\\", "/").split("/", false):
+		if component == ".":
+			continue
+		if component == "..":
+			if components.is_empty():
+				return ""
+			components.pop_back()
+			continue
+		components.append(component)
+	var normalized = ""
+	for component in components:
+		if normalized != "":
+			normalized += "/"
+		normalized += str(component)
+	return normalized
+
+
+static func _gml_file_packaged_relative_path(path):
+	var text = str(path)
+	var normalized = ""
+	for index in range(text.length()):
+		var code = text.unicode_at(index)
+		if code >= 65 and code <= 90:
+			normalized += char(code + 32)
+		elif code == 32:
+			normalized += "_"
+		else:
+			normalized += char(code)
+	return normalized
+
+
 static func _gml_file_plain_path(path):
-	return str(path).replace("\\", "/").strip_edges()
+	return str(path).replace("\\", "/")
 
 
 static func _gml_file_relative_path(path):
-	var relative = str(path).replace("\\", "/").strip_edges()
+	var relative = str(path).replace("\\", "/")
 	while relative.begins_with("./"):
 		relative = relative.substr(2)
 	while relative.begins_with("/"):

--- a/src/conversion/included_file_paths.py
+++ b/src/conversion/included_file_paths.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import ntpath
+import posixpath
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from src.conversion.project_source_paths import ProjectSourcePathError
+
+
+_ASCII_LOOKUP_TRANSLATION = str.maketrans(
+    {
+        **{
+            chr(codepoint): chr(codepoint + (ord("a") - ord("A")))
+            for codepoint in range(ord("A"), ord("Z") + 1)
+        },
+        " ": "_",
+    }
+)
+
+
+@dataclass(frozen=True)
+class IncludedFilePathAssignment:
+    """One stable Included File lookup-to-output path assignment.
+
+    ``collision_group`` contains every logical path in the connected
+    normalization or file/directory-prefix collision. ``has_collision`` marks
+    assignments at that group's deterministic reporting path, allowing the
+    converter to emit the complete group once while retaining each member's
+    own canonical lookup path.
+    """
+
+    original_logical_path: str
+    canonical_lookup_path: str
+    assigned_output_path: str
+    collision_group: tuple[str, ...]
+    has_collision: bool
+
+
+def canonical_included_file_lookup_path(logical_path: str) -> str:
+    """Return GameMaker's portable packaged-file lookup form.
+
+    GameMaker's documented Included File lookup normalization is ASCII-style:
+    ordinary uppercase Latin letters become lowercase and spaces become
+    underscores. Other characters remain unchanged. Path separators and dot
+    segments are normalized before applying those filename rules.
+    """
+
+    return _canonical_posix_relative_path(logical_path).translate(
+        _ASCII_LOOKUP_TRANSLATION
+    )
+
+
+def plan_included_file_paths(
+    logical_paths: Iterable[str],
+) -> tuple[IncludedFilePathAssignment, ...]:
+    """Assign deterministic, collision-safe output paths to Included Files.
+
+    Duplicate aliases of the same normalized logical path describe one file
+    and are coalesced. Every natural canonical lookup path is reserved before
+    collision suffixes are allocated, so a generated ``_2`` path can never
+    displace an actual file whose canonical name already ends in ``_2``.
+    """
+
+    normalized_paths = {
+        _canonical_posix_relative_path(logical_path)
+        for logical_path in logical_paths
+    }
+    groups: dict[str, list[str]] = defaultdict(list)
+    for logical_path in normalized_paths:
+        groups[_ascii_lookup_path(logical_path)].append(logical_path)
+
+    canonical_paths = set(groups)
+    canonical_directory_paths = {
+        directory
+        for canonical_path in canonical_paths
+        for directory in _parent_paths(canonical_path)
+    }
+    component_roots = {
+        canonical_path: _collision_component_root(
+            canonical_path,
+            canonical_paths,
+        )
+        for canonical_path in canonical_paths
+    }
+    component_paths: dict[str, list[str]] = defaultdict(list)
+    for canonical_path, component_root in component_roots.items():
+        component_paths[component_root].append(canonical_path)
+
+    collision_groups: dict[str, tuple[str, ...]] = {}
+    collision_roots: set[str] = set()
+    for component_root, component_members in component_paths.items():
+        ordered_component_paths = sorted(component_members)
+        logical_group = tuple(
+            logical_path
+            for canonical_path in ordered_component_paths
+            for logical_path in _ordered_logical_group(
+                canonical_path,
+                groups[canonical_path],
+            )
+        )
+        has_collision = (
+            len(ordered_component_paths) > 1
+            or len(logical_group) > 1
+        )
+        if has_collision:
+            collision_roots.add(component_root)
+        for canonical_path in ordered_component_paths:
+            collision_groups[canonical_path] = logical_group
+
+    reserved_paths = canonical_paths
+    assigned_paths: set[str] = set()
+    assigned_directory_paths: set[str] = set()
+    assignments: list[IncludedFilePathAssignment] = []
+
+    for canonical_path in sorted(groups):
+        logical_group = _ordered_logical_group(
+            canonical_path,
+            groups[canonical_path],
+        )
+        blocks_canonical_directory = canonical_path in canonical_directory_paths
+        component_root = component_roots[canonical_path]
+        collision_group = collision_groups[canonical_path]
+        reports_collision = (
+            component_root in collision_roots
+            and canonical_path == component_root
+        )
+        for group_index, logical_path in enumerate(logical_group):
+            if group_index == 0 and not blocks_canonical_directory:
+                output_path = canonical_path
+            else:
+                suffix_index = 2
+                while True:
+                    candidate = _path_with_suffix(canonical_path, suffix_index)
+                    if _path_is_available(
+                        candidate,
+                        reserved_paths=reserved_paths,
+                        canonical_directory_paths=canonical_directory_paths,
+                        assigned_paths=assigned_paths,
+                        assigned_directory_paths=assigned_directory_paths,
+                    ):
+                        output_path = candidate
+                        break
+                    suffix_index += 1
+
+            assigned_paths.add(output_path)
+            assigned_directory_paths.update(_parent_paths(output_path))
+            assignments.append(
+                IncludedFilePathAssignment(
+                    original_logical_path=logical_path,
+                    canonical_lookup_path=canonical_path,
+                    assigned_output_path=output_path,
+                    collision_group=collision_group,
+                    has_collision=reports_collision,
+                )
+            )
+
+    return tuple(
+        sorted(
+            assignments,
+            key=lambda assignment: assignment.original_logical_path,
+        )
+    )
+
+
+def _canonical_posix_relative_path(logical_path: str) -> str:
+    normalized_path = logical_path.replace("\\", "/")
+    if not normalized_path or "\0" in normalized_path:
+        raise ProjectSourcePathError(
+            f"Included File logical path is empty or invalid: {logical_path!r}"
+        )
+
+    normalized_path = posixpath.normpath(normalized_path)
+    if normalized_path in {"", "."}:
+        raise ProjectSourcePathError(
+            "Included File logical path does not name a project file: "
+            f"{logical_path!r}"
+        )
+    drive, _tail = ntpath.splitdrive(normalized_path)
+    if drive or normalized_path.startswith("/"):
+        raise ProjectSourcePathError(
+            "Included File logical path must be relative to the selected "
+            f"GameMaker project root: {logical_path!r}"
+        )
+    if normalized_path == ".." or normalized_path.startswith("../"):
+        raise ProjectSourcePathError(
+            "Included File logical path escapes the selected GameMaker "
+            f"project root through traversal: {logical_path!r}"
+        )
+    return normalized_path
+
+
+def _ascii_lookup_path(logical_path: str) -> str:
+    return logical_path.translate(_ASCII_LOOKUP_TRANSLATION)
+
+
+def _ordered_logical_group(
+    canonical_path: str,
+    logical_paths: Iterable[str],
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            logical_paths,
+            key=lambda logical_path: (
+                logical_path != canonical_path,
+                logical_path,
+            ),
+        )
+    )
+
+
+def _parent_paths(path: str) -> tuple[str, ...]:
+    parts = path.split("/")
+    return tuple(
+        "/".join(parts[:component_count])
+        for component_count in range(1, len(parts))
+    )
+
+
+def _collision_component_root(
+    canonical_path: str,
+    canonical_paths: set[str],
+) -> str:
+    for parent_path in _parent_paths(canonical_path):
+        if parent_path in canonical_paths:
+            return parent_path
+    return canonical_path
+
+
+def _path_is_available(
+    candidate: str,
+    *,
+    reserved_paths: set[str],
+    canonical_directory_paths: set[str],
+    assigned_paths: set[str],
+    assigned_directory_paths: set[str],
+) -> bool:
+    if (
+        candidate in reserved_paths
+        or candidate in canonical_directory_paths
+        or candidate in assigned_paths
+        or candidate in assigned_directory_paths
+    ):
+        return False
+    return not any(parent_path in assigned_paths for parent_path in _parent_paths(candidate))
+
+
+def _path_with_suffix(canonical_path: str, suffix_index: int) -> str:
+    directory, filename = posixpath.split(canonical_path)
+    stem, extension = posixpath.splitext(filename)
+    suffixed_filename = f"{stem}_{suffix_index}{extension}"
+    if not directory:
+        return suffixed_filename
+    return posixpath.join(directory, suffixed_filename)

--- a/src/conversion/included_file_registry.py
+++ b/src/conversion/included_file_registry.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Collection, Iterable
+from dataclasses import dataclass
+
+from src.conversion.asset_registry import atomic_write_confined_generated_text
+from src.conversion.included_file_paths import IncludedFilePathAssignment
+from src.conversion.type_defs import JsonDict
+
+
+INCLUDED_FILE_REGISTRY_RELATIVE_PATH = os.path.join(
+    "gm2godot",
+    "gml_included_file_registry.gd",
+)
+INCLUDED_FILE_REGISTRY_RESOURCE_PATH = (
+    "res://gm2godot/gml_included_file_registry.gd"
+)
+
+
+@dataclass(frozen=True)
+class IncludedFileRegistryEntry:
+    logical_path: str
+    canonical_path: str
+    assigned_path: str
+    emitted: bool
+
+    def to_godot_dict(self) -> JsonDict:
+        return {
+            "logical_path": self.logical_path,
+            "canonical_path": self.canonical_path,
+            "assigned_path": self.assigned_path,
+            "emitted": self.emitted,
+        }
+
+
+def build_included_file_registry_entries(
+    assignments: Iterable[IncludedFilePathAssignment],
+    emitted_logical_paths: Collection[str],
+) -> tuple[IncludedFileRegistryEntry, ...]:
+    """Return stable runtime entries for one finalized conversion attempt.
+
+    Planned-but-unavailable entries remain in the registry with ``emitted``
+    false. This lets runtime lookup reject a known missing or ambiguous source
+    instead of falling through to another file with the same packaged name.
+    """
+
+    emitted_paths = set(emitted_logical_paths)
+    entries = (
+        IncludedFileRegistryEntry(
+            logical_path=assignment.original_logical_path,
+            canonical_path=assignment.canonical_lookup_path,
+            assigned_path=assignment.assigned_output_path,
+            emitted=assignment.original_logical_path in emitted_paths,
+        )
+        for assignment in assignments
+    )
+    return tuple(
+        sorted(
+            entries,
+            key=lambda entry: (
+                entry.logical_path,
+                entry.canonical_path,
+                entry.assigned_path,
+            ),
+        )
+    )
+
+
+def render_included_file_registry_script(
+    entries: Iterable[IncludedFileRegistryEntry],
+) -> str:
+    ordered_entries = sorted(
+        entries,
+        key=lambda entry: (
+            entry.logical_path,
+            entry.canonical_path,
+            entry.assigned_path,
+        ),
+    )
+    payload = [entry.to_godot_dict() for entry in ordered_entries]
+    entries_literal = json.dumps(
+        payload,
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    )
+    return (
+        "extends RefCounted\n\n"
+        "const FORMAT_VERSION = 1\n"
+        f"const INCLUDED_FILES = {entries_literal}\n\n"
+        "static func gml_included_file_registry_entries():\n"
+        "\treturn INCLUDED_FILES\n"
+    )
+
+
+def render_included_file_registry(
+    assignments: Iterable[IncludedFilePathAssignment],
+    emitted_logical_paths: Collection[str],
+) -> str:
+    """Render the authoritative registry for one Included Files output set."""
+
+    return render_included_file_registry_script(
+        build_included_file_registry_entries(
+            assignments,
+            emitted_logical_paths,
+        )
+    )
+
+
+def write_included_file_registry(
+    godot_project_path: str,
+    assignments: Iterable[IncludedFilePathAssignment],
+    emitted_logical_paths: Collection[str],
+) -> str:
+    """Atomically publish the Included File lookup registry."""
+
+    registry_path = os.path.join(
+        godot_project_path,
+        INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+    )
+    atomic_write_confined_generated_text(
+        registry_path,
+        render_included_file_registry(
+            assignments,
+            emitted_logical_paths,
+        ),
+        confinement_root=godot_project_path,
+    )
+    return registry_path
+
+
+__all__ = [
+    "INCLUDED_FILE_REGISTRY_RELATIVE_PATH",
+    "INCLUDED_FILE_REGISTRY_RESOURCE_PATH",
+    "IncludedFileRegistryEntry",
+    "build_included_file_registry_entries",
+    "render_included_file_registry",
+    "render_included_file_registry_script",
+    "write_included_file_registry",
+]

--- a/src/conversion/included_files.py
+++ b/src/conversion/included_files.py
@@ -1,16 +1,30 @@
 from __future__ import annotations
 
+import ctypes
+import hashlib
 import os
 import posixpath
+import secrets
 import stat
-import shutil
+import sys
+import tempfile
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from typing import BinaryIO
+from typing import BinaryIO, Callable, cast
 
 from src.localization import get_localized
+from src.conversion.asset_registry import atomic_write_confined_generated_text
 from src.conversion.base_converter import BaseConverter
 from src.conversion.diagnostics import DiagnosticCollector
+from src.conversion.included_file_paths import (
+    IncludedFilePathAssignment,
+    canonical_included_file_lookup_path,
+    plan_included_file_paths,
+)
+from src.conversion.included_file_registry import (
+    INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+    render_included_file_registry,
+)
 from src.conversion.project_manifest import (
     GameMakerProjectManifest,
     ProjectManifestDiagnostic,
@@ -45,6 +59,3416 @@ class _IncludedFileConversionPlan:
     skipped_keys: tuple[str, ...]
 
 
+_PathIdentity = tuple[int, int]
+_PathFingerprint = tuple[int, int, int, int, int, int]
+_IncludedSourceFingerprint = tuple[int, int, int, int, int, int]
+_INCLUDED_FILES_ROOT_NAME = "included_files"
+_INCLUDED_FILES_STAGE_PREFIX = ".gm2godot-included-files-"
+
+
+@dataclass(frozen=True)
+class _IncludedCopyReceipt:
+    source_fingerprint: _IncludedSourceFingerprint
+    byte_count: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class _IncludedTreeEntry:
+    relative_path: str
+    kind: str
+    fingerprint: _PathFingerprint
+    ctime_ns: int | None
+    content_sha256: str | None
+
+
+@dataclass(frozen=True)
+class _IncludedTreeSnapshot:
+    root_fingerprint: _PathFingerprint | None
+    entries: tuple[_IncludedTreeEntry, ...]
+
+    @property
+    def identity(self) -> _PathIdentity | None:
+        if self.root_fingerprint is None:
+            return None
+        return self.root_fingerprint[:2]
+
+
+@dataclass(frozen=True)
+class _IncludedRegistrySnapshot:
+    directory_identity: _PathIdentity | None
+    file_identity: _PathIdentity | None
+    file_mode: int | None
+    content: bytes | None
+
+
+@dataclass(frozen=True)
+class _IncludedOutputSetTransaction:
+    project_identity: _PathIdentity
+    stage_container_path: str
+    stage_container_identity: _PathIdentity
+    staged_root_path: str
+    staged_root_snapshot: _IncludedTreeSnapshot
+    staged_registry_path: str
+    staged_registry_identity: _PathIdentity
+    staged_registry_content: bytes
+    previous_root_snapshot: _IncludedTreeSnapshot
+    previous_registry_snapshot: _IncludedRegistrySnapshot
+
+
+class _IncludedOutputSetCancelled(Exception):
+    """Signal cancellation while a reversible output-set commit is active."""
+
+
+_DIRECTORY_OPEN_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_DIRECTORY", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+
+
+def _included_descriptor_paths_supported() -> bool:
+    return (
+        os.name != "nt"
+        and hasattr(os, "O_DIRECTORY")
+        and hasattr(os, "O_NOFOLLOW")
+        and os.chmod in os.supports_fd
+        and os.listdir in os.supports_fd
+        and all(
+            operation in os.supports_dir_fd
+            for operation in (
+                os.mkdir,
+                os.open,
+                os.rmdir,
+                os.stat,
+                os.unlink,
+            )
+        )
+    )
+
+
+def _included_native_noreplace_available() -> bool:
+    return sys.platform == "darwin" or sys.platform.startswith("linux")
+
+
+def _open_pinned_included_directory(path: str) -> int:
+    if not _included_descriptor_paths_supported():
+        raise OSError("Descriptor-pinned Included Files paths are unavailable")
+    absolute_path = os.path.abspath(path)
+    components = [
+        component for component in absolute_path.split(os.sep) if component
+    ]
+    if not components:
+        return os.open(os.sep, _DIRECTORY_OPEN_FLAGS)
+    platform_anchor = os.path.join(os.sep, components[0])
+    resolved_anchor = os.path.realpath(platform_anchor)
+    current_fd = os.open(resolved_anchor, _DIRECTORY_OPEN_FLAGS)
+    try:
+        for component in components[1:]:
+            child_fd = os.open(
+                component,
+                _DIRECTORY_OPEN_FLAGS,
+                dir_fd=current_fd,
+            )
+            os.close(current_fd)
+            current_fd = child_fd
+        return current_fd
+    except BaseException:
+        os.close(current_fd)
+        raise
+
+
+def _open_pinned_included_parent(path: str) -> tuple[int, str]:
+    absolute_path = os.path.abspath(path)
+    parent_path, name = os.path.split(absolute_path)
+    if not name:
+        raise OSError(f"Included Files path has no movable leaf: {path}")
+    return _open_pinned_included_directory(parent_path), name
+
+
+def _directory_identity_from_fd(directory_fd: int) -> _PathIdentity:
+    directory_stat = os.fstat(directory_fd)
+    if not stat.S_ISDIR(directory_stat.st_mode):
+        raise OSError("Pinned Included Files descriptor is not a directory")
+    return directory_stat.st_dev, directory_stat.st_ino
+
+
+def _verify_included_directory_fd(
+    directory_fd: int,
+    expected_identity: _PathIdentity | None,
+    display_path: str,
+) -> _PathIdentity:
+    current_identity = _directory_identity_from_fd(directory_fd)
+    if expected_identity is not None and current_identity != expected_identity:
+        raise OSError(f"Included Files directory changed: {display_path}")
+    return current_identity
+
+
+def _included_entry_stat_at(
+    parent_fd: int,
+    name: str,
+) -> os.stat_result | None:
+    try:
+        return os.stat(
+            name,
+            dir_fd=parent_fd,
+            follow_symlinks=False,
+        )
+    except FileNotFoundError:
+        return None
+
+
+def _verify_included_entry_at(
+    parent_fd: int,
+    name: str,
+    expected_fingerprint: _PathFingerprint,
+    display_path: str,
+) -> None:
+    current_stat = _included_entry_stat_at(parent_fd, name)
+    if (
+        current_stat is None
+        or _included_path_fingerprint(current_stat) != expected_fingerprint
+    ):
+        raise OSError(f"Included Files entry changed: {display_path}")
+
+
+def _rename_included_transaction_entry_at(
+    source_parent_fd: int,
+    source_name: str,
+    destination_parent_fd: int,
+    destination_name: str,
+) -> None:
+    if not _included_native_noreplace_available():
+        raise OSError(
+            "Atomic non-replacing Included Files rename is unavailable on "
+            f"{sys.platform}"
+        )
+    libc = ctypes.CDLL(None, use_errno=True)
+    function_name = (
+        "renameatx_np" if sys.platform == "darwin" else "renameat2"
+    )
+    raw_function = getattr(libc, function_name, None)
+    if raw_function is None:
+        raise OSError(
+            f"Atomic non-replacing Included Files rename is unavailable: {function_name}"
+        )
+    rename_function = cast(
+        Callable[[int, bytes, int, bytes, int], int],
+        raw_function,
+    )
+    rename_exclusive_flag = 0x00000004 if sys.platform == "darwin" else 1
+    ctypes.set_errno(0)
+    result = rename_function(
+        source_parent_fd,
+        os.fsencode(source_name),
+        destination_parent_fd,
+        os.fsencode(destination_name),
+        rename_exclusive_flag,
+    )
+    if result != 0:
+        error_number = ctypes.get_errno()
+        raise OSError(
+            error_number,
+            os.strerror(error_number),
+            destination_name,
+        )
+
+
+def _before_included_transaction_rename(
+    _source_parent_fd: int,
+    _source_name: str,
+) -> None:
+    """Narrow test seam immediately before a namespace mutation."""
+
+
+def _before_included_transaction_rename_fallback(
+    _source: str,
+    _destination: str,
+) -> None:
+    """Narrow fallback test seam immediately before a namespace mutation."""
+
+
+def _preserve_or_restore_unexpected_moved_entry_at(
+    source_parent_fd: int,
+    source_name: str,
+    destination_parent_fd: int,
+    destination_name: str,
+    source_display_path: str,
+    destination_display_path: str,
+) -> OSError:
+    try:
+        _rename_included_transaction_entry_at(
+            destination_parent_fd,
+            destination_name,
+            source_parent_fd,
+            source_name,
+        )
+    except OSError as restore_error:
+        destination_parent_path = os.path.dirname(destination_display_path)
+        quarantine_name = (
+            f".{os.path.basename(destination_display_path)}."
+            f"{secrets.token_hex(8)}.quarantine"
+        )
+        quarantine_path = os.path.join(
+            destination_parent_path,
+            quarantine_name,
+        )
+        try:
+            _rename_included_transaction_entry_at(
+                destination_parent_fd,
+                destination_name,
+                destination_parent_fd,
+                quarantine_name,
+            )
+        except OSError as quarantine_error:
+            error = OSError(
+                "Unexpected Included Files replacement was preserved at "
+                f"{destination_display_path!r}; automatic restore to "
+                f"{source_display_path!r} failed"
+            )
+            error.add_note(f"Restore error: {restore_error}")
+            error.add_note(f"Quarantine error: {quarantine_error}")
+            return error
+        error = OSError(
+            "Unexpected Included Files replacement was preserved at "
+            f"recoverable quarantine path {quarantine_path!r}; automatic "
+            f"restore to {source_display_path!r} failed"
+        )
+        error.add_note(f"Restore error: {restore_error}")
+        return error
+    return OSError(
+        "Unexpected Included Files replacement was restored without loss to "
+        f"{source_display_path!r}; refused transaction move to "
+        f"{destination_display_path!r}"
+    )
+
+
+def _preserve_or_restore_unexpected_moved_entry_fallback(
+    source: str,
+    destination: str,
+) -> OSError:
+    try:
+        _rename_included_transaction_entry(destination, source)
+    except OSError as restore_error:
+        quarantine_path = (
+            destination
+            + "."
+            + secrets.token_hex(8)
+            + ".quarantine"
+        )
+        try:
+            _rename_included_transaction_entry(destination, quarantine_path)
+        except OSError as quarantine_error:
+            error = OSError(
+                "Unexpected Included Files replacement was preserved at "
+                f"{destination!r}; automatic restore to {source!r} failed"
+            )
+            error.add_note(f"Restore error: {restore_error}")
+            error.add_note(f"Quarantine error: {quarantine_error}")
+            return error
+        error = OSError(
+            "Unexpected Included Files replacement was preserved at "
+            f"recoverable quarantine path {quarantine_path!r}; automatic "
+            f"restore to {source!r} failed"
+        )
+        error.add_note(f"Restore error: {restore_error}")
+        return error
+    return OSError(
+        "Unexpected Included Files replacement was restored without loss to "
+        f"{source!r}; refused transaction move to {destination!r}"
+    )
+
+
+def _included_output_path_is_redirected(
+    path: str,
+    path_stat: os.stat_result,
+) -> bool:
+    if stat.S_ISLNK(path_stat.st_mode):
+        return True
+    junction_candidate: object = getattr(os.path, "isjunction", None)
+    if not callable(junction_candidate):
+        return False
+    junction_checker = cast(Callable[[str], bool], junction_candidate)
+    return junction_checker(path)
+
+
+def _included_path_fingerprint(path_stat: os.stat_result) -> _PathFingerprint:
+    return (
+        path_stat.st_dev,
+        path_stat.st_ino,
+        path_stat.st_mode,
+        path_stat.st_size,
+        path_stat.st_mtime_ns,
+        path_stat.st_nlink,
+    )
+
+
+def _included_source_fingerprint(
+    source_stat: os.stat_result,
+) -> _IncludedSourceFingerprint:
+    return (
+        source_stat.st_dev,
+        source_stat.st_ino,
+        source_stat.st_mode,
+        source_stat.st_size,
+        source_stat.st_mtime_ns,
+        source_stat.st_ctime_ns,
+    )
+
+
+def _digest_open_included_file(
+    opened_file: BinaryIO,
+) -> tuple[int, str]:
+    digest = hashlib.sha256()
+    byte_count = 0
+    while True:
+        chunk = opened_file.read(1024 * 1024)
+        if not chunk:
+            break
+        digest.update(chunk)
+        byte_count += len(chunk)
+    return byte_count, digest.hexdigest()
+
+
+def _digest_included_regular_file(
+    path: str,
+    expected_stat: os.stat_result,
+) -> str:
+    expected_fingerprint = _included_path_fingerprint(expected_stat)
+    expected_ctime_ns = expected_stat.st_ctime_ns
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    file_descriptor = os.open(path, flags)
+    try:
+        opened_stat = os.fstat(file_descriptor)
+        if (
+            not stat.S_ISREG(opened_stat.st_mode)
+            or _included_path_fingerprint(opened_stat) != expected_fingerprint
+            or opened_stat.st_ctime_ns != expected_ctime_ns
+        ):
+            raise OSError(f"Included Files file changed before hashing: {path}")
+        with os.fdopen(file_descriptor, "rb") as opened_file:
+            file_descriptor = -1
+            byte_count, content_sha256 = _digest_open_included_file(opened_file)
+    finally:
+        if file_descriptor >= 0:
+            os.close(file_descriptor)
+
+    current_stat = os.lstat(path)
+    if (
+        _included_output_path_is_redirected(path, current_stat)
+        or not stat.S_ISREG(current_stat.st_mode)
+        or _included_path_fingerprint(current_stat) != expected_fingerprint
+        or current_stat.st_ctime_ns != expected_ctime_ns
+        or byte_count != expected_stat.st_size
+    ):
+        raise OSError(f"Included Files file changed while hashing: {path}")
+    return content_sha256
+
+
+def _capture_fallback_directory_ancestors(
+    directory_path: str,
+) -> tuple[tuple[str, _PathIdentity], ...]:
+    absolute_path = os.path.abspath(directory_path)
+    drive, tail = os.path.splitdrive(absolute_path)
+    anchor = drive + os.sep
+    components = [component for component in tail.split(os.sep) if component]
+    if components:
+        platform_anchor = os.path.join(anchor, components[0])
+        current_path = os.path.realpath(platform_anchor)
+        remaining_components = components[1:]
+    else:
+        current_path = anchor
+        remaining_components = []
+    identities: list[tuple[str, _PathIdentity]] = []
+    for component in (None, *remaining_components):
+        if component is not None:
+            current_path = os.path.join(current_path, component)
+        try:
+            current_stat = os.lstat(current_path)
+        except OSError as error:
+            raise OSError(
+                f"Included Files directory ancestor changed: {current_path}"
+            ) from error
+        if (
+            _included_output_path_is_redirected(current_path, current_stat)
+            or not stat.S_ISDIR(current_stat.st_mode)
+        ):
+            raise OSError(
+                f"Refusing redirected or non-directory Included Files ancestor: "
+                f"{current_path}"
+            )
+        identities.append(
+            (current_path, (current_stat.st_dev, current_stat.st_ino))
+        )
+    return tuple(identities)
+
+
+def _verify_fallback_directory_ancestors(
+    identities: tuple[tuple[str, _PathIdentity], ...],
+) -> None:
+    for directory_path, expected_identity in identities:
+        try:
+            current_stat = os.lstat(directory_path)
+        except OSError as error:
+            raise OSError(
+                f"Included Files directory ancestor changed: {directory_path}"
+            ) from error
+        if (
+            _included_output_path_is_redirected(directory_path, current_stat)
+            or not stat.S_ISDIR(current_stat.st_mode)
+            or (current_stat.st_dev, current_stat.st_ino) != expected_identity
+        ):
+            raise OSError(
+                f"Included Files directory ancestor changed: {directory_path}"
+            )
+
+
+def _included_directory_identity(path: str) -> _PathIdentity | None:
+    if _included_descriptor_paths_supported():
+        try:
+            directory_fd = _open_pinned_included_directory(path)
+        except FileNotFoundError:
+            return None
+        except OSError as error:
+            raise OSError(
+                f"Refusing redirected or non-directory Included Files path: {path}"
+            ) from error
+        try:
+            return _directory_identity_from_fd(directory_fd)
+        finally:
+            os.close(directory_fd)
+
+    parent_path = os.path.dirname(os.path.abspath(path))
+    parent_identities = _capture_fallback_directory_ancestors(parent_path)
+    try:
+        path_stat = os.lstat(path)
+    except FileNotFoundError:
+        _verify_fallback_directory_ancestors(parent_identities)
+        return None
+    if (
+        _included_output_path_is_redirected(path, path_stat)
+        or not stat.S_ISDIR(path_stat.st_mode)
+    ):
+        raise OSError(f"Refusing redirected or non-directory Included Files path: {path}")
+    _verify_fallback_directory_ancestors(parent_identities)
+    return (path_stat.st_dev, path_stat.st_ino)
+
+
+def _included_regular_file_state_at(
+    parent_fd: int,
+    name: str,
+    display_path: str,
+    *,
+    allowed_identities: frozenset[_PathIdentity] | None = None,
+) -> tuple[_PathIdentity, int, bytes] | None:
+    path_stat = _included_entry_stat_at(parent_fd, name)
+    if path_stat is None:
+        return None
+    if not stat.S_ISREG(path_stat.st_mode):
+        raise OSError(
+            f"Refusing redirected or non-regular Included Files path: {display_path}"
+        )
+    path_identity = path_stat.st_dev, path_stat.st_ino
+    if (
+        allowed_identities is not None
+        and path_identity not in allowed_identities
+    ):
+        raise OSError(
+            f"Included Files path changed before reading: {display_path}"
+        )
+    expected_fingerprint = _included_path_fingerprint(path_stat)
+    expected_ctime_ns = path_stat.st_ctime_ns
+    file_descriptor = os.open(
+        name,
+        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        dir_fd=parent_fd,
+    )
+    try:
+        opened_stat = os.fstat(file_descriptor)
+        if (
+            not stat.S_ISREG(opened_stat.st_mode)
+            or _included_path_fingerprint(opened_stat) != expected_fingerprint
+            or opened_stat.st_ctime_ns != expected_ctime_ns
+        ):
+            raise OSError(
+                f"Included Files path changed while reading: {display_path}"
+            )
+        with os.fdopen(file_descriptor, "rb") as opened_file:
+            file_descriptor = -1
+            content = opened_file.read()
+    finally:
+        if file_descriptor >= 0:
+            os.close(file_descriptor)
+    current_stat = _included_entry_stat_at(parent_fd, name)
+    if (
+        current_stat is None
+        or not stat.S_ISREG(current_stat.st_mode)
+        or _included_path_fingerprint(current_stat) != expected_fingerprint
+        or current_stat.st_ctime_ns != expected_ctime_ns
+    ):
+        raise OSError(
+            f"Included Files path changed while reading: {display_path}"
+        )
+    return (
+        (current_stat.st_dev, current_stat.st_ino),
+        stat.S_IMODE(current_stat.st_mode),
+        content,
+    )
+
+
+def _before_included_fallback_regular_file_open(_path: str) -> None:
+    """Narrow test seam before opening a fallback regular-file path."""
+
+
+def _included_regular_file_state(
+    path: str,
+    *,
+    expected_parent_identity: _PathIdentity | None = None,
+    expected_fallback_ancestors: (
+        tuple[tuple[str, _PathIdentity], ...] | None
+    ) = None,
+    allowed_identities: frozenset[_PathIdentity] | None = None,
+) -> tuple[_PathIdentity, int, bytes] | None:
+    if _included_descriptor_paths_supported():
+        try:
+            parent_fd, name = _open_pinned_included_parent(path)
+        except FileNotFoundError:
+            return None
+        try:
+            _verify_included_directory_fd(
+                parent_fd,
+                expected_parent_identity,
+                os.path.dirname(path),
+            )
+            return _included_regular_file_state_at(
+                parent_fd,
+                name,
+                path,
+                allowed_identities=allowed_identities,
+            )
+        finally:
+            os.close(parent_fd)
+
+    parent_path = os.path.dirname(os.path.abspath(path))
+    if expected_fallback_ancestors is None:
+        parent_identities = _capture_fallback_directory_ancestors(parent_path)
+    else:
+        parent_identities = expected_fallback_ancestors
+        if (
+            not parent_identities
+            or os.path.normcase(os.path.abspath(parent_identities[-1][0]))
+            != os.path.normcase(parent_path)
+        ):
+            raise OSError(
+                f"Included Files fallback ancestry does not bind parent: {path}"
+            )
+    if (
+        expected_parent_identity is not None
+        and parent_identities[-1][1] != expected_parent_identity
+    ):
+        raise OSError(f"Included Files file parent changed: {path}")
+    try:
+        path_stat = os.lstat(path)
+    except FileNotFoundError:
+        _verify_fallback_directory_ancestors(parent_identities)
+        return None
+    if (
+        _included_output_path_is_redirected(path, path_stat)
+        or not stat.S_ISREG(path_stat.st_mode)
+    ):
+        raise OSError(f"Refusing redirected or non-regular Included Files path: {path}")
+    path_identity = path_stat.st_dev, path_stat.st_ino
+    if (
+        allowed_identities is not None
+        and path_identity not in allowed_identities
+    ):
+        raise OSError(f"Included Files path changed before reading: {path}")
+
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    _verify_fallback_directory_ancestors(parent_identities)
+    _before_included_fallback_regular_file_open(path)
+    file_descriptor = os.open(path, flags)
+    try:
+        opened_stat = os.fstat(file_descriptor)
+        if not stat.S_ISREG(opened_stat.st_mode) or not os.path.samestat(
+            path_stat,
+            opened_stat,
+        ):
+            raise OSError(f"Included Files path changed while reading: {path}")
+        _verify_fallback_directory_ancestors(parent_identities)
+        with os.fdopen(file_descriptor, "rb") as opened_file:
+            file_descriptor = -1
+            content = opened_file.read()
+    finally:
+        if file_descriptor >= 0:
+            os.close(file_descriptor)
+
+    current_stat = os.lstat(path)
+    if (
+        _included_output_path_is_redirected(path, current_stat)
+        or not stat.S_ISREG(current_stat.st_mode)
+        or _included_path_fingerprint(current_stat)
+        != _included_path_fingerprint(path_stat)
+        or current_stat.st_ctime_ns != path_stat.st_ctime_ns
+    ):
+        raise OSError(f"Included Files path changed while reading: {path}")
+    _verify_fallback_directory_ancestors(parent_identities)
+    return (
+        (current_stat.st_dev, current_stat.st_ino),
+        stat.S_IMODE(current_stat.st_mode),
+        content,
+    )
+
+
+def _digest_included_regular_file_at(
+    parent_fd: int,
+    name: str,
+    expected_stat: os.stat_result,
+    display_path: str,
+) -> str:
+    expected_fingerprint = _included_path_fingerprint(expected_stat)
+    expected_ctime_ns = expected_stat.st_ctime_ns
+    file_descriptor = os.open(
+        name,
+        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        dir_fd=parent_fd,
+    )
+    try:
+        opened_stat = os.fstat(file_descriptor)
+        if (
+            not stat.S_ISREG(opened_stat.st_mode)
+            or _included_path_fingerprint(opened_stat) != expected_fingerprint
+            or opened_stat.st_ctime_ns != expected_ctime_ns
+        ):
+            raise OSError(
+                f"Included Files file changed before hashing: {display_path}"
+            )
+        with os.fdopen(file_descriptor, "rb") as opened_file:
+            file_descriptor = -1
+            byte_count, content_sha256 = _digest_open_included_file(opened_file)
+    finally:
+        if file_descriptor >= 0:
+            os.close(file_descriptor)
+    current_stat = _included_entry_stat_at(parent_fd, name)
+    if (
+        current_stat is None
+        or not stat.S_ISREG(current_stat.st_mode)
+        or _included_path_fingerprint(current_stat) != expected_fingerprint
+        or current_stat.st_ctime_ns != expected_ctime_ns
+        or byte_count != expected_stat.st_size
+    ):
+        raise OSError(f"Included Files file changed while hashing: {display_path}")
+    return content_sha256
+
+
+def _open_included_tree_directory_at(parent_fd: int, name: str) -> int:
+    return os.open(
+        name,
+        _DIRECTORY_OPEN_FLAGS,
+        dir_fd=parent_fd,
+    )
+
+
+def _capture_included_tree_from_fd(
+    directory_fd: int,
+    relative_directory: str,
+    display_path: str,
+    verify_binding: Callable[[], None],
+) -> list[_IncludedTreeEntry]:
+    verify_binding()
+    try:
+        names = sorted(os.listdir(directory_fd))
+    except OSError as error:
+        raise OSError(
+            f"Could not inspect Included Files directory: {display_path}"
+        ) from error
+    entries: list[_IncludedTreeEntry] = []
+    for name in names:
+        verify_binding()
+        entry_path = os.path.join(display_path, name)
+        entry_stat = _included_entry_stat_at(directory_fd, name)
+        if entry_stat is None:
+            raise OSError(
+                f"Included Files tree changed while inspecting: {entry_path}"
+            )
+        relative_path = posixpath.join(relative_directory, name)
+        if stat.S_ISLNK(entry_stat.st_mode):
+            raise OSError(
+                f"Refusing redirected entry in Included Files tree: {entry_path}"
+            )
+        entry_fingerprint = _included_path_fingerprint(entry_stat)
+        if stat.S_ISDIR(entry_stat.st_mode):
+            child_fd = _open_included_tree_directory_at(directory_fd, name)
+            try:
+                child_stat = os.fstat(child_fd)
+                if (
+                    not stat.S_ISDIR(child_stat.st_mode)
+                    or _included_path_fingerprint(child_stat)
+                    != entry_fingerprint
+                ):
+                    raise OSError(
+                        f"Included Files directory changed: {entry_path}"
+                    )
+
+                def verify_child_binding() -> None:
+                    verify_binding()
+                    _verify_included_entry_at(
+                        directory_fd,
+                        name,
+                        entry_fingerprint,
+                        entry_path,
+                    )
+
+                entries.extend(
+                    _capture_included_tree_from_fd(
+                        child_fd,
+                        relative_path,
+                        entry_path,
+                        verify_child_binding,
+                    )
+                )
+            finally:
+                os.close(child_fd)
+            verify_binding()
+            _verify_included_entry_at(
+                directory_fd,
+                name,
+                entry_fingerprint,
+                entry_path,
+            )
+            kind = "directory"
+            ctime_ns = None
+            content_sha256 = None
+        elif stat.S_ISREG(entry_stat.st_mode):
+            kind = "file"
+            ctime_ns = entry_stat.st_ctime_ns
+            content_sha256 = _digest_included_regular_file_at(
+                directory_fd,
+                name,
+                entry_stat,
+                entry_path,
+            )
+        else:
+            raise OSError(
+                f"Refusing non-regular entry in Included Files tree: {entry_path}"
+            )
+        entries.append(
+            _IncludedTreeEntry(
+                relative_path=relative_path,
+                kind=kind,
+                fingerprint=entry_fingerprint,
+                ctime_ns=ctime_ns,
+                content_sha256=content_sha256,
+            )
+        )
+    verify_binding()
+    return entries
+
+
+def _capture_included_tree_descriptor(
+    root_path: str,
+    expected_parent_identity: _PathIdentity | None,
+) -> _IncludedTreeSnapshot:
+    parent_fd, root_name = _open_pinned_included_parent(root_path)
+    parent_identity = _directory_identity_from_fd(parent_fd)
+    if (
+        expected_parent_identity is not None
+        and parent_identity != expected_parent_identity
+    ):
+        os.close(parent_fd)
+        raise OSError(f"Included Files root parent changed: {root_path}")
+    parent_path = os.path.dirname(os.path.abspath(root_path))
+    try:
+        root_stat = _included_entry_stat_at(parent_fd, root_name)
+        if root_stat is None:
+            if _included_directory_identity(parent_path) != parent_identity:
+                raise OSError(
+                    f"Included Files root parent changed: {parent_path}"
+                )
+            return _IncludedTreeSnapshot(root_fingerprint=None, entries=())
+        if not stat.S_ISDIR(root_stat.st_mode):
+            raise OSError(
+                f"Refusing redirected or non-directory Included Files root: {root_path}"
+            )
+        root_fingerprint = _included_path_fingerprint(root_stat)
+        root_fd = _open_included_tree_directory_at(parent_fd, root_name)
+        try:
+            opened_root_stat = os.fstat(root_fd)
+            if _included_path_fingerprint(opened_root_stat) != root_fingerprint:
+                raise OSError(
+                    f"Included Files root changed while opening: {root_path}"
+                )
+
+            def verify_root_binding() -> None:
+                _verify_included_entry_at(
+                    parent_fd,
+                    root_name,
+                    root_fingerprint,
+                    root_path,
+                )
+
+            entries = _capture_included_tree_from_fd(
+                root_fd,
+                "",
+                root_path,
+                verify_root_binding,
+            )
+        finally:
+            os.close(root_fd)
+        verify_root_binding()
+        if _included_directory_identity(parent_path) != parent_identity:
+            raise OSError(f"Included Files root parent changed: {parent_path}")
+        return _IncludedTreeSnapshot(
+            root_fingerprint=root_fingerprint,
+            entries=tuple(
+                sorted(
+                    entries,
+                    key=lambda entry: (entry.relative_path, entry.kind),
+                )
+            ),
+        )
+    finally:
+        os.close(parent_fd)
+
+
+def _capture_included_tree_fallback(
+    root_path: str,
+    expected_parent_identity: _PathIdentity | None,
+) -> _IncludedTreeSnapshot:
+    root_parent_identities = _capture_fallback_directory_ancestors(
+        os.path.dirname(os.path.abspath(root_path))
+    )
+    if (
+        expected_parent_identity is not None
+        and root_parent_identities[-1][1] != expected_parent_identity
+    ):
+        raise OSError(f"Included Files root parent changed: {root_path}")
+    try:
+        root_stat = os.lstat(root_path)
+    except FileNotFoundError:
+        _verify_fallback_directory_ancestors(root_parent_identities)
+        return _IncludedTreeSnapshot(root_fingerprint=None, entries=())
+    if (
+        _included_output_path_is_redirected(root_path, root_stat)
+        or not stat.S_ISDIR(root_stat.st_mode)
+    ):
+        raise OSError(
+            f"Refusing redirected or non-directory Included Files root: {root_path}"
+        )
+
+    root_fingerprint = _included_path_fingerprint(root_stat)
+    entries: list[_IncludedTreeEntry] = []
+    pending: list[tuple[str, str]] = [("", root_path)]
+    while pending:
+        relative_directory, directory_path = pending.pop()
+        directory_identities = _capture_fallback_directory_ancestors(
+            directory_path
+        )
+        try:
+            directory_entries = sorted(
+                os.scandir(directory_path),
+                key=lambda entry: entry.name,
+            )
+        except OSError as error:
+            raise OSError(
+                f"Could not inspect Included Files directory: {directory_path}"
+            ) from error
+        for directory_entry in directory_entries:
+            entry_path = os.path.join(directory_path, directory_entry.name)
+            try:
+                entry_stat = os.lstat(entry_path)
+            except OSError as error:
+                raise OSError(
+                    f"Included Files tree changed while inspecting: {entry_path}"
+                ) from error
+            relative_path = posixpath.join(
+                relative_directory,
+                directory_entry.name,
+            )
+            if _included_output_path_is_redirected(entry_path, entry_stat):
+                raise OSError(
+                    f"Refusing redirected entry in Included Files tree: {entry_path}"
+                )
+            if stat.S_ISDIR(entry_stat.st_mode):
+                kind = "directory"
+                ctime_ns = None
+                content_sha256 = None
+                pending.append((relative_path, entry_path))
+            elif stat.S_ISREG(entry_stat.st_mode):
+                kind = "file"
+                ctime_ns = entry_stat.st_ctime_ns
+                content_sha256 = _digest_included_regular_file(
+                    entry_path,
+                    entry_stat,
+                )
+            else:
+                raise OSError(
+                    f"Refusing non-regular entry in Included Files tree: {entry_path}"
+                )
+            entries.append(
+                _IncludedTreeEntry(
+                    relative_path=relative_path,
+                    kind=kind,
+                    fingerprint=_included_path_fingerprint(entry_stat),
+                    ctime_ns=ctime_ns,
+                    content_sha256=content_sha256,
+                )
+            )
+        _verify_fallback_directory_ancestors(directory_identities)
+
+    _verify_fallback_directory_ancestors(root_parent_identities)
+    current_root_stat = os.lstat(root_path)
+    if (
+        _included_output_path_is_redirected(root_path, current_root_stat)
+        or not stat.S_ISDIR(current_root_stat.st_mode)
+        or _included_path_fingerprint(current_root_stat) != root_fingerprint
+    ):
+        raise OSError(f"Included Files root changed while inspecting: {root_path}")
+    return _IncludedTreeSnapshot(
+        root_fingerprint=root_fingerprint,
+        entries=tuple(
+            sorted(
+                entries,
+                key=lambda entry: (entry.relative_path, entry.kind),
+            )
+        ),
+    )
+
+
+def _capture_included_tree(
+    root_path: str,
+    *,
+    expected_parent_identity: _PathIdentity | None = None,
+) -> _IncludedTreeSnapshot:
+    if _included_descriptor_paths_supported():
+        return _capture_included_tree_descriptor(
+            root_path,
+            expected_parent_identity,
+        )
+    return _capture_included_tree_fallback(
+        root_path,
+        expected_parent_identity,
+    )
+
+
+def _verify_included_tree_snapshot(
+    root_path: str,
+    expected: _IncludedTreeSnapshot,
+    *,
+    expected_parent_identity: _PathIdentity | None = None,
+) -> None:
+    if (
+        _capture_included_tree(
+            root_path,
+            expected_parent_identity=expected_parent_identity,
+        )
+        != expected
+    ):
+        raise OSError(f"Included Files tree changed during conversion: {root_path}")
+
+
+def _verify_staged_included_inventory(
+    snapshot: _IncludedTreeSnapshot,
+    assigned_receipts: dict[str, _IncludedCopyReceipt],
+) -> None:
+    if snapshot.identity is None:
+        raise OSError("Included Files staging root disappeared before publication")
+    assigned_paths = set(assigned_receipts)
+    expected_directories = {
+        "/".join(path.split("/")[:component_count])
+        for path in assigned_paths
+        for component_count in range(1, len(path.split("/")))
+    }
+    actual_files = {
+        entry.relative_path
+        for entry in snapshot.entries
+        if entry.kind == "file"
+    }
+    actual_directories = {
+        entry.relative_path
+        for entry in snapshot.entries
+        if entry.kind == "directory"
+    }
+    if actual_files != assigned_paths or actual_directories != expected_directories:
+        raise OSError(
+            "Included Files staging inventory did not match its planned output set"
+        )
+    entries_by_path = {
+        entry.relative_path: entry
+        for entry in snapshot.entries
+        if entry.kind == "file"
+    }
+    for assigned_path, receipt in assigned_receipts.items():
+        staged_entry = entries_by_path[assigned_path]
+        if (
+            staged_entry.fingerprint[3] != receipt.byte_count
+            or staged_entry.content_sha256 != receipt.sha256
+        ):
+            raise OSError(
+                "Included Files staging payload did not match its immutable "
+                f"source receipt: {assigned_path}"
+            )
+
+
+def _included_registry_path(project_path: str) -> str:
+    return os.path.join(project_path, INCLUDED_FILE_REGISTRY_RELATIVE_PATH)
+
+
+def _before_included_registry_file_read(
+    _project_fd: int,
+    _registry_directory_name: str,
+) -> None:
+    """Narrow test seam after pinning the registry directory for capture."""
+
+
+def _before_included_registry_directory_binding_check(
+    _project_fd: int,
+    _registry_directory_name: str,
+) -> None:
+    """Narrow test seam after securely creating the registry directory."""
+
+
+def _capture_included_registry(
+    project_path: str,
+    *,
+    expected_project_identity: _PathIdentity | None = None,
+    allowed_file_identities: frozenset[_PathIdentity] | None = None,
+) -> _IncludedRegistrySnapshot:
+    registry_path = _included_registry_path(project_path)
+    registry_directory = os.path.dirname(registry_path)
+    if _included_descriptor_paths_supported():
+        project_fd, registry_directory_name = _open_pinned_included_parent(
+            registry_directory
+        )
+        try:
+            _verify_included_directory_fd(
+                project_fd,
+                expected_project_identity,
+                project_path,
+            )
+            registry_directory_stat = _included_entry_stat_at(
+                project_fd,
+                registry_directory_name,
+            )
+            if registry_directory_stat is None:
+                if expected_project_identity is not None:
+                    _verify_included_project_identity(
+                        project_path,
+                        expected_project_identity,
+                    )
+                return _IncludedRegistrySnapshot(
+                    directory_identity=None,
+                    file_identity=None,
+                    file_mode=None,
+                    content=None,
+                )
+            if not stat.S_ISDIR(registry_directory_stat.st_mode):
+                raise OSError(
+                    "Refusing redirected or non-directory Included File "
+                    f"registry path: {registry_directory}"
+                )
+            directory_identity = (
+                registry_directory_stat.st_dev,
+                registry_directory_stat.st_ino,
+            )
+            registry_directory_fd = os.open(
+                registry_directory_name,
+                _DIRECTORY_OPEN_FLAGS,
+                dir_fd=project_fd,
+            )
+            try:
+                if (
+                    _directory_identity_from_fd(registry_directory_fd)
+                    != directory_identity
+                ):
+                    raise OSError(
+                        "Included File registry directory changed while opening"
+                    )
+                _before_included_registry_file_read(
+                    project_fd,
+                    registry_directory_name,
+                )
+                file_state = _included_regular_file_state_at(
+                    registry_directory_fd,
+                    os.path.basename(registry_path),
+                    registry_path,
+                    allowed_identities=allowed_file_identities,
+                )
+                _verify_included_directory_entry_identity_at(
+                    project_fd,
+                    registry_directory_name,
+                    directory_identity,
+                    registry_directory,
+                )
+            finally:
+                os.close(registry_directory_fd)
+            if expected_project_identity is not None:
+                _verify_included_project_identity(
+                    project_path,
+                    expected_project_identity,
+                )
+            if file_state is None:
+                return _IncludedRegistrySnapshot(
+                    directory_identity=directory_identity,
+                    file_identity=None,
+                    file_mode=None,
+                    content=None,
+                )
+            file_identity, file_mode, content = file_state
+            return _IncludedRegistrySnapshot(
+                directory_identity=directory_identity,
+                file_identity=file_identity,
+                file_mode=file_mode,
+                content=content,
+            )
+        finally:
+            os.close(project_fd)
+
+    project_ancestors = _capture_fallback_directory_ancestors(project_path)
+    if (
+        expected_project_identity is not None
+        and project_ancestors[-1][1] != expected_project_identity
+    ):
+        raise OSError(f"Included Files directory changed: {project_path}")
+    try:
+        registry_directory_stat = os.lstat(registry_directory)
+    except FileNotFoundError:
+        _verify_fallback_directory_ancestors(project_ancestors)
+        return _IncludedRegistrySnapshot(
+            directory_identity=None,
+            file_identity=None,
+            file_mode=None,
+            content=None,
+        )
+    if (
+        _included_output_path_is_redirected(
+            registry_directory,
+            registry_directory_stat,
+        )
+        or not stat.S_ISDIR(registry_directory_stat.st_mode)
+    ):
+        raise OSError(
+            "Refusing redirected or non-directory Included File registry path: "
+            f"{registry_directory}"
+        )
+    directory_identity = (
+        registry_directory_stat.st_dev,
+        registry_directory_stat.st_ino,
+    )
+    registry_ancestors = (
+        *project_ancestors,
+        (registry_directory, directory_identity),
+    )
+    _verify_fallback_directory_ancestors(registry_ancestors)
+    file_state = _included_regular_file_state(
+        registry_path,
+        expected_parent_identity=directory_identity,
+        expected_fallback_ancestors=registry_ancestors,
+        allowed_identities=allowed_file_identities,
+    )
+    _verify_fallback_directory_ancestors(registry_ancestors)
+    if file_state is None:
+        return _IncludedRegistrySnapshot(
+            directory_identity=directory_identity,
+            file_identity=None,
+            file_mode=None,
+            content=None,
+        )
+    file_identity, file_mode, content = file_state
+    return _IncludedRegistrySnapshot(
+        directory_identity=directory_identity,
+        file_identity=file_identity,
+        file_mode=file_mode,
+        content=content,
+    )
+
+
+def _verify_included_registry_snapshot(
+    project_path: str,
+    expected: _IncludedRegistrySnapshot,
+    *,
+    expected_project_identity: _PathIdentity | None = None,
+) -> None:
+    if (
+        _capture_included_registry(
+            project_path,
+            expected_project_identity=expected_project_identity,
+            allowed_file_identities=(
+                frozenset()
+                if expected.file_identity is None
+                else frozenset({expected.file_identity})
+            ),
+        )
+        != expected
+    ):
+        raise OSError("Included File registry changed during conversion")
+
+
+def _verify_included_project_identity(
+    project_path: str,
+    expected_identity: _PathIdentity,
+) -> None:
+    if _included_directory_identity(project_path) != expected_identity:
+        raise OSError(f"Godot project root changed during Included Files conversion: {project_path}")
+
+
+def _verify_included_stage_container(
+    project_path: str,
+    project_identity: _PathIdentity,
+    stage_path: str,
+    stage_identity: _PathIdentity,
+) -> None:
+    _verify_included_project_identity(project_path, project_identity)
+    expected_parent = os.path.normcase(os.path.abspath(project_path))
+    actual_parent = os.path.normcase(
+        os.path.dirname(os.path.abspath(stage_path))
+    )
+    if actual_parent != expected_parent:
+        raise OSError("Included Files staging directory escaped the Godot project")
+    if _included_directory_identity(stage_path) != stage_identity:
+        raise OSError("Included Files staging directory changed during conversion")
+    _verify_included_project_identity(project_path, project_identity)
+
+
+def _create_included_output_stage(
+    project_path: str,
+    project_identity: _PathIdentity,
+) -> tuple[str, _PathIdentity]:
+    _verify_included_project_identity(project_path, project_identity)
+    if _included_descriptor_paths_supported():
+        project_fd = _open_pinned_included_directory(project_path)
+        stage_name = ""
+        stage_identity: _PathIdentity | None = None
+        try:
+            _verify_included_directory_fd(
+                project_fd,
+                project_identity,
+                project_path,
+            )
+            for _attempt in range(100):
+                candidate = (
+                    _INCLUDED_FILES_STAGE_PREFIX
+                    + secrets.token_hex(8)
+                    + ".stage"
+                )
+                try:
+                    os.mkdir(candidate, 0o700, dir_fd=project_fd)
+                except FileExistsError:
+                    continue
+                stage_name = candidate
+                break
+            if not stage_name:
+                raise OSError("Could not allocate Included Files staging directory")
+            stage_fd = os.open(
+                stage_name,
+                _DIRECTORY_OPEN_FLAGS,
+                dir_fd=project_fd,
+            )
+            try:
+                stage_identity = _directory_identity_from_fd(stage_fd)
+            finally:
+                os.close(stage_fd)
+            stage_stat = _included_entry_stat_at(project_fd, stage_name)
+            if (
+                stage_stat is None
+                or not stat.S_ISDIR(stage_stat.st_mode)
+                or (stage_stat.st_dev, stage_stat.st_ino) != stage_identity
+            ):
+                raise OSError("Included Files staging directory changed after creation")
+            _verify_included_directory_fd(
+                project_fd,
+                project_identity,
+                project_path,
+            )
+            if _included_directory_identity(project_path) != project_identity:
+                raise OSError(
+                    "Godot project root changed during Included Files staging"
+                )
+            return os.path.join(project_path, stage_name), stage_identity
+        except BaseException:
+            if stage_name and stage_identity is not None:
+                try:
+                    _remove_owned_included_tree(
+                        os.path.join(project_path, stage_name),
+                        stage_identity,
+                        expected_parent_identity=project_identity,
+                    )
+                except OSError:
+                    pass
+            raise
+        finally:
+            os.close(project_fd)
+
+    stage_path = tempfile.mkdtemp(
+        dir=project_path,
+        prefix=_INCLUDED_FILES_STAGE_PREFIX,
+        suffix=".stage",
+    )
+    stage_identity = _included_directory_identity(stage_path)
+    if stage_identity is None:
+        raise OSError("Included Files staging directory disappeared")
+    try:
+        _verify_included_project_identity(project_path, project_identity)
+        stage_parent_identity = _included_directory_identity(
+            os.path.dirname(stage_path)
+        )
+        if stage_parent_identity != project_identity:
+            raise OSError("Included Files staging directory escaped the Godot project")
+    except Exception:
+        try:
+            _remove_owned_included_tree(
+                stage_path,
+                stage_identity,
+                expected_parent_identity=project_identity,
+            )
+        except OSError:
+            pass
+        raise
+    return stage_path, stage_identity
+
+
+def _verify_included_directory_entry_identity_at(
+    parent_fd: int,
+    name: str,
+    expected_identity: _PathIdentity,
+    display_path: str,
+) -> None:
+    current_stat = _included_entry_stat_at(parent_fd, name)
+    if (
+        current_stat is None
+        or not stat.S_ISDIR(current_stat.st_mode)
+        or (current_stat.st_dev, current_stat.st_ino) != expected_identity
+    ):
+        raise OSError(f"Included Files directory changed: {display_path}")
+
+
+def _before_included_cleanup_quarantine(
+    _parent_fd: int,
+    _name: str,
+) -> None:
+    """Narrow test seam before moving a cleanup candidate to quarantine."""
+
+
+def _before_included_cleanup_remove(
+    _parent_fd: int,
+    _name: str,
+) -> None:
+    """Narrow test seam before removing a verified quarantine entry."""
+
+
+def _quarantine_included_entry_at(
+    parent_fd: int,
+    name: str,
+    expected_identity: _PathIdentity,
+    *,
+    expect_directory: bool,
+    display_path: str,
+) -> tuple[str, str]:
+    quarantine_name = (
+        f".{name}.{secrets.token_hex(8)}.quarantine"
+    )
+    quarantine_path = os.path.join(
+        os.path.dirname(display_path),
+        quarantine_name,
+    )
+    _before_included_cleanup_quarantine(parent_fd, name)
+    _rename_included_transaction_entry_at(
+        parent_fd,
+        name,
+        parent_fd,
+        quarantine_name,
+    )
+    quarantine_stat = _included_entry_stat_at(parent_fd, quarantine_name)
+    quarantine_is_expected_kind = (
+        quarantine_stat is not None
+        and (
+            stat.S_ISDIR(quarantine_stat.st_mode)
+            if expect_directory
+            else not stat.S_ISDIR(quarantine_stat.st_mode)
+        )
+    )
+    if (
+        not quarantine_is_expected_kind
+        or quarantine_stat is None
+        or (quarantine_stat.st_dev, quarantine_stat.st_ino)
+        != expected_identity
+    ):
+        raise _preserve_or_restore_unexpected_moved_entry_at(
+            parent_fd,
+            name,
+            parent_fd,
+            quarantine_name,
+            display_path,
+            quarantine_path,
+        )
+    return quarantine_name, quarantine_path
+
+
+def _unlink_exact_quarantined_entry_at(
+    parent_fd: int,
+    name: str,
+    expected_identity: _PathIdentity,
+    display_path: str,
+) -> None:
+    _before_included_cleanup_remove(parent_fd, name)
+    current_stat = _included_entry_stat_at(parent_fd, name)
+    if (
+        current_stat is None
+        or stat.S_ISDIR(current_stat.st_mode)
+        or (current_stat.st_dev, current_stat.st_ino) != expected_identity
+    ):
+        raise OSError(
+            "Refusing to remove changed Included Files quarantine; recoverable "
+            f"entry retained at {display_path!r}"
+        )
+    os.unlink(name, dir_fd=parent_fd)
+
+
+def _rmdir_exact_quarantined_entry_at(
+    parent_fd: int,
+    name: str,
+    expected_identity: _PathIdentity,
+    display_path: str,
+) -> None:
+    _before_included_cleanup_remove(parent_fd, name)
+    current_stat = _included_entry_stat_at(parent_fd, name)
+    if (
+        current_stat is None
+        or not stat.S_ISDIR(current_stat.st_mode)
+        or (current_stat.st_dev, current_stat.st_ino) != expected_identity
+    ):
+        raise OSError(
+            "Refusing to remove changed Included Files quarantine; recoverable "
+            f"directory retained at {display_path!r}"
+        )
+    os.rmdir(name, dir_fd=parent_fd)
+
+
+def _remove_included_tree_contents_at(
+    directory_fd: int,
+    display_path: str,
+    verify_binding: Callable[[], None],
+) -> None:
+    verify_binding()
+    for name in sorted(os.listdir(directory_fd)):
+        verify_binding()
+        entry_path = os.path.join(display_path, name)
+        entry_stat = _included_entry_stat_at(directory_fd, name)
+        if entry_stat is None:
+            raise OSError(f"Included Files cleanup entry changed: {entry_path}")
+        entry_identity = entry_stat.st_dev, entry_stat.st_ino
+        if stat.S_ISDIR(entry_stat.st_mode):
+            quarantined_name, quarantined_path = _quarantine_included_entry_at(
+                directory_fd,
+                name,
+                entry_identity,
+                expect_directory=True,
+                display_path=entry_path,
+            )
+            child_fd = os.open(
+                quarantined_name,
+                _DIRECTORY_OPEN_FLAGS,
+                dir_fd=directory_fd,
+            )
+            try:
+                if _directory_identity_from_fd(child_fd) != entry_identity:
+                    raise OSError(
+                        f"Included Files cleanup directory changed: {entry_path}"
+                    )
+
+                def verify_child_binding() -> None:
+                    verify_binding()
+                    _verify_included_directory_entry_identity_at(
+                        directory_fd,
+                        quarantined_name,
+                        entry_identity,
+                        quarantined_path,
+                    )
+
+                _remove_included_tree_contents_at(
+                    child_fd,
+                    quarantined_path,
+                    verify_child_binding,
+                )
+            finally:
+                os.close(child_fd)
+            verify_child_binding()
+            _rmdir_exact_quarantined_entry_at(
+                directory_fd,
+                quarantined_name,
+                entry_identity,
+                quarantined_path,
+            )
+        else:
+            quarantined_name, quarantined_path = _quarantine_included_entry_at(
+                directory_fd,
+                name,
+                entry_identity,
+                expect_directory=False,
+                display_path=entry_path,
+            )
+            _unlink_exact_quarantined_entry_at(
+                directory_fd,
+                quarantined_name,
+                entry_identity,
+                quarantined_path,
+            )
+    verify_binding()
+
+
+def _before_included_cleanup_quarantine_fallback(_path: str) -> None:
+    """Narrow fallback test seam before quarantining a cleanup candidate."""
+
+
+def _before_included_cleanup_remove_fallback(_path: str) -> None:
+    """Narrow fallback test seam before removing a quarantine candidate."""
+
+
+def _quarantine_included_entry_fallback(
+    path: str,
+    expected_identity: _PathIdentity,
+    *,
+    expect_directory: bool,
+) -> str:
+    quarantine_path = path + "." + secrets.token_hex(8) + ".quarantine"
+    _before_included_cleanup_quarantine_fallback(path)
+    _rename_included_transaction_entry(path, quarantine_path)
+    quarantine_stat = os.lstat(quarantine_path)
+    quarantine_is_expected_kind = (
+        stat.S_ISDIR(quarantine_stat.st_mode)
+        if expect_directory
+        else not stat.S_ISDIR(quarantine_stat.st_mode)
+    )
+    if (
+        _included_output_path_is_redirected(quarantine_path, quarantine_stat)
+        or not quarantine_is_expected_kind
+        or (quarantine_stat.st_dev, quarantine_stat.st_ino)
+        != expected_identity
+    ):
+        raise _preserve_or_restore_unexpected_moved_entry_fallback(
+            path,
+            quarantine_path,
+        )
+    return quarantine_path
+
+
+def _unlink_exact_quarantined_entry_fallback(
+    path: str,
+    expected_identity: _PathIdentity,
+) -> None:
+    _before_included_cleanup_remove_fallback(path)
+    current_stat = os.lstat(path)
+    if (
+        stat.S_ISDIR(current_stat.st_mode)
+        or (current_stat.st_dev, current_stat.st_ino) != expected_identity
+    ):
+        raise OSError(
+            "Refusing to remove changed Included Files quarantine; recoverable "
+            f"entry retained at {path!r}"
+        )
+    os.unlink(path)
+
+
+def _rmdir_exact_quarantined_entry_fallback(
+    path: str,
+    expected_identity: _PathIdentity,
+) -> None:
+    _before_included_cleanup_remove_fallback(path)
+    current_stat = os.lstat(path)
+    if (
+        not stat.S_ISDIR(current_stat.st_mode)
+        or (current_stat.st_dev, current_stat.st_ino) != expected_identity
+    ):
+        raise OSError(
+            "Refusing to remove changed Included Files quarantine; recoverable "
+            f"directory retained at {path!r}"
+        )
+    os.rmdir(path)
+
+
+def _remove_owned_included_tree_fallback(
+    path: str,
+    expected_identity: _PathIdentity,
+    expected_parent_identity: _PathIdentity | None,
+) -> None:
+    parent_path = os.path.dirname(os.path.abspath(path))
+    parent_identities = _capture_fallback_directory_ancestors(parent_path)
+    if (
+        expected_parent_identity is not None
+        and parent_identities[-1][1] != expected_parent_identity
+    ):
+        raise OSError(f"Included Files cleanup parent changed: {parent_path}")
+    try:
+        root_stat = os.lstat(path)
+    except FileNotFoundError:
+        _verify_fallback_directory_ancestors(parent_identities)
+        return
+    if (
+        _included_output_path_is_redirected(path, root_stat)
+        or not stat.S_ISDIR(root_stat.st_mode)
+        or (root_stat.st_dev, root_stat.st_ino) != expected_identity
+    ):
+        raise OSError(f"Refusing to remove changed Included Files tree: {path}")
+    quarantined_root_path = _quarantine_included_entry_fallback(
+        path,
+        expected_identity,
+        expect_directory=True,
+    )
+
+    def remove_directory(
+        directory_path: str,
+        directory_identity: _PathIdentity,
+    ) -> None:
+        directory_ancestors = _capture_fallback_directory_ancestors(
+            directory_path
+        )
+        if directory_ancestors[-1][1] != directory_identity:
+            raise OSError(
+                f"Included Files cleanup directory changed: {directory_path}"
+            )
+        for name in sorted(os.listdir(directory_path)):
+            _verify_fallback_directory_ancestors(directory_ancestors)
+            entry_path = os.path.join(directory_path, name)
+            entry_stat = os.lstat(entry_path)
+            entry_identity = entry_stat.st_dev, entry_stat.st_ino
+            if _included_output_path_is_redirected(entry_path, entry_stat):
+                raise OSError(
+                    f"Refusing redirected Included Files cleanup entry: {entry_path}"
+                )
+            if stat.S_ISDIR(entry_stat.st_mode):
+                quarantined_entry_path = _quarantine_included_entry_fallback(
+                    entry_path,
+                    entry_identity,
+                    expect_directory=True,
+                )
+                remove_directory(quarantined_entry_path, entry_identity)
+                _verify_fallback_directory_ancestors(directory_ancestors)
+                _rmdir_exact_quarantined_entry_fallback(
+                    quarantined_entry_path,
+                    entry_identity,
+                )
+            else:
+                _verify_fallback_directory_ancestors(directory_ancestors)
+                quarantined_entry_path = _quarantine_included_entry_fallback(
+                    entry_path,
+                    entry_identity,
+                    expect_directory=False,
+                )
+                _unlink_exact_quarantined_entry_fallback(
+                    quarantined_entry_path,
+                    entry_identity,
+                )
+        _verify_fallback_directory_ancestors(directory_ancestors)
+
+    remove_directory(quarantined_root_path, expected_identity)
+    _verify_fallback_directory_ancestors(parent_identities)
+    _rmdir_exact_quarantined_entry_fallback(
+        quarantined_root_path,
+        expected_identity,
+    )
+
+
+def _remove_owned_included_tree(
+    path: str,
+    expected_identity: _PathIdentity,
+    *,
+    expected_parent_identity: _PathIdentity | None = None,
+) -> None:
+    if not _included_descriptor_paths_supported():
+        _remove_owned_included_tree_fallback(
+            path,
+            expected_identity,
+            expected_parent_identity,
+        )
+        return
+    parent_fd, name = _open_pinned_included_parent(path)
+    try:
+        _verify_included_directory_fd(
+            parent_fd,
+            expected_parent_identity,
+            os.path.dirname(path),
+        )
+        root_stat = _included_entry_stat_at(parent_fd, name)
+        if root_stat is None:
+            return
+        if (
+            not stat.S_ISDIR(root_stat.st_mode)
+            or (root_stat.st_dev, root_stat.st_ino) != expected_identity
+        ):
+            raise OSError(f"Refusing to remove changed Included Files tree: {path}")
+        quarantined_name, quarantined_path = _quarantine_included_entry_at(
+            parent_fd,
+            name,
+            expected_identity,
+            expect_directory=True,
+            display_path=path,
+        )
+        root_fd = os.open(
+            quarantined_name,
+            _DIRECTORY_OPEN_FLAGS,
+            dir_fd=parent_fd,
+        )
+        try:
+            if _directory_identity_from_fd(root_fd) != expected_identity:
+                raise OSError(
+                    f"Refusing to remove changed Included Files tree: {path}"
+                )
+
+            def verify_root_binding() -> None:
+                _verify_included_directory_entry_identity_at(
+                    parent_fd,
+                    quarantined_name,
+                    expected_identity,
+                    quarantined_path,
+                )
+
+            _remove_included_tree_contents_at(
+                root_fd,
+                quarantined_path,
+                verify_root_binding,
+            )
+        finally:
+            os.close(root_fd)
+        verify_root_binding()
+        _rmdir_exact_quarantined_entry_at(
+            parent_fd,
+            quarantined_name,
+            expected_identity,
+            quarantined_path,
+        )
+    finally:
+        os.close(parent_fd)
+
+
+def _remove_owned_included_file(
+    path: str,
+    expected_identity: _PathIdentity,
+    *,
+    expected_parent_identity: _PathIdentity | None = None,
+) -> None:
+    parent_path = os.path.dirname(os.path.abspath(path))
+    if _included_descriptor_paths_supported():
+        parent_fd, name = _open_pinned_included_parent(path)
+        try:
+            _verify_included_directory_fd(
+                parent_fd,
+                expected_parent_identity,
+                parent_path,
+            )
+            file_stat = _included_entry_stat_at(parent_fd, name)
+            if file_stat is None:
+                return
+            if (
+                not stat.S_ISREG(file_stat.st_mode)
+                or (file_stat.st_dev, file_stat.st_ino) != expected_identity
+            ):
+                raise OSError(
+                    f"Refusing to remove changed Included Files file: {path}"
+                )
+            quarantined_name, quarantined_path = _quarantine_included_entry_at(
+                parent_fd,
+                name,
+                expected_identity,
+                expect_directory=False,
+                display_path=path,
+            )
+            file_descriptor = os.open(
+                quarantined_name,
+                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+                dir_fd=parent_fd,
+            )
+            try:
+                opened_stat = os.fstat(file_descriptor)
+                if (
+                    not stat.S_ISREG(opened_stat.st_mode)
+                    or (opened_stat.st_dev, opened_stat.st_ino)
+                    != expected_identity
+                ):
+                    raise OSError(
+                        f"Refusing to remove changed Included Files file: {path}"
+                    )
+                current_stat = _included_entry_stat_at(
+                    parent_fd,
+                    quarantined_name,
+                )
+                if (
+                    current_stat is None
+                    or (current_stat.st_dev, current_stat.st_ino)
+                    != expected_identity
+                ):
+                    raise OSError(
+                        f"Refusing to remove changed Included Files file: {path}"
+                    )
+                _unlink_exact_quarantined_entry_at(
+                    parent_fd,
+                    quarantined_name,
+                    expected_identity,
+                    quarantined_path,
+                )
+            finally:
+                os.close(file_descriptor)
+        finally:
+            os.close(parent_fd)
+        return
+
+    parent_identities = _capture_fallback_directory_ancestors(parent_path)
+    if (
+        expected_parent_identity is not None
+        and parent_identities[-1][1] != expected_parent_identity
+    ):
+        raise OSError(f"Included Files cleanup parent changed: {parent_path}")
+    try:
+        file_stat = os.lstat(path)
+    except FileNotFoundError:
+        _verify_fallback_directory_ancestors(parent_identities)
+        return
+    if (
+        _included_output_path_is_redirected(path, file_stat)
+        or not stat.S_ISREG(file_stat.st_mode)
+        or (file_stat.st_dev, file_stat.st_ino) != expected_identity
+    ):
+        raise OSError(f"Refusing to remove changed Included Files file: {path}")
+    _verify_fallback_directory_ancestors(parent_identities)
+    quarantined_path = _quarantine_included_entry_fallback(
+        path,
+        expected_identity,
+        expect_directory=False,
+    )
+    _unlink_exact_quarantined_entry_fallback(
+        quarantined_path,
+        expected_identity,
+    )
+
+
+def _remove_owned_empty_included_directory(
+    path: str,
+    expected_identity: _PathIdentity,
+    expected_parent_identity: _PathIdentity,
+) -> None:
+    parent_path = os.path.dirname(os.path.abspath(path))
+    if _included_descriptor_paths_supported():
+        parent_fd, name = _open_pinned_included_parent(path)
+        try:
+            _verify_included_directory_fd(
+                parent_fd,
+                expected_parent_identity,
+                parent_path,
+            )
+            _verify_included_directory_entry_identity_at(
+                parent_fd,
+                name,
+                expected_identity,
+                path,
+            )
+            quarantined_name, quarantined_path = _quarantine_included_entry_at(
+                parent_fd,
+                name,
+                expected_identity,
+                expect_directory=True,
+                display_path=path,
+            )
+            _rmdir_exact_quarantined_entry_at(
+                parent_fd,
+                quarantined_name,
+                expected_identity,
+                quarantined_path,
+            )
+        finally:
+            os.close(parent_fd)
+        return
+    parent_identities = _capture_fallback_directory_ancestors(parent_path)
+    if parent_identities[-1][1] != expected_parent_identity:
+        raise OSError(f"Included Files directory parent changed: {parent_path}")
+    current_identity = _included_directory_identity(path)
+    if current_identity != expected_identity:
+        raise OSError(f"Included Files directory changed: {path}")
+    _verify_fallback_directory_ancestors(parent_identities)
+    quarantined_path = _quarantine_included_entry_fallback(
+        path,
+        expected_identity,
+        expect_directory=True,
+    )
+    _rmdir_exact_quarantined_entry_fallback(
+        quarantined_path,
+        expected_identity,
+    )
+
+
+def _before_included_fallback_chmod_open(_path: str) -> None:
+    """Narrow test seam before opening a fallback chmod target."""
+
+
+def _chmod_exact_included_file(
+    path: str,
+    expected_identity: _PathIdentity,
+    mode: int,
+    expected_parent_identity: _PathIdentity,
+) -> None:
+    if _included_descriptor_paths_supported():
+        parent_fd, name = _open_pinned_included_parent(path)
+        try:
+            _verify_included_directory_fd(
+                parent_fd,
+                expected_parent_identity,
+                os.path.dirname(path),
+            )
+            file_descriptor = os.open(
+                name,
+                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+                dir_fd=parent_fd,
+            )
+            try:
+                opened_stat = os.fstat(file_descriptor)
+                if (
+                    not stat.S_ISREG(opened_stat.st_mode)
+                    or (opened_stat.st_dev, opened_stat.st_ino)
+                    != expected_identity
+                ):
+                    raise OSError(f"Included Files file changed: {path}")
+                os.chmod(file_descriptor, mode)
+            finally:
+                os.close(file_descriptor)
+        finally:
+            os.close(parent_fd)
+        return
+    parent_identities = _capture_fallback_directory_ancestors(
+        os.path.dirname(os.path.abspath(path))
+    )
+    if parent_identities[-1][1] != expected_parent_identity:
+        raise OSError(f"Included Files file parent changed: {path}")
+    try:
+        path_stat = os.lstat(path)
+    except FileNotFoundError as error:
+        raise OSError(f"Included Files file changed: {path}") from error
+    if (
+        _included_output_path_is_redirected(path, path_stat)
+        or not stat.S_ISREG(path_stat.st_mode)
+        or (path_stat.st_dev, path_stat.st_ino) != expected_identity
+    ):
+        raise OSError(f"Included Files file changed: {path}")
+    _verify_fallback_directory_ancestors(parent_identities)
+    _before_included_fallback_chmod_open(path)
+    file_descriptor = os.open(
+        path,
+        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+    )
+    path_chmod_required = False
+    try:
+        opened_stat = os.fstat(file_descriptor)
+        if (
+            not stat.S_ISREG(opened_stat.st_mode)
+            or (opened_stat.st_dev, opened_stat.st_ino) != expected_identity
+        ):
+            raise OSError(f"Included Files file changed: {path}")
+        _verify_fallback_directory_ancestors(parent_identities)
+        if os.chmod in os.supports_fd:
+            os.chmod(file_descriptor, mode)
+        elif os.name == "nt":
+            path_chmod_required = bool(opened_stat.st_mode & stat.S_IWRITE) != (
+                bool(mode & stat.S_IWRITE)
+            )
+        else:
+            raise OSError(
+                "Descriptor-bound Included Files chmod is unavailable on "
+                f"{sys.platform}"
+            )
+    finally:
+        os.close(file_descriptor)
+    if path_chmod_required:
+        quarantined_path = _quarantine_included_entry_fallback(
+            path,
+            expected_identity,
+            expect_directory=False,
+        )
+        try:
+            quarantined_stat = os.lstat(quarantined_path)
+            if (
+                not stat.S_ISREG(quarantined_stat.st_mode)
+                or (quarantined_stat.st_dev, quarantined_stat.st_ino)
+                != expected_identity
+            ):
+                raise OSError(
+                    "Included Files chmod quarantine changed: "
+                    f"{quarantined_path}"
+                )
+            os.chmod(quarantined_path, mode)
+            changed_stat = os.lstat(quarantined_path)
+            if (
+                not stat.S_ISREG(changed_stat.st_mode)
+                or (changed_stat.st_dev, changed_stat.st_ino)
+                != expected_identity
+            ):
+                raise OSError(
+                    "Included Files chmod quarantine changed: "
+                    f"{quarantined_path}"
+                )
+        except BaseException as error:
+            try:
+                _move_exact_included_file(
+                    quarantined_path,
+                    path,
+                    expected_identity,
+                    source_parent_identity=expected_parent_identity,
+                    destination_parent_identity=expected_parent_identity,
+                )
+            except OSError as restore_error:
+                error.add_note(
+                    "Included Files chmod quarantine restore also failed: "
+                    + str(restore_error)
+                )
+            raise
+        _move_exact_included_file(
+            quarantined_path,
+            path,
+            expected_identity,
+            source_parent_identity=expected_parent_identity,
+            destination_parent_identity=expected_parent_identity,
+        )
+    try:
+        current_stat = os.lstat(path)
+    except FileNotFoundError as error:
+        raise OSError(f"Included Files file changed: {path}") from error
+    if (
+        _included_output_path_is_redirected(path, current_stat)
+        or not stat.S_ISREG(current_stat.st_mode)
+        or (current_stat.st_dev, current_stat.st_ino) != expected_identity
+    ):
+        raise OSError(f"Included Files file changed: {path}")
+    _verify_fallback_directory_ancestors(parent_identities)
+
+
+def _unique_included_transaction_path(
+    directory: str,
+    label: str,
+) -> str:
+    for _attempt in range(100):
+        candidate = os.path.join(
+            directory,
+            f".{label}.{secrets.token_hex(8)}.backup",
+        )
+        if not os.path.lexists(candidate):
+            return candidate
+    raise OSError(f"Could not allocate Included Files transaction backup for {label}")
+
+
+def _rename_included_transaction_entry(source: str, destination: str) -> None:
+    if os.name != "nt":
+        raise OSError(
+            "Unsafe path-based Included Files rename is disabled on POSIX"
+        )
+    os.rename(source, destination)
+
+
+def _move_exact_included_entry(
+    source: str,
+    destination: str,
+    expected_identity: _PathIdentity,
+    *,
+    expect_directory: bool,
+    source_parent_identity: _PathIdentity | None,
+    destination_parent_identity: _PathIdentity | None,
+) -> None:
+    source_parent_path = os.path.dirname(os.path.abspath(source))
+    destination_parent_path = os.path.dirname(os.path.abspath(destination))
+    if _included_descriptor_paths_supported():
+        source_parent_fd, source_name = _open_pinned_included_parent(source)
+        try:
+            _verify_included_directory_fd(
+                source_parent_fd,
+                source_parent_identity,
+                source_parent_path,
+            )
+            destination_parent_fd, destination_name = (
+                _open_pinned_included_parent(destination)
+            )
+            try:
+                _verify_included_directory_fd(
+                    destination_parent_fd,
+                    destination_parent_identity,
+                    destination_parent_path,
+                )
+                source_stat = _included_entry_stat_at(
+                    source_parent_fd,
+                    source_name,
+                )
+                if source_stat is None:
+                    raise OSError(
+                        f"Included Files transaction source disappeared: {source}"
+                    )
+                source_is_expected_kind = (
+                    stat.S_ISDIR(source_stat.st_mode)
+                    if expect_directory
+                    else stat.S_ISREG(source_stat.st_mode)
+                )
+                if (
+                    not source_is_expected_kind
+                    or (source_stat.st_dev, source_stat.st_ino)
+                    != expected_identity
+                ):
+                    raise OSError(
+                        f"Included Files transaction source changed: {source}"
+                    )
+                _before_included_transaction_rename(
+                    source_parent_fd,
+                    source_name,
+                )
+                _rename_included_transaction_entry_at(
+                    source_parent_fd,
+                    source_name,
+                    destination_parent_fd,
+                    destination_name,
+                )
+                destination_stat = _included_entry_stat_at(
+                    destination_parent_fd,
+                    destination_name,
+                )
+                destination_is_expected_kind = (
+                    destination_stat is not None
+                    and (
+                        stat.S_ISDIR(destination_stat.st_mode)
+                        if expect_directory
+                        else stat.S_ISREG(destination_stat.st_mode)
+                    )
+                )
+                if (
+                    not destination_is_expected_kind
+                    or destination_stat is None
+                    or (destination_stat.st_dev, destination_stat.st_ino)
+                    != expected_identity
+                ):
+                    raise _preserve_or_restore_unexpected_moved_entry_at(
+                        source_parent_fd,
+                        source_name,
+                        destination_parent_fd,
+                        destination_name,
+                        source,
+                        destination,
+                    )
+            finally:
+                os.close(destination_parent_fd)
+        finally:
+            os.close(source_parent_fd)
+        return
+
+    source_parent_ancestors = _capture_fallback_directory_ancestors(
+        source_parent_path
+    )
+    destination_parent_ancestors = _capture_fallback_directory_ancestors(
+        destination_parent_path
+    )
+    if (
+        source_parent_identity is not None
+        and source_parent_ancestors[-1][1] != source_parent_identity
+    ):
+        raise OSError(f"Included Files source parent changed: {source_parent_path}")
+    if (
+        destination_parent_identity is not None
+        and destination_parent_ancestors[-1][1]
+        != destination_parent_identity
+    ):
+        raise OSError(
+            f"Included Files destination parent changed: {destination_parent_path}"
+        )
+    source_stat = os.lstat(source)
+    source_is_expected_kind = (
+        stat.S_ISDIR(source_stat.st_mode)
+        if expect_directory
+        else stat.S_ISREG(source_stat.st_mode)
+    )
+    if (
+        _included_output_path_is_redirected(source, source_stat)
+        or not source_is_expected_kind
+        or (source_stat.st_dev, source_stat.st_ino) != expected_identity
+    ):
+        raise OSError(f"Included Files transaction source changed: {source}")
+    if os.path.lexists(destination):
+        raise OSError(
+            f"Included Files transaction destination already exists: {destination}"
+        )
+    _verify_fallback_directory_ancestors(source_parent_ancestors)
+    _verify_fallback_directory_ancestors(destination_parent_ancestors)
+    _before_included_transaction_rename_fallback(source, destination)
+    _rename_included_transaction_entry(source, destination)
+    _verify_fallback_directory_ancestors(source_parent_ancestors)
+    _verify_fallback_directory_ancestors(destination_parent_ancestors)
+    destination_stat = os.lstat(destination)
+    destination_is_expected_kind = (
+        stat.S_ISDIR(destination_stat.st_mode)
+        if expect_directory
+        else stat.S_ISREG(destination_stat.st_mode)
+    )
+    if (
+        _included_output_path_is_redirected(destination, destination_stat)
+        or not destination_is_expected_kind
+        or (destination_stat.st_dev, destination_stat.st_ino)
+        != expected_identity
+    ):
+        raise _preserve_or_restore_unexpected_moved_entry_fallback(
+            source,
+            destination,
+        )
+
+
+def _move_exact_included_directory(
+    source: str,
+    destination: str,
+    expected_identity: _PathIdentity,
+    *,
+    source_parent_identity: _PathIdentity | None = None,
+    destination_parent_identity: _PathIdentity | None = None,
+) -> None:
+    _move_exact_included_entry(
+        source,
+        destination,
+        expected_identity,
+        expect_directory=True,
+        source_parent_identity=source_parent_identity,
+        destination_parent_identity=destination_parent_identity,
+    )
+
+
+def _move_exact_included_file(
+    source: str,
+    destination: str,
+    expected_identity: _PathIdentity,
+    *,
+    source_parent_identity: _PathIdentity | None = None,
+    destination_parent_identity: _PathIdentity | None = None,
+) -> None:
+    _move_exact_included_entry(
+        source,
+        destination,
+        expected_identity,
+        expect_directory=False,
+        source_parent_identity=source_parent_identity,
+        destination_parent_identity=destination_parent_identity,
+    )
+
+
+def _prepare_included_registry_directory(
+    project_path: str,
+    expected: _IncludedRegistrySnapshot,
+    project_identity: _PathIdentity,
+) -> tuple[str, _PathIdentity, bool]:
+    registry_directory = os.path.dirname(_included_registry_path(project_path))
+    current_identity = _included_directory_identity(registry_directory)
+    if expected.directory_identity is not None:
+        if current_identity != expected.directory_identity:
+            raise OSError("Included File registry directory changed during conversion")
+        return registry_directory, expected.directory_identity, False
+    if current_identity is not None:
+        raise OSError("Included File registry directory appeared during conversion")
+    if _included_descriptor_paths_supported():
+        project_fd = _open_pinned_included_directory(project_path)
+        try:
+            _verify_included_directory_fd(
+                project_fd,
+                project_identity,
+                project_path,
+            )
+            registry_name = os.path.basename(registry_directory)
+            os.mkdir(registry_name, 0o755, dir_fd=project_fd)
+            registry_fd = os.open(
+                registry_name,
+                _DIRECTORY_OPEN_FLAGS,
+                dir_fd=project_fd,
+            )
+            try:
+                created_identity = _directory_identity_from_fd(registry_fd)
+            finally:
+                os.close(registry_fd)
+            _before_included_registry_directory_binding_check(
+                project_fd,
+                registry_name,
+            )
+            registry_stat = _included_entry_stat_at(project_fd, registry_name)
+            if (
+                registry_stat is None
+                or not stat.S_ISDIR(registry_stat.st_mode)
+                or (registry_stat.st_dev, registry_stat.st_ino)
+                != created_identity
+            ):
+                raise OSError(
+                    "Included File registry directory changed after creation"
+                )
+        finally:
+            os.close(project_fd)
+    else:
+        project_ancestors = _capture_fallback_directory_ancestors(project_path)
+        if project_ancestors[-1][1] != project_identity:
+            raise OSError(
+                "Godot project root changed before registry directory creation"
+            )
+        os.mkdir(registry_directory, 0o755)
+        _verify_fallback_directory_ancestors(project_ancestors)
+        created_identity = _included_directory_identity(registry_directory)
+        if created_identity is None:
+            raise OSError(
+                "Included File registry directory disappeared after creation"
+            )
+    visible_identity = _included_directory_identity(registry_directory)
+    if visible_identity != created_identity:
+        raise OSError(
+            "Included File registry directory changed after secure creation"
+        )
+    if (
+        _included_regular_file_state(
+            _included_registry_path(project_path),
+            expected_parent_identity=created_identity,
+            allowed_identities=frozenset(),
+        )
+        is not None
+    ):
+        raise OSError("Included File registry appeared during directory creation")
+    return registry_directory, created_identity, True
+
+
+def _rollback_included_output_set(
+    transaction: _IncludedOutputSetTransaction,
+    *,
+    root_backup_path: str,
+    registry_backup_path: str,
+    registry_directory_path: str,
+    registry_directory_identity: _PathIdentity | None,
+    registry_directory_created: bool,
+) -> tuple[Exception, ...]:
+    errors: list[Exception] = []
+    final_root_path = os.path.join(
+        os.path.dirname(transaction.stage_container_path),
+        _INCLUDED_FILES_ROOT_NAME,
+    )
+    final_registry_path = _included_registry_path(
+        os.path.dirname(transaction.stage_container_path)
+    )
+
+    try:
+        project_path = os.path.dirname(transaction.stage_container_path)
+        _verify_included_project_identity(
+            project_path,
+            transaction.project_identity,
+        )
+        previous_registry_directory_identity = (
+            transaction.previous_registry_snapshot.directory_identity
+        )
+        final_registry_parent_identity = (
+            registry_directory_identity
+            if registry_directory_identity is not None
+            else previous_registry_directory_identity
+        )
+        previous_registry_identity = (
+            transaction.previous_registry_snapshot.file_identity
+        )
+        allowed_current_registry_identities = {
+            transaction.staged_registry_identity
+        }
+        if previous_registry_identity is not None:
+            allowed_current_registry_identities.add(previous_registry_identity)
+
+        if final_registry_parent_identity is None:
+            if _included_directory_identity(registry_directory_path) is not None:
+                raise OSError(
+                    "Refusing to inspect an Included File registry directory "
+                    "that appeared during rollback"
+                )
+            current_registry_state = None
+        else:
+            current_registry_state = _included_regular_file_state(
+                final_registry_path,
+                expected_parent_identity=final_registry_parent_identity,
+                allowed_identities=frozenset(
+                    allowed_current_registry_identities
+                ),
+            )
+        current_registry_identity = (
+            current_registry_state[0]
+            if current_registry_state is not None
+            else None
+        )
+        if previous_registry_identity is None:
+            backup_registry_identity = None
+        else:
+            if previous_registry_directory_identity is None:
+                raise AssertionError(
+                    "A previous Included File registry requires its directory"
+                )
+            backup_registry_state = _included_regular_file_state(
+                registry_backup_path,
+                expected_parent_identity=(
+                    previous_registry_directory_identity
+                ),
+                allowed_identities=frozenset({previous_registry_identity}),
+            )
+            backup_registry_identity = (
+                backup_registry_state[0]
+                if backup_registry_state is not None
+                else None
+            )
+        if current_registry_identity == transaction.staged_registry_identity:
+            if final_registry_parent_identity is None:
+                raise AssertionError(
+                    "A published Included File registry requires its directory"
+                )
+            _move_exact_included_file(
+                final_registry_path,
+                transaction.staged_registry_path,
+                transaction.staged_registry_identity,
+                source_parent_identity=final_registry_parent_identity,
+                destination_parent_identity=transaction.stage_container_identity,
+            )
+            current_registry_identity = None
+        elif current_registry_identity not in {None, previous_registry_identity}:
+            raise OSError("Refusing to overwrite an unknown Included File registry during rollback")
+
+        if previous_registry_identity is None:
+            if backup_registry_identity is not None or current_registry_identity is not None:
+                raise OSError("Could not restore the previously absent Included File registry")
+        elif current_registry_identity == previous_registry_identity:
+            if backup_registry_identity is not None:
+                raise OSError("Included File registry rollback left a duplicate backup")
+        elif backup_registry_identity == previous_registry_identity:
+            if (
+                previous_registry_directory_identity is None
+                or final_registry_parent_identity is None
+            ):
+                raise AssertionError(
+                    "A previous Included File registry requires its directory"
+                )
+            _move_exact_included_file(
+                registry_backup_path,
+                final_registry_path,
+                previous_registry_identity,
+                source_parent_identity=(
+                    previous_registry_directory_identity
+                ),
+                destination_parent_identity=final_registry_parent_identity,
+            )
+        else:
+            raise OSError("Previous Included File registry backup is unavailable")
+    except Exception as error:
+        errors.append(error)
+
+    try:
+        current_root_identity = _included_directory_identity(final_root_path)
+        backup_root_identity = _included_directory_identity(root_backup_path)
+        previous_root_identity = transaction.previous_root_snapshot.identity
+        staged_root_identity = transaction.staged_root_snapshot.identity
+        if staged_root_identity is None:
+            raise AssertionError("A staged Included Files root must be present")
+        if current_root_identity == staged_root_identity:
+            _move_exact_included_directory(
+                final_root_path,
+                transaction.staged_root_path,
+                staged_root_identity,
+                source_parent_identity=transaction.project_identity,
+                destination_parent_identity=transaction.stage_container_identity,
+            )
+            current_root_identity = None
+        elif current_root_identity not in {None, previous_root_identity}:
+            raise OSError("Refusing to overwrite an unknown Included Files root during rollback")
+
+        if previous_root_identity is None:
+            if backup_root_identity is not None or current_root_identity is not None:
+                raise OSError("Could not restore the previously absent Included Files root")
+        elif current_root_identity == previous_root_identity:
+            if backup_root_identity is not None:
+                raise OSError("Included Files rollback left a duplicate root backup")
+        elif backup_root_identity == previous_root_identity:
+            _move_exact_included_directory(
+                root_backup_path,
+                final_root_path,
+                previous_root_identity,
+                source_parent_identity=transaction.project_identity,
+                destination_parent_identity=transaction.project_identity,
+            )
+        else:
+            raise OSError("Previous Included Files root backup is unavailable")
+    except Exception as error:
+        errors.append(error)
+
+    if registry_directory_created and registry_directory_identity is not None:
+        try:
+            _remove_owned_empty_included_directory(
+                registry_directory_path,
+                registry_directory_identity,
+                transaction.project_identity,
+            )
+        except Exception as error:
+            errors.append(error)
+    return tuple(errors)
+
+
+def _commit_included_output_set(
+    project_path: str,
+    transaction: _IncludedOutputSetTransaction,
+    conversion_running: ConversionRunning,
+) -> tuple[str, ...]:
+    """Publish one rollback-protected root/registry generation.
+
+    The two public paths require separate renames, so ordinary conversion is
+    not a synchronization mechanism for concurrent readers. A process crash
+    between those renames also requires a future persistent recovery journal;
+    this transaction only guarantees rollback for failures observed in-process.
+    Cleanup and publication also assume no non-cooperating process mutates this
+    managed namespace: portable inode-conditional rename/unlink primitives do
+    not exist. Issue #727 owns the locking/generation-pointer redesign.
+    """
+    final_root_path = os.path.join(project_path, _INCLUDED_FILES_ROOT_NAME)
+    final_registry_path = _included_registry_path(project_path)
+    root_backup_path = _unique_included_transaction_path(
+        project_path,
+        "included_files",
+    )
+    registry_directory_path = os.path.dirname(final_registry_path)
+    registry_backup_path = _unique_included_transaction_path(
+        registry_directory_path
+        if transaction.previous_registry_snapshot.directory_identity is not None
+        else project_path,
+        "gml_included_file_registry.gd",
+    )
+    registry_directory_identity: _PathIdentity | None = None
+    registry_directory_created = False
+
+    try:
+        _verify_included_project_identity(
+            project_path,
+            transaction.project_identity,
+        )
+        _verify_included_stage_container(
+            project_path,
+            transaction.project_identity,
+            transaction.stage_container_path,
+            transaction.stage_container_identity,
+        )
+        _verify_included_tree_snapshot(
+            final_root_path,
+            transaction.previous_root_snapshot,
+            expected_parent_identity=transaction.project_identity,
+        )
+        _verify_included_registry_snapshot(
+            project_path,
+            transaction.previous_registry_snapshot,
+            expected_project_identity=transaction.project_identity,
+        )
+        _verify_included_tree_snapshot(
+            transaction.staged_root_path,
+            transaction.staged_root_snapshot,
+            expected_parent_identity=transaction.stage_container_identity,
+        )
+        staged_registry_state = _included_regular_file_state(
+            transaction.staged_registry_path,
+            expected_parent_identity=transaction.stage_container_identity,
+            allowed_identities=frozenset(
+                {transaction.staged_registry_identity}
+            ),
+        )
+        if (
+            staged_registry_state is None
+            or staged_registry_state[0] != transaction.staged_registry_identity
+            or staged_registry_state[2] != transaction.staged_registry_content
+        ):
+            raise OSError("Included File registry staging candidate changed")
+        if not conversion_running():
+            raise _IncludedOutputSetCancelled()
+
+        (
+            registry_directory_path,
+            registry_directory_identity,
+            registry_directory_created,
+        ) = _prepare_included_registry_directory(
+            project_path,
+            transaction.previous_registry_snapshot,
+            transaction.project_identity,
+        )
+        if transaction.previous_registry_snapshot.file_mode is not None:
+            _chmod_exact_included_file(
+                transaction.staged_registry_path,
+                transaction.staged_registry_identity,
+                transaction.previous_registry_snapshot.file_mode,
+                transaction.stage_container_identity,
+            )
+            staged_registry_state = _included_regular_file_state(
+                transaction.staged_registry_path,
+                expected_parent_identity=transaction.stage_container_identity,
+                allowed_identities=frozenset(
+                    {transaction.staged_registry_identity}
+                ),
+            )
+            if (
+                staged_registry_state is None
+                or staged_registry_state[0] != transaction.staged_registry_identity
+                or staged_registry_state[2] != transaction.staged_registry_content
+            ):
+                raise OSError("Included File registry staging candidate changed")
+
+        previous_root_identity = transaction.previous_root_snapshot.identity
+        if previous_root_identity is not None:
+            _move_exact_included_directory(
+                final_root_path,
+                root_backup_path,
+                previous_root_identity,
+                source_parent_identity=transaction.project_identity,
+                destination_parent_identity=transaction.project_identity,
+            )
+        if not conversion_running():
+            raise _IncludedOutputSetCancelled()
+
+        staged_root_identity = transaction.staged_root_snapshot.identity
+        if staged_root_identity is None:
+            raise AssertionError("A staged Included Files root must be present")
+        _move_exact_included_directory(
+            transaction.staged_root_path,
+            final_root_path,
+            staged_root_identity,
+            source_parent_identity=transaction.stage_container_identity,
+            destination_parent_identity=transaction.project_identity,
+        )
+        _verify_included_tree_snapshot(
+            final_root_path,
+            transaction.staged_root_snapshot,
+            expected_parent_identity=transaction.project_identity,
+        )
+        if not conversion_running():
+            raise _IncludedOutputSetCancelled()
+
+        previous_registry_identity = (
+            transaction.previous_registry_snapshot.file_identity
+        )
+        if previous_registry_identity is not None:
+            registry_backup_path = _unique_included_transaction_path(
+                registry_directory_path,
+                "gml_included_file_registry.gd",
+            )
+            _move_exact_included_file(
+                final_registry_path,
+                registry_backup_path,
+                previous_registry_identity,
+                source_parent_identity=registry_directory_identity,
+                destination_parent_identity=registry_directory_identity,
+            )
+        if not conversion_running():
+            raise _IncludedOutputSetCancelled()
+
+        _move_exact_included_file(
+            transaction.staged_registry_path,
+            final_registry_path,
+            transaction.staged_registry_identity,
+            source_parent_identity=transaction.stage_container_identity,
+            destination_parent_identity=registry_directory_identity,
+        )
+        published_registry_state = _included_regular_file_state(
+            final_registry_path,
+            expected_parent_identity=registry_directory_identity,
+            allowed_identities=frozenset(
+                {transaction.staged_registry_identity}
+            ),
+        )
+        if (
+            published_registry_state is None
+            or published_registry_state[0] != transaction.staged_registry_identity
+            or published_registry_state[2] != transaction.staged_registry_content
+        ):
+            raise OSError("Included File registry changed after publication")
+        if not conversion_running():
+            raise _IncludedOutputSetCancelled()
+        _verify_included_stage_container(
+            project_path,
+            transaction.project_identity,
+            transaction.stage_container_path,
+            transaction.stage_container_identity,
+        )
+    except BaseException as error:
+        rollback_errors = _rollback_included_output_set(
+            transaction,
+            root_backup_path=root_backup_path,
+            registry_backup_path=registry_backup_path,
+            registry_directory_path=registry_directory_path,
+            registry_directory_identity=registry_directory_identity,
+            registry_directory_created=registry_directory_created,
+        )
+        if rollback_errors:
+            error.add_note(
+                "Included Files rollback also failed: "
+                + "; ".join(str(rollback_error) for rollback_error in rollback_errors)
+            )
+        raise
+
+    cleanup_errors: list[str] = []
+    previous_root_identity = transaction.previous_root_snapshot.identity
+    if previous_root_identity is not None:
+        try:
+            _remove_owned_included_tree(
+                root_backup_path,
+                previous_root_identity,
+                expected_parent_identity=transaction.project_identity,
+            )
+        except OSError as error:
+            cleanup_errors.append(str(error))
+    previous_registry_identity = transaction.previous_registry_snapshot.file_identity
+    if previous_registry_identity is not None:
+        try:
+            _remove_owned_included_file(
+                registry_backup_path,
+                previous_registry_identity,
+                expected_parent_identity=registry_directory_identity,
+            )
+        except OSError as error:
+            cleanup_errors.append(str(error))
+    return tuple(cleanup_errors)
+
+
+def _included_output_components(
+    project_path: str,
+    output_path: str,
+) -> tuple[str, ...]:
+    project_root = os.path.abspath(project_path)
+    absolute_output = os.path.abspath(output_path)
+    try:
+        contained = os.path.normcase(
+            os.path.commonpath((project_root, absolute_output))
+        ) == os.path.normcase(project_root)
+    except ValueError:
+        contained = False
+    relative_path = (
+        os.path.relpath(absolute_output, project_root)
+        if contained
+        else os.pardir
+    )
+    components = tuple(relative_path.split(os.sep))
+    if (
+        not contained
+        or os.path.isabs(relative_path)
+        or len(components) < 2
+        or components[0] != "included_files"
+        or any(component in {"", ".", ".."} for component in components)
+    ):
+        raise ValueError(
+            f"Generated Included File output escapes its managed root: {output_path}"
+        )
+    return components
+
+
+def _ensure_included_output_project_root(project_path: str) -> tuple[int, int]:
+    os.makedirs(project_path, exist_ok=True)
+    project_stat = os.lstat(project_path)
+    if (
+        _included_output_path_is_redirected(project_path, project_stat)
+        or not stat.S_ISDIR(project_stat.st_mode)
+    ):
+        raise OSError(
+            f"Refusing redirected Included File output root: {project_path}"
+        )
+    return (project_stat.st_dev, project_stat.st_ino)
+
+
+def _confined_included_output_supported() -> bool:
+    return (
+        os.name != "nt"
+        and os.chmod in os.supports_fd
+        and os.utime in os.supports_fd
+        and all(
+            operation in os.supports_dir_fd
+            for operation in (os.open, os.mkdir, os.stat, os.rename, os.unlink)
+        )
+    )
+
+
+def _open_or_create_included_output_directory(
+    parent_fd: int,
+    component: str,
+    flags: int,
+) -> int:
+    try:
+        return os.open(component, flags, dir_fd=parent_fd)
+    except FileNotFoundError:
+        try:
+            os.mkdir(component, 0o755, dir_fd=parent_fd)
+        except FileExistsError:
+            pass
+        try:
+            return os.open(component, flags, dir_fd=parent_fd)
+        except OSError as error:
+            raise OSError(
+                "Refusing redirected Included File output directory: "
+                f"{component}"
+            ) from error
+    except OSError as error:
+        raise OSError(
+            f"Refusing redirected Included File output directory: {component}"
+        ) from error
+
+
+def _verify_open_included_output_directory(
+    project_path: str,
+    directory_path: str,
+    directory_fd: int,
+) -> None:
+    try:
+        path_stat = os.lstat(directory_path)
+        open_stat = os.fstat(directory_fd)
+    except OSError as error:
+        raise OSError(
+            f"Included File output directory changed: {directory_path}"
+        ) from error
+    project_real = os.path.normcase(os.path.realpath(project_path))
+    directory_real = os.path.normcase(os.path.realpath(directory_path))
+    try:
+        contained = (
+            os.path.commonpath((project_real, directory_real))
+            == project_real
+        )
+    except ValueError:
+        contained = False
+    if (
+        _included_output_path_is_redirected(directory_path, path_stat)
+        or not stat.S_ISDIR(path_stat.st_mode)
+        or (path_stat.st_dev, path_stat.st_ino)
+        != (open_stat.st_dev, open_stat.st_ino)
+        or not contained
+    ):
+        raise OSError(
+            f"Refusing redirected Included File output directory: {directory_path}"
+        )
+
+
+def _included_output_state_at(
+    directory_fd: int,
+    filename: str,
+) -> tuple[int, int] | None:
+    try:
+        output_stat = os.stat(
+            filename,
+            dir_fd=directory_fd,
+            follow_symlinks=False,
+        )
+    except FileNotFoundError:
+        return None
+    if not stat.S_ISREG(output_stat.st_mode):
+        raise OSError(
+            f"Refusing non-regular Included File output: {filename}"
+        )
+    return (output_stat.st_dev, output_stat.st_ino)
+
+
+def _verify_included_output_state_at(
+    directory_fd: int,
+    filename: str,
+    expected_identity: tuple[int, int] | None,
+) -> None:
+    current_identity = _included_output_state_at(directory_fd, filename)
+    if current_identity != expected_identity:
+        raise OSError(
+            f"Included File output changed during publication: {filename}"
+        )
+
+
+def _apply_included_output_metadata(
+    file_descriptor: int,
+    source_stat: os.stat_result,
+) -> None:
+    if os.chmod in os.supports_fd:
+        os.chmod(file_descriptor, stat.S_IMODE(source_stat.st_mode))
+    if os.utime in os.supports_fd:
+        os.utime(
+            file_descriptor,
+            ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns),
+        )
+
+
+def _read_included_payload_chunk(source_file: BinaryIO) -> bytes:
+    return source_file.read(1024 * 1024)
+
+
+def _copy_included_payload(
+    source_file: BinaryIO,
+    target_file: BinaryIO,
+    source_stat: os.stat_result,
+) -> _IncludedCopyReceipt:
+    expected_fingerprint = _included_source_fingerprint(source_stat)
+    if source_file.tell() != 0:
+        raise OSError("GameMaker Included File source did not start at offset zero")
+    before_copy = os.fstat(source_file.fileno())
+    if (
+        not stat.S_ISREG(before_copy.st_mode)
+        or _included_source_fingerprint(before_copy) != expected_fingerprint
+    ):
+        raise OSError("GameMaker Included File source changed before copying")
+
+    digest = hashlib.sha256()
+    byte_count = 0
+    while True:
+        chunk = _read_included_payload_chunk(source_file)
+        if not chunk:
+            break
+        written = target_file.write(chunk)
+        if written != len(chunk):
+            raise OSError("Could not write the complete Included File payload")
+        digest.update(chunk)
+        byte_count += len(chunk)
+
+    after_copy = os.fstat(source_file.fileno())
+    if (
+        not stat.S_ISREG(after_copy.st_mode)
+        or _included_source_fingerprint(after_copy) != expected_fingerprint
+        or byte_count != source_stat.st_size
+    ):
+        raise OSError("GameMaker Included File source changed while copying")
+    streamed_sha256 = digest.hexdigest()
+    source_file.seek(0)
+    verified_byte_count, verified_sha256 = _digest_open_included_file(
+        source_file
+    )
+    after_verification = os.fstat(source_file.fileno())
+    if (
+        _included_source_fingerprint(after_verification)
+        != expected_fingerprint
+        or verified_byte_count != byte_count
+        or verified_sha256 != streamed_sha256
+    ):
+        raise OSError(
+            "GameMaker Included File source payload changed while copying"
+        )
+    return _IncludedCopyReceipt(
+        source_fingerprint=expected_fingerprint,
+        byte_count=byte_count,
+        sha256=streamed_sha256,
+    )
+
+
+def _stage_included_output_at(
+    directory_fd: int,
+    filename: str,
+    source_file: BinaryIO,
+    source_stat: os.stat_result,
+    verify_directory: Callable[[], None],
+) -> _IncludedCopyReceipt:
+    verify_directory()
+    output_identity = _included_output_state_at(directory_fd, filename)
+    temporary_name = ""
+    file_descriptor = -1
+    for _attempt in range(100):
+        temporary_name = f".gm2godot-{secrets.token_hex(8)}.tmp"
+        try:
+            file_descriptor = os.open(
+                temporary_name,
+                os.O_WRONLY
+                | os.O_CREAT
+                | os.O_EXCL
+                | getattr(os, "O_NOFOLLOW", 0),
+                0o600,
+                dir_fd=directory_fd,
+            )
+            break
+        except FileExistsError:
+            continue
+    if file_descriptor < 0:
+        raise OSError(f"Could not stage Included File output: {filename}")
+
+    temporary_stat = os.fstat(file_descriptor)
+    temporary_identity = (temporary_stat.st_dev, temporary_stat.st_ino)
+    temporary_pending = True
+    published_pending = False
+    try:
+        with os.fdopen(file_descriptor, "wb") as target_file:
+            file_descriptor = -1
+            copy_receipt = _copy_included_payload(
+                source_file,
+                target_file,
+                source_stat,
+            )
+            target_file.flush()
+            _apply_included_output_metadata(
+                target_file.fileno(),
+                source_stat,
+            )
+            os.fsync(target_file.fileno())
+        staged_stat = os.stat(
+            temporary_name,
+            dir_fd=directory_fd,
+            follow_symlinks=False,
+        )
+        if (
+            not stat.S_ISREG(staged_stat.st_mode)
+            or (staged_stat.st_dev, staged_stat.st_ino) != temporary_identity
+        ):
+            raise OSError(f"Included File staging output changed: {filename}")
+        verify_directory()
+        _verify_included_output_state_at(
+            directory_fd,
+            filename,
+            output_identity,
+        )
+        verify_directory()
+        os.rename(
+            temporary_name,
+            filename,
+            src_dir_fd=directory_fd,
+            dst_dir_fd=directory_fd,
+        )
+        temporary_pending = False
+        published_pending = True
+        published_stat = os.stat(
+            filename,
+            dir_fd=directory_fd,
+            follow_symlinks=False,
+        )
+        if (
+            not stat.S_ISREG(published_stat.st_mode)
+            or (published_stat.st_dev, published_stat.st_ino)
+            != temporary_identity
+        ):
+            raise OSError(f"Included File output changed after publication: {filename}")
+        verify_directory()
+        published_pending = False
+        return copy_receipt
+    finally:
+        if file_descriptor >= 0:
+            os.close(file_descriptor)
+        if temporary_pending and temporary_name:
+            try:
+                current_stat = os.stat(
+                    temporary_name,
+                    dir_fd=directory_fd,
+                    follow_symlinks=False,
+                )
+                if (
+                    current_stat.st_dev,
+                    current_stat.st_ino,
+                ) == temporary_identity:
+                    os.unlink(temporary_name, dir_fd=directory_fd)
+            except OSError:
+                pass
+        if published_pending:
+            try:
+                current_stat = os.stat(
+                    filename,
+                    dir_fd=directory_fd,
+                    follow_symlinks=False,
+                )
+                if (
+                    stat.S_ISREG(current_stat.st_mode)
+                    and (
+                        current_stat.st_dev,
+                        current_stat.st_ino,
+                    )
+                    == temporary_identity
+                ):
+                    os.unlink(filename, dir_fd=directory_fd)
+            except OSError:
+                pass
+
+
+def _publish_included_output_at(
+    project_path: str,
+    components: tuple[str, ...],
+    source_file: BinaryIO,
+    source_stat: os.stat_result,
+) -> _IncludedCopyReceipt:
+    directory_flags = os.O_RDONLY
+    directory_flags |= getattr(os, "O_DIRECTORY", 0)
+    directory_flags |= getattr(os, "O_NOFOLLOW", 0)
+    project_fd = os.open(project_path, directory_flags)
+    current_fd = project_fd
+    try:
+        _verify_open_included_output_directory(
+            project_path,
+            project_path,
+            project_fd,
+        )
+        for component in components[:-1]:
+            child_fd = _open_or_create_included_output_directory(
+                current_fd,
+                component,
+                directory_flags,
+            )
+            if current_fd != project_fd:
+                os.close(current_fd)
+            current_fd = child_fd
+
+        output_directory = os.path.join(project_path, *components[:-1])
+        def verify_output_directory() -> None:
+            _verify_open_included_output_directory(
+                project_path,
+                output_directory,
+                current_fd,
+            )
+
+        verify_output_directory()
+        receipt = _stage_included_output_at(
+            current_fd,
+            components[-1],
+            source_file,
+            source_stat,
+            verify_output_directory,
+        )
+        verify_output_directory()
+        return receipt
+    finally:
+        if current_fd != project_fd:
+            os.close(current_fd)
+        os.close(project_fd)
+
+
+def _prepare_included_output_directories_fallback(
+    project_path: str,
+    directory_components: tuple[str, ...],
+) -> tuple[tuple[str, tuple[int, int]], ...]:
+    project_real = os.path.normcase(os.path.realpath(project_path))
+    directory_path = project_path
+    identities: list[tuple[str, tuple[int, int]]] = []
+    for component in (None, *directory_components):
+        if component is not None:
+            directory_path = os.path.join(directory_path, component)
+            try:
+                directory_stat = os.lstat(directory_path)
+            except FileNotFoundError:
+                try:
+                    os.mkdir(directory_path)
+                except FileExistsError:
+                    pass
+                directory_stat = os.lstat(directory_path)
+        else:
+            directory_stat = os.lstat(directory_path)
+        directory_real = os.path.normcase(os.path.realpath(directory_path))
+        try:
+            contained = (
+                os.path.commonpath((project_real, directory_real))
+                == project_real
+            )
+        except ValueError:
+            contained = False
+        if (
+            _included_output_path_is_redirected(directory_path, directory_stat)
+            or not stat.S_ISDIR(directory_stat.st_mode)
+            or not contained
+        ):
+            raise OSError(
+                "Refusing redirected Included File output directory: "
+                f"{directory_path}"
+            )
+        identities.append(
+            (
+                directory_path,
+                (directory_stat.st_dev, directory_stat.st_ino),
+            )
+        )
+    return tuple(identities)
+
+
+def _verify_included_output_directories_fallback(
+    identities: tuple[tuple[str, tuple[int, int]], ...],
+) -> None:
+    for directory_path, expected_identity in identities:
+        try:
+            directory_stat = os.lstat(directory_path)
+        except OSError as error:
+            raise OSError(
+                f"Included File output directory changed: {directory_path}"
+            ) from error
+        if (
+            _included_output_path_is_redirected(directory_path, directory_stat)
+            or not stat.S_ISDIR(directory_stat.st_mode)
+            or (directory_stat.st_dev, directory_stat.st_ino)
+            != expected_identity
+        ):
+            raise OSError(
+                f"Included File output directory changed: {directory_path}"
+            )
+
+
+def _verify_included_output_stage_fallback(
+    staged_path: str,
+    expected_identity: tuple[int, int],
+    expected_project_identity: tuple[int, int],
+) -> None:
+    try:
+        staged_stat = os.lstat(staged_path)
+        parent_path = os.path.dirname(staged_path) or os.curdir
+        parent_stat = os.lstat(parent_path)
+    except OSError as error:
+        raise OSError(
+            f"Included File staging output changed: {staged_path}"
+        ) from error
+    if (
+        _included_output_path_is_redirected(staged_path, staged_stat)
+        or not stat.S_ISREG(staged_stat.st_mode)
+        or (staged_stat.st_dev, staged_stat.st_ino) != expected_identity
+        or _included_output_path_is_redirected(parent_path, parent_stat)
+        or not stat.S_ISDIR(parent_stat.st_mode)
+        or (parent_stat.st_dev, parent_stat.st_ino)
+        != expected_project_identity
+    ):
+        raise OSError(
+            f"Included File staging output changed: {staged_path}"
+        )
+
+
+def _remove_included_output_stage_fallback(
+    staged_paths: tuple[str, ...],
+    expected_identity: tuple[int, int],
+) -> None:
+    checked_paths: set[str] = set()
+    for staged_path in staged_paths:
+        normalized_path = os.path.normcase(os.path.abspath(staged_path))
+        if normalized_path in checked_paths:
+            continue
+        checked_paths.add(normalized_path)
+        try:
+            staged_stat = os.lstat(staged_path)
+        except OSError:
+            continue
+        if (
+            not stat.S_ISREG(staged_stat.st_mode)
+            or (staged_stat.st_dev, staged_stat.st_ino) != expected_identity
+        ):
+            continue
+        try:
+            os.unlink(staged_path)
+        except PermissionError:
+            if os.name != "nt":
+                raise
+            os.chmod(staged_path, stat.S_IWRITE)
+            writable_stat = os.lstat(staged_path)
+            if (
+                not stat.S_ISREG(writable_stat.st_mode)
+                or (writable_stat.st_dev, writable_stat.st_ino)
+                != expected_identity
+            ):
+                raise OSError(
+                    f"Included File staging output changed: {staged_path}"
+                )
+            os.unlink(staged_path)
+        return
+
+
+def _included_output_state(
+    output_path: str,
+) -> tuple[int, int] | None:
+    try:
+        output_stat = os.lstat(output_path)
+    except FileNotFoundError:
+        return None
+    if not stat.S_ISREG(output_stat.st_mode):
+        raise OSError(
+            f"Refusing non-regular Included File output: {output_path}"
+        )
+    return (output_stat.st_dev, output_stat.st_ino)
+
+
+def _verify_included_output_state(
+    output_path: str,
+    expected_identity: tuple[int, int] | None,
+) -> None:
+    current_identity = _included_output_state(output_path)
+    if current_identity != expected_identity:
+        raise OSError(
+            f"Included File output changed during publication: {output_path}"
+        )
+
+
+def _publish_included_output_fallback(
+    project_path: str,
+    components: tuple[str, ...],
+    source_file: BinaryIO,
+    source_stat: os.stat_result,
+) -> _IncludedCopyReceipt:
+    directory_identities = _prepare_included_output_directories_fallback(
+        project_path,
+        components[:-1],
+    )
+    output_directory = os.path.join(project_path, *components[:-1])
+    output_path = os.path.join(output_directory, components[-1])
+    output_identity = _included_output_state(output_path)
+    file_descriptor, temporary_path = tempfile.mkstemp(
+        dir=project_path,
+        prefix=".gm2godot-",
+        suffix=".tmp",
+    )
+    temporary_stat = os.fstat(file_descriptor)
+    temporary_identity = (temporary_stat.st_dev, temporary_stat.st_ino)
+    resolved_temporary_path = temporary_path
+    temporary_pending = True
+    try:
+        resolved_temporary_path = os.path.realpath(temporary_path)
+        _verify_included_output_directories_fallback(
+            directory_identities[:1]
+        )
+        _verify_included_output_stage_fallback(
+            resolved_temporary_path,
+            temporary_identity,
+            directory_identities[0][1],
+        )
+        _verify_included_output_directories_fallback(
+            directory_identities[:1]
+        )
+        with os.fdopen(file_descriptor, "wb") as target_file:
+            file_descriptor = -1
+            copy_receipt = _copy_included_payload(
+                source_file,
+                target_file,
+                source_stat,
+            )
+            target_file.flush()
+            _apply_included_output_metadata(
+                target_file.fileno(),
+                source_stat,
+            )
+            os.fsync(target_file.fileno())
+        _verify_included_output_directories_fallback(directory_identities)
+        _verify_included_output_stage_fallback(
+            resolved_temporary_path,
+            temporary_identity,
+            directory_identities[0][1],
+        )
+        _verify_included_output_state(output_path, output_identity)
+        _verify_included_output_directories_fallback(directory_identities)
+        os.replace(resolved_temporary_path, output_path)
+        temporary_pending = False
+        published_stat = os.lstat(output_path)
+        if (
+            not stat.S_ISREG(published_stat.st_mode)
+            or (published_stat.st_dev, published_stat.st_ino)
+            != temporary_identity
+        ):
+            raise OSError(
+                f"Included File output changed after publication: {output_path}"
+            )
+        return copy_receipt
+    finally:
+        if file_descriptor >= 0:
+            os.close(file_descriptor)
+        if temporary_pending:
+            try:
+                _remove_included_output_stage_fallback(
+                    (resolved_temporary_path, temporary_path),
+                    temporary_identity,
+                )
+            except OSError:
+                pass
+
+
+def _publish_confined_included_output(
+    project_path: str,
+    output_path: str,
+    source_file: BinaryIO,
+    source_stat: os.stat_result,
+) -> _IncludedCopyReceipt:
+    components = _included_output_components(project_path, output_path)
+    _ensure_included_output_project_root(project_path)
+    if _confined_included_output_supported():
+        return _publish_included_output_at(
+            project_path,
+            components,
+            source_file,
+            source_stat,
+        )
+    return _publish_included_output_fallback(
+        project_path,
+        components,
+        source_file,
+        source_stat,
+    )
+
+
 class IncludedFilesConverter(BaseConverter):
     def __init__(self, gm_project_path: StrPath, godot_project_path: StrPath, log_callback: LogCallback = print,
                  progress_callback: ProgressCallback | None = None, conversion_running: ConversionRunning | None = None,
@@ -54,6 +3478,7 @@ class IncludedFilesConverter(BaseConverter):
         super().__init__(gm_project_path, godot_project_path, log_callback, progress_callback, conversion_running,
                          update_log_callback, compact_logging, max_workers=max_workers,
                          diagnostics=diagnostics)
+        self._active_output_project_path: str | None = None
 
     def _process_file(
         self,
@@ -61,7 +3486,7 @@ class IncludedFilesConverter(BaseConverter):
         godot_file_path: str,
         rel_path: str,
         owner_source_path: str = "datafiles",
-    ) -> tuple[str, bool] | None:
+    ) -> tuple[str, bool, _IncludedCopyReceipt | None] | None:
         if not self.conversion_running():
             return None
         self._resource_requested(rel_path)
@@ -75,25 +3500,57 @@ class IncludedFilesConverter(BaseConverter):
             )
             if opened_source is None:
                 self._resource_failed(rel_path)
-                return rel_path, False
+                return rel_path, False, None
 
             source_file, source_stat = opened_source
             with source_file:
-                with open(godot_file_path, "wb") as target_file:
-                    shutil.copyfileobj(source_file, target_file)
-
-            # Preserve metadata without consulting the source path again after
-            # its validated descriptor has been pinned.
-            os.chmod(godot_file_path, stat.S_IMODE(source_stat.st_mode))
-            os.utime(
-                godot_file_path,
-                ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns),
-            )
+                try:
+                    copy_receipt = _publish_confined_included_output(
+                        self._active_output_project_path
+                        or self.godot_project_path,
+                        godot_file_path,
+                        source_file,
+                        source_stat,
+                    )
+                except (OSError, ValueError) as error:
+                    self._resource_failed(rel_path)
+                    self._report_included_file_output_rejection(
+                        rel_path,
+                        godot_file_path,
+                        error,
+                    )
+                    return rel_path, False, None
         except Exception:
             self._resource_failed(rel_path)
             raise
-        self._resource_completed(rel_path)
-        return rel_path, True
+        return rel_path, True, copy_receipt
+
+    def _report_included_file_output_rejection(
+        self,
+        relative_path: str,
+        output_path: str,
+        error: BaseException,
+    ) -> None:
+        message = (
+            "Error: Refusing to publish GameMaker Included File "
+            f"{relative_path!r} to {output_path!r}: {error}"
+        )
+        with self._lock:
+            if self.diagnostics is not None:
+                self.diagnostics.add(
+                    "error",
+                    "GM2GD-INCLUDED-FILE-OUTPUT-REJECTED",
+                    message,
+                    source_path="datafiles/" + relative_path,
+                    resource=relative_path,
+                    resource_type="included_file",
+                    manifest_entry="generated Included File output",
+                    workaround=(
+                        "Remove redirected or non-regular entries from the "
+                        "Godot included_files output tree and retry conversion."
+                    ),
+                )
+            self.log_callback(message)
 
     def _open_confined_source_file(
         self,
@@ -615,67 +4072,331 @@ class IncludedFilesConverter(BaseConverter):
             )
         self._safe_log(message)
 
+    def _report_included_file_path_collisions(
+        self,
+        assignments: tuple[IncludedFilePathAssignment, ...],
+    ) -> None:
+        reported_paths: set[str] = set()
+        assignments_by_source = {
+            assignment.original_logical_path: assignment.assigned_output_path
+            for assignment in assignments
+        }
+        for assignment in assignments:
+            canonical_path = assignment.canonical_lookup_path
+            if not assignment.has_collision or canonical_path in reported_paths:
+                continue
+            reported_paths.add(canonical_path)
+            rendered_assignments = ", ".join(
+                f"{source_path!r} -> {assignments_by_source[source_path]!r}"
+                for source_path in assignment.collision_group
+            )
+            message = (
+                "Warning: GameMaker Included File paths conflict after "
+                f"packaged-name normalization at {canonical_path!r}; "
+                "deterministic output paths were assigned: "
+                f"{rendered_assignments}."
+            )
+            if self.diagnostics is not None:
+                self.diagnostics.add(
+                    "warning",
+                    "GM2GD-INCLUDED-FILE-PATH-COLLISION",
+                    message,
+                    source_path="datafiles",
+                    resource=canonical_path,
+                    resource_type="included_file",
+                    manifest_entry="normalized Included File output path",
+                    workaround=(
+                        "Rename the conflicting Included Files so their "
+                        "lowercase, space-to-underscore packaged paths do not "
+                        "collide as files or directories."
+                    ),
+                )
+            self._safe_log(message)
+
     def convert_included_files(self) -> None:
-        godot_included_path = os.path.join(self.godot_project_path, "included_files")
         plan = self._included_file_conversion_plan()
         for resource_key in plan.requested_keys:
             self._resource_requested(resource_key)
         for resource_key in plan.skipped_keys:
             self._resource_skipped(resource_key)
 
+        planned_logical_paths: list[str] = []
+        for logical_path in (
+            *plan.requested_keys,
+            *(source.relative_path for source in plan.available_files),
+        ):
+            try:
+                canonical_included_file_lookup_path(logical_path)
+            except ProjectSourcePathError:
+                continue
+            planned_logical_paths.append(logical_path)
+        path_assignments = plan_included_file_paths(planned_logical_paths)
+        assignments_by_source = {
+            assignment.original_logical_path: assignment
+            for assignment in path_assignments
+        }
+
         if not plan.requested_keys:
             self.log_callback(get_localized("Console_Convertor_IncludedFiles_Error_NotFound"))
-            return
-
         all_files = list(plan.available_files)
-        if not all_files:
-            return
+        if path_assignments:
+            self._report_included_file_path_collisions(path_assignments)
 
-        os.makedirs(godot_included_path, exist_ok=True)
-
-        # Pre-create all directories
-        for source in all_files:
-            godot_dir = os.path.dirname(
-                os.path.join(
-                    godot_included_path,
-                    *source.relative_path.split("/"),
-                )
+        project_identity = _ensure_included_output_project_root(
+            self.godot_project_path
+        )
+        public_root_path = os.path.join(
+            self.godot_project_path,
+            _INCLUDED_FILES_ROOT_NAME,
+        )
+        previous_root_snapshot: _IncludedTreeSnapshot
+        previous_registry_snapshot: _IncludedRegistrySnapshot
+        try:
+            previous_root_snapshot = _capture_included_tree(
+                public_root_path,
+                expected_parent_identity=project_identity,
             )
-            os.makedirs(godot_dir, exist_ok=True)
-
-        total_files = len(all_files)
-        processed_files = 0
-
-        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            futures_map: dict[Future[tuple[str, bool] | None], str] = {}
+            previous_registry_snapshot = _capture_included_registry(
+                self.godot_project_path,
+                expected_project_identity=project_identity,
+            )
+        except Exception as error:
             for source in all_files:
-                godot_file_path = os.path.join(
-                    godot_included_path,
-                    *source.relative_path.split("/"),
-                )
-                future = executor.submit(
-                    self._process_file,
-                    source.filesystem_path,
-                    godot_file_path,
+                self._resource_failed(source.relative_path)
+                assignment = assignments_by_source[source.relative_path]
+                self._report_included_file_output_rejection(
                     source.relative_path,
-                    source.owner_source_path,
+                    os.path.join(
+                        public_root_path,
+                        *assignment.assigned_output_path.split("/"),
+                    ),
+                    error,
                 )
-                futures_map[future] = source.relative_path
+            raise
 
-            for future in as_completed(futures_map):
-                result = future.result()
-                if result is None:
-                    self.log_callback(get_localized("Console_Convertor_IncludedFiles_Stopped"))
-                    return
+        stage_container_path: str | None = None
+        stage_container_identity: _PathIdentity | None = None
+        active_error: BaseException | None = None
+        transaction_committed = False
+        try:
+            (
+                stage_container_path,
+                stage_container_identity,
+            ) = _create_included_output_stage(
+                self.godot_project_path,
+                project_identity,
+            )
+            staged_root_path = os.path.join(
+                stage_container_path,
+                _INCLUDED_FILES_ROOT_NAME,
+            )
+            os.mkdir(staged_root_path, 0o755)
+            staged_root_identity = _included_directory_identity(staged_root_path)
+            if staged_root_identity is None:
+                raise OSError("Included Files staging root disappeared")
 
-                processed_files += 1
-                rel_path, copied = result
-                if copied:
-                    if self.compact_logging:
-                        self._safe_log_progress(os.path.basename(rel_path), processed_files, total_files)
-                    else:
-                        self._safe_log(get_localized("Console_Convertor_IncludedFiles_Copied").format(path=rel_path))
-                self._safe_progress(int((processed_files / total_files) * 100))
+            self._active_output_project_path = stage_container_path
+            successful_logical_paths: set[str] = set()
+            copy_receipts: dict[str, _IncludedCopyReceipt] = {}
+            worker_failed = False
+            worker_cancelled = False
+            first_worker_error: BaseException | None = None
+            processed_files = 0
+            total_files = len(all_files)
+            try:
+                with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+                    futures_map: dict[
+                        Future[
+                            tuple[
+                                str,
+                                bool,
+                                _IncludedCopyReceipt | None,
+                            ]
+                            | None
+                        ],
+                        str,
+                    ] = {}
+                    for source in all_files:
+                        assignment = assignments_by_source[source.relative_path]
+                        staged_output_path = os.path.join(
+                            staged_root_path,
+                            *assignment.assigned_output_path.split("/"),
+                        )
+                        future = executor.submit(
+                            self._process_file,
+                            source.filesystem_path,
+                            staged_output_path,
+                            source.relative_path,
+                            source.owner_source_path,
+                        )
+                        futures_map[future] = source.relative_path
+
+                    for future in as_completed(futures_map):
+                        try:
+                            result = future.result()
+                        except BaseException as error:
+                            worker_failed = True
+                            if first_worker_error is None:
+                                first_worker_error = error
+                            continue
+                        if result is None:
+                            worker_cancelled = True
+                            continue
+                        processed_files += 1
+                        relative_path, copied, copy_receipt = result
+                        if copied:
+                            if copy_receipt is None:
+                                worker_failed = True
+                                continue
+                            successful_logical_paths.add(relative_path)
+                            copy_receipts[relative_path] = copy_receipt
+                        else:
+                            worker_failed = True
+                        if total_files:
+                            self._safe_progress(
+                                min(
+                                    99,
+                                    int((processed_files / total_files) * 99),
+                                )
+                            )
+            finally:
+                self._active_output_project_path = None
+
+            if worker_failed:
+                for source in all_files:
+                    self._resource_failed(source.relative_path)
+                if first_worker_error is not None:
+                    raise first_worker_error
+                raise OSError(
+                    "Included Files output-set staging failed; the previous "
+                    "managed output was preserved"
+                )
+            if (
+                worker_cancelled
+                or not self.conversion_running()
+                or len(successful_logical_paths) != len(all_files)
+            ):
+                for source in all_files:
+                    self._resource_skipped(source.relative_path)
+                self.log_callback(
+                    get_localized("Console_Convertor_IncludedFiles_Stopped")
+                )
+                return
+
+            staged_root_snapshot = _capture_included_tree(
+                staged_root_path,
+                expected_parent_identity=stage_container_identity,
+            )
+            assigned_receipts = {
+                assignments_by_source[source.relative_path].assigned_output_path:
+                    copy_receipts[source.relative_path]
+                for source in all_files
+            }
+            _verify_staged_included_inventory(
+                staged_root_snapshot,
+                assigned_receipts,
+            )
+
+            emitted_logical_paths = {
+                source.relative_path for source in all_files
+            }
+            staged_registry_text = render_included_file_registry(
+                path_assignments,
+                emitted_logical_paths,
+            )
+            staged_registry_path = os.path.join(
+                stage_container_path,
+                "gml_included_file_registry.gd",
+            )
+            atomic_write_confined_generated_text(
+                staged_registry_path,
+                staged_registry_text,
+                confinement_root=stage_container_path,
+            )
+            staged_registry_state = _included_regular_file_state(
+                staged_registry_path,
+                expected_parent_identity=stage_container_identity,
+            )
+            if staged_registry_state is None:
+                raise OSError("Included File registry staging candidate disappeared")
+            staged_registry_identity, _staged_mode, staged_registry_content = (
+                staged_registry_state
+            )
+
+            transaction = _IncludedOutputSetTransaction(
+                project_identity=project_identity,
+                stage_container_path=stage_container_path,
+                stage_container_identity=stage_container_identity,
+                staged_root_path=staged_root_path,
+                staged_root_snapshot=staged_root_snapshot,
+                staged_registry_path=staged_registry_path,
+                staged_registry_identity=staged_registry_identity,
+                staged_registry_content=staged_registry_content,
+                previous_root_snapshot=previous_root_snapshot,
+                previous_registry_snapshot=previous_registry_snapshot,
+            )
+            cleanup_warnings = _commit_included_output_set(
+                self.godot_project_path,
+                transaction,
+                self.conversion_running,
+            )
+            transaction_committed = True
+            for cleanup_warning in cleanup_warnings:
+                self._safe_log(
+                    "Warning: Included Files transaction cleanup failed: "
+                    + cleanup_warning
+                )
+
+            for source in all_files:
+                self._resource_completed(source.relative_path)
+                if self.compact_logging:
+                    self._safe_log_progress(
+                        os.path.basename(source.relative_path),
+                        len(successful_logical_paths),
+                        len(all_files),
+                    )
+                else:
+                    self._safe_log(
+                        get_localized(
+                            "Console_Convertor_IncludedFiles_Copied"
+                        ).format(path=source.relative_path)
+                    )
+            self._safe_progress(100)
+        except _IncludedOutputSetCancelled:
+            for source in all_files:
+                self._resource_skipped(source.relative_path)
+            self.log_callback(
+                get_localized("Console_Convertor_IncludedFiles_Stopped")
+            )
+            return
+        except BaseException as error:
+            active_error = error
+            for source in all_files:
+                self._resource_failed(source.relative_path)
+            raise
+        finally:
+            self._active_output_project_path = None
+            if (
+                stage_container_path is not None
+                and stage_container_identity is not None
+            ):
+                try:
+                    _remove_owned_included_tree(
+                        stage_container_path,
+                        stage_container_identity,
+                        expected_parent_identity=project_identity,
+                    )
+                except OSError as cleanup_error:
+                    if active_error is not None:
+                        active_error.add_note(
+                            "Included Files staging cleanup also failed: "
+                            + str(cleanup_error)
+                        )
+                    elif transaction_committed:
+                        self._safe_log(
+                            "Warning: Included Files staging cleanup failed: "
+                            + str(cleanup_error)
+                        )
 
     def convert_all(self) -> None:
         self._reset_resource_outcomes()

--- a/src/conversion/included_files.py
+++ b/src/conversion/included_files.py
@@ -61,6 +61,8 @@ class _IncludedFileConversionPlan:
 
 _PathIdentity = tuple[int, int]
 _PathFingerprint = tuple[int, int, int, int, int, int]
+_PathHandleBinding = tuple[int, int, int, int, int, int]
+_HandleState = tuple[int, int, int, int, int, int, int]
 _IncludedSourceFingerprint = tuple[int, int, int, int, int, int]
 _INCLUDED_FILES_ROOT_NAME = "included_files"
 _INCLUDED_FILES_STAGE_PREFIX = ".gm2godot-included-files-"
@@ -403,6 +405,35 @@ def _included_path_fingerprint(path_stat: os.stat_result) -> _PathFingerprint:
     )
 
 
+def _included_path_handle_binding(
+    file_stat: os.stat_result,
+) -> _PathHandleBinding:
+    """Return metadata that is stable across path and handle stat on Windows."""
+
+    return (
+        file_stat.st_dev,
+        file_stat.st_ino,
+        stat.S_IFMT(file_stat.st_mode),
+        file_stat.st_size,
+        file_stat.st_mtime_ns,
+        file_stat.st_nlink,
+    )
+
+
+def _included_handle_state(file_stat: os.stat_result) -> _HandleState:
+    """Return metadata used to detect mutation of one open file handle."""
+
+    return (
+        file_stat.st_dev,
+        file_stat.st_ino,
+        file_stat.st_mode,
+        file_stat.st_size,
+        file_stat.st_mtime_ns,
+        file_stat.st_ctime_ns,
+        file_stat.st_nlink,
+    )
+
+
 def _included_source_fingerprint(
     source_stat: os.stat_result,
 ) -> _IncludedSourceFingerprint:
@@ -435,6 +466,7 @@ def _digest_included_regular_file(
     expected_stat: os.stat_result,
 ) -> str:
     expected_fingerprint = _included_path_fingerprint(expected_stat)
+    expected_binding = _included_path_handle_binding(expected_stat)
     expected_ctime_ns = expected_stat.st_ctime_ns
     flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
     file_descriptor = os.open(path, flags)
@@ -442,26 +474,35 @@ def _digest_included_regular_file(
         opened_stat = os.fstat(file_descriptor)
         if (
             not stat.S_ISREG(opened_stat.st_mode)
-            or _included_path_fingerprint(opened_stat) != expected_fingerprint
-            or opened_stat.st_ctime_ns != expected_ctime_ns
+            or _included_path_handle_binding(opened_stat) != expected_binding
         ):
             raise OSError(f"Included Files file changed before hashing: {path}")
+        opened_state = _included_handle_state(opened_stat)
         with os.fdopen(file_descriptor, "rb") as opened_file:
             file_descriptor = -1
             byte_count, content_sha256 = _digest_open_included_file(opened_file)
+            current_opened_stat = os.fstat(opened_file.fileno())
+            if (
+                _included_handle_state(current_opened_stat) != opened_state
+                or byte_count != expected_stat.st_size
+            ):
+                raise OSError(
+                    f"Included Files file changed while hashing: {path}"
+                )
+
+            current_stat = os.lstat(path)
+            if (
+                _included_output_path_is_redirected(path, current_stat)
+                or not stat.S_ISREG(current_stat.st_mode)
+                or _included_path_fingerprint(current_stat) != expected_fingerprint
+                or current_stat.st_ctime_ns != expected_ctime_ns
+            ):
+                raise OSError(
+                    f"Included Files file changed while hashing: {path}"
+                )
     finally:
         if file_descriptor >= 0:
             os.close(file_descriptor)
-
-    current_stat = os.lstat(path)
-    if (
-        _included_output_path_is_redirected(path, current_stat)
-        or not stat.S_ISREG(current_stat.st_mode)
-        or _included_path_fingerprint(current_stat) != expected_fingerprint
-        or current_stat.st_ctime_ns != expected_ctime_ns
-        or byte_count != expected_stat.st_size
-    ):
-        raise OSError(f"Included Files file changed while hashing: {path}")
     return content_sha256
 
 
@@ -727,6 +768,7 @@ def _digest_included_regular_file_at(
     display_path: str,
 ) -> str:
     expected_fingerprint = _included_path_fingerprint(expected_stat)
+    expected_binding = _included_path_handle_binding(expected_stat)
     expected_ctime_ns = expected_stat.st_ctime_ns
     file_descriptor = os.open(
         name,
@@ -737,27 +779,40 @@ def _digest_included_regular_file_at(
         opened_stat = os.fstat(file_descriptor)
         if (
             not stat.S_ISREG(opened_stat.st_mode)
-            or _included_path_fingerprint(opened_stat) != expected_fingerprint
-            or opened_stat.st_ctime_ns != expected_ctime_ns
+            or _included_path_handle_binding(opened_stat) != expected_binding
         ):
             raise OSError(
                 f"Included Files file changed before hashing: {display_path}"
             )
+        opened_state = _included_handle_state(opened_stat)
         with os.fdopen(file_descriptor, "rb") as opened_file:
             file_descriptor = -1
             byte_count, content_sha256 = _digest_open_included_file(opened_file)
+            current_opened_stat = os.fstat(opened_file.fileno())
+            if (
+                _included_handle_state(current_opened_stat) != opened_state
+                or byte_count != expected_stat.st_size
+            ):
+                raise OSError(
+                    "Included Files file changed while hashing: "
+                    f"{display_path}"
+                )
+
+            current_stat = _included_entry_stat_at(parent_fd, name)
+            if (
+                current_stat is None
+                or not stat.S_ISREG(current_stat.st_mode)
+                or _included_path_fingerprint(current_stat)
+                != expected_fingerprint
+                or current_stat.st_ctime_ns != expected_ctime_ns
+            ):
+                raise OSError(
+                    "Included Files file changed while hashing: "
+                    f"{display_path}"
+                )
     finally:
         if file_descriptor >= 0:
             os.close(file_descriptor)
-    current_stat = _included_entry_stat_at(parent_fd, name)
-    if (
-        current_stat is None
-        or not stat.S_ISREG(current_stat.st_mode)
-        or _included_path_fingerprint(current_stat) != expected_fingerprint
-        or current_stat.st_ctime_ns != expected_ctime_ns
-        or byte_count != expected_stat.st_size
-    ):
-        raise OSError(f"Included Files file changed while hashing: {display_path}")
     return content_sha256
 
 
@@ -931,6 +986,10 @@ def _capture_included_tree_descriptor(
         os.close(parent_fd)
 
 
+def _after_included_fallback_tree_directory_scan(_path: str) -> None:
+    """Narrow test seam after a fallback path scan returns its entries."""
+
+
 def _capture_included_tree_fallback(
     root_path: str,
     expected_parent_identity: _PathIdentity | None,
@@ -964,6 +1023,7 @@ def _capture_included_tree_fallback(
         directory_identities = _capture_fallback_directory_ancestors(
             directory_path
         )
+        _verify_fallback_directory_ancestors(directory_identities)
         try:
             directory_entries = sorted(
                 os.scandir(directory_path),
@@ -973,7 +1033,10 @@ def _capture_included_tree_fallback(
             raise OSError(
                 f"Could not inspect Included Files directory: {directory_path}"
             ) from error
+        _after_included_fallback_tree_directory_scan(directory_path)
+        _verify_fallback_directory_ancestors(directory_identities)
         for directory_entry in directory_entries:
+            _verify_fallback_directory_ancestors(directory_identities)
             entry_path = os.path.join(directory_path, directory_entry.name)
             try:
                 entry_stat = os.lstat(entry_path)
@@ -997,6 +1060,7 @@ def _capture_included_tree_fallback(
             elif stat.S_ISREG(entry_stat.st_mode):
                 kind = "file"
                 ctime_ns = entry_stat.st_ctime_ns
+                _verify_fallback_directory_ancestors(directory_identities)
                 content_sha256 = _digest_included_regular_file(
                     entry_path,
                     entry_stat,
@@ -1014,6 +1078,7 @@ def _capture_included_tree_fallback(
                     content_sha256=content_sha256,
                 )
             )
+            _verify_fallback_directory_ancestors(directory_identities)
         _verify_fallback_directory_ancestors(directory_identities)
 
     _verify_fallback_directory_ancestors(root_parent_identities)

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.7"
+VERSION = "0.7.8"
 
 
 def get_version():

--- a/tests/fixtures/golden/basic_scripts/expected_snapshot.json
+++ b/tests/fixtures/golden/basic_scripts/expected_snapshot.json
@@ -7,7 +7,7 @@
   },
   "fixture": "basic_scripts",
   "hashes": {
-    "gm2godot/gml_runtime.gd": "sha256:8cfe8be87ed7833f513d2dc2aebf065aa811428c9c177af4a52c7764758f84c4",
+    "gm2godot/gml_runtime.gd": "sha256:9279b17b1b53b7439ffb2928598f1028cb7e70dca8d8b0018981920fc0298e21",
     "gm2godot/managers/gm_assets.gd": "sha256:4121345bd843a0bb3487fcba4756a3b2f18700685f5858db5f62f8992d96a76f",
     "gm2godot/managers/gm_async.gd": "sha256:d0a73997476f0e889892f85a6c343fc5b44fecdf9fa547e943902632aedf9df3",
     "gm2godot/managers/gm_audio.gd": "sha256:995a1df58e7f8ad03fa8ed7e9a195cdcfcf256643d73ac06a88bb6bbec82fba4",

--- a/tests/fixtures/part2/corpus.json
+++ b/tests/fixtures/part2/corpus.json
@@ -87,7 +87,7 @@
       "resource_type": "GMIncludedFile",
       "game_maker_resource_path": "projects/resource_matrix/datafiles/config/defaults.json",
       "source_path": "source/resource_matrix.gml",
-      "assertion_paths": ["tests/test_included_files.py::TestIncludedFilesConverterNestedDirs.test_preserves_directory_structure"]
+      "assertion_paths": ["tests/test_included_files.py::TestIncludedFilesConverterNestedDirs.test_normalizes_nested_packaged_paths"]
     },
     {
       "area": "fonts",

--- a/tests/test_asset_registry.py
+++ b/tests/test_asset_registry.py
@@ -9,7 +9,7 @@ import sys
 import tempfile
 import threading
 import unittest
-from typing import Iterable, cast
+from typing import BinaryIO, Iterable, cast
 from unittest.mock import patch
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -23,6 +23,7 @@ from src.conversion.asset_registry import (
     GROUP_COMPATIBILITY_REPORT_RELATIVE_PATH,
     _ProjectResource,
 )
+from src.conversion import asset_registry as asset_registry_module
 from src.conversion.animation_curve_registry import ANIMATION_CURVE_REGISTRY_RELATIVE_PATH
 from src.conversion.converter import Converter
 from src.conversion.conversion_outcome import ConversionCounts
@@ -2403,6 +2404,205 @@ class TestAssetRegistryConverter(unittest.TestCase):
                 for diagnostic in diagnostics.diagnostics()
             )
         )
+
+    def test_windows_path_handle_fingerprint_match_ignores_only_ctime(
+        self,
+    ) -> None:
+        baseline = (11, 22, 33, 44, 55)
+        ctime_only_drift = (11, 22, 33, 44, 99)
+        real_drift = {
+            "device": (12, 22, 33, 44, 55),
+            "inode": (11, 23, 33, 44, 55),
+            "size": (11, 22, 34, 44, 55),
+            "mtime": (11, 22, 33, 45, 55),
+        }
+
+        with patch.object(
+            asset_registry_module,
+            "_uses_windows_included_file_path_handle_semantics",
+            return_value=True,
+        ):
+            self.assertTrue(
+                asset_registry_module._included_file_path_handle_fingerprints_match(
+                    baseline,
+                    ctime_only_drift,
+                )
+            )
+            for field, fingerprint in real_drift.items():
+                with self.subTest(field=field):
+                    self.assertFalse(
+                        asset_registry_module._included_file_path_handle_fingerprints_match(
+                            baseline,
+                            fingerprint,
+                        )
+                    )
+
+        with patch.object(
+            asset_registry_module,
+            "_uses_windows_included_file_path_handle_semantics",
+            return_value=False,
+        ):
+            self.assertFalse(
+                asset_registry_module._included_file_path_handle_fingerprints_match(
+                    baseline,
+                    ctime_only_drift,
+                )
+            )
+
+    def test_windows_fallback_rejects_same_inode_output_change(self) -> None:
+        payload = b"GOOD"
+        self._write_included_source("payload.bin", payload)
+        self._write_included_output("payload.bin", payload)
+        source_path = os.path.join(
+            self.gm_dir,
+            "datafiles",
+            "payload.bin",
+        )
+        output_path = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "payload.bin",
+        )
+        output_stat = os.lstat(output_path)
+        converter = self._converter()
+        original_match = asset_registry_module._included_file_streams_match
+        original_fingerprint = (
+            asset_registry_module._included_file_content_fingerprint
+        )
+        original_verify = converter._verify_included_file_output_fallback
+        verify_calls = 0
+        mutated = False
+
+        def compare_then_mutate(
+            source_file: BinaryIO,
+            output_file: BinaryIO,
+        ) -> tuple[bool, str, str]:
+            nonlocal mutated
+            matches = original_match(source_file, output_file)
+            with open(output_path, "r+b", buffering=0) as mutator:
+                mutator.write(b"EVIL")
+                os.fsync(mutator.fileno())
+            os.utime(
+                output_path,
+                ns=(output_stat.st_atime_ns, output_stat.st_mtime_ns),
+            )
+            if os.lstat(output_path).st_mtime_ns != output_stat.st_mtime_ns:
+                self.skipTest("Filesystem cannot restore nanosecond mtime")
+            mutated = True
+            return matches
+
+        def verify_initial_path_state(
+            directory_identities: list[tuple[str, tuple[int, int]]],
+            path: str,
+            expected_fingerprint: tuple[int, int, int, int, int],
+        ) -> None:
+            nonlocal verify_calls
+            verify_calls += 1
+            if verify_calls == 1:
+                original_verify(
+                    directory_identities,
+                    path,
+                    expected_fingerprint,
+                )
+
+        def windows_creation_time_fingerprint(
+            file_stat: os.stat_result,
+        ) -> tuple[int, int, int, int, int]:
+            fingerprint = original_fingerprint(file_stat)
+            return (*fingerprint[:4], output_stat.st_ctime_ns)
+
+        with open(source_path, "rb") as source_file:
+            with (
+                patch.object(
+                    asset_registry_module,
+                    "_uses_windows_included_file_path_handle_semantics",
+                    return_value=True,
+                ),
+                patch.object(
+                    asset_registry_module,
+                    "_included_file_streams_match",
+                    side_effect=compare_then_mutate,
+                ),
+                patch.object(
+                    asset_registry_module,
+                    "_included_file_content_fingerprint",
+                    side_effect=windows_creation_time_fingerprint,
+                ),
+                patch.object(
+                    converter,
+                    "_verify_included_file_output_fallback",
+                    side_effect=verify_initial_path_state,
+                ),
+                self.assertRaisesRegex(OSError, "changed during validation"),
+            ):
+                converter._included_file_output_matches_fallback(
+                    output_path,
+                    ("included_files", "payload.bin"),
+                    source_file,
+                )
+
+        self.assertTrue(mutated)
+        self.assertEqual(verify_calls, 1)
+        with open(output_path, "rb") as output_file:
+            self.assertEqual(output_file.read(), b"EVIL")
+
+    def test_windows_fallback_rejects_same_inode_source_change(self) -> None:
+        payload = b"GOOD"
+        self._write_included_source("payload.bin", payload)
+        self._write_included_output("payload.bin", payload)
+        source_path = os.path.join(
+            self.gm_dir,
+            "datafiles",
+            "payload.bin",
+        )
+        output_path = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "payload.bin",
+        )
+        source_stat = os.lstat(source_path)
+        converter = self._converter()
+        original_match = asset_registry_module._included_file_streams_match
+        mutated = False
+
+        def compare_then_mutate(
+            source_file: BinaryIO,
+            output_file: BinaryIO,
+        ) -> tuple[bool, str, str]:
+            nonlocal mutated
+            result = original_match(source_file, output_file)
+            with open(source_path, "r+b", buffering=0) as mutator:
+                mutator.write(b"EVIL")
+                os.fsync(mutator.fileno())
+            os.utime(
+                source_path,
+                ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns),
+            )
+            if os.lstat(source_path).st_mtime_ns != source_stat.st_mtime_ns:
+                self.skipTest("Filesystem cannot restore nanosecond mtime")
+            mutated = True
+            return result
+
+        with open(source_path, "rb") as source_file:
+            with (
+                patch.object(
+                    asset_registry_module,
+                    "_included_file_streams_match",
+                    side_effect=compare_then_mutate,
+                ),
+                self.assertRaisesRegex(OSError, "source changed during validation"),
+            ):
+                converter._included_file_output_matches_fallback(
+                    output_path,
+                    ("included_files", "payload.bin"),
+                    source_file,
+                )
+
+        self.assertTrue(mutated)
+        with open(source_path, "rb") as source_file:
+            self.assertEqual(source_file.read(), b"EVIL")
+        with open(output_path, "rb") as output_file:
+            self.assertEqual(output_file.read(), b"GOOD")
 
     def test_convert_all_omits_redirected_included_file_output(self) -> None:
         self._write_included_source("payload.bin", b"matching payload")

--- a/tests/test_asset_registry.py
+++ b/tests/test_asset_registry.py
@@ -18,6 +18,7 @@ if PROJECT_ROOT not in sys.path:
 
 from src.conversion.asset_registry import (
     ASSET_REGISTRY_RELATIVE_PATH,
+    AssetRegistryEntry,
     AssetRegistryConverter,
     GROUP_COMPATIBILITY_REPORT_RELATIVE_PATH,
     _ProjectResource,
@@ -31,6 +32,7 @@ from src.conversion.extension_registry import (
     extension_stub_relative_script_path,
 )
 from src.conversion.fonts import FontConverter
+from src.conversion.included_files import IncludedFilesConverter
 from src.conversion.path_registry import PATH_REGISTRY_RELATIVE_PATH
 from src.conversion.type_defs import JsonDict, StrPath
 
@@ -128,6 +130,35 @@ class TestAssetRegistryConverter(unittest.TestCase):
             macro_configuration=macro_configuration,
             diagnostics=diagnostics,
         )
+
+    def _emit_included_files(self) -> None:
+        IncludedFilesConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=lambda _message: None,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+        ).convert_included_files()
+
+    def _write_included_source(self, relative_path: str, payload: bytes) -> None:
+        source_path = os.path.join(
+            self.gm_dir,
+            "datafiles",
+            *relative_path.split("/"),
+        )
+        os.makedirs(os.path.dirname(source_path), exist_ok=True)
+        with open(source_path, "wb") as source_file:
+            source_file.write(payload)
+
+    def _write_included_output(self, relative_path: str, payload: bytes) -> None:
+        output_path = os.path.join(
+            self.godot_dir,
+            "included_files",
+            *relative_path.split("/"),
+        )
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "wb") as output_file:
+            output_file.write(payload)
 
     def test_bundled_font_registry_path_matches_safe_emitted_filename(self) -> None:
         _write_yyp(self.gm_dir, [("fonts", "fnt_ui")])
@@ -1892,6 +1923,631 @@ class TestAssetRegistryConverter(unittest.TestCase):
             "res://included_files/real/payload.txt",
         )
 
+    def test_included_file_registry_paths_match_converted_outputs(self) -> None:
+        payloads = {
+            "Config/My File.BIN": b"\x00nested\xffpayload",
+            "Foo Bar/item.bin": b"normalized nested-prefix payload",
+            "Read Me.txt": b"normalized collision payload",
+            "foo_bar": b"normalized blocking-file payload",
+            "read_me.txt": b"canonical payload",
+            "read_me_2.txt": b"natural suffix payload",
+        }
+        for relative_path, payload in payloads.items():
+            source_path = os.path.join(
+                self.gm_dir,
+                "datafiles",
+                *relative_path.split("/"),
+            )
+            os.makedirs(os.path.dirname(source_path), exist_ok=True)
+            with open(source_path, "wb") as source_file:
+                source_file.write(payload)
+
+        registry_converter = self._converter()
+        entries = {
+            entry.name: entry
+            for entry in registry_converter.build_entries()
+            if entry.kind == "included_files"
+        }
+
+        self.assertEqual(set(entries), set(payloads))
+        self.assertEqual(
+            {name: entry.godot_path for name, entry in entries.items()},
+            {
+                "Config/My File.BIN": (
+                    "res://included_files/config/my_file.bin"
+                ),
+                "Foo Bar/item.bin": (
+                    "res://included_files/foo_bar/item.bin"
+                ),
+                "Read Me.txt": "res://included_files/read_me_3.txt",
+                "foo_bar": "res://included_files/foo_bar_2",
+                "read_me.txt": "res://included_files/read_me.txt",
+                "read_me_2.txt": "res://included_files/read_me_2.txt",
+            },
+        )
+        self.assertEqual(
+            {name: entry.source_path for name, entry in entries.items()},
+            {
+                name: "datafiles/" + name
+                for name in payloads
+            },
+        )
+
+        resources = registry_converter._ordered_project_resources()
+        self.assertEqual(
+            registry_converter._stable_godot_paths(resources),
+            registry_converter._stable_godot_paths(reversed(resources)),
+        )
+
+        included_converter = IncludedFilesConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=lambda _message: None,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+        )
+        included_converter.convert_included_files()
+
+        for name, payload in payloads.items():
+            output_path = os.path.join(
+                self.godot_dir,
+                *entries[name].godot_path.removeprefix("res://").split("/"),
+            )
+            self.assertTrue(os.path.isfile(output_path), output_path)
+            with open(output_path, "rb") as output_file:
+                self.assertEqual(output_file.read(), payload)
+
+    def test_convert_all_omits_absent_included_file_output(self) -> None:
+        self._write_included_source("payload.bin", b"current payload")
+        diagnostics = DiagnosticCollector()
+        converter = self._converter(diagnostics=diagnostics)
+
+        registry_path = converter.convert_all()
+
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(
+                requested=1,
+                executed=1,
+                skipped=1,
+            ),
+        )
+        with open(registry_path, "r", encoding="utf-8") as registry_file:
+            self.assertNotIn('"name": "payload.bin"', registry_file.read())
+        unavailable = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code
+            == "GM2GD-ASSET-REGISTRY-OUTPUT-UNAVAILABLE"
+        ]
+        self.assertEqual(len(unavailable), 1, unavailable)
+        self.assertEqual(unavailable[0].source_path, "datafiles/payload.bin")
+        self.assertEqual(unavailable[0].resource, "payload.bin")
+        self.assertEqual(unavailable[0].resource_type, "included_file")
+        self.assertEqual(
+            unavailable[0].manifest_entry,
+            "generated Included File output",
+        )
+
+    def test_convert_all_omits_stale_included_file_output(self) -> None:
+        self._write_included_source("payload.bin", b"current payload")
+        self._write_included_output("payload.bin", b"stale payload")
+        diagnostics = DiagnosticCollector()
+        converter = self._converter(diagnostics=diagnostics)
+
+        registry_path = converter.convert_all()
+
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(
+                requested=1,
+                executed=1,
+                skipped=1,
+            ),
+        )
+        with open(registry_path, "r", encoding="utf-8") as registry_file:
+            self.assertNotIn('"name": "payload.bin"', registry_file.read())
+        unavailable = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code
+            == "GM2GD-ASSET-REGISTRY-OUTPUT-UNAVAILABLE"
+        ]
+        self.assertEqual(len(unavailable), 1, unavailable)
+
+    def test_convert_all_filters_colliders_after_full_path_planning(self) -> None:
+        self._write_included_source("Read Me.txt", b"suffixed payload")
+        self._write_included_source("read_me.txt", b"canonical payload")
+        diagnostics = DiagnosticCollector()
+        converter = self._converter(diagnostics=diagnostics)
+        planned = {
+            entry.name: entry.godot_path
+            for entry in converter.build_entries()
+            if entry.kind == "included_files"
+        }
+        self.assertEqual(
+            planned,
+            {
+                "Read Me.txt": "res://included_files/read_me_2.txt",
+                "read_me.txt": "res://included_files/read_me.txt",
+            },
+        )
+        self._write_included_output("read_me.txt", b"stale canonical output")
+        self._write_included_output("read_me_2.txt", b"suffixed payload")
+
+        registry_path = converter.convert_all()
+
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(
+                requested=2,
+                executed=2,
+                completed=1,
+                skipped=1,
+            ),
+        )
+        with open(registry_path, "r", encoding="utf-8") as registry_file:
+            registry = registry_file.read()
+        self.assertIn('"name": "Read Me.txt"', registry)
+        self.assertIn(
+            '"godot_path": "res://included_files/read_me_2.txt"',
+            registry,
+        )
+        self.assertNotIn('"name": "read_me.txt"', registry)
+        unavailable = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code
+            == "GM2GD-ASSET-REGISTRY-OUTPUT-UNAVAILABLE"
+        ]
+        self.assertEqual(
+            [diagnostic.resource for diagnostic in unavailable],
+            ["read_me.txt"],
+        )
+
+    def test_prior_single_collision_output_satisfies_no_new_collision_claim(
+        self,
+    ) -> None:
+        self._write_included_source("Read Me.txt", b"original payload")
+        self._emit_included_files()
+        self._write_included_source("read_me.txt", b"new canonical payload")
+        diagnostics = DiagnosticCollector()
+        converter = self._converter(diagnostics=diagnostics)
+
+        registry_path = converter.convert_all()
+
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(
+                requested=2,
+                executed=2,
+                skipped=2,
+            ),
+        )
+        with open(registry_path, "r", encoding="utf-8") as registry_file:
+            registry = registry_file.read()
+        self.assertNotIn('"name": "Read Me.txt"', registry)
+        self.assertNotIn('"name": "read_me.txt"', registry)
+        unavailable = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code
+            == "GM2GD-ASSET-REGISTRY-OUTPUT-UNAVAILABLE"
+        ]
+        self.assertEqual(
+            {diagnostic.resource for diagnostic in unavailable},
+            {"Read Me.txt", "read_me.txt"},
+        )
+
+    def test_missing_canonical_reserves_suffix_for_matching_normalized_alias(
+        self,
+    ) -> None:
+        _write_json(
+            os.path.join(self.gm_dir, "AssetRegistryTest.yyp"),
+            {
+                "resources": [],
+                "IncludedFiles": [
+                    {
+                        "name": "read_me.txt",
+                        "path": "datafiles/read_me.txt",
+                    }
+                ],
+                "RoomOrderNodes": [],
+                "resourceType": "GMProject",
+            },
+        )
+        self._write_included_source("Read Me.txt", b"alias payload")
+        self._write_included_output("read_me_2.txt", b"alias payload")
+        diagnostics = DiagnosticCollector()
+        converter = self._converter(diagnostics=diagnostics)
+
+        registry_path = converter.convert_all()
+
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(
+                requested=2,
+                executed=1,
+                completed=1,
+                skipped=1,
+            ),
+        )
+        with open(registry_path, "r", encoding="utf-8") as registry_file:
+            registry = registry_file.read()
+        self.assertIn('"name": "Read Me.txt"', registry)
+        self.assertIn(
+            '"godot_path": "res://included_files/read_me_2.txt"',
+            registry,
+        )
+        self.assertNotIn('"name": "read_me.txt"', registry)
+
+    def test_identical_stale_canonical_output_cannot_satisfy_normalized_alias(
+        self,
+    ) -> None:
+        _write_json(
+            os.path.join(self.gm_dir, "AssetRegistryTest.yyp"),
+            {
+                "resources": [],
+                "IncludedFiles": [
+                    {
+                        "name": "read_me.txt",
+                        "path": "datafiles/read_me.txt",
+                    }
+                ],
+                "RoomOrderNodes": [],
+                "resourceType": "GMProject",
+            },
+        )
+        self._write_included_source("Read Me.txt", b"identical alias payload")
+        self._write_included_output("read_me.txt", b"identical alias payload")
+        diagnostics = DiagnosticCollector()
+        converter = self._converter(diagnostics=diagnostics)
+
+        registry_path = converter.convert_all()
+
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(
+                requested=2,
+                executed=1,
+                skipped=2,
+            ),
+        )
+        with open(registry_path, "r", encoding="utf-8") as registry_file:
+            registry = registry_file.read()
+        self.assertNotIn('"name": "Read Me.txt"', registry)
+        self.assertNotIn('"name": "read_me.txt"', registry)
+        unavailable_outputs = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code
+            == "GM2GD-ASSET-REGISTRY-OUTPUT-UNAVAILABLE"
+        ]
+        self.assertEqual(
+            [diagnostic.resource for diagnostic in unavailable_outputs],
+            ["Read Me.txt"],
+        )
+
+    def test_missing_natural_suffix_reserves_third_normalized_alias_path(
+        self,
+    ) -> None:
+        _write_json(
+            os.path.join(self.gm_dir, "AssetRegistryTest.yyp"),
+            {
+                "resources": [],
+                "IncludedFiles": [
+                    {
+                        "name": "read_me_2.txt",
+                        "path": "datafiles/read_me_2.txt",
+                    }
+                ],
+                "RoomOrderNodes": [],
+                "resourceType": "GMProject",
+            },
+        )
+        self._write_included_source("read_me.txt", b"canonical payload")
+        self._write_included_source("Read Me.txt", b"alias payload")
+        self._write_included_output("read_me.txt", b"canonical payload")
+        self._write_included_output("read_me_3.txt", b"alias payload")
+        converter = self._converter()
+
+        registry_path = converter.convert_all()
+
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(
+                requested=3,
+                executed=2,
+                completed=2,
+                skipped=1,
+            ),
+        )
+        with open(registry_path, "r", encoding="utf-8") as registry_file:
+            registry = registry_file.read()
+        self.assertIn('"name": "read_me.txt"', registry)
+        self.assertIn('"name": "Read Me.txt"', registry)
+        self.assertIn(
+            '"godot_path": "res://included_files/read_me_3.txt"',
+            registry,
+        )
+        self.assertNotIn('"name": "read_me_2.txt"', registry)
+
+    def test_missing_nested_alias_reserves_suffix_for_blocking_file(self) -> None:
+        _write_json(
+            os.path.join(self.gm_dir, "AssetRegistryTest.yyp"),
+            {
+                "resources": [],
+                "IncludedFiles": [
+                    {
+                        "name": "item.txt",
+                        "path": "datafiles/Foo Bar/item.txt",
+                    }
+                ],
+                "RoomOrderNodes": [],
+                "resourceType": "GMProject",
+            },
+        )
+        self._write_included_source("foo_bar", b"blocking file payload")
+        self._write_included_output("foo_bar_2", b"blocking file payload")
+        converter = self._converter()
+
+        registry_path = converter.convert_all()
+
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(
+                requested=2,
+                executed=1,
+                completed=1,
+                skipped=1,
+            ),
+        )
+        with open(registry_path, "r", encoding="utf-8") as registry_file:
+            registry = registry_file.read()
+        self.assertIn('"name": "foo_bar"', registry)
+        self.assertIn(
+            '"godot_path": "res://included_files/foo_bar_2"',
+            registry,
+        )
+        self.assertNotIn('"name": "Foo Bar/item.txt"', registry)
+
+    def test_rejected_traversal_does_not_reserve_safe_alias_basename(
+        self,
+    ) -> None:
+        _write_json(
+            os.path.join(self.gm_dir, "AssetRegistryTest.yyp"),
+            {
+                "resources": [],
+                "IncludedFiles": [
+                    {
+                        "name": "read_me.txt",
+                        "path": "datafiles/../../outside/read_me.txt",
+                    }
+                ],
+                "RoomOrderNodes": [],
+                "resourceType": "GMProject",
+            },
+        )
+        self._write_included_source("Read Me.txt", b"alias payload")
+        self._write_included_output("read_me.txt", b"alias payload")
+        diagnostics = DiagnosticCollector()
+        converter = self._converter(diagnostics=diagnostics)
+
+        registry_path = converter.convert_all()
+
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(
+                requested=2,
+                executed=1,
+                completed=1,
+                skipped=1,
+            ),
+        )
+        with open(registry_path, "r", encoding="utf-8") as registry_file:
+            registry = registry_file.read()
+        self.assertIn('"name": "Read Me.txt"', registry)
+        self.assertIn(
+            '"godot_path": "res://included_files/read_me.txt"',
+            registry,
+        )
+        self.assertTrue(
+            any(
+                diagnostic.code == "GM2GD-SOURCE-PATH-REJECTED"
+                for diagnostic in diagnostics.diagnostics()
+            )
+        )
+
+    def test_convert_all_advertises_matching_included_file_output(self) -> None:
+        self._write_included_source("payload.bin", b"matching payload")
+        self._write_included_output("payload.bin", b"matching payload")
+        diagnostics = DiagnosticCollector()
+        converter = self._converter(diagnostics=diagnostics)
+
+        registry_path = converter.convert_all()
+
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(
+                requested=1,
+                executed=1,
+                completed=1,
+            ),
+        )
+        with open(registry_path, "r", encoding="utf-8") as registry_file:
+            self.assertIn('"name": "payload.bin"', registry_file.read())
+        self.assertFalse(
+            any(
+                diagnostic.code
+                == "GM2GD-ASSET-REGISTRY-OUTPUT-UNAVAILABLE"
+                for diagnostic in diagnostics.diagnostics()
+            )
+        )
+
+    def test_convert_all_omits_redirected_included_file_output(self) -> None:
+        self._write_included_source("payload.bin", b"matching payload")
+        referent_path = os.path.join(self.godot_dir, "matching-payload.bin")
+        with open(referent_path, "wb") as referent_file:
+            referent_file.write(b"matching payload")
+        output_directory = os.path.join(self.godot_dir, "included_files")
+        os.makedirs(output_directory, exist_ok=True)
+        output_path = os.path.join(output_directory, "payload.bin")
+        try:
+            os.symlink(referent_path, output_path)
+        except (NotImplementedError, OSError) as exc:
+            self.skipTest(f"Symbolic links are unavailable: {exc}")
+        diagnostics = DiagnosticCollector()
+        converter = self._converter(diagnostics=diagnostics)
+
+        registry_path = converter.convert_all()
+
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(
+                requested=1,
+                executed=1,
+                skipped=1,
+            ),
+        )
+        with open(registry_path, "r", encoding="utf-8") as registry_file:
+            self.assertNotIn('"name": "payload.bin"', registry_file.read())
+        unavailable = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code
+            == "GM2GD-ASSET-REGISTRY-OUTPUT-UNAVAILABLE"
+        ]
+        self.assertEqual(len(unavailable), 1, unavailable)
+
+    def test_output_delete_at_registry_publish_boundary_leaves_no_registry(
+        self,
+    ) -> None:
+        self._write_included_source("payload.bin", b"matching payload")
+        self._write_included_output("payload.bin", b"matching payload")
+        output_path = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "payload.bin",
+        )
+        registry_path = os.path.join(
+            self.godot_dir,
+            ASSET_REGISTRY_RELATIVE_PATH,
+        )
+        converter = self._converter()
+        real_revalidate = converter.revalidate_published_entries
+        validation_calls = 0
+
+        def delete_then_revalidate(
+            entries: tuple[AssetRegistryEntry, ...],
+        ) -> None:
+            nonlocal validation_calls
+            validation_calls += 1
+            if validation_calls == 1:
+                os.unlink(output_path)
+            real_revalidate(entries)
+
+        with (
+            patch.object(
+                converter,
+                "revalidate_published_entries",
+                side_effect=delete_then_revalidate,
+            ),
+            self.assertRaisesRegex(
+                OSError,
+                "publication inputs changed",
+            ),
+        ):
+            converter.convert_all()
+
+        self.assertEqual(validation_calls, 1)
+        self.assertFalse(os.path.exists(registry_path))
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(
+                requested=1,
+                executed=1,
+                failed=1,
+            ),
+        )
+
+    def test_output_byte_change_after_registry_publish_removes_registry(
+        self,
+    ) -> None:
+        self._write_included_source("payload.bin", b"matching payload")
+        self._write_included_output("payload.bin", b"matching payload")
+        output_path = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "payload.bin",
+        )
+        registry_path = os.path.join(
+            self.godot_dir,
+            ASSET_REGISTRY_RELATIVE_PATH,
+        )
+        converter = self._converter()
+        real_revalidate = converter.revalidate_published_entries
+        validation_calls = 0
+
+        def mutate_then_revalidate(
+            entries: tuple[AssetRegistryEntry, ...],
+        ) -> None:
+            nonlocal validation_calls
+            validation_calls += 1
+            if validation_calls == 2:
+                with open(output_path, "wb") as output_file:
+                    output_file.write(b"changed after publication")
+            real_revalidate(entries)
+
+        with (
+            patch.object(
+                converter,
+                "revalidate_published_entries",
+                side_effect=mutate_then_revalidate,
+            ),
+            self.assertRaisesRegex(
+                OSError,
+                "publication inputs changed",
+            ),
+        ):
+            converter.convert_all()
+
+        self.assertEqual(validation_calls, 2)
+        self.assertFalse(os.path.exists(registry_path))
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(
+                requested=1,
+                executed=1,
+                failed=1,
+            ),
+        )
+
     def test_project_yyp_link_is_rejected_before_disk_fallback(self) -> None:
         self._write_resource(
             "sprites",
@@ -2727,6 +3383,8 @@ class TestAssetRegistryConverter(unittest.TestCase):
         diagnostics = DiagnosticCollector()
         converter = self._converter(diagnostics=diagnostics)
 
+        self._emit_included_files()
+
         registry_path = converter.convert_all()
 
         self.assertEqual(
@@ -2759,6 +3417,47 @@ class TestAssetRegistryConverter(unittest.TestCase):
             "IncludedFiles[1].path",
         )
 
+    def test_nested_gmincludedfile_resource_is_one_logical_resource(self) -> None:
+        _write_json(
+            os.path.join(self.gm_dir, "AssetRegistryTest.yyp"),
+            {
+                "resources": [
+                    {
+                        "id": {
+                            "name": "safe.json",
+                            "path": "datafiles/config/safe.json",
+                        },
+                        "resourceType": "GMIncludedFile",
+                    }
+                ],
+                "RoomOrderNodes": [],
+                "resourceType": "GMProject",
+            },
+        )
+        self._write_included_source("config/safe.json", b"safe payload")
+        self._write_included_output("config/safe.json", b"safe payload")
+        converter = self._converter()
+
+        registry_path = converter.convert_all()
+
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(
+                requested=1,
+                executed=1,
+                completed=1,
+            ),
+        )
+        with open(registry_path, "r", encoding="utf-8") as registry_file:
+            registry = registry_file.read()
+        self.assertIn('"name": "config/safe.json"', registry)
+        self.assertIn(
+            '"godot_path": "res://included_files/config/safe.json"',
+            registry,
+        )
+
     def test_current_gamemaker_file_path_directory_combines_payload_name(
         self,
     ) -> None:
@@ -2787,6 +3486,8 @@ class TestAssetRegistryConverter(unittest.TestCase):
         )
         diagnostics = DiagnosticCollector()
         converter = self._converter(diagnostics=diagnostics)
+
+        self._emit_included_files()
 
         registry_path = converter.convert_all()
 

--- a/tests/test_asset_registry.py
+++ b/tests/test_asset_registry.py
@@ -3799,6 +3799,10 @@ class TestAssetRegistryConverter(unittest.TestCase):
         )
         _write_file(registry_path, "previous registry\n")
         os.chmod(registry_path, 0o640)
+        previous_stat = os.stat(registry_path)
+        previous_identity = previous_stat.st_dev, previous_stat.st_ino
+        previous_mode = stat.S_IMODE(previous_stat.st_mode)
+        previous_writable = bool(previous_stat.st_mode & stat.S_IWRITE)
 
         with patch(
             "src.conversion.asset_registry.write_animation_curve_registry",
@@ -3812,7 +3816,20 @@ class TestAssetRegistryConverter(unittest.TestCase):
 
         with open(registry_path, "r", encoding="utf-8") as registry_file:
             self.assertEqual(registry_file.read(), "previous registry\n")
-        self.assertEqual(stat.S_IMODE(os.stat(registry_path).st_mode), 0o640)
+        current_stat = os.stat(registry_path)
+        self.assertEqual(
+            (current_stat.st_dev, current_stat.st_ino),
+            previous_identity,
+        )
+        self.assertEqual(
+            bool(current_stat.st_mode & stat.S_IWRITE),
+            previous_writable,
+        )
+        if os.name != "nt":
+            self.assertEqual(
+                stat.S_IMODE(current_stat.st_mode),
+                previous_mode,
+            )
         self.assertEqual(
             converter.conversion_step_result(
                 finalize_unfinished_as=None,
@@ -3972,6 +3989,10 @@ class TestAssetRegistryConverter(unittest.TestCase):
         registry_directory = os.path.dirname(registry_path)
         _write_file(registry_path, "previous registry\n")
         os.chmod(registry_path, 0o640)
+        previous_stat = os.stat(registry_path)
+        previous_identity = previous_stat.st_dev, previous_stat.st_ino
+        previous_mode = stat.S_IMODE(previous_stat.st_mode)
+        previous_writable = bool(previous_stat.st_mode & stat.S_IWRITE)
 
         for patched_name, error_message in (
             ("os.fsync", "stage failed"),
@@ -3990,10 +4011,20 @@ class TestAssetRegistryConverter(unittest.TestCase):
 
                 with open(registry_path, "r", encoding="utf-8") as registry_file:
                     self.assertEqual(registry_file.read(), "previous registry\n")
+                current_stat = os.stat(registry_path)
                 self.assertEqual(
-                    stat.S_IMODE(os.stat(registry_path).st_mode),
-                    0o640,
+                    (current_stat.st_dev, current_stat.st_ino),
+                    previous_identity,
                 )
+                self.assertEqual(
+                    bool(current_stat.st_mode & stat.S_IWRITE),
+                    previous_writable,
+                )
+                if os.name != "nt":
+                    self.assertEqual(
+                        stat.S_IMODE(current_stat.st_mode),
+                        previous_mode,
+                    )
                 staged_prefix = f".{os.path.basename(registry_path)}."
                 self.assertFalse(
                     any(
@@ -4016,10 +4047,27 @@ class TestAssetRegistryConverter(unittest.TestCase):
                 0o600,
             )
         os.chmod(registry_path, 0o600)
+        previous_stat = os.stat(registry_path)
+        previous_identity = previous_stat.st_dev, previous_stat.st_ino
+        previous_mode = stat.S_IMODE(previous_stat.st_mode)
+        previous_writable = bool(previous_stat.st_mode & stat.S_IWRITE)
 
         AssetRegistryConverter._atomic_write_text(registry_path, "second\n")
 
-        self.assertEqual(stat.S_IMODE(os.stat(registry_path).st_mode), 0o600)
+        current_stat = os.stat(registry_path)
+        self.assertNotEqual(
+            (current_stat.st_dev, current_stat.st_ino),
+            previous_identity,
+        )
+        self.assertEqual(
+            bool(current_stat.st_mode & stat.S_IWRITE),
+            previous_writable,
+        )
+        if os.name != "nt":
+            self.assertEqual(
+                stat.S_IMODE(current_stat.st_mode),
+                previous_mode,
+            )
         with open(registry_path, "r", encoding="utf-8") as registry_file:
             self.assertEqual(registry_file.read(), "second\n")
 

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -212,6 +212,8 @@ class TestCIWorkflows(unittest.TestCase):
             "tests.test_architecture_policy",
             "tests.test_converter",
             "tests.test_cli",
+            "tests.test_included_files.TestIncludedFilesManagedRootTransaction",
+            "tests.test_included_files.TestIncludedFilesConverterOutputContainment",
         ):
             with self.subTest(module=module):
                 self.assertIn(module, windows_job)

--- a/tests/test_conversion_manifest.py
+++ b/tests/test_conversion_manifest.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 from src import cli
 from src.conversion import conversion_manifest as conversion_manifest_module
 from src.conversion.architecture_policy import ARCHITECTURE_POLICY_RELATIVE_PATH
+from src.conversion.asset_registry import AssetRegistryConverter, AssetRegistryEntry
 from src.conversion.conversion_manifest import (
     CONVERSION_ATTEMPT_RELATIVE_PATH,
     CONVERSION_MANIFEST_RELATIVE_PATH,
@@ -201,6 +202,335 @@ class TestConversionManifest(unittest.TestCase):
                 diagnostic["code"] == "GM2GD-PATH-COLLISION-RENAMED"
                 for diagnostic in cast(list[dict[str, object]], manifest["path_diagnostics"])
             )
+        )
+
+    def test_manifest_groups_included_file_packaged_lookup_collisions(
+        self,
+    ) -> None:
+        gm_dir = self.temp_dir / "gm"
+        godot_dir = self.temp_dir / "godot"
+        gm_dir.mkdir()
+        godot_dir.mkdir()
+        (gm_dir / "IncludedFiles.yyp").write_text(
+            json.dumps(
+                {
+                    "%Name": "IncludedFiles",
+                    "resourceType": "GMProject",
+                    "resources": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        entries = (
+            AssetRegistryEntry(
+                id=0,
+                name="Config/Read Me.TXT",
+                kind="included_files",
+                asset_type="included_file",
+                type_name="Included File",
+                source_path="datafiles/Config/Read Me.TXT",
+                godot_path="res://included_files/config/read_me_3.txt",
+                legacy_id="",
+            ),
+            AssetRegistryEntry(
+                id=1,
+                name="config/read_me.txt",
+                kind="included_files",
+                asset_type="included_file",
+                type_name="Included File",
+                source_path="datafiles/config/read_me.txt",
+                godot_path="res://included_files/config/read_me.txt",
+                legacy_id="",
+            ),
+            AssetRegistryEntry(
+                id=2,
+                name="config/read_me_2.txt",
+                kind="included_files",
+                asset_type="included_file",
+                type_name="Included File",
+                source_path="datafiles/config/read_me_2.txt",
+                godot_path="res://included_files/config/read_me_2.txt",
+                legacy_id="",
+            ),
+        )
+
+        with patch.object(
+            conversion_manifest_module,
+            "_asset_registry_entries",
+            return_value=entries,
+        ):
+            manifest = build_conversion_manifest(
+                str(gm_dir),
+                str(godot_dir),
+                target_platform="windows",
+                enabled_converters=[],
+                output_snapshot=capture_conversion_output_snapshot(
+                    str(godot_dir)
+                ),
+                conversion_outcome=self._successful_outcome(),
+            )
+
+        resources = cast(list[dict[str, object]], manifest["resources"])
+        self.assertEqual(
+            {
+                str(resource["name"]): str(resource["godot_path"])
+                for resource in resources
+            },
+            {
+                "Config/Read Me.TXT": (
+                    "res://included_files/config/read_me_3.txt"
+                ),
+                "config/read_me.txt": (
+                    "res://included_files/config/read_me.txt"
+                ),
+                "config/read_me_2.txt": (
+                    "res://included_files/config/read_me_2.txt"
+                ),
+            },
+        )
+        collisions = [
+            diagnostic
+            for diagnostic in cast(
+                list[dict[str, object]],
+                manifest["path_diagnostics"],
+            )
+            if diagnostic["code"] == "GM2GD-PATH-COLLISION-RENAMED"
+        ]
+        self.assertEqual(len(collisions), 1)
+        collision = collisions[0]
+        self.assertEqual(
+            collision["base_godot_path_casefold"],
+            "res://included_files/config/read_me.txt",
+        )
+        collision_resources = cast(
+            list[dict[str, object]],
+            collision["resources"],
+        )
+        self.assertEqual(
+            {
+                str(resource["name"]): (
+                    str(resource["base_godot_path"]),
+                    str(resource["stable_godot_path"]),
+                )
+                for resource in collision_resources
+            },
+            {
+                "Config/Read Me.TXT": (
+                    "res://included_files/config/read_me.txt",
+                    "res://included_files/config/read_me_3.txt",
+                ),
+                "config/read_me.txt": (
+                    "res://included_files/config/read_me.txt",
+                    "res://included_files/config/read_me.txt",
+                ),
+            },
+        )
+
+    def test_manifest_groups_included_file_prefix_collisions_independent_of_order(
+        self,
+    ) -> None:
+        gm_dir = self.temp_dir / "gm-prefix"
+        godot_dir = self.temp_dir / "godot-prefix"
+        gm_dir.mkdir()
+        godot_dir.mkdir()
+        (gm_dir / "IncludedFiles.yyp").write_text(
+            json.dumps(
+                {
+                    "%Name": "IncludedFiles",
+                    "resourceType": "GMProject",
+                    "resources": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        entries = (
+            AssetRegistryEntry(
+                id=0,
+                name="foo_bar",
+                kind="included_files",
+                asset_type="included_file",
+                type_name="Included File",
+                source_path="datafiles/foo_bar",
+                godot_path="res://included_files/foo_bar_3",
+                legacy_id="",
+            ),
+            AssetRegistryEntry(
+                id=1,
+                name="Foo Bar/item.txt",
+                kind="included_files",
+                asset_type="included_file",
+                type_name="Included File",
+                source_path="datafiles/Foo Bar/item.txt",
+                godot_path="res://included_files/foo_bar/item.txt",
+                legacy_id="",
+            ),
+            AssetRegistryEntry(
+                id=2,
+                name="foo_bar_2",
+                kind="included_files",
+                asset_type="included_file",
+                type_name="Included File",
+                source_path="datafiles/foo_bar_2",
+                godot_path="res://included_files/foo_bar_2",
+                legacy_id="",
+            ),
+        )
+
+        def path_diagnostics_for(
+            registry_entries: tuple[AssetRegistryEntry, ...],
+        ) -> list[dict[str, object]]:
+            with patch.object(
+                conversion_manifest_module,
+                "_asset_registry_entries",
+                return_value=registry_entries,
+            ):
+                manifest = build_conversion_manifest(
+                    str(gm_dir),
+                    str(godot_dir),
+                    target_platform="windows",
+                    enabled_converters=[],
+                    output_snapshot=capture_conversion_output_snapshot(
+                        str(godot_dir)
+                    ),
+                    conversion_outcome=self._successful_outcome(),
+                )
+            return cast(
+                list[dict[str, object]],
+                manifest["path_diagnostics"],
+            )
+
+        forward = path_diagnostics_for(entries)
+        reverse = path_diagnostics_for(tuple(reversed(entries)))
+
+        self.assertEqual(forward, reverse)
+        collisions = [
+            diagnostic
+            for diagnostic in forward
+            if diagnostic["code"] == "GM2GD-PATH-COLLISION-RENAMED"
+        ]
+        self.assertEqual(len(collisions), 1)
+        collision = collisions[0]
+        self.assertEqual(
+            collision["base_godot_path_casefold"],
+            "res://included_files/foo_bar",
+        )
+        collision_resources = cast(
+            list[dict[str, object]],
+            collision["resources"],
+        )
+        self.assertEqual(
+            {
+                str(resource["name"]): (
+                    str(resource["base_godot_path"]),
+                    str(resource["stable_godot_path"]),
+                )
+                for resource in collision_resources
+            },
+            {
+                "foo_bar": (
+                    "res://included_files/foo_bar",
+                    "res://included_files/foo_bar_3",
+                ),
+                "Foo Bar/item.txt": (
+                    "res://included_files/foo_bar/item.txt",
+                    "res://included_files/foo_bar/item.txt",
+                ),
+            },
+        )
+
+    def test_manifest_excludes_unavailable_included_file_outputs(self) -> None:
+        gm_dir = self.temp_dir / "gm-publication-filter"
+        godot_dir = self.temp_dir / "godot-publication-filter"
+        datafiles_dir = gm_dir / "datafiles"
+        included_files_dir = godot_dir / "included_files"
+        datafiles_dir.mkdir(parents=True)
+        included_files_dir.mkdir(parents=True)
+        (gm_dir / "IncludedFiles.yyp").write_text(
+            json.dumps(
+                {
+                    "%Name": "IncludedFiles",
+                    "resourceType": "GMProject",
+                    "resources": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        (datafiles_dir / "absent.bin").write_bytes(b"absent output payload")
+        (datafiles_dir / "stale.bin").write_bytes(b"current stale payload")
+        (datafiles_dir / "matching.bin").write_bytes(b"matching payload")
+        (included_files_dir / "stale.bin").write_bytes(b"old stale payload")
+        (included_files_dir / "matching.bin").write_bytes(b"matching payload")
+
+        manifest = build_conversion_manifest(
+            str(gm_dir),
+            str(godot_dir),
+            target_platform="windows",
+            enabled_converters=[],
+            output_snapshot=capture_conversion_output_snapshot(str(godot_dir)),
+            conversion_outcome=self._successful_outcome(),
+        )
+
+        resources = cast(list[dict[str, object]], manifest["resources"])
+        included_resources = {
+            str(resource["name"]): str(resource["godot_path"])
+            for resource in resources
+            if resource["kind"] == "included_files"
+        }
+        self.assertEqual(
+            included_resources,
+            {
+                "matching.bin": "res://included_files/matching.bin",
+            },
+        )
+
+    def test_manifest_reserves_missing_canonical_before_normalized_alias(
+        self,
+    ) -> None:
+        gm_dir = self.temp_dir / "gm-reserved-included-path"
+        godot_dir = self.temp_dir / "godot-reserved-included-path"
+        datafiles_dir = gm_dir / "datafiles"
+        included_files_dir = godot_dir / "included_files"
+        datafiles_dir.mkdir(parents=True)
+        included_files_dir.mkdir(parents=True)
+        (gm_dir / "IncludedFiles.yyp").write_text(
+            json.dumps(
+                {
+                    "%Name": "IncludedFiles",
+                    "resourceType": "GMProject",
+                    "resources": [],
+                    "IncludedFiles": [
+                        {
+                            "name": "read_me.txt",
+                            "path": "datafiles/read_me.txt",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        (datafiles_dir / "Read Me.txt").write_bytes(b"alias payload")
+        (included_files_dir / "read_me_2.txt").write_bytes(b"alias payload")
+
+        manifest = build_conversion_manifest(
+            str(gm_dir),
+            str(godot_dir),
+            target_platform="windows",
+            enabled_converters=[],
+            output_snapshot=capture_conversion_output_snapshot(str(godot_dir)),
+            conversion_outcome=self._successful_outcome(),
+        )
+
+        resources = cast(list[dict[str, object]], manifest["resources"])
+        included_resources = {
+            str(resource["name"]): str(resource["godot_path"])
+            for resource in resources
+            if resource["kind"] == "included_files"
+        }
+        self.assertEqual(
+            included_resources,
+            {
+                "Read Me.txt": "res://included_files/read_me_2.txt",
+            },
         )
 
     def test_manifest_records_source_project_ide_version(self) -> None:
@@ -612,6 +942,112 @@ class TestConversionManifest(unittest.TestCase):
             self._write_artifacts(godot_dir)
 
         self.assertFalse((godot_dir / "gm2godot").exists())
+
+    def test_included_output_delete_at_manifest_boundary_rolls_back_pair(
+        self,
+    ) -> None:
+        (
+            gm_dir,
+            godot_dir,
+            output_path,
+            manifest_path,
+            attempt_path,
+            manifest_before,
+            attempt_before,
+        ) = self._included_publication_fixture("delete-boundary")
+        real_revalidate = AssetRegistryConverter.revalidate_published_entries
+        validation_calls = 0
+
+        def delete_then_revalidate(
+            converter: AssetRegistryConverter,
+            entries: tuple[AssetRegistryEntry, ...],
+        ) -> None:
+            nonlocal validation_calls
+            validation_calls += 1
+            if validation_calls == 1:
+                output_path.unlink()
+            real_revalidate(converter, entries)
+
+        with (
+            patch.object(
+                AssetRegistryConverter,
+                "revalidate_published_entries",
+                new=delete_then_revalidate,
+            ),
+            self.assertRaisesRegex(
+                OSError,
+                "publication inputs changed",
+            ),
+        ):
+            write_conversion_artifacts(
+                str(gm_dir),
+                str(godot_dir),
+                target_platform="windows",
+                enabled_converters=(),
+                output_snapshot=capture_conversion_output_snapshot(
+                    str(godot_dir)
+                ),
+                manifest_outcome=self._successful_outcome(),
+                attempt_outcome=self._successful_outcome(),
+            )
+
+        self.assertEqual(validation_calls, 1)
+        self.assertEqual(manifest_path.read_bytes(), manifest_before)
+        self.assertEqual(attempt_path.read_bytes(), attempt_before)
+        self.assertEqual(self._temporary_artifact_files(godot_dir), [])
+
+    def test_included_output_byte_change_after_manifest_publish_rolls_back_pair(
+        self,
+    ) -> None:
+        (
+            gm_dir,
+            godot_dir,
+            output_path,
+            manifest_path,
+            attempt_path,
+            manifest_before,
+            attempt_before,
+        ) = self._included_publication_fixture("change-after-publish")
+        real_revalidate = AssetRegistryConverter.revalidate_published_entries
+        validation_calls = 0
+
+        def mutate_then_revalidate(
+            converter: AssetRegistryConverter,
+            entries: tuple[AssetRegistryEntry, ...],
+        ) -> None:
+            nonlocal validation_calls
+            validation_calls += 1
+            if validation_calls == 2:
+                output_path.write_bytes(b"changed after manifest publication")
+            real_revalidate(converter, entries)
+
+        with (
+            patch.object(
+                AssetRegistryConverter,
+                "revalidate_published_entries",
+                new=mutate_then_revalidate,
+            ),
+            self.assertRaisesRegex(
+                OSError,
+                "publication inputs changed",
+            ),
+        ):
+            write_conversion_artifacts(
+                str(gm_dir),
+                str(godot_dir),
+                target_platform="windows",
+                enabled_converters=(),
+                output_snapshot=capture_conversion_output_snapshot(
+                    str(godot_dir)
+                ),
+                manifest_outcome=self._successful_outcome(),
+                attempt_outcome=self._successful_outcome(),
+            )
+
+        self.assertEqual(validation_calls, 2)
+        self.assertEqual(manifest_path.read_bytes(), manifest_before)
+        self.assertEqual(attempt_path.read_bytes(), attempt_before)
+        self.assertEqual(self._temporary_artifact_files(godot_dir), [])
 
     def test_outcome_steps_must_match_enabled_conversion_plan(self) -> None:
         godot_dir = self.temp_dir / "godot"
@@ -2198,6 +2634,48 @@ class TestConversionManifest(unittest.TestCase):
             output_snapshot=capture_conversion_output_snapshot(str(godot_dir)),
             manifest_outcome=selected_manifest_outcome,
             attempt_outcome=selected_attempt_outcome,
+        )
+
+    def _included_publication_fixture(
+        self,
+        name: str,
+    ) -> tuple[Path, Path, Path, Path, Path, bytes, bytes]:
+        gm_dir = self.temp_dir / f"{name}-gm"
+        godot_dir = self.temp_dir / f"{name}-godot"
+        datafiles_dir = gm_dir / "datafiles"
+        included_files_dir = godot_dir / "included_files"
+        artifact_dir = godot_dir / "gm2godot"
+        datafiles_dir.mkdir(parents=True)
+        included_files_dir.mkdir(parents=True)
+        artifact_dir.mkdir(parents=True)
+        (gm_dir / "IncludedFiles.yyp").write_text(
+            json.dumps(
+                {
+                    "%Name": "IncludedFiles",
+                    "resourceType": "GMProject",
+                    "resources": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        payload = b"matching included payload"
+        (datafiles_dir / "payload.bin").write_bytes(payload)
+        output_path = included_files_dir / "payload.bin"
+        output_path.write_bytes(payload)
+        manifest_path = artifact_dir / "conversion_manifest.json"
+        attempt_path = artifact_dir / "conversion_attempt.json"
+        manifest_before = b"previous canonical manifest\n"
+        attempt_before = b"previous conversion attempt\n"
+        manifest_path.write_bytes(manifest_before)
+        attempt_path.write_bytes(attempt_before)
+        return (
+            gm_dir,
+            godot_dir,
+            output_path,
+            manifest_path,
+            attempt_path,
+            manifest_before,
+            attempt_before,
         )
 
     @staticmethod

--- a/tests/test_files_ini_json_godot.py
+++ b/tests/test_files_ini_json_godot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -9,6 +10,7 @@ import unittest
 from pathlib import Path
 
 from src.conversion.gml_runtime import write_gml_runtime
+from src.conversion.included_files import IncludedFilesConverter
 
 
 def _find_godot_binary() -> str | None:
@@ -37,6 +39,21 @@ class TestFilesIniJsonGodotSmoke(unittest.TestCase):
         if godot_binary is None:
             self.skipTest("Godot binary not available")
 
+        version_result = subprocess.run(
+            [godot_binary, "--version"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=10,
+        )
+        self.assertEqual(version_result.returncode, 0, version_result.stdout)
+        if not version_result.stdout.strip().startswith("4.7.1."):
+            self.skipTest(
+                "Exact Godot 4.7.1 required; found "
+                + version_result.stdout.strip()
+            )
+
         smoke_script = textwrap.dedent(
             """\
             extends Node2D
@@ -61,10 +78,110 @@ class TestFilesIniJsonGodotSmoke(unittest.TestCase):
             \tif not _check(GMRuntime.gml_builtin_global("temp_directory").begins_with("user://"), "temp_directory not user path"):
             \t\treturn
 
-            \tGMRuntime.gml_file_delete("config/default.txt")
-            \tif not _check(GMRuntime.gml_file_exists("config/default.txt"), "included file not found"):
+            \tGMRuntime.gml_file_delete("Config/My File.txt")
+            \tif not _check(GMRuntime.gml_file_resolve_path("Config/My File.txt", true) == "user://gm2godot/Config/My File.txt", "relative write path was normalized or escaped user storage"):
             \t\treturn
-            \tvar included = GMRuntime.gml_file_text_open_read("config/default.txt")
+            \tif not _check(GMRuntime.gml_file_resolve_path("Config/My File.txt", false) == "res://included_files/config/my_file.txt", "included text path was not normalized for packaged lookup"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_file_resolve_path("Binary Data/My Bytes.bin", false) == "res://included_files/binary_data/my_bytes.bin", "nested included binary path was not normalized"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_file_resolve_path("Missing Folder/Missing File.txt", false) == "user://gm2godot/Missing Folder/Missing File.txt", "missing relative read did not fall back to exact user path"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_file_resolve_path("user://explicit.txt", false) == "user://explicit.txt", "explicit user path changed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_file_resolve_path("res://included_files/config/my_file.txt", false) == "res://included_files/config/my_file.txt", "explicit resource read path changed"):
+            \t\treturn
+
+            \tGMRuntime.gml_file_delete("Read Me.txt")
+            \tGMRuntime.gml_file_delete("read_me.txt")
+            \tGMRuntime.gml_file_delete("READ_ME_2.TXT")
+            \tGMRuntime.gml_file_delete("READ ME.TXT")
+            \tGMRuntime.gml_file_delete("foo_bar")
+            \tGMRuntime.gml_file_delete("Foo Bar/item.txt")
+            \tGMRuntime.gml_file_delete("Gone File.txt")
+            \tGMRuntime.gml_file_delete("Ghost File.txt")
+            \tif not _check(GMRuntime.gml_file_resolve_path("Read Me.txt", false) == "res://included_files/read_me_3.txt", "exact colliding logical path did not use reserved suffix"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_file_resolve_path("read_me.txt", false) == "res://included_files/read_me.txt", "canonical collision member resolved incorrectly"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_file_resolve_path("READ_ME_2.TXT", false) == "res://included_files/read_me_2.txt", "unique canonical natural suffix lookup failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_file_resolve_path("READ ME.TXT", false) == "user://gm2godot/READ ME.TXT", "ambiguous canonical lookup did not fail closed"):
+            \t\treturn
+            \tif not _check(not GMRuntime.gml_file_exists("READ ME.TXT"), "ambiguous canonical lookup selected a payload"):
+            \t\treturn
+            \tvar collision_reader = GMRuntime.gml_file_text_open_read("Read Me.txt")
+            \tif not _check(GMRuntime.gml_file_text_read_string(collision_reader) == "normalized collision", "exact collision payload mismatch"):
+            \t\treturn
+            \tGMRuntime.gml_file_text_close(collision_reader)
+            \tvar canonical_reader = GMRuntime.gml_file_text_open_read("read_me.txt")
+            \tif not _check(GMRuntime.gml_file_text_read_string(canonical_reader) == "canonical collision", "canonical collision payload mismatch"):
+            \t\treturn
+            \tGMRuntime.gml_file_text_close(canonical_reader)
+
+            \tif not _check(GMRuntime.gml_file_resolve_path("foo_bar", false) == "res://included_files/foo_bar_2", "file/directory blocker file did not resolve to relocation"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_file_resolve_path("Foo Bar/item.txt", false) == "res://included_files/foo_bar/item.txt", "file/directory blocker nested file path mismatch"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_directory_exists("Foo Bar"), "file/directory blocker directory lookup failed"):
+            \t\treturn
+            \tvar blocker_reader = GMRuntime.gml_file_text_open_read("foo_bar")
+            \tif not _check(GMRuntime.gml_file_text_read_string(blocker_reader) == "blocking file", "relocated blocking file payload mismatch"):
+            \t\treturn
+            \tGMRuntime.gml_file_text_close(blocker_reader)
+            \tvar nested_reader = GMRuntime.gml_file_text_open_read("Foo Bar/item.txt")
+            \tif not _check(GMRuntime.gml_file_text_read_string(nested_reader) == "nested item", "nested blocker payload mismatch"):
+            \t\treturn
+            \tGMRuntime.gml_file_text_close(nested_reader)
+
+            \tif not _check(GMRuntime.gml_file_resolve_path("Gone File.txt", false) == "user://gm2godot/Gone File.txt", "known missing assigned target fell through to canonical payload"):
+            \t\treturn
+            \tif not _check(not GMRuntime.gml_file_exists("Gone File.txt"), "known missing assigned target selected canonical payload"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_file_resolve_path("Ghost File.txt", false) == "user://gm2godot/Ghost File.txt", "planned but unemitted logical path fell through to canonical payload"):
+            \t\treturn
+            \tif not _check(not GMRuntime.gml_file_exists("Ghost File.txt"), "planned but unemitted logical path selected canonical payload"):
+            \t\treturn
+
+            \tGMRuntime.gml_file_delete(" Leading.txt")
+            \tGMRuntime.gml_file_delete("Trailing.txt ")
+            \tif not _check(GMRuntime.gml_file_resolve_path(" Leading.txt", true) == "user://gm2godot/ Leading.txt", "leading-space write path lost its literal space"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_file_resolve_path("Trailing.txt ", true) == "user://gm2godot/Trailing.txt ", "trailing-space write path lost its literal space"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_file_resolve_path(" Leading.txt", false) == "res://included_files/_leading.txt", "leading-space packaged lookup mismatch"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_file_resolve_path("Trailing.txt ", false) == "res://included_files/trailing.txt_", "trailing-space packaged lookup mismatch"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_file_exists(" Leading.txt") and GMRuntime.gml_file_exists("Trailing.txt "), "edge-space included file not found"):
+            \t\treturn
+            \tvar leading_space_reader = GMRuntime.gml_file_text_open_read(" Leading.txt")
+            \tif not _check(GMRuntime.gml_file_text_read_string(leading_space_reader) == "leading packaged", "leading-space included text mismatch"):
+            \t\treturn
+            \tGMRuntime.gml_file_text_close(leading_space_reader)
+            \tvar trailing_space_reader = GMRuntime.gml_file_text_open_read("Trailing.txt ")
+            \tif not _check(GMRuntime.gml_file_text_read_string(trailing_space_reader) == "trailing packaged", "trailing-space included text mismatch"):
+            \t\treturn
+            \tGMRuntime.gml_file_text_close(trailing_space_reader)
+
+            \tvar leading_space_writer = GMRuntime.gml_file_text_open_write(" Leading.txt")
+            \tGMRuntime.gml_file_text_write_string(leading_space_writer, "leading user")
+            \tGMRuntime.gml_file_text_close(leading_space_writer)
+            \tvar trailing_space_writer = GMRuntime.gml_file_text_open_write("Trailing.txt ")
+            \tGMRuntime.gml_file_text_write_string(trailing_space_writer, "trailing user")
+            \tGMRuntime.gml_file_text_close(trailing_space_writer)
+            \tif not _check(GMRuntime.gml_file_resolve_path(" Leading.txt", false) == "user://gm2godot/ Leading.txt", "leading-space user override did not take precedence"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_file_resolve_path("Trailing.txt ", false) == "user://gm2godot/Trailing.txt ", "trailing-space user override did not take precedence"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_file_delete(" Leading.txt") and GMRuntime.gml_file_delete("Trailing.txt "), "edge-space user override delete failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_file_resolve_path(" Leading.txt", false) == "res://included_files/_leading.txt" and GMRuntime.gml_file_resolve_path("Trailing.txt ", false) == "res://included_files/trailing.txt_", "edge-space packaged files did not reappear"):
+            \t\treturn
+
+            \tif not _check(GMRuntime.gml_file_exists("Config/My File.txt"), "included file not found through mixed-case logical path"):
+            \t\treturn
+            \tvar included = GMRuntime.gml_file_text_open_read("Config/My File.txt")
             \tif not _check(GMRuntime.gml_file_text_read_string(included) == "included", "included text mismatch"):
             \t\treturn
             \tif not _check(GMRuntime.gml_file_text_read_real(included) == 42, "included real mismatch"):
@@ -72,6 +189,29 @@ class TestFilesIniJsonGodotSmoke(unittest.TestCase):
             \tif not _check(GMRuntime.gml_file_text_eof(included), "included EOF mismatch"):
             \t\treturn
             \tGMRuntime.gml_file_text_close(included)
+
+            \tvar included_buffer = GMRuntime.gml_buffer_load("Binary Data/My Bytes.bin")
+            \tif not _check(GMRuntime.gml_buffer_exists(included_buffer), "included binary buffer_load failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_buffer_get_used_size(included_buffer) == 5, "included binary size mismatch"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_buffer_peek(included_buffer, 0, 1) == 0 and GMRuntime.gml_buffer_peek(included_buffer, 4, 1) == 255, "included binary contents mismatch"):
+            \t\treturn
+            \tGMRuntime.gml_buffer_delete(included_buffer)
+
+            \tvar override_writer = GMRuntime.gml_file_text_open_write("Config/My File.txt")
+            \tGMRuntime.gml_file_text_write_string(override_writer, "user override")
+            \tGMRuntime.gml_file_text_close(override_writer)
+            \tif not _check(GMRuntime.gml_file_resolve_path("Config/My File.txt", false) == "user://gm2godot/Config/My File.txt", "exact user override did not take precedence"):
+            \t\treturn
+            \tvar override_reader = GMRuntime.gml_file_text_open_read("Config/My File.txt")
+            \tif not _check(GMRuntime.gml_file_text_read_string(override_reader) == "user override", "user override content mismatch"):
+            \t\treturn
+            \tGMRuntime.gml_file_text_close(override_reader)
+            \tif not _check(GMRuntime.gml_file_delete("Config/My File.txt"), "user override delete failed"):
+            \t\treturn
+            \tif not _check(GMRuntime.gml_file_resolve_path("Config/My File.txt", false) == "res://included_files/config/my_file.txt", "packaged file did not reappear after deleting override"):
+            \t\treturn
 
             \tif not _check(GMRuntime.gml_filename_name("save/profile.txt") == "profile", "filename_name mismatch"):
             \t\treturn
@@ -170,9 +310,143 @@ class TestFilesIniJsonGodotSmoke(unittest.TestCase):
         )
 
         with tempfile.TemporaryDirectory() as tmp:
-            project_dir = Path(tmp)
+            workspace = Path(tmp)
+            gm_project_dir = workspace / "gamemaker"
+            project_dir = workspace / "godot"
+            _write_text(
+                gm_project_dir / "RuntimeParity.yyp",
+                json.dumps(
+                    {
+                        "IncludedFiles": [
+                            {
+                                "name": "My File.txt",
+                                "filePath": "datafiles/Config",
+                            },
+                            {
+                                "name": "My Bytes.bin",
+                                "filePath": "datafiles/Binary Data",
+                            },
+                            {
+                                "name": " Leading.txt",
+                                "filePath": "datafiles",
+                            },
+                            {
+                                "name": "Trailing.txt ",
+                                "filePath": "datafiles",
+                            },
+                            {
+                                "name": "Ghost File.txt",
+                                "filePath": "datafiles",
+                            },
+                        ]
+                    }
+                ),
+            )
+            _write_text(
+                gm_project_dir / "datafiles" / "Config" / "My File.txt",
+                "included\n42\n",
+            )
+            _write_text(
+                gm_project_dir / "datafiles" / " Leading.txt",
+                "leading packaged\n",
+            )
+            _write_text(
+                gm_project_dir / "datafiles" / "Trailing.txt ",
+                "trailing packaged\n",
+            )
+            collision_payloads = {
+                "Read Me.txt": "normalized collision\n",
+                "read_me.txt": "canonical collision\n",
+                "read_me_2.txt": "natural suffix\n",
+                "foo_bar": "blocking file\n",
+                "Foo Bar/item.txt": "nested item\n",
+                "Gone File.txt": "target removed after conversion\n",
+                "gone_file.txt": "canonical payload must not leak\n",
+                "ghost_file.txt": "unavailable alias must not leak\n",
+            }
+            for relative_path, payload in collision_payloads.items():
+                _write_text(
+                    gm_project_dir
+                    / "datafiles"
+                    / Path(*relative_path.split("/")),
+                    payload,
+                )
+            binary_source = (
+                gm_project_dir
+                / "datafiles"
+                / "Binary Data"
+                / "My Bytes.bin"
+            )
+            binary_source.parent.mkdir(parents=True, exist_ok=True)
+            binary_source.write_bytes(bytes((0, 1, 127, 128, 255)))
+
+            IncludedFilesConverter(
+                os.fspath(gm_project_dir),
+                os.fspath(project_dir),
+                log_callback=lambda _message: None,
+                progress_callback=lambda _value: None,
+                conversion_running=lambda: True,
+                max_workers=1,
+            ).convert_all()
+
+            self.assertEqual(
+                (
+                    project_dir
+                    / "included_files"
+                    / "config"
+                    / "my_file.txt"
+                ).read_text(encoding="utf-8"),
+                "included\n42\n",
+            )
+            self.assertEqual(
+                (
+                    project_dir
+                    / "included_files"
+                    / "binary_data"
+                    / "my_bytes.bin"
+                ).read_bytes(),
+                bytes((0, 1, 127, 128, 255)),
+            )
+            self.assertEqual(
+                (project_dir / "included_files" / "_leading.txt").read_text(
+                    encoding="utf-8"
+                ),
+                "leading packaged\n",
+            )
+            self.assertEqual(
+                (project_dir / "included_files" / "trailing.txt_").read_text(
+                    encoding="utf-8"
+                ),
+                "trailing packaged\n",
+            )
+            self.assertEqual(
+                (project_dir / "included_files" / "read_me_3.txt").read_text(
+                    encoding="utf-8"
+                ),
+                "normalized collision\n",
+            )
+            self.assertEqual(
+                (project_dir / "included_files" / "foo_bar_2").read_text(
+                    encoding="utf-8"
+                ),
+                "blocking file\n",
+            )
+            self.assertEqual(
+                (
+                    project_dir
+                    / "included_files"
+                    / "foo_bar"
+                    / "item.txt"
+                ).read_text(encoding="utf-8"),
+                "nested item\n",
+            )
+            missing_assigned_target = (
+                project_dir / "included_files" / "gone_file_2.txt"
+            )
+            self.assertTrue(missing_assigned_target.is_file())
+            missing_assigned_target.unlink()
+
             _write_text(project_dir / "project.godot", "[application]\n")
-            _write_text(project_dir / "datafiles" / "config" / "default.txt", "included\n42\n")
             write_gml_runtime(str(project_dir))
             _write_text(project_dir / "smoke.gd", smoke_script)
             _write_text(project_dir / "smoke.tscn", smoke_scene)

--- a/tests/test_gml_runtime.py
+++ b/tests/test_gml_runtime.py
@@ -1829,6 +1829,50 @@ class TestGMLRuntimeScript(unittest.TestCase):
         for helper_name in helper_names:
             self.assertIn(f"static func {helper_name}", GML_RUNTIME_SCRIPT)
 
+    def test_runtime_file_paths_preserve_literal_edge_spaces(self):
+        self.assertIn(
+            'static func _gml_file_plain_path(path):\n\treturn str(path).replace("\\\\", "/")',
+            GML_RUNTIME_SCRIPT,
+        )
+        self.assertIn(
+            'var relative = str(path).replace("\\\\", "/")',
+            GML_RUNTIME_SCRIPT,
+        )
+        self.assertNotIn(
+            'str(path).replace("\\\\", "/").strip_edges()',
+            GML_RUNTIME_SCRIPT,
+        )
+        self.assertIn(
+            'elif code == 32:\n\t\t\tnormalized += "_"',
+            GML_RUNTIME_SCRIPT,
+        )
+
+    def test_runtime_loads_dedicated_included_file_path_registry(self):
+        self.assertIn(
+            'const GML_INCLUDED_FILE_REGISTRY_PATH = "res://gm2godot/gml_included_file_registry.gd"',
+            GML_RUNTIME_SCRIPT,
+        )
+        self.assertIn(
+            "static func _gml_included_file_registry_ensure_loaded():",
+            GML_RUNTIME_SCRIPT,
+        )
+        self.assertIn(
+            'registry_script.gml_included_file_registry_entries()',
+            GML_RUNTIME_SCRIPT,
+        )
+        self.assertIn(
+            "static func _gml_file_resolve_path(path, write = false, expect_directory = false):",
+            GML_RUNTIME_SCRIPT,
+        )
+        self.assertIn(
+            "_gml_file_resolve_path(path, false, true)",
+            GML_RUNTIME_SCRIPT,
+        )
+        self.assertNotIn(
+            "_gml_asset_registry_ensure_loaded()\n\tif _gml_included_file_exact_paths",
+            GML_RUNTIME_SCRIPT,
+        )
+
     def test_runtime_helpers_keep_any_values_untyped(self):
         self.assertNotRegex(GML_RUNTIME_SCRIPT, r"static func \w+\([^)]*:\s")
         self.assertNotIn("Array[", GML_RUNTIME_SCRIPT)

--- a/tests/test_included_file_paths.py
+++ b/tests/test_included_file_paths.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import unittest
+
+from src.conversion.included_file_paths import (
+    canonical_included_file_lookup_path,
+    plan_included_file_paths,
+)
+from src.conversion.project_source_paths import ProjectSourcePathError
+
+
+class TestIncludedFilePaths(unittest.TestCase):
+    def assertAssignedPathsArePrefixFree(self, logical_paths: list[str]) -> None:
+        output_paths = [
+            assignment.assigned_output_path
+            for assignment in plan_included_file_paths(logical_paths)
+        ]
+        for possible_parent in output_paths:
+            for possible_child in output_paths:
+                if possible_parent == possible_child:
+                    continue
+                self.assertFalse(
+                    possible_child.startswith(possible_parent + "/"),
+                    f"{possible_parent!r} blocks {possible_child!r}",
+                )
+
+    def test_canonicalizes_nested_portable_paths_and_ascii_lookup_names(
+        self,
+    ) -> None:
+        assignment = plan_included_file_paths(
+            [r"Languages\UI Files\English Guide.TXT"]
+        )[0]
+
+        self.assertEqual(
+            assignment.original_logical_path,
+            "Languages/UI Files/English Guide.TXT",
+        )
+        self.assertEqual(
+            assignment.canonical_lookup_path,
+            "languages/ui_files/english_guide.txt",
+        )
+        self.assertEqual(
+            assignment.assigned_output_path,
+            "languages/ui_files/english_guide.txt",
+        )
+        self.assertEqual(
+            assignment.collision_group,
+            ("Languages/UI Files/English Guide.TXT",),
+        )
+        self.assertFalse(assignment.has_collision)
+
+    def test_lookup_normalization_is_ascii_only(self) -> None:
+        self.assertEqual(
+            canonical_included_file_lookup_path("Données/Ä FILE.TXT"),
+            "données/Ä_file.txt",
+        )
+
+    def test_case_and_space_collisions_receive_suffixes_before_extension(
+        self,
+    ) -> None:
+        assignments = {
+            assignment.original_logical_path: assignment
+            for assignment in plan_included_file_paths(
+                ["read_me.txt", "READ ME.TXT", "Read Me.txt"]
+            )
+        }
+
+        self.assertEqual(
+            assignments["read_me.txt"].assigned_output_path,
+            "read_me.txt",
+        )
+        self.assertEqual(
+            assignments["READ ME.TXT"].assigned_output_path,
+            "read_me_2.txt",
+        )
+        self.assertEqual(
+            assignments["Read Me.txt"].assigned_output_path,
+            "read_me_3.txt",
+        )
+        for assignment in assignments.values():
+            self.assertEqual(assignment.canonical_lookup_path, "read_me.txt")
+            self.assertEqual(
+                assignment.collision_group,
+                ("read_me.txt", "READ ME.TXT", "Read Me.txt"),
+            )
+            self.assertTrue(assignment.has_collision)
+
+    def test_assignments_are_independent_of_input_order(self) -> None:
+        paths = [
+            "nested/File.txt",
+            "NESTED/FILE.TXT",
+            "Nested/file.txt",
+            "nested/file_2.txt",
+        ]
+
+        forward = plan_included_file_paths(paths)
+        reverse = plan_included_file_paths(reversed(paths))
+
+        self.assertEqual(forward, reverse)
+
+    def test_natural_canonical_suffix_paths_are_reserved(self) -> None:
+        assignments = {
+            assignment.original_logical_path: assignment.assigned_output_path
+            for assignment in plan_included_file_paths(
+                ["File.txt", "file.txt", "file_2.txt"]
+            )
+        }
+
+        self.assertEqual(assignments["file.txt"], "file.txt")
+        self.assertEqual(assignments["file_2.txt"], "file_2.txt")
+        self.assertEqual(assignments["File.txt"], "file_3.txt")
+
+    def test_nested_directories_have_independent_collision_groups(self) -> None:
+        assignments = {
+            assignment.original_logical_path: assignment.assigned_output_path
+            for assignment in plan_included_file_paths(
+                [
+                    "Alpha/File.txt",
+                    "alpha/file.txt",
+                    "Beta/File.txt",
+                    "beta/file.txt",
+                ]
+            )
+        }
+
+        self.assertEqual(assignments["alpha/file.txt"], "alpha/file.txt")
+        self.assertEqual(assignments["Alpha/File.txt"], "alpha/file_2.txt")
+        self.assertEqual(assignments["beta/file.txt"], "beta/file.txt")
+        self.assertEqual(assignments["Beta/File.txt"], "beta/file_2.txt")
+
+    def test_normalized_file_prefix_is_relocated_away_from_directory(
+        self,
+    ) -> None:
+        cases = (
+            ("foo_bar", "Foo Bar/item.txt"),
+            ("Foo Bar", "foo_bar/item.txt"),
+        )
+        for file_path, nested_path in cases:
+            with self.subTest(file_path=file_path, nested_path=nested_path):
+                paths = [file_path, nested_path, "unrelated.txt"]
+                assignments = {
+                    assignment.original_logical_path: assignment
+                    for assignment in plan_included_file_paths(paths)
+                }
+
+                self.assertEqual(
+                    assignments[file_path].assigned_output_path,
+                    "foo_bar_2",
+                )
+                self.assertEqual(
+                    assignments[nested_path].assigned_output_path,
+                    "foo_bar/item.txt",
+                )
+                self.assertEqual(
+                    assignments["unrelated.txt"].assigned_output_path,
+                    "unrelated.txt",
+                )
+                self.assertEqual(
+                    assignments[file_path].collision_group,
+                    (file_path, nested_path),
+                )
+                self.assertEqual(
+                    assignments[nested_path].collision_group,
+                    (file_path, nested_path),
+                )
+                self.assertTrue(assignments[file_path].has_collision)
+                self.assertFalse(assignments[nested_path].has_collision)
+                self.assertAssignedPathsArePrefixFree(paths)
+
+    def test_nested_file_prefixes_relocate_each_blocking_file(self) -> None:
+        paths = [
+            "tree",
+            "tree/branch.txt",
+            "tree/branch.txt/leaf.bin",
+        ]
+        assignments = {
+            assignment.original_logical_path: assignment
+            for assignment in plan_included_file_paths(paths)
+        }
+
+        self.assertEqual(assignments["tree"].assigned_output_path, "tree_2")
+        self.assertEqual(
+            assignments["tree/branch.txt"].assigned_output_path,
+            "tree/branch_2.txt",
+        )
+        self.assertEqual(
+            assignments["tree/branch.txt/leaf.bin"].assigned_output_path,
+            "tree/branch.txt/leaf.bin",
+        )
+        expected_group = tuple(paths)
+        for assignment in assignments.values():
+            self.assertEqual(assignment.collision_group, expected_group)
+        reporting_assignments = [
+            assignment.original_logical_path
+            for assignment in assignments.values()
+            if assignment.has_collision
+        ]
+        self.assertEqual(reporting_assignments, ["tree"])
+        self.assertAssignedPathsArePrefixFree(paths)
+
+    def test_prefix_relocation_reserves_natural_files_and_directories(
+        self,
+    ) -> None:
+        paths = [
+            "foo",
+            "foo/bar.txt",
+            "foo_2",
+            "foo_3/item.txt",
+        ]
+        assignments = {
+            assignment.original_logical_path: assignment.assigned_output_path
+            for assignment in plan_included_file_paths(paths)
+        }
+
+        self.assertEqual(assignments["foo"], "foo_4")
+        self.assertEqual(assignments["foo/bar.txt"], "foo/bar.txt")
+        self.assertEqual(assignments["foo_2"], "foo_2")
+        self.assertEqual(assignments["foo_3/item.txt"], "foo_3/item.txt")
+        self.assertAssignedPathsArePrefixFree(paths)
+
+    def test_prefix_collision_assignments_are_input_order_independent(
+        self,
+    ) -> None:
+        paths = [
+            "root",
+            "ROOT/Child File.txt",
+            "root/child_file.txt/grandchild.bin",
+            "root_2",
+            "sibling.txt",
+        ]
+
+        self.assertEqual(
+            plan_included_file_paths(paths),
+            plan_included_file_paths(reversed(paths)),
+        )
+        self.assertAssignedPathsArePrefixFree(paths)
+
+    def test_duplicate_normalized_logical_paths_are_coalesced(self) -> None:
+        assignments = plan_included_file_paths(
+            ["nested/unused/../file.txt", "nested/file.txt"]
+        )
+
+        self.assertEqual(len(assignments), 1)
+        self.assertEqual(
+            assignments[0].original_logical_path,
+            "nested/file.txt",
+        )
+        self.assertFalse(assignments[0].has_collision)
+
+    def test_unsafe_absolute_and_traversal_paths_are_rejected(self) -> None:
+        unsafe_paths = (
+            "",
+            ".",
+            "folder/..",
+            "../outside.txt",
+            "safe/../../outside.txt",
+            "/absolute.txt",
+            r"C:\absolute.txt",
+            "C:drive-relative.txt",
+            r"\\server\share\payload.txt",
+            "invalid\0name.txt",
+        )
+
+        for logical_path in unsafe_paths:
+            with self.subTest(logical_path=logical_path):
+                with self.assertRaises(ProjectSourcePathError):
+                    plan_included_file_paths([logical_path])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_included_file_registry.py
+++ b/tests/test_included_file_registry.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from src.conversion.included_file_paths import plan_included_file_paths
+from src.conversion.included_file_registry import (
+    INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+    build_included_file_registry_entries,
+    render_included_file_registry_script,
+    write_included_file_registry,
+)
+
+
+class TestIncludedFileRegistry(unittest.TestCase):
+    def test_entries_preserve_planned_assignments_and_emission_state(self) -> None:
+        assignments = plan_included_file_paths(
+            (
+                "read_me_2.txt",
+                "Read Me.txt",
+                "read_me.txt",
+                "foo_bar",
+                "Foo Bar/item.txt",
+            )
+        )
+        emitted = {
+            "Read Me.txt",
+            "read_me.txt",
+            "read_me_2.txt",
+            "Foo Bar/item.txt",
+        }
+
+        entries = build_included_file_registry_entries(assignments, emitted)
+
+        self.assertEqual(
+            {
+                entry.logical_path: (
+                    entry.canonical_path,
+                    entry.assigned_path,
+                    entry.emitted,
+                )
+                for entry in entries
+            },
+            {
+                "Foo Bar/item.txt": (
+                    "foo_bar/item.txt",
+                    "foo_bar/item.txt",
+                    True,
+                ),
+                "Read Me.txt": ("read_me.txt", "read_me_3.txt", True),
+                "foo_bar": ("foo_bar", "foo_bar_2", False),
+                "read_me.txt": ("read_me.txt", "read_me.txt", True),
+                "read_me_2.txt": (
+                    "read_me_2.txt",
+                    "read_me_2.txt",
+                    True,
+                ),
+            },
+        )
+
+    def test_registry_rendering_is_independent_of_input_order(self) -> None:
+        assignments = plan_included_file_paths(
+            ("Read Me.txt", "read_me.txt", "read_me_2.txt")
+        )
+        entries = build_included_file_registry_entries(
+            assignments,
+            {assignment.original_logical_path for assignment in assignments},
+        )
+
+        forward = render_included_file_registry_script(entries)
+        reverse = render_included_file_registry_script(reversed(entries))
+
+        self.assertEqual(forward, reverse)
+        self.assertIn("const FORMAT_VERSION = 1", forward)
+        self.assertIn(
+            "static func gml_included_file_registry_entries():",
+            forward,
+        )
+        self.assertIn('"assigned_path": "read_me_3.txt"', forward)
+
+    def test_writer_publishes_empty_authoritative_registry(self) -> None:
+        with tempfile.TemporaryDirectory() as godot_project_path:
+            registry_path = write_included_file_registry(
+                godot_project_path,
+                (),
+                (),
+            )
+
+            self.assertEqual(
+                registry_path,
+                os.path.join(
+                    godot_project_path,
+                    INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+                ),
+            )
+            with open(registry_path, encoding="utf-8") as registry_file:
+                content = registry_file.read()
+            self.assertIn("const INCLUDED_FILES = []", content)
+
+    def test_writer_rejects_redirected_registry_directory(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as godot_project_path,
+            tempfile.TemporaryDirectory() as outside_path,
+        ):
+            try:
+                os.symlink(
+                    outside_path,
+                    os.path.join(godot_project_path, "gm2godot"),
+                )
+            except (NotImplementedError, OSError) as error:
+                self.skipTest(f"Symbolic links are unavailable: {error}")
+
+            with self.assertRaises(OSError):
+                write_included_file_registry(
+                    godot_project_path,
+                    (),
+                    (),
+                )
+
+            self.assertFalse(
+                os.path.exists(
+                    os.path.join(
+                        outside_path,
+                        "gml_included_file_registry.gd",
+                    )
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_included_files.py
+++ b/tests/test_included_files.py
@@ -3,21 +3,27 @@
 import json
 import os
 import posixpath
+import stat
 import sys
 import shutil
 import tempfile
 import threading
 import unittest
+from typing import BinaryIO, Callable
 from unittest.mock import MagicMock, patch
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
+from src.conversion import included_files as included_files_module
 from src.conversion.included_files import IncludedFilesConverter
+from src.conversion.included_file_registry import (
+    INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+)
 from src.conversion.conversion_outcome import ConversionCounts
 from src.conversion.converter import Converter
-from src.conversion.diagnostics import DiagnosticCollector
+from src.conversion.diagnostics import ConversionDiagnostic, DiagnosticCollector
 from src.conversion.project_source_paths import ResolvedProjectSourcePath
 
 
@@ -60,6 +66,25 @@ class TestIncludedFilesConverterBasic(unittest.TestCase):
             content = f.read()
         self.assertEqual(content, "test content")
 
+        registry_path = os.path.join(
+            self.godot_dir,
+            INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+        )
+        with open(registry_path, encoding="utf-8") as registry_file:
+            registry_content = registry_file.read()
+        self.assertIn('"logical_path": "test.txt"', registry_content)
+        self.assertIn('"assigned_path": "test.txt"', registry_content)
+        self.assertIn('"emitted": true', registry_content)
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(
+                    self.godot_dir,
+                    "gm2godot",
+                    "gml_asset_registry.gd",
+                )
+            )
+        )
+
     def test_multiple_files(self):
         datafiles_dir = os.path.join(self.gm_dir, "datafiles")
         for name in ("config.ini", "data.csv"):
@@ -72,6 +97,27 @@ class TestIncludedFilesConverterBasic(unittest.TestCase):
         for name in ("test.txt", "config.ini", "data.csv"):
             expected = os.path.join(self.godot_dir, "included_files", name)
             self.assertTrue(os.path.isfile(expected), f"Expected {expected}")
+
+    def test_empty_included_files_conversion_prunes_stale_root_and_writes_empty_registry(self):
+        converter = self._make_converter()
+        converter.convert_all()
+        os.unlink(self.test_file)
+
+        converter.convert_all()
+
+        self.assertEqual(
+            os.listdir(os.path.join(self.godot_dir, "included_files")),
+            [],
+        )
+        with open(
+            os.path.join(
+                self.godot_dir,
+                INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+            ),
+            encoding="utf-8",
+        ) as registry_file:
+            registry_content = registry_file.read()
+        self.assertIn("const INCLUDED_FILES = []", registry_content)
 
     def test_malformed_yyp_retains_disk_discovery_fallback(self):
         with open(
@@ -159,6 +205,1708 @@ class TestIncludedFilesConverterBasic(unittest.TestCase):
             ).resources,
             ConversionCounts(requested=2, executed=2, completed=2),
         )
+
+    def test_registry_publication_failure_restores_previous_output_pair(self):
+        converter = self._make_converter()
+        converter.convert_all()
+        root_path = os.path.join(self.godot_dir, "included_files")
+        registry_path = os.path.join(
+            self.godot_dir,
+            INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+        )
+        previous_root_identity = os.lstat(root_path).st_ino
+        with open(registry_path, "rb") as registry_file:
+            previous_registry = registry_file.read()
+        with open(self.test_file, "w", encoding="utf-8") as source_file:
+            source_file.write("updated content")
+        original_move = included_files_module._move_exact_included_file
+
+        def publish_then_fail(
+            source: str,
+            destination: str,
+            expected_identity: tuple[int, int],
+            *,
+            source_parent_identity: tuple[int, int] | None = None,
+            destination_parent_identity: tuple[int, int] | None = None,
+        ) -> None:
+            original_move(
+                source,
+                destination,
+                expected_identity,
+                source_parent_identity=source_parent_identity,
+                destination_parent_identity=destination_parent_identity,
+            )
+            if destination == registry_path:
+                raise OSError("registry publication failed")
+
+        with patch.object(
+            included_files_module,
+            "_move_exact_included_file",
+            side_effect=publish_then_fail,
+        ):
+            with self.assertRaisesRegex(
+                OSError,
+                "registry publication failed",
+            ):
+                converter.convert_all()
+
+        self.assertEqual(os.lstat(root_path).st_ino, previous_root_identity)
+        with open(
+            os.path.join(root_path, "test.txt"),
+            encoding="utf-8",
+        ) as output_file:
+            self.assertEqual(output_file.read(), "test content")
+        with open(registry_path, "rb") as registry_file:
+            self.assertEqual(registry_file.read(), previous_registry)
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(requested=1, executed=1, failed=1),
+        )
+
+
+class TestIncludedFilesManagedRootTransaction(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.datafiles_dir = os.path.join(self.gm_dir, "datafiles")
+        os.makedirs(self.datafiles_dir)
+        self.running = threading.Event()
+        self.running.set()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+
+    def _converter(self, *, max_workers: int = 2) -> IncludedFilesConverter:
+        return IncludedFilesConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=lambda _message: None,
+            progress_callback=lambda _value: None,
+            conversion_running=self.running.is_set,
+            max_workers=max_workers,
+        )
+
+    def _write(self, relative_path: str, content: str) -> None:
+        output_path = os.path.join(
+            self.datafiles_dir,
+            *relative_path.split("/"),
+        )
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as output_file:
+            output_file.write(content)
+
+    def _pair_snapshot(self) -> tuple[int, dict[str, bytes], int, bytes]:
+        root_path = os.path.join(self.godot_dir, "included_files")
+        registry_path = os.path.join(
+            self.godot_dir,
+            INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+        )
+        files: dict[str, bytes] = {}
+        for directory, _subdirectories, filenames in os.walk(root_path):
+            for filename in filenames:
+                file_path = os.path.join(directory, filename)
+                relative_path = os.path.relpath(
+                    file_path,
+                    root_path,
+                ).replace(os.sep, "/")
+                with open(file_path, "rb") as output_file:
+                    files[relative_path] = output_file.read()
+        with open(registry_path, "rb") as registry_file:
+            registry_content = registry_file.read()
+        return (
+            os.lstat(root_path).st_ino,
+            files,
+            os.lstat(registry_path).st_ino,
+            registry_content,
+        )
+
+    def _assert_no_transaction_debris(self) -> None:
+        project_debris = [
+            name
+            for name in os.listdir(self.godot_dir)
+            if name.startswith(".gm2godot-included-files-")
+            or name.startswith(".included_files.")
+        ]
+        registry_directory = os.path.join(self.godot_dir, "gm2godot")
+        registry_debris = (
+            [
+                name
+                for name in os.listdir(registry_directory)
+                if name.startswith(".gml_included_file_registry.gd.")
+                and name.endswith(".backup")
+            ]
+            if os.path.isdir(registry_directory)
+            else []
+        )
+        self.assertEqual(project_debris, [])
+        self.assertEqual(registry_debris, [])
+
+    def test_regular_file_in_place_of_managed_root_is_preserved(self) -> None:
+        self._write("new.txt", "new")
+        root_path = os.path.join(self.godot_dir, "included_files")
+        with open(root_path, "wb") as root_file:
+            root_file.write(b"unmanaged sentinel")
+        converter = self._converter(max_workers=1)
+
+        with self.assertRaisesRegex(OSError, "non-directory Included Files root"):
+            converter.convert_all()
+
+        with open(root_path, "rb") as root_file:
+            self.assertEqual(root_file.read(), b"unmanaged sentinel")
+        self.assertFalse(
+            os.path.lexists(
+                os.path.join(
+                    self.godot_dir,
+                    INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+                )
+            )
+        )
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(requested=1, executed=1, failed=1),
+        )
+        self._assert_no_transaction_debris()
+
+    def test_fifo_in_staged_root_preserves_previous_pair(self) -> None:
+        if not hasattr(os, "mkfifo"):
+            self.skipTest("FIFOs are unavailable")
+        converter = self._converter(max_workers=1)
+        self._write("old.txt", "old")
+        converter.convert_all()
+        previous_pair = self._pair_snapshot()
+        os.unlink(os.path.join(self.datafiles_dir, "old.txt"))
+        self._write("new.txt", "new")
+        original_process = converter._process_file
+
+        def inject_fifo(
+            gm_file_path: str,
+            godot_file_path: str,
+            relative_path: str,
+            owner_source_path: str,
+        ) -> tuple[str, bool, object | None] | None:
+            result = original_process(
+                gm_file_path,
+                godot_file_path,
+                relative_path,
+                owner_source_path,
+            )
+            os.mkfifo(os.path.join(os.path.dirname(godot_file_path), "rogue.fifo"))
+            return result
+
+        with patch.object(
+            converter,
+            "_process_file",
+            side_effect=inject_fifo,
+        ), self.assertRaisesRegex(OSError, "non-regular entry"):
+            converter.convert_all()
+
+        self.assertEqual(self._pair_snapshot(), previous_pair)
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(requested=1, executed=1, failed=1),
+        )
+        self._assert_no_transaction_debris()
+
+    def test_torn_source_mutation_during_copy_preserves_previous_pair(
+        self,
+    ) -> None:
+        converter = self._converter(max_workers=1)
+        self._write("old.txt", "old")
+        converter.convert_all()
+        previous_pair = self._pair_snapshot()
+        os.unlink(os.path.join(self.datafiles_dir, "old.txt"))
+        source_path = os.path.join(self.datafiles_dir, "new.bin")
+        pre_mutation_payload = b"A" * (2 * 1024 * 1024)
+        post_mutation_payload = b"B" * (2 * 1024 * 1024)
+        with open(source_path, "wb") as source_file:
+            source_file.write(pre_mutation_payload)
+        original_stat = os.stat(source_path)
+        original_read = included_files_module._read_included_payload_chunk
+        original_fingerprint = included_files_module._included_source_fingerprint
+        mutated = False
+        streamed_chunks: list[bytes] = []
+
+        def mutate_already_read_bytes(source_file: BinaryIO) -> bytes:
+            nonlocal mutated
+            chunk = original_read(source_file)
+            if chunk:
+                streamed_chunks.append(chunk)
+            if not mutated and chunk:
+                with open(source_path, "r+b", buffering=0) as mutator:
+                    mutator.seek(0)
+                    mutator.write(post_mutation_payload)
+                    os.fsync(mutator.fileno())
+                os.utime(
+                    source_path,
+                    ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+                )
+                mutated = True
+            return chunk
+
+        def windows_style_fingerprint(
+            source_stat: os.stat_result,
+        ) -> tuple[int, int, int, int, int, int]:
+            fingerprint = original_fingerprint(source_stat)
+            return (*fingerprint[:-1], original_stat.st_ctime_ns)
+
+        with (
+            patch.object(
+                included_files_module,
+                "_read_included_payload_chunk",
+                side_effect=mutate_already_read_bytes,
+            ),
+            patch.object(
+                included_files_module,
+                "_included_source_fingerprint",
+                side_effect=windows_style_fingerprint,
+            ),
+            self.assertRaisesRegex(OSError, "output-set staging failed"),
+        ):
+            converter.convert_all()
+
+        self.assertTrue(mutated)
+        streamed_payload = b"".join(streamed_chunks)
+        self.assertEqual(
+            streamed_payload,
+            b"A" * (1024 * 1024) + b"B" * (1024 * 1024),
+        )
+        self.assertNotEqual(streamed_payload, pre_mutation_payload)
+        self.assertNotEqual(streamed_payload, post_mutation_payload)
+        self.assertEqual(self._pair_snapshot(), previous_pair)
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(requested=1, executed=1, failed=1),
+        )
+        self._assert_no_transaction_debris()
+
+    def test_same_size_staged_mutation_with_restored_mtime_is_rejected(
+        self,
+    ) -> None:
+        converter = self._converter(max_workers=1)
+        self._write("old.txt", "old")
+        converter.convert_all()
+        previous_pair = self._pair_snapshot()
+        os.unlink(os.path.join(self.datafiles_dir, "old.txt"))
+        self._write("new.txt", "GOOD")
+        original_commit = included_files_module._commit_included_output_set
+        mutated = False
+
+        def mutate_then_commit(
+            project_path: str,
+            transaction: included_files_module._IncludedOutputSetTransaction,
+            conversion_running: Callable[[], bool],
+        ) -> tuple[str, ...]:
+            nonlocal mutated
+            staged_file = os.path.join(
+                transaction.staged_root_path,
+                "new.txt",
+            )
+            staged_stat = os.stat(staged_file)
+            with open(staged_file, "r+b", buffering=0) as output_file:
+                output_file.write(b"EVIL")
+                os.fsync(output_file.fileno())
+            os.utime(
+                staged_file,
+                ns=(staged_stat.st_atime_ns, staged_stat.st_mtime_ns),
+            )
+            if os.stat(staged_file).st_mtime_ns != staged_stat.st_mtime_ns:
+                self.skipTest("Filesystem cannot restore nanosecond mtime")
+            mutated = True
+            return original_commit(
+                project_path,
+                transaction,
+                conversion_running,
+            )
+
+        with patch.object(
+            included_files_module,
+            "_commit_included_output_set",
+            side_effect=mutate_then_commit,
+        ), self.assertRaisesRegex(OSError, "tree changed"):
+            converter.convert_all()
+
+        self.assertTrue(mutated)
+        self.assertEqual(self._pair_snapshot(), previous_pair)
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(requested=1, executed=1, failed=1),
+        )
+        self._assert_no_transaction_debris()
+
+    def test_first_registry_publication_failure_restores_absent_pair(
+        self,
+    ) -> None:
+        converter = self._converter(max_workers=1)
+        self._write("new.txt", "new")
+        final_root_path = os.path.join(self.godot_dir, "included_files")
+        final_registry_path = os.path.join(
+            self.godot_dir,
+            INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+        )
+        registry_directory = os.path.dirname(final_registry_path)
+        original_move = included_files_module._move_exact_included_file
+        publication_failed = False
+
+        def publish_then_fail(
+            source: str,
+            destination: str,
+            expected_identity: tuple[int, int],
+            *,
+            source_parent_identity: tuple[int, int] | None = None,
+            destination_parent_identity: tuple[int, int] | None = None,
+        ) -> None:
+            nonlocal publication_failed
+            original_move(
+                source,
+                destination,
+                expected_identity,
+                source_parent_identity=source_parent_identity,
+                destination_parent_identity=destination_parent_identity,
+            )
+            if destination == final_registry_path and not publication_failed:
+                publication_failed = True
+                raise OSError("injected first registry publication failure")
+
+        with patch.object(
+            included_files_module,
+            "_move_exact_included_file",
+            side_effect=publish_then_fail,
+        ), self.assertRaisesRegex(
+            OSError,
+            "injected first registry publication failure",
+        ):
+            converter.convert_all()
+
+        self.assertTrue(publication_failed)
+        self.assertFalse(os.path.lexists(final_root_path))
+        self.assertFalse(os.path.lexists(final_registry_path))
+        self.assertFalse(os.path.lexists(registry_directory))
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(requested=1, executed=1, failed=1),
+        )
+        self._assert_no_transaction_debris()
+
+    def test_preprepare_rollback_refuses_appeared_registry_before_read(
+        self,
+    ) -> None:
+        converter = self._converter(max_workers=1)
+        self._write("new.txt", "new")
+        final_registry_path = os.path.join(
+            self.godot_dir,
+            INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+        )
+        original_verify_tree = (
+            included_files_module._verify_included_tree_snapshot
+        )
+        original_file_state_at = (
+            included_files_module._included_regular_file_state_at
+        )
+        injected = False
+        appeared_registry_read_attempts: list[str] = []
+
+        def inject_registry_before_prepare(
+            root_path: str,
+            expected: included_files_module._IncludedTreeSnapshot,
+            *,
+            expected_parent_identity: tuple[int, int] | None = None,
+        ) -> None:
+            nonlocal injected
+            original_verify_tree(
+                root_path,
+                expected,
+                expected_parent_identity=expected_parent_identity,
+            )
+            if (
+                not injected
+                and os.path.basename(os.path.dirname(root_path)).startswith(
+                    ".gm2godot-included-files-"
+                )
+            ):
+                os.makedirs(os.path.dirname(final_registry_path))
+                with open(final_registry_path, "wb") as registry_file:
+                    registry_file.write(b"unknown appeared registry")
+                injected = True
+                raise OSError("injected failure before registry prepare")
+
+        def record_registry_state_attempt(
+            parent_fd: int,
+            name: str,
+            display_path: str,
+            *,
+            allowed_identities: frozenset[tuple[int, int]] | None = None,
+        ) -> tuple[tuple[int, int], int, bytes] | None:
+            if display_path == final_registry_path:
+                appeared_registry_read_attempts.append(display_path)
+            return original_file_state_at(
+                parent_fd,
+                name,
+                display_path,
+                allowed_identities=allowed_identities,
+            )
+
+        with (
+            patch.object(
+                included_files_module,
+                "_verify_included_tree_snapshot",
+                side_effect=inject_registry_before_prepare,
+            ),
+            patch.object(
+                included_files_module,
+                "_included_regular_file_state_at",
+                side_effect=record_registry_state_attempt,
+            ),
+            self.assertRaisesRegex(
+                OSError,
+                "injected failure before registry prepare",
+            ),
+        ):
+            converter.convert_all()
+
+        self.assertTrue(injected)
+        self.assertEqual(appeared_registry_read_attempts, [])
+        with open(final_registry_path, "rb") as registry_file:
+            self.assertEqual(registry_file.read(), b"unknown appeared registry")
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(requested=1, executed=1, failed=1),
+        )
+        self.assertFalse(
+            any(
+                name.startswith(".gm2godot-included-files-")
+                for name in os.listdir(self.godot_dir)
+            )
+        )
+
+    def test_unknown_registry_backup_destination_is_not_overwritten(
+        self,
+    ) -> None:
+        converter = self._converter(max_workers=1)
+        self._write("old.txt", "old")
+        converter.convert_all()
+        previous_pair = self._pair_snapshot()
+        os.unlink(os.path.join(self.datafiles_dir, "old.txt"))
+        self._write("new.txt", "new")
+        original_rename = (
+            included_files_module._rename_included_transaction_entry_at
+        )
+        sentinel_name: str | None = None
+
+        def inject_unknown_destination(
+            source_parent_fd: int,
+            source_name: str,
+            destination_parent_fd: int,
+            destination_name: str,
+        ) -> None:
+            nonlocal sentinel_name
+            if (
+                sentinel_name is None
+                and destination_name.startswith(
+                    ".gml_included_file_registry.gd."
+                )
+                and destination_name.endswith(".backup")
+            ):
+                sentinel_fd = os.open(
+                    destination_name,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    0o600,
+                    dir_fd=destination_parent_fd,
+                )
+                try:
+                    os.write(sentinel_fd, b"unknown sentinel")
+                    os.fsync(sentinel_fd)
+                finally:
+                    os.close(sentinel_fd)
+                sentinel_name = destination_name
+            original_rename(
+                source_parent_fd,
+                source_name,
+                destination_parent_fd,
+                destination_name,
+            )
+
+        with patch.object(
+            included_files_module,
+            "_rename_included_transaction_entry_at",
+            side_effect=inject_unknown_destination,
+        ), self.assertRaises(OSError):
+            converter.convert_all()
+
+        self.assertIsNotNone(sentinel_name)
+        self.assertEqual(self._pair_snapshot(), previous_pair)
+        if sentinel_name is not None:
+            sentinel_path = os.path.join(
+                self.godot_dir,
+                "gm2godot",
+                sentinel_name,
+            )
+            with open(sentinel_path, "rb") as sentinel_file:
+                self.assertEqual(sentinel_file.read(), b"unknown sentinel")
+        project_debris = [
+            name
+            for name in os.listdir(self.godot_dir)
+            if name.startswith(".gm2godot-included-files-")
+            or name.startswith(".included_files.")
+        ]
+        self.assertEqual(project_debris, [])
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(requested=1, executed=1, failed=1),
+        )
+
+    def test_cleanup_root_swap_does_not_delete_unknown_replacement(
+        self,
+    ) -> None:
+        logs: list[str] = []
+        converter = IncludedFilesConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=self.running.is_set,
+            max_workers=1,
+        )
+        self._write("old.txt", "old")
+        converter.convert_all()
+        os.unlink(os.path.join(self.datafiles_dir, "old.txt"))
+        self._write("new.txt", "new")
+        victim_path = os.path.join(self.godot_dir, ".cleanup-victim")
+        os.mkdir(victim_path)
+        with open(
+            os.path.join(victim_path, "victim.txt"),
+            "w",
+            encoding="utf-8",
+        ) as victim_file:
+            victim_file.write("victim sentinel")
+        parked_backup = os.path.join(self.godot_dir, ".parked-old-root")
+        swapped_backup_path: str | None = None
+
+        def swap_cleanup_root(
+            parent_fd: int,
+            name: str,
+        ) -> None:
+            nonlocal swapped_backup_path
+            if (
+                swapped_backup_path is None
+                and name.startswith(".included_files.")
+                and name.endswith(".backup")
+            ):
+                os.rename(
+                    name,
+                    os.path.basename(parked_backup),
+                    src_dir_fd=parent_fd,
+                    dst_dir_fd=parent_fd,
+                )
+                os.rename(
+                    os.path.basename(victim_path),
+                    name,
+                    src_dir_fd=parent_fd,
+                    dst_dir_fd=parent_fd,
+                )
+                swapped_backup_path = os.path.join(self.godot_dir, name)
+
+        with patch.object(
+            included_files_module,
+            "_before_included_cleanup_quarantine",
+            side_effect=swap_cleanup_root,
+        ):
+            converter.convert_all()
+
+        self.assertIsNotNone(swapped_backup_path)
+        with open(
+            os.path.join(self.godot_dir, "included_files", "new.txt"),
+            encoding="utf-8",
+        ) as public_file:
+            self.assertEqual(public_file.read(), "new")
+        with open(
+            os.path.join(parked_backup, "old.txt"),
+            encoding="utf-8",
+        ) as parked_file:
+            self.assertEqual(parked_file.read(), "old")
+        if swapped_backup_path is not None:
+            with open(
+                os.path.join(swapped_backup_path, "victim.txt"),
+                encoding="utf-8",
+            ) as victim_file:
+                self.assertEqual(victim_file.read(), "victim sentinel")
+        self.assertTrue(
+            any("transaction cleanup failed" in message for message in logs),
+            logs,
+        )
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(requested=1, executed=1, completed=1),
+        )
+        self.assertFalse(
+            any(
+                name.startswith(".gm2godot-included-files-")
+                for name in os.listdir(self.godot_dir)
+            )
+        )
+
+    def test_transaction_source_swap_restores_unknown_replacement_without_loss(
+        self,
+    ) -> None:
+        if not (
+            included_files_module._included_descriptor_paths_supported()
+            and included_files_module._included_native_noreplace_available()
+        ):
+            self.skipTest("Descriptor-pinned no-replace rename is unavailable")
+        transaction_directory = os.path.join(self.godot_dir, "source-swap")
+        os.mkdir(transaction_directory)
+        source_path = os.path.join(transaction_directory, "source.txt")
+        replacement_path = os.path.join(
+            transaction_directory,
+            "replacement.txt",
+        )
+        parked_path = os.path.join(transaction_directory, "parked-owned.txt")
+        destination_path = os.path.join(transaction_directory, "published.txt")
+        with open(source_path, "w", encoding="utf-8") as source_file:
+            source_file.write("owned source")
+        with open(replacement_path, "w", encoding="utf-8") as replacement_file:
+            replacement_file.write("unknown replacement")
+        source_stat = os.lstat(source_path)
+        parent_stat = os.lstat(transaction_directory)
+        swapped = False
+
+        def swap_source(parent_fd: int, source_name: str) -> None:
+            nonlocal swapped
+            if swapped or source_name != "source.txt":
+                return
+            os.rename(
+                source_name,
+                os.path.basename(parked_path),
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
+            os.rename(
+                os.path.basename(replacement_path),
+                source_name,
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
+            swapped = True
+
+        with patch.object(
+            included_files_module,
+            "_before_included_transaction_rename",
+            side_effect=swap_source,
+        ), self.assertRaisesRegex(OSError, "restored without loss"):
+            included_files_module._move_exact_included_file(
+                source_path,
+                destination_path,
+                (source_stat.st_dev, source_stat.st_ino),
+                source_parent_identity=(parent_stat.st_dev, parent_stat.st_ino),
+                destination_parent_identity=(
+                    parent_stat.st_dev,
+                    parent_stat.st_ino,
+                ),
+            )
+
+        self.assertTrue(swapped)
+        with open(source_path, encoding="utf-8") as source_file:
+            self.assertEqual(source_file.read(), "unknown replacement")
+        with open(parked_path, encoding="utf-8") as parked_file:
+            self.assertEqual(parked_file.read(), "owned source")
+        self.assertFalse(os.path.lexists(destination_path))
+
+    def test_cleanup_file_swap_restores_unknown_replacement_without_loss(
+        self,
+    ) -> None:
+        if not (
+            included_files_module._included_descriptor_paths_supported()
+            and included_files_module._included_native_noreplace_available()
+        ):
+            self.skipTest("Descriptor-pinned no-replace rename is unavailable")
+        cleanup_directory = os.path.join(self.godot_dir, "file-cleanup-swap")
+        os.mkdir(cleanup_directory)
+        owned_path = os.path.join(cleanup_directory, "owned.txt")
+        replacement_path = os.path.join(cleanup_directory, "replacement.txt")
+        parked_path = os.path.join(cleanup_directory, "parked-owned.txt")
+        with open(owned_path, "w", encoding="utf-8") as owned_file:
+            owned_file.write("owned cleanup file")
+        with open(replacement_path, "w", encoding="utf-8") as replacement_file:
+            replacement_file.write("unknown replacement")
+        owned_stat = os.lstat(owned_path)
+        parent_stat = os.lstat(cleanup_directory)
+        swapped = False
+
+        def swap_cleanup_file(parent_fd: int, name: str) -> None:
+            nonlocal swapped
+            if swapped or name != "owned.txt":
+                return
+            os.rename(
+                name,
+                os.path.basename(parked_path),
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
+            os.rename(
+                os.path.basename(replacement_path),
+                name,
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
+            swapped = True
+
+        with patch.object(
+            included_files_module,
+            "_before_included_cleanup_quarantine",
+            side_effect=swap_cleanup_file,
+        ), self.assertRaisesRegex(OSError, "restored without loss"):
+            included_files_module._remove_owned_included_file(
+                owned_path,
+                (owned_stat.st_dev, owned_stat.st_ino),
+                expected_parent_identity=(
+                    parent_stat.st_dev,
+                    parent_stat.st_ino,
+                ),
+            )
+
+        self.assertTrue(swapped)
+        with open(owned_path, encoding="utf-8") as owned_file:
+            self.assertEqual(owned_file.read(), "unknown replacement")
+        with open(parked_path, encoding="utf-8") as parked_file:
+            self.assertEqual(parked_file.read(), "owned cleanup file")
+
+    def test_cleanup_tree_final_rmdir_retains_unknown_replacement(
+        self,
+    ) -> None:
+        if not (
+            included_files_module._included_descriptor_paths_supported()
+            and included_files_module._included_native_noreplace_available()
+        ):
+            self.skipTest("Descriptor-pinned no-replace rename is unavailable")
+        owned_path = os.path.join(self.godot_dir, "owned-empty-tree")
+        replacement_path = os.path.join(self.godot_dir, "replacement-empty-tree")
+        parked_path = os.path.join(self.godot_dir, "parked-owned-tree")
+        os.mkdir(owned_path)
+        os.mkdir(replacement_path)
+        owned_stat = os.lstat(owned_path)
+        replacement_stat = os.lstat(replacement_path)
+        project_stat = os.lstat(self.godot_dir)
+        retained_path: str | None = None
+
+        def swap_quarantine_before_rmdir(parent_fd: int, name: str) -> None:
+            nonlocal retained_path
+            if retained_path is not None or not name.startswith(
+                ".owned-empty-tree."
+            ):
+                return
+            os.rename(
+                name,
+                os.path.basename(parked_path),
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
+            os.rename(
+                os.path.basename(replacement_path),
+                name,
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
+            retained_path = os.path.join(self.godot_dir, name)
+
+        with patch.object(
+            included_files_module,
+            "_before_included_cleanup_remove",
+            side_effect=swap_quarantine_before_rmdir,
+        ), self.assertRaisesRegex(OSError, "recoverable directory retained"):
+            included_files_module._remove_owned_included_tree(
+                owned_path,
+                (owned_stat.st_dev, owned_stat.st_ino),
+                expected_parent_identity=(
+                    project_stat.st_dev,
+                    project_stat.st_ino,
+                ),
+            )
+
+        self.assertIsNotNone(retained_path)
+        self.assertEqual(
+            (
+                os.lstat(retained_path or "").st_dev,
+                os.lstat(retained_path or "").st_ino,
+            ),
+            (replacement_stat.st_dev, replacement_stat.st_ino),
+        )
+        self.assertEqual(
+            (os.lstat(parked_path).st_dev, os.lstat(parked_path).st_ino),
+            (owned_stat.st_dev, owned_stat.st_ino),
+        )
+        self.assertFalse(os.path.lexists(owned_path))
+
+    def test_registry_capture_rejects_directory_swap_without_mixing_bytes(
+        self,
+    ) -> None:
+        if not included_files_module._included_descriptor_paths_supported():
+            self.skipTest("Descriptor-pinned registry capture is unavailable")
+        registry_directory = os.path.join(self.godot_dir, "gm2godot")
+        replacement_directory = os.path.join(
+            self.godot_dir,
+            "replacement-registry",
+        )
+        parked_directory = os.path.join(self.godot_dir, "parked-registry")
+        os.mkdir(registry_directory)
+        os.mkdir(replacement_directory)
+        registry_name = os.path.basename(INCLUDED_FILE_REGISTRY_RELATIVE_PATH)
+        with open(
+            os.path.join(registry_directory, registry_name),
+            "wb",
+        ) as registry_file:
+            registry_file.write(b"old registry bytes")
+        with open(
+            os.path.join(replacement_directory, registry_name),
+            "wb",
+        ) as replacement_file:
+            replacement_file.write(b"new registry bytes")
+        swapped = False
+
+        def swap_registry_directory(project_fd: int, name: str) -> None:
+            nonlocal swapped
+            if swapped:
+                return
+            os.rename(
+                name,
+                os.path.basename(parked_directory),
+                src_dir_fd=project_fd,
+                dst_dir_fd=project_fd,
+            )
+            os.rename(
+                os.path.basename(replacement_directory),
+                name,
+                src_dir_fd=project_fd,
+                dst_dir_fd=project_fd,
+            )
+            swapped = True
+
+        with patch.object(
+            included_files_module,
+            "_before_included_registry_file_read",
+            side_effect=swap_registry_directory,
+        ), self.assertRaisesRegex(OSError, "directory changed"):
+            included_files_module._capture_included_registry(self.godot_dir)
+
+        self.assertTrue(swapped)
+        with open(
+            os.path.join(registry_directory, registry_name),
+            "rb",
+        ) as registry_file:
+            self.assertEqual(registry_file.read(), b"new registry bytes")
+        with open(
+            os.path.join(parked_directory, registry_name),
+            "rb",
+        ) as parked_file:
+            self.assertEqual(parked_file.read(), b"old registry bytes")
+
+    def test_registry_verifier_rejects_project_swap_before_reading_bytes(
+        self,
+    ) -> None:
+        if not included_files_module._included_descriptor_paths_supported():
+            self.skipTest("Descriptor-pinned registry capture is unavailable")
+        project_path = os.path.join(self.godot_dir, "project-root")
+        parked_project = os.path.join(self.godot_dir, "parked-project-root")
+        registry_name = os.path.basename(INCLUDED_FILE_REGISTRY_RELATIVE_PATH)
+        old_registry_directory = os.path.join(project_path, "gm2godot")
+        os.makedirs(old_registry_directory)
+        with open(
+            os.path.join(old_registry_directory, registry_name),
+            "wb",
+        ) as registry_file:
+            registry_file.write(b"old registry bytes")
+        project_stat = os.lstat(project_path)
+        project_identity = (project_stat.st_dev, project_stat.st_ino)
+        expected_snapshot = included_files_module._capture_included_registry(
+            project_path,
+            expected_project_identity=project_identity,
+        )
+        os.rename(project_path, parked_project)
+        replacement_registry_directory = os.path.join(project_path, "gm2godot")
+        os.makedirs(replacement_registry_directory)
+        replacement_registry_path = os.path.join(
+            replacement_registry_directory,
+            registry_name,
+        )
+        with open(replacement_registry_path, "wb") as replacement_file:
+            replacement_file.write(b"new replacement bytes")
+        original_file_state_at = (
+            included_files_module._included_regular_file_state_at
+        )
+        observed_registry_bytes: list[bytes] = []
+
+        def record_registry_read(
+            parent_fd: int,
+            name: str,
+            display_path: str,
+        ) -> tuple[tuple[int, int], int, bytes] | None:
+            state = original_file_state_at(parent_fd, name, display_path)
+            if state is not None:
+                observed_registry_bytes.append(state[2])
+            return state
+
+        with patch.object(
+            included_files_module,
+            "_included_regular_file_state_at",
+            side_effect=record_registry_read,
+        ), self.assertRaisesRegex(OSError, "directory changed"):
+            included_files_module._verify_included_registry_snapshot(
+                project_path,
+                expected_snapshot,
+                expected_project_identity=project_identity,
+            )
+
+        self.assertEqual(observed_registry_bytes, [])
+        with open(replacement_registry_path, "rb") as replacement_file:
+            self.assertEqual(replacement_file.read(), b"new replacement bytes")
+        with open(
+            os.path.join(parked_project, "gm2godot", registry_name),
+            "rb",
+        ) as parked_file:
+            self.assertEqual(parked_file.read(), b"old registry bytes")
+
+    def test_fallback_registry_read_rejects_project_swap_before_bytes(
+        self,
+    ) -> None:
+        project_path = os.path.join(self.godot_dir, "fallback-project-root")
+        replacement_project = os.path.join(
+            self.godot_dir,
+            "replacement-fallback-project",
+        )
+        parked_project = os.path.join(
+            self.godot_dir,
+            "parked-fallback-project",
+        )
+        registry_name = os.path.basename(INCLUDED_FILE_REGISTRY_RELATIVE_PATH)
+        old_registry_path = os.path.join(project_path, "gm2godot", registry_name)
+        replacement_registry_path = os.path.join(
+            replacement_project,
+            "gm2godot",
+            registry_name,
+        )
+        os.makedirs(os.path.dirname(old_registry_path))
+        os.makedirs(os.path.dirname(replacement_registry_path))
+        with open(old_registry_path, "wb") as registry_file:
+            registry_file.write(b"old fallback registry bytes")
+        with open(replacement_registry_path, "wb") as replacement_file:
+            replacement_file.write(b"new fallback replacement bytes")
+        project_stat = os.lstat(project_path)
+        project_identity = (project_stat.st_dev, project_stat.st_ino)
+        with patch.object(
+            included_files_module,
+            "_included_descriptor_paths_supported",
+            return_value=False,
+        ):
+            expected_snapshot = included_files_module._capture_included_registry(
+                project_path,
+                expected_project_identity=project_identity,
+            )
+        swapped = False
+        opened_for_read: list[int] = []
+        original_fdopen = os.fdopen
+
+        def swap_project_before_open(path: str) -> None:
+            nonlocal swapped
+            if swapped or path != old_registry_path:
+                return
+            os.rename(project_path, parked_project)
+            os.rename(replacement_project, project_path)
+            swapped = True
+
+        def record_fdopen(
+            file_descriptor: int,
+            _mode: str = "r",
+        ) -> BinaryIO:
+            opened_for_read.append(file_descriptor)
+            return original_fdopen(file_descriptor, "rb")
+
+        with (
+            patch.object(
+                included_files_module,
+                "_included_descriptor_paths_supported",
+                return_value=False,
+            ),
+            patch.object(
+                included_files_module,
+                "_before_included_fallback_regular_file_open",
+                side_effect=swap_project_before_open,
+            ),
+            patch.object(
+                included_files_module.os,
+                "fdopen",
+                side_effect=record_fdopen,
+            ),
+            self.assertRaises(OSError),
+        ):
+            included_files_module._verify_included_registry_snapshot(
+                project_path,
+                expected_snapshot,
+                expected_project_identity=project_identity,
+            )
+
+        self.assertTrue(swapped)
+        self.assertEqual(opened_for_read, [])
+        with open(
+            os.path.join(project_path, "gm2godot", registry_name),
+            "rb",
+        ) as replacement_file:
+            self.assertEqual(
+                replacement_file.read(),
+                b"new fallback replacement bytes",
+            )
+        with open(
+            os.path.join(parked_project, "gm2godot", registry_name),
+            "rb",
+        ) as parked_file:
+            self.assertEqual(parked_file.read(), b"old fallback registry bytes")
+
+    def test_created_registry_directory_swap_is_not_adopted(self) -> None:
+        if not included_files_module._included_descriptor_paths_supported():
+            self.skipTest("Descriptor-pinned registry creation is unavailable")
+        registry_directory = os.path.join(self.godot_dir, "gm2godot")
+        replacement_directory = os.path.join(
+            self.godot_dir,
+            "replacement-registry",
+        )
+        parked_directory = os.path.join(
+            self.godot_dir,
+            "parked-created-registry",
+        )
+        os.mkdir(replacement_directory)
+        sentinel_path = os.path.join(replacement_directory, "sentinel.txt")
+        with open(sentinel_path, "w", encoding="utf-8") as sentinel_file:
+            sentinel_file.write("unknown registry directory")
+        project_stat = os.lstat(self.godot_dir)
+        empty_snapshot = included_files_module._IncludedRegistrySnapshot(
+            directory_identity=None,
+            file_identity=None,
+            file_mode=None,
+            content=None,
+        )
+        swapped = False
+
+        def swap_created_registry(project_fd: int, name: str) -> None:
+            nonlocal swapped
+            if swapped:
+                return
+            os.rename(
+                name,
+                os.path.basename(parked_directory),
+                src_dir_fd=project_fd,
+                dst_dir_fd=project_fd,
+            )
+            os.rename(
+                os.path.basename(replacement_directory),
+                name,
+                src_dir_fd=project_fd,
+                dst_dir_fd=project_fd,
+            )
+            swapped = True
+
+        with patch.object(
+            included_files_module,
+            "_before_included_registry_directory_binding_check",
+            side_effect=swap_created_registry,
+        ), self.assertRaisesRegex(OSError, "changed after creation"):
+            included_files_module._prepare_included_registry_directory(
+                self.godot_dir,
+                empty_snapshot,
+                (project_stat.st_dev, project_stat.st_ino),
+            )
+
+        self.assertTrue(swapped)
+        with open(
+            os.path.join(registry_directory, "sentinel.txt"),
+            encoding="utf-8",
+        ) as sentinel_file:
+            self.assertEqual(sentinel_file.read(), "unknown registry directory")
+        self.assertEqual(os.listdir(parked_directory), [])
+
+    def test_fallback_chmod_source_swap_does_not_mutate_replacement(
+        self,
+    ) -> None:
+        chmod_directory = os.path.join(self.godot_dir, "chmod-swap")
+        os.mkdir(chmod_directory)
+        owned_path = os.path.join(chmod_directory, "owned.txt")
+        replacement_path = os.path.join(chmod_directory, "replacement.txt")
+        parked_path = os.path.join(chmod_directory, "parked-owned.txt")
+        with open(owned_path, "w", encoding="utf-8") as owned_file:
+            owned_file.write("owned chmod target")
+        with open(replacement_path, "w", encoding="utf-8") as replacement_file:
+            replacement_file.write("unknown replacement")
+        os.chmod(owned_path, 0o600)
+        os.chmod(replacement_path, 0o640)
+        owned_stat = os.lstat(owned_path)
+        replacement_mode = stat.S_IMODE(os.lstat(replacement_path).st_mode)
+        parent_stat = os.lstat(chmod_directory)
+        swapped = False
+
+        def swap_before_open(path: str) -> None:
+            nonlocal swapped
+            if swapped or path != owned_path:
+                return
+            os.rename(owned_path, parked_path)
+            os.rename(replacement_path, owned_path)
+            swapped = True
+
+        with (
+            patch.object(
+                included_files_module,
+                "_included_descriptor_paths_supported",
+                return_value=False,
+            ),
+            patch.object(
+                included_files_module,
+                "_before_included_fallback_chmod_open",
+                side_effect=swap_before_open,
+            ),
+            self.assertRaisesRegex(OSError, "file changed"),
+        ):
+            included_files_module._chmod_exact_included_file(
+                owned_path,
+                (owned_stat.st_dev, owned_stat.st_ino),
+                0o444,
+                (parent_stat.st_dev, parent_stat.st_ino),
+            )
+
+        self.assertTrue(swapped)
+        self.assertEqual(
+            stat.S_IMODE(os.lstat(owned_path).st_mode),
+            replacement_mode,
+        )
+        self.assertEqual(
+            stat.S_IMODE(os.lstat(parked_path).st_mode),
+            0o600,
+        )
+
+    def test_windows_fallback_chmod_skips_matching_write_bit(self) -> None:
+        chmod_directory = os.path.join(self.godot_dir, "windows-chmod-match")
+        os.mkdir(chmod_directory)
+        owned_path = os.path.join(chmod_directory, "owned.txt")
+        with open(owned_path, "w", encoding="utf-8") as owned_file:
+            owned_file.write("owned chmod target")
+        os.chmod(owned_path, 0o600)
+        owned_stat = os.lstat(owned_path)
+        parent_stat = os.lstat(chmod_directory)
+        supports_without_chmod = set(os.supports_fd)
+        supports_without_chmod.discard(os.chmod)
+
+        with (
+            patch.object(
+                included_files_module,
+                "_included_descriptor_paths_supported",
+                return_value=False,
+            ),
+            patch.object(included_files_module.os, "name", "nt"),
+            patch.object(
+                included_files_module.os,
+                "supports_fd",
+                supports_without_chmod,
+            ),
+            patch.object(
+                included_files_module,
+                "_before_included_cleanup_quarantine_fallback",
+                side_effect=AssertionError("matching mode must not quarantine"),
+            ),
+        ):
+            included_files_module._chmod_exact_included_file(
+                owned_path,
+                (owned_stat.st_dev, owned_stat.st_ino),
+                0o640,
+                (parent_stat.st_dev, parent_stat.st_ino),
+            )
+
+        self.assertEqual(
+            (os.lstat(owned_path).st_dev, os.lstat(owned_path).st_ino),
+            (owned_stat.st_dev, owned_stat.st_ino),
+        )
+
+    def test_windows_fallback_chmod_uses_reversible_quarantine(self) -> None:
+        chmod_directory = os.path.join(self.godot_dir, "windows-chmod-change")
+        os.mkdir(chmod_directory)
+        owned_path = os.path.join(chmod_directory, "owned.txt")
+        with open(owned_path, "w", encoding="utf-8") as owned_file:
+            owned_file.write("owned chmod target")
+        os.chmod(owned_path, 0o600)
+        owned_stat = os.lstat(owned_path)
+        parent_stat = os.lstat(chmod_directory)
+        supports_without_chmod = set(os.supports_fd)
+        supports_without_chmod.discard(os.chmod)
+        quarantined_paths: list[str] = []
+
+        with (
+            patch.object(
+                included_files_module,
+                "_included_descriptor_paths_supported",
+                return_value=False,
+            ),
+            patch.object(included_files_module.os, "name", "nt"),
+            patch.object(
+                included_files_module.os,
+                "supports_fd",
+                supports_without_chmod,
+            ),
+            patch.object(
+                included_files_module,
+                "_before_included_cleanup_quarantine_fallback",
+                side_effect=quarantined_paths.append,
+            ),
+        ):
+            included_files_module._chmod_exact_included_file(
+                owned_path,
+                (owned_stat.st_dev, owned_stat.st_ino),
+                0o400,
+                (parent_stat.st_dev, parent_stat.st_ino),
+            )
+
+        self.assertEqual(quarantined_paths, [owned_path])
+        self.assertEqual(
+            (os.lstat(owned_path).st_dev, os.lstat(owned_path).st_ino),
+            (owned_stat.st_dev, owned_stat.st_ino),
+        )
+        self.assertFalse(os.lstat(owned_path).st_mode & stat.S_IWRITE)
+        self.assertFalse(
+            any(name.endswith(".quarantine") for name in os.listdir(chmod_directory))
+        )
+        os.chmod(owned_path, 0o600)
+
+    def test_moved_and_symlinked_stage_container_is_rejected(self) -> None:
+        converter = self._converter(max_workers=1)
+        self._write("old.txt", "old")
+        converter.convert_all()
+        previous_pair = self._pair_snapshot()
+        os.unlink(os.path.join(self.datafiles_dir, "old.txt"))
+        self._write("new.txt", "new")
+        moved_stage = os.path.join(self.gm_dir, "moved-stage")
+        original_commit = included_files_module._commit_included_output_set
+        stage_link: str | None = None
+
+        def redirect_stage_then_commit(
+            project_path: str,
+            transaction: included_files_module._IncludedOutputSetTransaction,
+            conversion_running: Callable[[], bool],
+        ) -> tuple[str, ...]:
+            nonlocal stage_link
+            os.rename(transaction.stage_container_path, moved_stage)
+            try:
+                os.symlink(moved_stage, transaction.stage_container_path)
+            except (NotImplementedError, OSError) as error:
+                os.rename(moved_stage, transaction.stage_container_path)
+                self.skipTest(f"Symbolic links are unavailable: {error}")
+            stage_link = transaction.stage_container_path
+            return original_commit(
+                project_path,
+                transaction,
+                conversion_running,
+            )
+
+        try:
+            with patch.object(
+                included_files_module,
+                "_commit_included_output_set",
+                side_effect=redirect_stage_then_commit,
+            ), self.assertRaisesRegex(OSError, "redirected or non-directory"):
+                converter.convert_all()
+
+            self.assertIsNotNone(stage_link)
+            self.assertEqual(self._pair_snapshot(), previous_pair)
+            self.assertTrue(os.path.islink(stage_link or ""))
+            self.assertTrue(os.path.isdir(moved_stage))
+            self.assertEqual(
+                converter.conversion_step_result(
+                    finalize_unfinished_as=None,
+                ).resources,
+                ConversionCounts(requested=1, executed=1, failed=1),
+            )
+        finally:
+            if stage_link is not None and os.path.islink(stage_link):
+                os.unlink(stage_link)
+
+    def test_deep_directory_swap_is_not_followed_during_tree_capture(
+        self,
+    ) -> None:
+        scan_root = os.path.join(self.godot_dir, "scan-root")
+        deep_directory = os.path.join(scan_root, "a", "b")
+        os.makedirs(deep_directory)
+        with open(
+            os.path.join(deep_directory, "contained.txt"),
+            "w",
+            encoding="utf-8",
+        ) as contained_file:
+            contained_file.write("contained")
+        outside_directory = os.path.join(self.gm_dir, "outside-scan")
+        os.mkdir(outside_directory)
+        outside_file = os.path.join(outside_directory, "external.txt")
+        with open(outside_file, "w", encoding="utf-8") as external_file:
+            external_file.write("external sentinel")
+        parked_directory = os.path.join(scan_root, "parked-b")
+        original_open = included_files_module._open_included_tree_directory_at
+        swapped = False
+
+        def swap_before_open(parent_fd: int, name: str) -> int:
+            nonlocal swapped
+            if not swapped and name == "b":
+                os.rename(deep_directory, parked_directory)
+                try:
+                    os.symlink(outside_directory, deep_directory)
+                except (NotImplementedError, OSError) as error:
+                    os.rename(parked_directory, deep_directory)
+                    self.skipTest(f"Symbolic links are unavailable: {error}")
+                swapped = True
+            return original_open(parent_fd, name)
+
+        try:
+            with patch.object(
+                included_files_module,
+                "_open_included_tree_directory_at",
+                side_effect=swap_before_open,
+            ), self.assertRaises(OSError):
+                included_files_module._capture_included_tree(scan_root)
+
+            self.assertTrue(swapped)
+            with open(outside_file, encoding="utf-8") as external_file:
+                self.assertEqual(external_file.read(), "external sentinel")
+        finally:
+            if os.path.islink(deep_directory):
+                os.unlink(deep_directory)
+            if os.path.isdir(parked_directory):
+                os.rename(parked_directory, deep_directory)
+
+    def test_native_noreplace_preserves_file_and_directory_destinations(
+        self,
+    ) -> None:
+        if not (
+            included_files_module._included_descriptor_paths_supported()
+            and included_files_module._included_native_noreplace_available()
+        ):
+            self.skipTest("Native no-replace rename is unavailable")
+        transaction_directory = os.path.join(
+            self.godot_dir,
+            "native-noreplace",
+        )
+        os.mkdir(transaction_directory)
+        with open(
+            os.path.join(transaction_directory, "source.txt"),
+            "w",
+            encoding="utf-8",
+        ) as source_file:
+            source_file.write("source")
+        with open(
+            os.path.join(transaction_directory, "destination.txt"),
+            "w",
+            encoding="utf-8",
+        ) as destination_file:
+            destination_file.write("destination")
+        os.mkdir(os.path.join(transaction_directory, "source-dir"))
+        os.mkdir(os.path.join(transaction_directory, "destination-dir"))
+        directory_fd = included_files_module._open_pinned_included_directory(
+            transaction_directory
+        )
+        try:
+            for source_name, destination_name in (
+                ("source.txt", "destination.txt"),
+                ("source-dir", "destination-dir"),
+            ):
+                with self.subTest(source_name=source_name), self.assertRaises(
+                    OSError
+                ):
+                    included_files_module._rename_included_transaction_entry_at(
+                        directory_fd,
+                        source_name,
+                        directory_fd,
+                        destination_name,
+                    )
+        finally:
+            os.close(directory_fd)
+        with open(
+            os.path.join(transaction_directory, "source.txt"),
+            encoding="utf-8",
+        ) as source_file:
+            self.assertEqual(source_file.read(), "source")
+        with open(
+            os.path.join(transaction_directory, "destination.txt"),
+            encoding="utf-8",
+        ) as destination_file:
+            self.assertEqual(destination_file.read(), "destination")
+        self.assertTrue(
+            os.path.isdir(os.path.join(transaction_directory, "source-dir"))
+        )
+        self.assertTrue(
+            os.path.isdir(
+                os.path.join(transaction_directory, "destination-dir")
+            )
+        )
+
+    def test_native_noreplace_missing_capability_fails_closed(self) -> None:
+        if not included_files_module._included_descriptor_paths_supported():
+            self.skipTest("Descriptor-pinned paths are unavailable")
+        transaction_directory = os.path.join(
+            self.godot_dir,
+            "native-unavailable",
+        )
+        os.mkdir(transaction_directory)
+        source_path = os.path.join(transaction_directory, "source.txt")
+        with open(source_path, "w", encoding="utf-8") as source_file:
+            source_file.write("source")
+        directory_fd = included_files_module._open_pinned_included_directory(
+            transaction_directory
+        )
+        try:
+            with patch.object(
+                included_files_module,
+                "_included_native_noreplace_available",
+                return_value=False,
+            ), self.assertRaisesRegex(OSError, "unavailable"):
+                included_files_module._rename_included_transaction_entry_at(
+                    directory_fd,
+                    "source.txt",
+                    directory_fd,
+                    "destination.txt",
+                )
+        finally:
+            os.close(directory_fd)
+        self.assertTrue(os.path.isfile(source_path))
+        self.assertFalse(
+            os.path.lexists(
+                os.path.join(transaction_directory, "destination.txt")
+            )
+        )
+
+    def test_repeated_conversion_supports_file_directory_file_shapes(self) -> None:
+        converter = self._converter()
+        self._write("foo_bar", "blocking file")
+        converter.convert_all()
+        root_path = os.path.join(self.godot_dir, "included_files")
+        self.assertTrue(os.path.isfile(os.path.join(root_path, "foo_bar")))
+
+        self._write("Foo Bar/item.txt", "nested file")
+        converter.convert_all()
+        self.assertTrue(
+            os.path.isfile(os.path.join(root_path, "foo_bar", "item.txt"))
+        )
+        with open(
+            os.path.join(root_path, "foo_bar_2"),
+            encoding="utf-8",
+        ) as output_file:
+            self.assertEqual(output_file.read(), "blocking file")
+
+        shutil.rmtree(os.path.join(self.datafiles_dir, "Foo Bar"))
+        converter.convert_all()
+        self.assertTrue(os.path.isfile(os.path.join(root_path, "foo_bar")))
+        self.assertFalse(os.path.lexists(os.path.join(root_path, "foo_bar_2")))
+        self.assertEqual(os.listdir(root_path), ["foo_bar"])
+        self._assert_no_transaction_debris()
+
+    def test_worker_failure_preserves_previous_pair_and_fails_all_files(self) -> None:
+        converter = self._converter(max_workers=1)
+        self._write("old.txt", "old")
+        converter.convert_all()
+        previous_pair = self._pair_snapshot()
+        os.unlink(os.path.join(self.datafiles_dir, "old.txt"))
+        self._write("a_ok.txt", "ok")
+        self._write("z_fail.txt", "fail")
+        original_publish = included_files_module._publish_confined_included_output
+
+        def fail_selected_output(
+            project_path: str,
+            output_path: str,
+            source_file: BinaryIO,
+            source_stat: os.stat_result,
+        ) -> included_files_module._IncludedCopyReceipt:
+            if output_path.endswith("z_fail.txt"):
+                raise OSError("injected worker failure")
+            return original_publish(
+                project_path,
+                output_path,
+                source_file,
+                source_stat,
+            )
+
+        with patch.object(
+            included_files_module,
+            "_publish_confined_included_output",
+            side_effect=fail_selected_output,
+        ):
+            with self.assertRaisesRegex(OSError, "output-set staging failed"):
+                converter.convert_all()
+
+        self.assertEqual(self._pair_snapshot(), previous_pair)
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(requested=2, executed=2, failed=2),
+        )
+        self._assert_no_transaction_debris()
+
+    def test_cancellation_after_workers_stage_preserves_previous_pair(self) -> None:
+        converter = self._converter(max_workers=2)
+        self._write("old.txt", "old")
+        converter.convert_all()
+        previous_pair = self._pair_snapshot()
+        os.unlink(os.path.join(self.datafiles_dir, "old.txt"))
+        self._write("a.txt", "a")
+        self._write("b.txt", "b")
+        original_process = converter._process_file
+        staged_barrier = threading.Barrier(2)
+
+        def stage_then_cancel(
+            gm_file_path: str,
+            godot_file_path: str,
+            relative_path: str,
+            owner_source_path: str,
+        ) -> tuple[str, bool, object | None] | None:
+            result = original_process(
+                gm_file_path,
+                godot_file_path,
+                relative_path,
+                owner_source_path,
+            )
+            staged_barrier.wait(timeout=5)
+            self.running.clear()
+            return result
+
+        with patch.object(
+            converter,
+            "_process_file",
+            side_effect=stage_then_cancel,
+        ):
+            converter.convert_all()
+
+        self.assertEqual(self._pair_snapshot(), previous_pair)
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(requested=2, executed=2, skipped=2),
+        )
+        self.assertTrue(converter.conversion_step_result().cancelled)
+        self._assert_no_transaction_debris()
+
+    def test_public_pair_stays_old_until_every_worker_finishes(self) -> None:
+        converter = self._converter(max_workers=2)
+        self._write("old.txt", "old")
+        converter.convert_all()
+        previous_pair = self._pair_snapshot()
+        os.unlink(os.path.join(self.datafiles_dir, "old.txt"))
+        self._write("a.txt", "a")
+        self._write("b.txt", "b")
+        original_process = converter._process_file
+        blocked = threading.Event()
+        release = threading.Event()
+        thread_errors: list[BaseException] = []
+
+        def block_one_worker(
+            gm_file_path: str,
+            godot_file_path: str,
+            relative_path: str,
+            owner_source_path: str,
+        ) -> tuple[str, bool, object | None] | None:
+            result = original_process(
+                gm_file_path,
+                godot_file_path,
+                relative_path,
+                owner_source_path,
+            )
+            if relative_path == "b.txt":
+                blocked.set()
+                if not release.wait(timeout=5):
+                    raise TimeoutError("worker release timed out")
+            return result
+
+        def run_conversion() -> None:
+            try:
+                converter.convert_all()
+            except BaseException as error:
+                thread_errors.append(error)
+
+        with patch.object(
+            converter,
+            "_process_file",
+            side_effect=block_one_worker,
+        ):
+            conversion_thread = threading.Thread(target=run_conversion)
+            conversion_thread.start()
+            try:
+                self.assertTrue(blocked.wait(timeout=5))
+                self.assertEqual(self._pair_snapshot(), previous_pair)
+            finally:
+                release.set()
+                conversion_thread.join(timeout=5)
+
+        self.assertFalse(conversion_thread.is_alive())
+        self.assertEqual(thread_errors, [])
+        root_path = os.path.join(self.godot_dir, "included_files")
+        self.assertEqual(sorted(os.listdir(root_path)), ["a.txt", "b.txt"])
+        self._assert_no_transaction_debris()
+
+    def test_second_root_rename_failure_restores_previous_pair(self) -> None:
+        converter = self._converter(max_workers=1)
+        self._write("old.txt", "old")
+        converter.convert_all()
+        previous_pair = self._pair_snapshot()
+        os.unlink(os.path.join(self.datafiles_dir, "old.txt"))
+        self._write("new.txt", "new")
+        original_move = included_files_module._move_exact_included_directory
+        final_root_path = os.path.join(self.godot_dir, "included_files")
+
+        def fail_staged_root_publish(
+            source: str,
+            destination: str,
+            expected_identity: tuple[int, int],
+            *,
+            source_parent_identity: tuple[int, int] | None = None,
+            destination_parent_identity: tuple[int, int] | None = None,
+        ) -> None:
+            if (
+                destination == final_root_path
+                and ".gm2godot-included-files-" in source
+            ):
+                raise OSError("injected root publication failure")
+            original_move(
+                source,
+                destination,
+                expected_identity,
+                source_parent_identity=source_parent_identity,
+                destination_parent_identity=destination_parent_identity,
+            )
+
+        with patch.object(
+            included_files_module,
+            "_move_exact_included_directory",
+            side_effect=fail_staged_root_publish,
+        ):
+            with self.assertRaisesRegex(
+                OSError,
+                "injected root publication failure",
+            ):
+                converter.convert_all()
+
+        self.assertEqual(self._pair_snapshot(), previous_pair)
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(requested=1, executed=1, failed=1),
+        )
+        self._assert_no_transaction_debris()
 
 
 class TestIncludedFilesManifestAccounting(unittest.TestCase):
@@ -250,6 +1998,19 @@ class TestIncludedFilesManifestAccounting(unittest.TestCase):
             unavailable[0].manifest_entry,
             "IncludedFiles[0].filePath",
         )
+        with open(
+            os.path.join(
+                self.godot_dir,
+                INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+            ),
+            encoding="utf-8",
+        ) as registry_file:
+            registry_content = registry_file.read()
+        self.assertIn(
+            '"logical_path": "config/missing.txt"',
+            registry_content,
+        )
+        self.assertIn('"emitted": false', registry_content)
 
     def test_safe_missing_and_disk_only_file_have_strict_counts(self) -> None:
         safe_source = os.path.join(self.datafiles_dir, "config", "safe.txt")
@@ -317,6 +2078,21 @@ class TestIncludedFilesManifestAccounting(unittest.TestCase):
         ]
         self.assertEqual(len(unavailable), 1)
         self.assertEqual(unavailable[0].resource, "missing.txt")
+        with open(
+            os.path.join(
+                self.godot_dir,
+                INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+            ),
+            encoding="utf-8",
+        ) as registry_file:
+            registry_content = registry_file.read()
+        self.assertIn(
+            '"logical_path": "config/missing.txt"',
+            registry_content,
+        )
+        self.assertIn('"logical_path": "config/safe.txt"', registry_content)
+        self.assertEqual(registry_content.count('"emitted": false'), 1)
+        self.assertEqual(registry_content.count('"emitted": true'), 2)
 
     def test_duplicate_exact_manifest_file_is_accounted_once(self) -> None:
         source_path = os.path.join(self.datafiles_dir, "once.txt")
@@ -382,7 +2158,7 @@ class TestIncludedFilesManifestAccounting(unittest.TestCase):
 
 
 class TestIncludedFilesConverterNestedDirs(unittest.TestCase):
-    """Test that nested directory structures are preserved."""
+    """Test that nested Included Files use GameMaker's packaged names."""
 
     def setUp(self):
         self.gm_dir = tempfile.mkdtemp()
@@ -404,20 +2180,36 @@ class TestIncludedFilesConverterNestedDirs(unittest.TestCase):
         shutil.rmtree(self.gm_dir)
         shutil.rmtree(self.godot_dir)
 
-    def _make_converter(self):
+    def _make_converter(
+        self,
+        diagnostics: DiagnosticCollector | None = None,
+    ) -> IncludedFilesConverter:
         return IncludedFilesConverter(
             self.gm_dir, self.godot_dir,
             log_callback=lambda msg: self.logs.append(msg),
             progress_callback=lambda v: None,
             conversion_running=lambda: True,
+            diagnostics=diagnostics,
+            max_workers=1,
         )
 
-    def test_preserves_directory_structure(self):
+    def test_normalizes_nested_packaged_paths(self):
         converter = self._make_converter()
         converter.convert_all()
 
-        expected_lang = os.path.join(self.godot_dir, "included_files", "Languages", "english.lang")
-        expected_rank = os.path.join(self.godot_dir, "included_files", "Modding", "Ranking System", "ranks.txt")
+        expected_lang = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "languages",
+            "english.lang",
+        )
+        expected_rank = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "modding",
+            "ranking_system",
+            "ranks.txt",
+        )
 
         self.assertTrue(os.path.isfile(expected_lang), f"Expected {expected_lang}")
         self.assertTrue(os.path.isfile(expected_rank), f"Expected {expected_rank}")
@@ -426,6 +2218,134 @@ class TestIncludedFilesConverterNestedDirs(unittest.TestCase):
             self.assertEqual(f.read(), "lang data")
         with open(expected_rank, "r", encoding="utf-8") as f:
             self.assertEqual(f.read(), "rank data")
+
+    def test_collision_paths_reserve_natural_suffixes_and_warn_once(self) -> None:
+        datafiles_dir = os.path.join(self.gm_dir, "datafiles")
+        fixtures = {
+            "read_me.txt": "canonical",
+            "Read Me.txt": "normalized collision",
+            "read_me_2.txt": "natural suffix",
+        }
+        for filename, content in fixtures.items():
+            with open(
+                os.path.join(datafiles_dir, filename),
+                "w",
+                encoding="utf-8",
+            ) as source_file:
+                source_file.write(content)
+
+        diagnostics = DiagnosticCollector()
+        converter = self._make_converter(diagnostics)
+        converter.convert_all()
+
+        expected_outputs = {
+            "read_me.txt": "canonical",
+            "read_me_2.txt": "natural suffix",
+            "read_me_3.txt": "normalized collision",
+        }
+        for filename, content in expected_outputs.items():
+            with self.subTest(filename=filename):
+                output_path = os.path.join(
+                    self.godot_dir,
+                    "included_files",
+                    filename,
+                )
+                with open(output_path, "r", encoding="utf-8") as output_file:
+                    self.assertEqual(output_file.read(), content)
+
+        collision_diagnostics = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-INCLUDED-FILE-PATH-COLLISION"
+        ]
+        self.assertEqual(len(collision_diagnostics), 1)
+        collision = collision_diagnostics[0]
+        self.assertEqual(collision.severity, "warning")
+        self.assertEqual(collision.source_path, "datafiles")
+        self.assertEqual(collision.resource, "read_me.txt")
+        self.assertEqual(collision.resource_type, "included_file")
+        self.assertIn("'read_me.txt' -> 'read_me.txt'", collision.message)
+        self.assertIn("'Read Me.txt' -> 'read_me_3.txt'", collision.message)
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(requested=5, executed=5, completed=5),
+        )
+        with open(
+            os.path.join(
+                self.godot_dir,
+                INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+            ),
+            encoding="utf-8",
+        ) as registry_file:
+            registry_content = registry_file.read()
+        self.assertIn('"logical_path": "Read Me.txt"', registry_content)
+        self.assertIn('"assigned_path": "read_me_3.txt"', registry_content)
+        self.assertEqual(registry_content.count('"emitted": true'), 5)
+
+    def test_file_directory_prefix_collision_is_relocated_and_reported(
+        self,
+    ) -> None:
+        datafiles_dir = os.path.join(self.gm_dir, "datafiles")
+        with open(
+            os.path.join(datafiles_dir, "foo_bar"),
+            "w",
+            encoding="utf-8",
+        ) as source_file:
+            source_file.write("blocking file")
+        nested_directory = os.path.join(datafiles_dir, "Foo Bar")
+        os.makedirs(nested_directory)
+        with open(
+            os.path.join(nested_directory, "item.txt"),
+            "w",
+            encoding="utf-8",
+        ) as source_file:
+            source_file.write("nested file")
+
+        diagnostics = DiagnosticCollector()
+        converter = self._make_converter(diagnostics)
+        converter.convert_all()
+
+        blocking_output = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "foo_bar_2",
+        )
+        nested_output = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "foo_bar",
+            "item.txt",
+        )
+        with open(blocking_output, "r", encoding="utf-8") as output_file:
+            self.assertEqual(output_file.read(), "blocking file")
+        with open(nested_output, "r", encoding="utf-8") as output_file:
+            self.assertEqual(output_file.read(), "nested file")
+
+        collision_diagnostics = [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-INCLUDED-FILE-PATH-COLLISION"
+        ]
+        self.assertEqual(len(collision_diagnostics), 1)
+        collision = collision_diagnostics[0]
+        self.assertEqual(collision.resource, "foo_bar")
+        self.assertEqual(
+            collision.manifest_entry,
+            "normalized Included File output path",
+        )
+        self.assertIn("'foo_bar' -> 'foo_bar_2'", collision.message)
+        self.assertIn(
+            "'Foo Bar/item.txt' -> 'foo_bar/item.txt'",
+            collision.message,
+        )
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(requested=4, executed=4, completed=4),
+        )
 
 
 class TestIncludedFilesConverterSkipsYY(unittest.TestCase):
@@ -484,6 +2404,756 @@ class TestIncludedFilesConverterMissingFolder(unittest.TestCase):
         converter.convert_all()
         self.assertTrue(len(self.logs) > 0,
                         "Expected at least one log message for missing datafiles folder")
+
+
+class TestIncludedFilesConverterOutputContainment(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gm_dir = tempfile.mkdtemp()
+        self.godot_dir = tempfile.mkdtemp()
+        self.outside_dir = tempfile.mkdtemp()
+        self.datafiles_dir = os.path.join(self.gm_dir, "datafiles")
+        os.makedirs(self.datafiles_dir)
+        self.source_path = os.path.join(self.datafiles_dir, "payload.bin")
+        self.payload = b"\x00included\xffpayload"
+        with open(self.source_path, "wb") as source_file:
+            source_file.write(self.payload)
+        os.chmod(self.source_path, 0o640)
+        os.utime(
+            self.source_path,
+            ns=(1_700_000_000_123_456_789, 1_700_000_001_987_654_321),
+        )
+        self.logs: list[str] = []
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.gm_dir)
+        shutil.rmtree(self.godot_dir)
+        shutil.rmtree(self.outside_dir)
+
+    def _convert(
+        self,
+        *,
+        force_fallback: bool = False,
+        expect_failure: bool = False,
+    ) -> tuple[IncludedFilesConverter, DiagnosticCollector]:
+        diagnostics = DiagnosticCollector()
+        converter = IncludedFilesConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=self.logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            max_workers=1,
+            diagnostics=diagnostics,
+        )
+        def convert() -> None:
+            if force_fallback:
+                with patch.object(
+                    included_files_module,
+                    "_confined_included_output_supported",
+                    return_value=False,
+                ):
+                    converter.convert_all()
+            else:
+                converter.convert_all()
+
+        if expect_failure:
+            with self.assertRaises(OSError):
+                convert()
+        else:
+            convert()
+        return converter, diagnostics
+
+    @staticmethod
+    def _output_rejections(
+        diagnostics: DiagnosticCollector,
+    ) -> list[ConversionDiagnostic]:
+        return [
+            diagnostic
+            for diagnostic in diagnostics.diagnostics()
+            if diagnostic.code == "GM2GD-INCLUDED-FILE-OUTPUT-REJECTED"
+        ]
+
+    def _make_symlink(self, target: str, link_path: str) -> None:
+        try:
+            os.symlink(target, link_path)
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+
+    def _assert_failed_output(
+        self,
+        converter: IncludedFilesConverter,
+        diagnostics: DiagnosticCollector,
+        *,
+        requested: int = 1,
+        completed: int = 0,
+        rejection_count: int | None = None,
+    ) -> None:
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(
+                requested=requested,
+                executed=requested,
+                completed=completed,
+                failed=requested - completed,
+            ),
+        )
+        rejections = self._output_rejections(diagnostics)
+        expected_rejections = (
+            requested - completed
+            if rejection_count is None
+            else rejection_count
+        )
+        self.assertEqual(len(rejections), expected_rejections, rejections)
+        self.assertTrue(
+            all(
+                diagnostic.severity == "error"
+                and diagnostic.resource_type == "included_file"
+                and diagnostic.manifest_entry
+                == "generated Included File output"
+                for diagnostic in rejections
+            ),
+            rejections,
+        )
+
+    def test_normal_copy_preserves_binary_bytes_and_metadata(self) -> None:
+        output_path = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "payload.bin",
+        )
+        source_stat = os.stat(self.source_path)
+
+        for force_fallback in (False, True):
+            with self.subTest(force_fallback=force_fallback):
+                converter, diagnostics = self._convert(
+                    force_fallback=force_fallback,
+                )
+
+                with open(output_path, "rb") as output_file:
+                    self.assertEqual(output_file.read(), self.payload)
+                output_stat = os.stat(output_path)
+                if os.chmod in os.supports_fd:
+                    self.assertEqual(
+                        stat.S_IMODE(output_stat.st_mode),
+                        stat.S_IMODE(source_stat.st_mode),
+                    )
+                if os.utime in os.supports_fd:
+                    self.assertEqual(
+                        output_stat.st_mtime_ns,
+                        source_stat.st_mtime_ns,
+                    )
+                self.assertEqual(
+                    converter.conversion_step_result(
+                        finalize_unfinished_as=None,
+                    ).resources,
+                    ConversionCounts(requested=1, executed=1, completed=1),
+                )
+                self.assertEqual(self._output_rejections(diagnostics), [])
+
+    def test_rejects_redirected_included_files_root(self) -> None:
+        managed_root = os.path.join(self.godot_dir, "included_files")
+        outside_output = os.path.join(self.outside_dir, "payload.bin")
+        with open(outside_output, "wb") as outside_file:
+            outside_file.write(b"outside sentinel")
+        self._make_symlink(self.outside_dir, managed_root)
+
+        for force_fallback in (False, True):
+            with self.subTest(force_fallback=force_fallback):
+                converter, diagnostics = self._convert(
+                    force_fallback=force_fallback,
+                    expect_failure=True,
+                )
+
+                self.assertTrue(os.path.islink(managed_root))
+                with open(outside_output, "rb") as outside_file:
+                    self.assertEqual(outside_file.read(), b"outside sentinel")
+                self._assert_failed_output(converter, diagnostics)
+
+    def test_rejects_redirected_nested_output_directory(self) -> None:
+        nested_source_dir = os.path.join(self.datafiles_dir, "Nested")
+        os.makedirs(nested_source_dir)
+        with open(
+            os.path.join(nested_source_dir, "child.bin"),
+            "wb",
+        ) as source_file:
+            source_file.write(b"nested payload")
+        managed_root = os.path.join(self.godot_dir, "included_files")
+        os.makedirs(managed_root)
+        nested_output = os.path.join(managed_root, "nested")
+        outside_output = os.path.join(self.outside_dir, "child.bin")
+        with open(outside_output, "wb") as outside_file:
+            outside_file.write(b"outside sentinel")
+        self._make_symlink(self.outside_dir, nested_output)
+
+        for force_fallback in (False, True):
+            with self.subTest(force_fallback=force_fallback):
+                converter, diagnostics = self._convert(
+                    force_fallback=force_fallback,
+                    expect_failure=True,
+                )
+
+                self.assertTrue(os.path.islink(nested_output))
+                with open(outside_output, "rb") as outside_file:
+                    self.assertEqual(outside_file.read(), b"outside sentinel")
+                self._assert_failed_output(
+                    converter,
+                    diagnostics,
+                    requested=2,
+                )
+
+    def test_rejects_final_output_symlink(self) -> None:
+        managed_root = os.path.join(self.godot_dir, "included_files")
+        os.makedirs(managed_root)
+        output_path = os.path.join(managed_root, "payload.bin")
+        outside_output = os.path.join(self.outside_dir, "payload.bin")
+        with open(outside_output, "wb") as outside_file:
+            outside_file.write(b"outside sentinel")
+        self._make_symlink(outside_output, output_path)
+
+        for force_fallback in (False, True):
+            with self.subTest(force_fallback=force_fallback):
+                converter, diagnostics = self._convert(
+                    force_fallback=force_fallback,
+                    expect_failure=True,
+                )
+
+                self.assertTrue(os.path.islink(output_path))
+                with open(outside_output, "rb") as outside_file:
+                    self.assertEqual(outside_file.read(), b"outside sentinel")
+                self._assert_failed_output(converter, diagnostics)
+
+    def test_replaces_final_hardlink_without_mutating_referent(self) -> None:
+        managed_root = os.path.join(self.godot_dir, "included_files")
+        os.makedirs(managed_root)
+        output_path = os.path.join(managed_root, "payload.bin")
+        outside_output = os.path.join(self.outside_dir, "payload.bin")
+        with open(outside_output, "wb") as outside_file:
+            outside_file.write(b"outside sentinel")
+
+        for force_fallback in (False, True):
+            with self.subTest(force_fallback=force_fallback):
+                if os.path.lexists(output_path):
+                    os.unlink(output_path)
+                try:
+                    os.link(outside_output, output_path)
+                except (NotImplementedError, OSError) as error:
+                    self.skipTest(f"Hard links are unavailable: {error}")
+
+                converter, diagnostics = self._convert(
+                    force_fallback=force_fallback,
+                )
+
+                with open(outside_output, "rb") as outside_file:
+                    self.assertEqual(outside_file.read(), b"outside sentinel")
+                with open(output_path, "rb") as output_file:
+                    self.assertEqual(output_file.read(), self.payload)
+                self.assertNotEqual(
+                    os.stat(outside_output).st_ino,
+                    os.stat(output_path).st_ino,
+                )
+                self.assertEqual(
+                    converter.conversion_step_result(
+                        finalize_unfinished_as=None,
+                    ).resources,
+                    ConversionCounts(requested=1, executed=1, completed=1),
+                )
+                self.assertEqual(self._output_rejections(diagnostics), [])
+
+    def test_late_final_output_swap_is_rejected_without_external_mutation(
+        self,
+    ) -> None:
+        if not included_files_module._confined_included_output_supported():
+            self.skipTest("Descriptor-relative Included File output is unavailable")
+        managed_root = os.path.join(self.godot_dir, "included_files")
+        os.makedirs(managed_root)
+        output_path = os.path.join(managed_root, "payload.bin")
+        with open(output_path, "wb") as output_file:
+            output_file.write(b"previous output")
+        outside_output = os.path.join(self.outside_dir, "payload.bin")
+        with open(outside_output, "wb") as outside_file:
+            outside_file.write(b"outside sentinel")
+        original_verify = included_files_module._verify_included_output_state_at
+        swapped = False
+
+        def swap_then_verify(
+            directory_fd: int,
+            filename: str,
+            expected_identity: tuple[int, int] | None,
+        ) -> None:
+            nonlocal swapped
+            if not swapped:
+                os.unlink(output_path)
+                self._make_symlink(outside_output, output_path)
+                swapped = True
+            original_verify(directory_fd, filename, expected_identity)
+
+        diagnostics = DiagnosticCollector()
+        converter = IncludedFilesConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=self.logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            max_workers=1,
+            diagnostics=diagnostics,
+        )
+        with patch.object(
+            included_files_module,
+            "_verify_included_output_state_at",
+            side_effect=swap_then_verify,
+        ), self.assertRaises(OSError):
+            converter.convert_all()
+
+        self.assertTrue(os.path.islink(output_path))
+        with open(outside_output, "rb") as outside_file:
+            self.assertEqual(outside_file.read(), b"outside sentinel")
+        self.assertFalse(
+            any(name.startswith(".gm2godot-") for name in os.listdir(managed_root))
+        )
+        self._assert_failed_output(
+            converter,
+            diagnostics,
+            rejection_count=0,
+        )
+
+    def test_late_output_directory_relocation_is_rejected_before_publish(
+        self,
+    ) -> None:
+        if not included_files_module._confined_included_output_supported():
+            self.skipTest("Descriptor-relative Included File output is unavailable")
+        os.unlink(self.source_path)
+        nested_source = os.path.join(
+            self.datafiles_dir,
+            "Nested",
+            "payload.bin",
+        )
+        os.makedirs(os.path.dirname(nested_source))
+        with open(nested_source, "wb") as source_file:
+            source_file.write(self.payload)
+        nested_output = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "nested",
+        )
+        os.makedirs(nested_output)
+        moved_directory = os.path.join(self.outside_dir, "moved_nested")
+        original_verify = (
+            included_files_module._verify_open_included_output_directory
+        )
+        nested_verifications = 0
+
+        def relocate_then_verify(
+            project_path: str,
+            directory_path: str,
+            directory_fd: int,
+        ) -> None:
+            nonlocal nested_verifications
+            if os.path.normcase(directory_path).endswith(
+                os.path.normcase(os.path.join("included_files", "nested"))
+            ):
+                nested_verifications += 1
+                if nested_verifications == 3:
+                    os.rename(nested_output, moved_directory)
+            original_verify(project_path, directory_path, directory_fd)
+
+        diagnostics = DiagnosticCollector()
+        converter = IncludedFilesConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=self.logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            max_workers=1,
+            diagnostics=diagnostics,
+        )
+        with patch.object(
+            included_files_module,
+            "_verify_open_included_output_directory",
+            side_effect=relocate_then_verify,
+        ), self.assertRaises(OSError):
+            converter.convert_all()
+
+        self.assertTrue(os.path.isdir(moved_directory))
+        self.assertEqual(os.listdir(moved_directory), [])
+        self.assertFalse(
+            any(
+                name.startswith(".gm2godot-")
+                for name in os.listdir(self.godot_dir)
+            )
+        )
+        self._assert_failed_output(
+            converter,
+            diagnostics,
+            rejection_count=0,
+        )
+
+    def test_final_rename_cannot_follow_swapped_output_directory(self) -> None:
+        if not included_files_module._confined_included_output_supported():
+            self.skipTest("Descriptor-relative Included File output is unavailable")
+        os.unlink(self.source_path)
+        nested_source = os.path.join(
+            self.datafiles_dir,
+            "Nested",
+            "payload.bin",
+        )
+        os.makedirs(os.path.dirname(nested_source))
+        with open(nested_source, "wb") as source_file:
+            source_file.write(self.payload)
+        nested_output = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "nested",
+        )
+        os.makedirs(nested_output)
+        moved_directory = os.path.join(
+            self.godot_dir,
+            ".moved_nested",
+        )
+        redirected_directory = os.path.join(
+            self.outside_dir,
+            "redirected_nested",
+        )
+        os.makedirs(redirected_directory)
+        outside_output = os.path.join(
+            redirected_directory,
+            "payload.bin",
+        )
+        with open(outside_output, "wb") as outside_file:
+            outside_file.write(b"outside sentinel")
+        original_rename = os.rename
+        swapped = False
+        publication_dir_fds: tuple[int, int] | None = None
+
+        def relocate_before_publish(
+            source: str,
+            destination: str,
+            *,
+            src_dir_fd: int | None = None,
+            dst_dir_fd: int | None = None,
+        ) -> None:
+            nonlocal publication_dir_fds, swapped
+            if (
+                not swapped
+                and src_dir_fd is not None
+                and dst_dir_fd is not None
+                and source.startswith(".gm2godot-")
+            ):
+                original_rename(nested_output, moved_directory)
+                self._make_symlink(
+                    redirected_directory,
+                    nested_output,
+                )
+                publication_dir_fds = (src_dir_fd, dst_dir_fd)
+                swapped = True
+            original_rename(
+                source,
+                destination,
+                src_dir_fd=src_dir_fd,
+                dst_dir_fd=dst_dir_fd,
+            )
+
+        diagnostics = DiagnosticCollector()
+        converter = IncludedFilesConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=self.logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            max_workers=1,
+            diagnostics=diagnostics,
+        )
+        with (
+            patch.object(
+                included_files_module,
+                "_confined_included_output_supported",
+                return_value=True,
+            ),
+            patch.object(
+                included_files_module.os,
+                "rename",
+                side_effect=relocate_before_publish,
+            ),
+            self.assertRaises(OSError),
+        ):
+            converter.convert_all()
+
+        self.assertTrue(swapped)
+        self.assertIsNotNone(publication_dir_fds)
+        if publication_dir_fds is not None:
+            self.assertEqual(
+                publication_dir_fds[0],
+                publication_dir_fds[1],
+            )
+        self.assertTrue(os.path.islink(nested_output))
+        with open(outside_output, "rb") as outside_file:
+            self.assertEqual(outside_file.read(), b"outside sentinel")
+        self.assertEqual(os.listdir(moved_directory), [])
+        self.assertFalse(
+            any(
+                name.startswith(".gm2godot-")
+                for name in os.listdir(self.godot_dir)
+            )
+        )
+        self._assert_failed_output(
+            converter,
+            diagnostics,
+            rejection_count=0,
+        )
+
+    def test_fallback_late_final_swap_is_rejected_without_external_mutation(
+        self,
+    ) -> None:
+        managed_root = os.path.join(self.godot_dir, "included_files")
+        os.makedirs(managed_root)
+        output_path = os.path.join(managed_root, "payload.bin")
+        with open(output_path, "wb") as output_file:
+            output_file.write(b"previous output")
+        outside_output = os.path.join(self.outside_dir, "payload.bin")
+        with open(outside_output, "wb") as outside_file:
+            outside_file.write(b"outside sentinel")
+        original_verify = included_files_module._verify_included_output_state
+        swapped = False
+
+        def swap_then_verify(
+            path: str,
+            expected_identity: tuple[int, int] | None,
+        ) -> None:
+            nonlocal swapped
+            if not swapped:
+                os.unlink(output_path)
+                self._make_symlink(outside_output, output_path)
+                swapped = True
+            original_verify(path, expected_identity)
+
+        diagnostics = DiagnosticCollector()
+        converter = IncludedFilesConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=self.logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            max_workers=1,
+            diagnostics=diagnostics,
+        )
+        with (
+            patch.object(
+                included_files_module,
+                "_confined_included_output_supported",
+                return_value=False,
+            ),
+            patch.object(
+                included_files_module,
+                "_verify_included_output_state",
+                side_effect=swap_then_verify,
+            ),
+            self.assertRaises(OSError),
+        ):
+            converter.convert_all()
+
+        self.assertTrue(os.path.islink(output_path))
+        with open(outside_output, "rb") as outside_file:
+            self.assertEqual(outside_file.read(), b"outside sentinel")
+        self.assertFalse(
+            any(name.startswith(".gm2godot-") for name in os.listdir(managed_root))
+        )
+        self._assert_failed_output(
+            converter,
+            diagnostics,
+            rejection_count=0,
+        )
+
+    def test_fallback_late_directory_relocation_cleans_project_stage(
+        self,
+    ) -> None:
+        os.unlink(self.source_path)
+        nested_source = os.path.join(
+            self.datafiles_dir,
+            "Nested",
+            "payload.bin",
+        )
+        os.makedirs(os.path.dirname(nested_source))
+        with open(nested_source, "wb") as source_file:
+            source_file.write(self.payload)
+        nested_output = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "nested",
+        )
+        os.makedirs(nested_output)
+        moved_directory = os.path.join(self.outside_dir, "moved_nested")
+        original_verify = (
+            included_files_module._verify_included_output_directories_fallback
+        )
+        moved = False
+
+        def relocate_then_verify(
+            identities: tuple[tuple[str, tuple[int, int]], ...],
+        ) -> None:
+            nonlocal moved
+            if not moved and len(identities) > 1:
+                os.rename(nested_output, moved_directory)
+                moved = True
+            original_verify(identities)
+
+        diagnostics = DiagnosticCollector()
+        converter = IncludedFilesConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=self.logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            max_workers=1,
+            diagnostics=diagnostics,
+        )
+        with (
+            patch.object(
+                included_files_module,
+                "_confined_included_output_supported",
+                return_value=False,
+            ),
+            patch.object(
+                included_files_module,
+                "_verify_included_output_directories_fallback",
+                side_effect=relocate_then_verify,
+            ),
+            self.assertRaises(OSError),
+        ):
+            converter.convert_all()
+
+        self.assertTrue(os.path.isdir(moved_directory))
+        self.assertEqual(os.listdir(moved_directory), [])
+        self.assertFalse(
+            any(
+                name.startswith(".gm2godot-")
+                for name in os.listdir(self.godot_dir)
+            )
+        )
+        self._assert_failed_output(
+            converter,
+            diagnostics,
+            rejection_count=0,
+        )
+
+    def test_fallback_project_root_swap_cleans_external_stage_before_copy(
+        self,
+    ) -> None:
+        moved_project = os.path.join(
+            self.outside_dir,
+            "moved_project",
+        )
+        original_mkstemp = tempfile.mkstemp
+        original_rename = os.rename
+        swapped = False
+
+        def relocate_before_stage(
+            suffix: str | None = None,
+            prefix: str | None = None,
+            dir: str | None = None,
+            text: bool = False,
+        ) -> tuple[int, str]:
+            nonlocal swapped
+            original_rename(self.godot_dir, moved_project)
+            try:
+                self._make_symlink(self.outside_dir, self.godot_dir)
+            except BaseException:
+                original_rename(moved_project, self.godot_dir)
+                raise
+            swapped = True
+            return original_mkstemp(
+                suffix=suffix,
+                prefix=prefix,
+                dir=dir,
+                text=text,
+            )
+
+        diagnostics = DiagnosticCollector()
+        converter = IncludedFilesConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=self.logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            max_workers=1,
+            diagnostics=diagnostics,
+        )
+        try:
+            with (
+                patch.object(
+                    included_files_module,
+                    "_confined_included_output_supported",
+                    return_value=False,
+                ),
+                patch.object(
+                    included_files_module.tempfile,
+                    "mkstemp",
+                    side_effect=relocate_before_stage,
+                ),
+                self.assertRaises(OSError),
+            ):
+                converter.convert_all()
+
+            outside_files = [
+                os.path.join(directory, filename)
+                for directory, _subdirectories, filenames in os.walk(
+                    self.outside_dir
+                )
+                for filename in filenames
+            ]
+            self.assertTrue(swapped)
+            self.assertEqual(outside_files, [])
+            self._assert_failed_output(converter, diagnostics)
+        finally:
+            if os.path.islink(self.godot_dir):
+                os.unlink(self.godot_dir)
+            if os.path.isdir(moved_project):
+                original_rename(moved_project, self.godot_dir)
+
+    def test_fallback_rejects_mocked_windows_junction(self) -> None:
+        managed_root = os.path.join(self.godot_dir, "included_files")
+        os.makedirs(managed_root)
+        normalized_managed_root = os.path.normcase(os.path.abspath(managed_root))
+
+        def is_mock_junction(path: str) -> bool:
+            return (
+                os.path.normcase(os.path.abspath(path))
+                == normalized_managed_root
+            )
+
+        diagnostics = DiagnosticCollector()
+        converter = IncludedFilesConverter(
+            self.gm_dir,
+            self.godot_dir,
+            log_callback=self.logs.append,
+            progress_callback=lambda _value: None,
+            conversion_running=lambda: True,
+            max_workers=1,
+            diagnostics=diagnostics,
+        )
+        with (
+            patch.object(
+                included_files_module,
+                "_confined_included_output_supported",
+                return_value=False,
+            ),
+            patch.object(
+                included_files_module,
+                "_included_descriptor_paths_supported",
+                return_value=False,
+            ),
+            patch.object(
+                os.path,
+                "isjunction",
+                side_effect=is_mock_junction,
+                create=True,
+            ),
+            self.assertRaises(OSError),
+        ):
+            converter.convert_all()
+
+        self.assertEqual(os.listdir(managed_root), [])
+        self._assert_failed_output(converter, diagnostics)
 
 
 class TestIncludedFilesConverterSourceContainment(unittest.TestCase):
@@ -649,7 +3319,10 @@ class TestIncludedFilesConverterSourceContainment(unittest.TestCase):
                     output_path,
                     f"rejected_{index}.txt",
                 )
-                self.assertEqual(result, (f"rejected_{index}.txt", False))
+                self.assertEqual(
+                    result,
+                    (f"rejected_{index}.txt", False, None),
+                )
                 self.assertFalse(os.path.exists(output_path))
 
         rejected = self._source_path_rejections()
@@ -679,7 +3352,7 @@ class TestIncludedFilesConverterSourceContainment(unittest.TestCase):
             godot_file_path: str,
             rel_path: str,
             owner_source_path: str,
-        ) -> tuple[str, bool] | None:
+        ) -> tuple[str, bool, object | None] | None:
             nonlocal swapped
             if not swapped and rel_path == "swapped.txt":
                 os.remove(source_path)
@@ -696,7 +3369,7 @@ class TestIncludedFilesConverterSourceContainment(unittest.TestCase):
             converter,
             "_process_file",
             side_effect=swap_then_process,
-        ):
+        ), self.assertRaisesRegex(OSError, "output-set staging failed"):
             converter.convert_all()
 
         self.assertFalse(
@@ -709,6 +3382,14 @@ class TestIncludedFilesConverterSourceContainment(unittest.TestCase):
         self.assertEqual(rejected[0].source_path, "datafiles")
         self.assertEqual(rejected[0].resource, "swapped.txt")
         self.assertEqual(rejected[0].manifest_entry, "discovered datafiles file")
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(
+                    self.godot_dir,
+                    INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+                )
+            )
+        )
 
     def test_revalidates_nested_directory_before_listing(self) -> None:
         nested_directory = os.path.join(self.datafiles_dir, "nested")

--- a/tests/test_included_files.py
+++ b/tests/test_included_files.py
@@ -858,11 +858,39 @@ class TestIncludedFilesManagedRootTransaction(unittest.TestCase):
                 destination_name,
             )
 
-        with patch.object(
-            included_files_module,
-            "_rename_included_transaction_entry_at",
-            side_effect=inject_unknown_destination,
-        ), self.assertRaises(OSError):
+        def inject_unknown_destination_fallback(
+            _source: str,
+            destination: str,
+        ) -> None:
+            nonlocal sentinel_name
+            destination_name = os.path.basename(destination)
+            if (
+                sentinel_name is None
+                and destination_name.startswith(
+                    ".gml_included_file_registry.gd."
+                )
+                and destination_name.endswith(".backup")
+            ):
+                with open(destination, "xb") as sentinel_file:
+                    sentinel_file.write(b"unknown sentinel")
+                    sentinel_file.flush()
+                    os.fsync(sentinel_file.fileno())
+                sentinel_name = destination_name
+
+        rename_patcher = (
+            patch.object(
+                included_files_module,
+                "_rename_included_transaction_entry_at",
+                side_effect=inject_unknown_destination,
+            )
+            if included_files_module._included_descriptor_paths_supported()
+            else patch.object(
+                included_files_module,
+                "_before_included_transaction_rename_fallback",
+                side_effect=inject_unknown_destination_fallback,
+            )
+        )
+        with rename_patcher, self.assertRaises(OSError):
             converter.convert_all()
 
         self.assertIsNotNone(sentinel_name)
@@ -940,11 +968,32 @@ class TestIncludedFilesManagedRootTransaction(unittest.TestCase):
                 )
                 swapped_backup_path = os.path.join(self.godot_dir, name)
 
-        with patch.object(
-            included_files_module,
-            "_before_included_cleanup_quarantine",
-            side_effect=swap_cleanup_root,
-        ):
+        def swap_cleanup_root_fallback(path: str) -> None:
+            nonlocal swapped_backup_path
+            name = os.path.basename(path)
+            if (
+                swapped_backup_path is None
+                and name.startswith(".included_files.")
+                and name.endswith(".backup")
+            ):
+                os.rename(path, parked_backup)
+                os.rename(victim_path, path)
+                swapped_backup_path = path
+
+        cleanup_patcher = (
+            patch.object(
+                included_files_module,
+                "_before_included_cleanup_quarantine",
+                side_effect=swap_cleanup_root,
+            )
+            if included_files_module._included_descriptor_paths_supported()
+            else patch.object(
+                included_files_module,
+                "_before_included_cleanup_quarantine_fallback",
+                side_effect=swap_cleanup_root_fallback,
+            )
+        )
+        with cleanup_patcher:
             converter.convert_all()
 
         self.assertIsNotNone(swapped_backup_path)

--- a/tests/test_included_files.py
+++ b/tests/test_included_files.py
@@ -1,5 +1,6 @@
 # pyright: reportPrivateUsage=false
 
+import hashlib
 import json
 import os
 import posixpath
@@ -9,6 +10,7 @@ import shutil
 import tempfile
 import threading
 import unittest
+from types import SimpleNamespace
 from typing import BinaryIO, Callable
 from unittest.mock import MagicMock, patch
 
@@ -343,6 +345,122 @@ class TestIncludedFilesManagedRootTransaction(unittest.TestCase):
         )
         self.assertEqual(project_debris, [])
         self.assertEqual(registry_debris, [])
+
+    @staticmethod
+    def _modeled_handle_stat(
+        path_stat: os.stat_result,
+        *,
+        ctime_offset: int,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            st_dev=path_stat.st_dev,
+            st_ino=path_stat.st_ino,
+            st_mode=path_stat.st_mode ^ stat.S_IXUSR,
+            st_size=path_stat.st_size,
+            st_mtime_ns=path_stat.st_mtime_ns,
+            st_ctime_ns=path_stat.st_ctime_ns + ctime_offset,
+            st_nlink=path_stat.st_nlink,
+        )
+
+    def test_digest_accepts_stable_path_handle_metadata_skew(self) -> None:
+        payload = b"stable staged payload"
+        staged_path = os.path.join(self.godot_dir, "staged.bin")
+        with open(staged_path, "wb") as staged_file:
+            staged_file.write(payload)
+        path_stat = os.lstat(staged_path)
+        handle_stat = self._modeled_handle_stat(
+            path_stat,
+            ctime_offset=1,
+        )
+
+        with patch.object(
+            included_files_module.os,
+            "fstat",
+            side_effect=(handle_stat, handle_stat),
+        ):
+            digest = included_files_module._digest_included_regular_file(
+                staged_path,
+                path_stat,
+            )
+
+        self.assertEqual(digest, hashlib.sha256(payload).hexdigest())
+
+    def test_digest_rejects_open_handle_change_during_hashing(self) -> None:
+        staged_path = os.path.join(self.godot_dir, "staged.bin")
+        with open(staged_path, "wb") as staged_file:
+            staged_file.write(b"mutated staged payload")
+        path_stat = os.lstat(staged_path)
+        opened_stat = self._modeled_handle_stat(
+            path_stat,
+            ctime_offset=1,
+        )
+        changed_stat = self._modeled_handle_stat(
+            path_stat,
+            ctime_offset=2,
+        )
+
+        with (
+            patch.object(
+                included_files_module.os,
+                "fstat",
+                side_effect=(opened_stat, changed_stat),
+            ),
+            self.assertRaisesRegex(OSError, "changed while hashing"),
+        ):
+            included_files_module._digest_included_regular_file(
+                staged_path,
+                path_stat,
+            )
+
+    def test_descriptor_digest_rechecks_the_open_handle(self) -> None:
+        if not included_files_module._included_descriptor_paths_supported():
+            self.skipTest("Descriptor-pinned Included Files paths are unavailable")
+        payload = b"descriptor staged payload"
+        staged_path = os.path.join(self.godot_dir, "staged.bin")
+        with open(staged_path, "wb") as staged_file:
+            staged_file.write(payload)
+        path_stat = os.lstat(staged_path)
+        opened_stat = self._modeled_handle_stat(
+            path_stat,
+            ctime_offset=1,
+        )
+        changed_stat = self._modeled_handle_stat(
+            path_stat,
+            ctime_offset=2,
+        )
+        parent_fd = included_files_module._open_pinned_included_directory(
+            self.godot_dir
+        )
+        try:
+            with patch.object(
+                included_files_module.os,
+                "fstat",
+                side_effect=(opened_stat, opened_stat),
+            ):
+                digest = included_files_module._digest_included_regular_file_at(
+                    parent_fd,
+                    "staged.bin",
+                    path_stat,
+                    staged_path,
+                )
+            self.assertEqual(digest, hashlib.sha256(payload).hexdigest())
+
+            with (
+                patch.object(
+                    included_files_module.os,
+                    "fstat",
+                    side_effect=(opened_stat, changed_stat),
+                ),
+                self.assertRaisesRegex(OSError, "changed while hashing"),
+            ):
+                included_files_module._digest_included_regular_file_at(
+                    parent_fd,
+                    "staged.bin",
+                    path_stat,
+                    staged_path,
+                )
+        finally:
+            os.close(parent_fd)
 
     def test_regular_file_in_place_of_managed_root_is_preserved(self) -> None:
         self._write("new.txt", "new")
@@ -1354,7 +1472,11 @@ class TestIncludedFilesManagedRootTransaction(unittest.TestCase):
         os.chmod(owned_path, 0o600)
         os.chmod(replacement_path, 0o640)
         owned_stat = os.lstat(owned_path)
-        replacement_mode = stat.S_IMODE(os.lstat(replacement_path).st_mode)
+        owned_mode = stat.S_IMODE(owned_stat.st_mode)
+        replacement_stat = os.lstat(replacement_path)
+        replacement_mode = stat.S_IMODE(replacement_stat.st_mode)
+        owned_writable = bool(owned_stat.st_mode & stat.S_IWRITE)
+        replacement_writable = bool(replacement_stat.st_mode & stat.S_IWRITE)
         parent_stat = os.lstat(chmod_directory)
         swapped = False
 
@@ -1387,14 +1509,37 @@ class TestIncludedFilesManagedRootTransaction(unittest.TestCase):
             )
 
         self.assertTrue(swapped)
+        current_replacement_stat = os.lstat(owned_path)
+        current_owned_stat = os.lstat(parked_path)
         self.assertEqual(
-            stat.S_IMODE(os.lstat(owned_path).st_mode),
-            replacement_mode,
+            (current_replacement_stat.st_dev, current_replacement_stat.st_ino),
+            (replacement_stat.st_dev, replacement_stat.st_ino),
         )
         self.assertEqual(
-            stat.S_IMODE(os.lstat(parked_path).st_mode),
-            0o600,
+            (current_owned_stat.st_dev, current_owned_stat.st_ino),
+            (owned_stat.st_dev, owned_stat.st_ino),
         )
+        self.assertEqual(
+            bool(current_replacement_stat.st_mode & stat.S_IWRITE),
+            replacement_writable,
+        )
+        self.assertEqual(
+            bool(current_owned_stat.st_mode & stat.S_IWRITE),
+            owned_writable,
+        )
+        with open(owned_path, encoding="utf-8") as replacement_file:
+            self.assertEqual(replacement_file.read(), "unknown replacement")
+        with open(parked_path, encoding="utf-8") as owned_file:
+            self.assertEqual(owned_file.read(), "owned chmod target")
+        if os.name != "nt":
+            self.assertEqual(
+                stat.S_IMODE(current_replacement_stat.st_mode),
+                replacement_mode,
+            )
+            self.assertEqual(
+                stat.S_IMODE(current_owned_stat.st_mode),
+                owned_mode,
+            )
 
     def test_windows_fallback_chmod_skips_matching_write_bit(self) -> None:
         chmod_directory = os.path.join(self.godot_dir, "windows-chmod-match")
@@ -1539,6 +1684,10 @@ class TestIncludedFilesManagedRootTransaction(unittest.TestCase):
             if stage_link is not None and os.path.islink(stage_link):
                 os.unlink(stage_link)
 
+    @unittest.skipUnless(
+        included_files_module._included_descriptor_paths_supported(),
+        "Descriptor-pinned Included Files paths are unavailable",
+    )
     def test_deep_directory_swap_is_not_followed_during_tree_capture(
         self,
     ) -> None:
@@ -1586,6 +1735,71 @@ class TestIncludedFilesManagedRootTransaction(unittest.TestCase):
         finally:
             if os.path.islink(deep_directory):
                 os.unlink(deep_directory)
+            if os.path.isdir(parked_directory):
+                os.rename(parked_directory, deep_directory)
+
+    def test_fallback_deep_directory_swap_during_scan_is_detected_before_hashing(
+        self,
+    ) -> None:
+        scan_root = os.path.join(self.godot_dir, "fallback-scan-root")
+        deep_directory = os.path.join(scan_root, "a", "b")
+        os.makedirs(deep_directory)
+        with open(
+            os.path.join(deep_directory, "contained.txt"),
+            "w",
+            encoding="utf-8",
+        ) as contained_file:
+            contained_file.write("contained")
+        outside_directory = os.path.join(self.gm_dir, "fallback-outside-scan")
+        os.mkdir(outside_directory)
+        outside_file = os.path.join(outside_directory, "external.txt")
+        with open(outside_file, "w", encoding="utf-8") as external_file:
+            external_file.write("external sentinel")
+        parked_directory = os.path.join(scan_root, "parked-b")
+        original_digest = included_files_module._digest_included_regular_file
+        swapped = False
+
+        def swap_after_scan(path: str) -> None:
+            nonlocal swapped
+            if swapped or os.path.normcase(path) != os.path.normcase(
+                deep_directory
+            ):
+                return
+            os.rename(deep_directory, parked_directory)
+            os.rename(outside_directory, deep_directory)
+            swapped = True
+
+        try:
+            with (
+                patch.object(
+                    included_files_module,
+                    "_included_descriptor_paths_supported",
+                    return_value=False,
+                ),
+                patch.object(
+                    included_files_module,
+                    "_after_included_fallback_tree_directory_scan",
+                    side_effect=swap_after_scan,
+                ),
+                patch.object(
+                    included_files_module,
+                    "_digest_included_regular_file",
+                    wraps=original_digest,
+                ) as digest_file,
+                self.assertRaises(OSError),
+            ):
+                included_files_module._capture_included_tree(scan_root)
+
+            self.assertTrue(swapped)
+            digest_file.assert_not_called()
+            with open(
+                os.path.join(deep_directory, "external.txt"),
+                encoding="utf-8",
+            ) as external_file:
+                self.assertEqual(external_file.read(), "external sentinel")
+        finally:
+            if swapped and os.path.isdir(deep_directory):
+                os.rename(deep_directory, outside_directory)
             if os.path.isdir(parked_directory):
                 os.rename(parked_directory, deep_directory)
 

--- a/tests/test_resource_matrix_godot.py
+++ b/tests/test_resource_matrix_godot.py
@@ -34,6 +34,7 @@ REPRESENTATIVE_OUTPUTS = (
     "addons/gm2godot_extensions/ext_analytics/ext_analytics_extension.gd",
     "default_bus_layout.tres",
     "gm2godot/gml_asset_registry.gd",
+    "gm2godot/gml_included_file_registry.gd",
     "gm2godot/gml_runtime.gd",
     "icon.ico",
     "icon.png",

--- a/tests/test_tcc_conversion.py
+++ b/tests/test_tcc_conversion.py
@@ -207,7 +207,7 @@ class TestTCCConversion(unittest.TestCase):
 
     def test_included_files_subdirectories(self):
         included_dir = os.path.join(self.godot_dir, "included_files")
-        for name in ("Calendar", "Challenges", "Fonts", "Languages", "Other", "Quests"):
+        for name in ("calendar", "challenges", "fonts", "languages", "other", "quests"):
             self.assertTrue(
                 os.path.isdir(os.path.join(included_dir, name)),
                 f"Expected included_files/{name}/ directory",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_7(self) -> None:
-        self.assertEqual(get_version(), "0.7.7")
+    def test_release_version_is_0_7_8(self) -> None:
+        self.assertEqual(get_version(), "0.7.8")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- align Included File emission and generated GML reads on `res://included_files/` with literal `user://gm2godot/` overrides first
- add GameMaker case/space normalization, deterministic collision-safe paths, diagnostics, and a dedicated runtime registry shared with asset/manifest publication
- publish the managed file tree and registry through a rollback-protected, descriptor-pinned transaction with source/content receipts and Windows fallback coverage
- make Windows path/handle validation portable while retaining exact handle-state and symmetric SHA-256 source/output mutation checks
- document the runtime contract and bump the release surfaces to 0.7.8

## Why

The converter emitted Included Files under `res://included_files/`, while generated file APIs still searched `res://datafiles/`. Colliding or unavailable declarations could also make emitted files, registries, and runtime lookup disagree.

## Validation

- `./venv/bin/python -m unittest` — 1,898 passed, 39 skipped
- native Windows transaction job — 401 passed, 37 platform-gated skips
- changed-surface matrix — 351 passed, 20 platform-gated skips
- `./venv/bin/ruff check .`
- `./venv/bin/pyright --warnings` — 0 errors, 0 warnings
- exact Godot smoke — 2 passed on `4.7.1.stable.official.a13da4feb`
- all 11 required PR checks passed, including Linux/macOS/Windows builds, current GameMaker LTS fixtures, TCC/Monophobia conversion, and Godot smoke
- independent filesystem, Windows portability, source-receipt, and final scope reviews completed with no open correctness finding

Crash-recoverable cross-path publication remains tracked in #727; native Windows junction/read-only coverage is #728; unchanged-generation performance is #729; asset-registry receipt reuse is #731; read-only Windows registry publication is #732.

Closes #713
