### PR TITLE
Prevent release reruns from overwriting tagged releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.8, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.9, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,25 @@ jobs:
       - name: Check if tag already exists
         id: check_tag
         run: |
-          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
+          set -euo pipefail
+          tag_ref="refs/tags/v${{ steps.version.outputs.version }}"
+          ls_remote_status=0
+          git ls-remote --exit-code --refs origin "$tag_ref" >/dev/null || ls_remote_status=$?
+
+          case "$ls_remote_status" in
+            0)
+              exists=true
+              ;;
+            2)
+              exists=false
+              ;;
+            *)
+              echo "::error::Failed to query exact remote tag $tag_ref (git ls-remote exit $ls_remote_status)." >&2
+              exit "$ls_remote_status"
+              ;;
+          esac
+
+          echo "exists=$exists" >> "$GITHUB_OUTPUT"
 
   build:
     needs: get-version
@@ -138,7 +152,7 @@ jobs:
 
   release:
     needs: [get-version, build]
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && needs.get-version.outputs.tag_exists == 'false'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.9 - 2026-07-18
+
+- Made release reruns idempotent through an authoritative exact remote-tag check: existing versions skip builds and publication without changing assets, absent tags proceed, and lookup failures stop the workflow; updated maintainer guidance to match.
+
 ## 0.7.8 - 2026-07-18
 
 - Aligned Included File emission, asset registry and conversion-manifest paths, and generated GML file APIs on `res://included_files/`, using GameMaker packaged-name normalization (ASCII `A`–`Z` to lowercase and spaces to underscores) with deterministic collision-safe suffixes and diagnostics.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.8`.
+Current source version: `0.7.9`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.8 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.9 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.8 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.9 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.8 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.9 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.8 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.9 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.8 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.9 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.8;
+- GM2Godot 0.7.9;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.8 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.9 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -20,7 +20,7 @@ Download the asset for your operating system from [GitHub Releases](https://gith
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar, footer, or **Help → About GM2Godot** shows version `0.7.8`.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.9`.
 
 ## Run from source
 
@@ -70,6 +70,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.8`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.9`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.8 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.9 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -8,7 +8,7 @@ This page documents the current maintainer path for a versioned release and for 
 
 ## Release model
 
-`src/version.py` is the release trigger and source version. A pull request that changes it starts cross-platform artifact builds; the merged change starts the `Build and Release` workflow on `main`. The workflow builds Linux, macOS, and Windows archives, creates the macOS DMG, and publishes the GitHub release/tag. Every release must use a new version: do not reuse a tag or treat a workflow rerun as a no-op.
+`src/version.py` is the release trigger and source version. A pull request that changes it starts cross-platform artifact builds; the merged change starts the `Build and Release` workflow on `main`. The workflow builds Linux, macOS, and Windows archives, creates the macOS DMG, and publishes the GitHub release/tag. Every new release must use a new version. A rerun or manual dispatch for a version whose exact remote tag already exists is an intentional no-op: the workflow skips build and publication without changing the existing release. If the remote tag lookup fails for any reason other than an absent exact ref, the workflow stops before building.
 
 The release workflow is canonical at [`.github/workflows/release.yml`](https://github.com/Infiland/GM2Godot/blob/main/.github/workflows/release.yml).
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.8 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.9 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.8"
+VERSION = "0.7.9"
 
 
 def get_version():

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import tempfile
-import textwrap
 import unittest
 import zipfile
 from pathlib import Path
@@ -66,17 +66,139 @@ def _godot_env_lines(content: str) -> tuple[str, ...]:
 
 
 def _workflow_run_script(content: str, step_name: str) -> str:
-    marker = f"      - name: {step_name}\n        run: |\n"
+    marker = f"      - name: {step_name}\n"
     _, separator, remainder = content.partition(marker)
     if not separator:
         raise AssertionError(f"Workflow step not found: {step_name}")
 
+    metadata, separator, remainder = remainder.partition("        run: |\n")
+    if not separator or "\n      - " in metadata:
+        raise AssertionError(f"Workflow run script not found: {step_name}")
+
     script_lines: list[str] = []
     for line in remainder.splitlines():
-        if line.startswith("      - name: "):
+        if line and not line.startswith("          "):
             break
-        script_lines.append(line)
-    return textwrap.dedent("\n".join(script_lines)).strip() + "\n"
+        script_lines.append(line[10:] if line else "")
+    return "\n".join(script_lines).strip() + "\n"
+
+
+def _run_git(
+    cwd: Path,
+    *arguments: str,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    environment = _isolated_git_environment()
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=cwd,
+        check=check,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+
+def _isolated_git_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    for name in tuple(environment):
+        if name.startswith("GIT_"):
+            del environment[name]
+    environment["GIT_CONFIG_NOSYSTEM"] = "1"
+    environment["GIT_CONFIG_GLOBAL"] = os.devnull
+    environment["GIT_TERMINAL_PROMPT"] = "0"
+    environment["GIT_ALLOW_PROTOCOL"] = "file"
+    return environment
+
+
+def _make_shallow_no_tags_checkout(
+    root: Path,
+    tags: tuple[str, ...],
+) -> Path:
+    source = root / "source"
+    remote = root / "remote.git"
+    checkout = root / "checkout"
+
+    _run_git(root, "init", "--initial-branch=main", str(source))
+    _run_git(
+        source,
+        "-c",
+        "user.name=GM2Godot CI",
+        "-c",
+        "user.email=ci@example.invalid",
+        "commit",
+        "--allow-empty",
+        "-m",
+        "tagged commit",
+    )
+    for tag in tags:
+        _run_git(source, "tag", tag)
+    _run_git(
+        source,
+        "-c",
+        "user.name=GM2Godot CI",
+        "-c",
+        "user.email=ci@example.invalid",
+        "commit",
+        "--allow-empty",
+        "-m",
+        "current main",
+    )
+    _run_git(root, "clone", "--bare", str(source), str(remote))
+    _run_git(
+        root,
+        "clone",
+        "--depth=1",
+        "--no-tags",
+        "--branch",
+        "main",
+        remote.resolve().as_uri(),
+        str(checkout),
+    )
+
+    shallow = _run_git(
+        checkout,
+        "rev-parse",
+        "--is-shallow-repository",
+    ).stdout.strip()
+    if shallow != "true":
+        raise AssertionError("Tag-check fixture must be a shallow checkout")
+    if _run_git(checkout, "tag", "--list").stdout:
+        raise AssertionError("Tag-check fixture unexpectedly fetched local tags")
+    tag_option = _run_git(
+        checkout,
+        "config",
+        "--get",
+        "remote.origin.tagOpt",
+    ).stdout.strip()
+    if tag_option != "--no-tags":
+        raise AssertionError("Tag-check fixture must keep remote tag fetching disabled")
+    return checkout
+
+
+def _run_release_tag_check(
+    content: str,
+    checkout: Path,
+    version: str,
+    output_path: Path,
+) -> subprocess.CompletedProcess[str]:
+    version_expression = "${{ steps.version.outputs.version }}"
+    script = _workflow_run_script(content, "Check if tag already exists")
+    if version_expression not in script:
+        raise AssertionError("Release tag-check script lost its version expression")
+    script = script.replace(version_expression, version)
+
+    output_path.write_text("", encoding="utf-8")
+    environment = _isolated_git_environment()
+    environment["GITHUB_OUTPUT"] = str(output_path)
+    return subprocess.run(
+        ["bash", "-c", script],
+        cwd=checkout,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
 
 
 def _write_raw_artifact_archive(
@@ -177,6 +299,146 @@ class TestCIWorkflows(unittest.TestCase):
             "Missing or empty verified archive: "
             "raw-artifacts/GM2Godot-macos/GM2Godot-macos.zip",
             result.stderr,
+        )
+
+    def test_release_tag_check_finds_exact_remote_tag_without_local_tags(
+        self,
+    ) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        content = workflow.read_text(encoding="utf-8")
+        tag_ref = "refs/tags/v0.7.9"
+
+        with tempfile.TemporaryDirectory() as temp_directory:
+            root = Path(temp_directory)
+            checkout = _make_shallow_no_tags_checkout(
+                root,
+                ("v0.7.9", "v0.7.90", "v0.7.9-rc1"),
+            )
+            local_tag = _run_git(
+                checkout,
+                "rev-parse",
+                "--verify",
+                tag_ref,
+                check=False,
+            )
+            remote_tag = _run_git(
+                checkout,
+                "ls-remote",
+                "--exit-code",
+                "--refs",
+                "origin",
+                tag_ref,
+                check=False,
+            )
+            output_path = root / "github-output.txt"
+            result = _run_release_tag_check(
+                content,
+                checkout,
+                "0.7.9",
+                output_path,
+            )
+
+            self.assertNotEqual(local_tag.returncode, 0)
+            self.assertEqual(remote_tag.returncode, 0, remote_tag.stderr)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(output_path.read_text(encoding="utf-8"), "exists=true\n")
+
+    def test_release_tag_check_rejects_similarly_prefixed_remote_tags(
+        self,
+    ) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        content = workflow.read_text(encoding="utf-8")
+        tag_ref = "refs/tags/v0.7.9"
+
+        with tempfile.TemporaryDirectory() as temp_directory:
+            root = Path(temp_directory)
+            checkout = _make_shallow_no_tags_checkout(
+                root,
+                ("v0.7.90", "v0.7.9-rc1"),
+            )
+            remote_tag = _run_git(
+                checkout,
+                "ls-remote",
+                "--exit-code",
+                "--refs",
+                "origin",
+                tag_ref,
+                check=False,
+            )
+            output_path = root / "github-output.txt"
+            result = _run_release_tag_check(
+                content,
+                checkout,
+                "0.7.9",
+                output_path,
+            )
+
+            self.assertEqual(remote_tag.returncode, 2, remote_tag.stderr)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(output_path.read_text(encoding="utf-8"), "exists=false\n")
+
+    def test_release_tag_check_fails_closed_for_broken_origin(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        content = workflow.read_text(encoding="utf-8")
+        tag_ref = "refs/tags/v0.7.9"
+
+        with tempfile.TemporaryDirectory() as temp_directory:
+            root = Path(temp_directory)
+            checkout = _make_shallow_no_tags_checkout(root, ("v0.7.9",))
+            missing_remote = (root / "missing.git").resolve().as_uri()
+            _run_git(checkout, "remote", "set-url", "origin", missing_remote)
+            remote_tag = _run_git(
+                checkout,
+                "ls-remote",
+                "--exit-code",
+                "--refs",
+                "origin",
+                tag_ref,
+                check=False,
+            )
+            output_path = root / "github-output.txt"
+            result = _run_release_tag_check(
+                content,
+                checkout,
+                "0.7.9",
+                output_path,
+            )
+
+            self.assertNotIn(remote_tag.returncode, (0, 2))
+            self.assertEqual(result.returncode, remote_tag.returncode)
+            self.assertEqual(output_path.read_text(encoding="utf-8"), "")
+            self.assertIn("::error::Failed to query exact remote tag", result.stderr)
+            self.assertIn(tag_ref, result.stderr)
+            self.assertIn(
+                f"git ls-remote exit {remote_tag.returncode}",
+                result.stderr,
+            )
+
+    def test_release_jobs_require_authoritative_remote_tag_absence(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        content = workflow.read_text(encoding="utf-8")
+        script = _workflow_run_script(content, "Check if tag already exists")
+        build_job = content[content.index("  build:"):content.index("  release:")]
+        release_job = content[content.index("  release:"):]
+        absence_guard = "needs.get-version.outputs.tag_exists == 'false'"
+        build_job_conditions = [
+            line for line in build_job.splitlines() if line.startswith("    if: ")
+        ]
+        release_job_conditions = [
+            line for line in release_job.splitlines() if line.startswith("    if: ")
+        ]
+
+        self.assertIn("set -euo pipefail", script)
+        self.assertIn(
+            'git ls-remote --exit-code --refs origin "$tag_ref"',
+            script,
+        )
+        self.assertIn('tag_ref="refs/tags/v${{ steps.version.outputs.version }}"', script)
+        self.assertNotIn("git rev-parse", script)
+        self.assertEqual(build_job_conditions, [f"    if: {absence_guard}"])
+        self.assertEqual(
+            release_job_conditions,
+            [f"    if: github.event_name != 'pull_request' && {absence_guard}"],
         )
 
     def test_unit_workflow_runs_discovery_for_golden_and_threshold_gates(self) -> None:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_8(self) -> None:
-        self.assertEqual(get_version(), "0.7.8")
+    def test_release_version_is_0_7_9(self) -> None:
+        self.assertEqual(get_version(), "0.7.9")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #722

## What changed

- Replaced the shallow checkout's local-only tag lookup with an authoritative, exact `git ls-remote --exit-code --refs origin refs/tags/v<version>` query.
- Treats status 0 as present, status 2 as absent, and every other remote/auth/network result as fatal.
- Requires both the build matrix and release publisher to observe `tag_exists == 'false'`.
- Added executable regression tests using depth-1/no-tag clones, exact and similarly prefixed tags, and a broken remote.
- Bumped the release to 0.7.9 and updated the canonical release/Wiki source guidance.

## Why

`actions/checkout` fetches one commit and no tags by default, so `git rev-parse v<version>` could not see an already-published remote tag. A manual dispatch or rerun could therefore rebuild and enter the release publisher for an existing version.

The new check follows the documented checkout behavior and Git's documented `ls-remote --exit-code` status contract:

- https://github.com/actions/checkout
- https://git-scm.com/docs/git-ls-remote

## Validation

- `./venv/bin/python -m unittest` — 1,902 tests, 39 expected skips
- focused workflow/version/documentation suites — 26/26
- adversarial fixture run with forced global commit/tag signing — passed
- `./venv/bin/ruff check .` — clean
- `./venv/bin/pyright --warnings` — 0 errors, 0 warnings
- checksum-verified actionlint v1.7.12 — clean
- exact Godot `4.7.1.stable.official.a13da4feb` runtime checks — 2/2
- three independent diff reviews completed; all findings resolved

## Scope boundaries and post-merge proof

The `docs/wiki/` changes update canonical sources only; the live Wiki remains uninitialized under #712. GUI title/About and CLI surfaces use 0.7.9, while native macOS `Info.plist` metadata remains separately tracked by #735.

After merge, this PR still requires live proof that v0.7.9 publishes all platform assets normally, followed by a manual dispatch proving the existing-tag path skips every build/release job and leaves asset IDs, digests, sizes, and timestamps unchanged.
