### PR TITLE
Smoke-test release actions before merge

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.11, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.12, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/.github/workflows/release-action-smoke.yml
+++ b/.github/workflows/release-action-smoke.yml
@@ -1,0 +1,180 @@
+name: Release Action Smoke
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/release.yml'
+      - '.github/workflows/release-action-smoke.yml'
+
+permissions: {}
+
+jobs:
+  upload-sentinel:
+    name: Upload deterministic sentinel
+    runs-on: ubuntu-latest
+    outputs:
+      artifact_digest: ${{ steps.upload_sentinel.outputs['artifact-digest'] }}
+    steps:
+      - name: Create sentinel
+        run: |
+          set -euo pipefail
+          mkdir -p sentinel
+          printf 'GM2Godot release action smoke\n' \
+            > sentinel/release-action-sentinel.txt
+
+      - name: Upload sentinel
+        id: upload_sentinel
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: release-action-smoke
+          path: sentinel/release-action-sentinel.txt
+          if-no-files-found: error
+          retention-days: 1
+
+  verify-sentinel:
+    name: Download and verify sentinel
+    needs: upload-sentinel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download verified sentinel archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-action-smoke
+          path: raw-artifacts/release-action-smoke
+          skip-decompress: true
+          digest-mismatch: error
+
+      - name: Verify sentinel archive and bytes
+        env:
+          EXPECTED_ARCHIVE_SHA256: ${{ needs.upload-sentinel.outputs.artifact_digest }}
+        run: |
+          set -euo pipefail
+
+          archive=raw-artifacts/release-action-smoke/release-action-smoke.zip
+          if [[ ! -s "$archive" ]]; then
+            echo "::error::Missing or empty sentinel archive: $archive" >&2
+            exit 1
+          fi
+          if [[ ! "$EXPECTED_ARCHIVE_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::Upload action returned an invalid artifact digest." >&2
+            exit 1
+          fi
+
+          actual_archive_sha256="$(sha256sum "$archive")"
+          actual_archive_sha256="${actual_archive_sha256%% *}"
+          if [[ "$actual_archive_sha256" != "$EXPECTED_ARCHIVE_SHA256" ]]; then
+            echo "::error::Downloaded archive differs from the uploaded artifact." >&2
+            exit 1
+          fi
+
+          archive_entries="$(unzip -Z1 "$archive")"
+          if [[ "$archive_entries" != "release-action-sentinel.txt" ]]; then
+            echo "::error::Unexpected sentinel archive layout: $archive_entries" >&2
+            exit 1
+          fi
+
+          unzip -p "$archive" release-action-sentinel.txt \
+            > release-action-sentinel.txt
+          printf '%s  %s\n' \
+            f1efea0ac477ea11ec0fe4d13d9bfdcc2908ed8a6e2c71b91952388c1aaf48e6 \
+            release-action-sentinel.txt \
+            | sha256sum --check --strict -
+          if ! cmp -s \
+            <(printf 'GM2Godot release action smoke\n') \
+            release-action-sentinel.txt; then
+            echo "::error::Sentinel bytes changed during the artifact round-trip." >&2
+            exit 1
+          fi
+
+  publisher-startup:
+    name: publisher-startup
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Load publisher and reject before GitHub API access
+        id: publisher_startup
+        continue-on-error: true
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        env:
+          GITHUB_TOKEN: gm2godot-release-smoke-invalid-token
+        with:
+          repository: github/gm2godot-release-smoke-never-create
+          token: gm2godot-release-smoke-invalid-token
+          tag_name: gm2godot-release-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+          files: __gm2godot_release_smoke_missing__/${{ github.run_id }}-${{ github.run_attempt }}/must-not-exist
+          fail_on_unmatched_files: true
+          overwrite_files: false
+
+      - name: Assert the publisher rejected the probe
+        if: ${{ always() }}
+        env:
+          PUBLISHER_OUTCOME: ${{ steps.publisher_startup.outcome }}
+        run: |
+          set -euo pipefail
+          if [[ "$PUBLISHER_OUTCOME" != "failure" ]]; then
+            echo "::error::Publisher unexpectedly crossed its local rejection boundary (outcome: $PUBLISHER_OUTCOME)." >&2
+            exit 1
+          fi
+
+  publisher-startup-receipt:
+    name: publisher-startup-receipt
+    if: ${{ always() }}
+    needs: publisher-startup
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+    steps:
+      - name: Verify the action-originated publisher rejection
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          EXPECTED_PATTERN: __gm2godot_release_smoke_missing__/${{ github.run_id }}-${{ github.run_attempt }}/must-not-exist
+        run: |
+          set -euo pipefail
+
+          jobs_endpoint="repos/${REPOSITORY}/actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT}/jobs?per_page=100"
+          job_ids="$(
+            gh api \
+              --method GET \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2026-03-10" \
+              "$jobs_endpoint" \
+              --jq '.jobs[] | select(.name == "publisher-startup") | .id'
+          )"
+          job_count="$(printf '%s\n' "$job_ids" | sed '/^$/d' | wc -l | tr -d '[:space:]')"
+          if [[ "$job_count" -ne 1 ]]; then
+            echo "::error::Expected exactly one publisher-startup job; found $job_count." >&2
+            exit 1
+          fi
+          job_id="$(printf '%s\n' "$job_ids" | sed -n '1p')"
+
+          log_file="$RUNNER_TEMP/publisher-startup.log"
+          downloaded=false
+          for retry in 1 2 3 4 5; do
+            if gh api \
+              --method GET \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2026-03-10" \
+              "repos/${REPOSITORY}/actions/jobs/${job_id}/logs" \
+              > "$log_file"; then
+              downloaded=true
+              break
+            fi
+            sleep 2
+          done
+          if [[ "$downloaded" != "true" ]]; then
+            echo "::error::Publisher job log was unavailable after bounded retries." >&2
+            exit 1
+          fi
+
+          if ! grep -Fq \
+            "Pattern '$EXPECTED_PATTERN' does not match any files." \
+            "$log_file"; then
+            echo "::error::The pinned action did not emit its expected startup diagnostic." >&2
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.12 - 2026-07-18
+
+- Added a pull-request-only release-action smoke that round-trips and verifies a deterministic artifact through the production pins, then proves the release publisher loaded and stopped at a credentialless pre-network boundary without changing tags or releases.
+
 ## 0.7.11 - 2026-07-18
 
 - Enabled weekly Dependabot checks for SHA-pinned GitHub Actions while preserving immutable references and their same-line release-version comments.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.11`.
+Current source version: `0.7.12`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.11 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.12 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.11 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.12 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.11 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.12 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.11 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.12 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.11 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.12 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.11;
+- GM2Godot 0.7.12;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.11 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.12 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -20,7 +20,7 @@ Download the asset for your operating system from [GitHub Releases](https://gith
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.11`.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.12`.
 
 ## Run from source
 
@@ -70,6 +70,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.11`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.12`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.11 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.12 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -15,6 +15,8 @@ Publication-capable push and manual-dispatch runs share one concurrency group ac
 When the exact remote tag is absent, the workflow uses an authenticated, paginated release query before any platform build and repeats the negative check to reduce listing-consistency risk. GitHub returns drafts only to a push-capable token, so this check runs in a separate non-PR job with `contents: write`; that job does not check out or execute repository code. Any exact-tag release object observed by those checks—including a draft, partial, or unexpectedly published release—fails closed with identifying details rather than being reused or changed automatically. An API, authentication, pagination, or response-validation failure also stops publication. Record the diagnostic and run URL, inspect the tag, release, and expected asset inventory, then have a maintainer clean up the inconsistent state explicitly before dispatching a new run. Preserve a completed release and its asset IDs and digests. If the exact remote tag already exists, the workflow remains the #722 no-op path; that path is not a complete release-integrity audit. The concurrency group serializes this workflow's publishers, not an external UI/API publisher that changes release state after the last preflight query.
 
 The release workflow is canonical at [`.github/workflows/release.yml`](https://github.com/Infiland/GM2Godot/blob/main/.github/workflows/release.yml).
+
+Pull requests that change the release workflow or its dedicated smoke workflow run [`.github/workflows/release-action-smoke.yml`](https://github.com/Infiland/GM2Godot/blob/main/.github/workflows/release-action-smoke.yml). The smoke is independent of the project version and remote tag state. It verifies a deterministic cross-job artifact round-trip through the exact production upload/download pins, starts the exact publisher pin with no write permission or usable credential, stops it locally on a guaranteed-missing file before GitHub API access, and verifies the action-originated diagnostic from a separate read-only receipt job.
 
 ## Versioned-change checklist
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.11 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.12 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.11"
+VERSION = "0.7.12"
 
 
 def get_version():

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -58,6 +59,12 @@ EXTERNAL_FIXTURE_REPOSITORIES = (
     ),
 )
 RELEASE_PREFLIGHT_TEST_TAG = "v999.123.456"
+RELEASE_SMOKE_ARTIFACT = "release-action-smoke"
+RELEASE_SMOKE_SENTINEL = "release-action-sentinel.txt"
+RELEASE_SMOKE_PAYLOAD = b"GM2Godot release action smoke\n"
+RELEASE_SMOKE_PAYLOAD_SHA256 = (
+    "f1efea0ac477ea11ec0fe4d13d9bfdcc2908ed8a6e2c71b91952388c1aaf48e6"
+)
 
 
 def _godot_env_lines(content: str) -> tuple[str, ...]:
@@ -325,6 +332,382 @@ def _write_raw_artifact_archive(
 
 
 class TestCIWorkflows(unittest.TestCase):
+    def test_release_action_smoke_is_pr_only_and_credentialless(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release-action-smoke.yml"
+        content = workflow.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "on:\n"
+            "  pull_request:\n"
+            "    branches: [main]\n"
+            "    paths:\n"
+            "      - '.github/workflows/release.yml'\n"
+            "      - '.github/workflows/release-action-smoke.yml'\n",
+            content,
+        )
+        self.assertEqual(content.count("permissions:"), 3)
+        self.assertIn("\npermissions: {}\n", content)
+        self.assertEqual(content.count("permissions: {}"), 2)
+        self.assertIn("permissions:\n      actions: read", content)
+        for forbidden in (
+            "pull_request_target:",
+            "workflow_dispatch:",
+            "schedule:",
+            "\n  push:",
+            "actions/checkout@",
+            "secrets.",
+            "contents: write",
+            "write-all",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, content)
+        self.assertNotRegex(content, r"(?im)^\s+[a-z0-9_-]+:\s+write\s*$")
+        self.assertNotRegex(content, r"\b(?:PAT|PERSONAL_ACCESS_TOKEN)\b")
+        self.assertNotRegex(content, r"(?i)\bsecrets\s*(?:\.|\[)")
+
+    def test_release_action_smoke_is_independent_of_release_state(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release-action-smoke.yml"
+        content = workflow.read_text(encoding="utf-8")
+
+        for forbidden in (
+            "src/version.py",
+            "VERSION",
+            "get-version",
+            "tag_exists",
+            "needs.get-version",
+            "git ls-remote",
+            "refs/tags/",
+            "release-state-preflight",
+            "gm2godot-release-publisher",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, content)
+        self.assertIn(
+            "tag_name: gm2godot-release-smoke-"
+            "${{ github.run_id }}-${{ github.run_attempt }}",
+            content,
+        )
+
+    def test_release_action_smoke_reuses_production_action_pins(self) -> None:
+        release = (
+            PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        ).read_text(encoding="utf-8")
+        smoke = (
+            PROJECT_ROOT / ".github" / "workflows" / "release-action-smoke.yml"
+        ).read_text(encoding="utf-8")
+
+        for action in (
+            "actions/upload-artifact",
+            "actions/download-artifact",
+            "softprops/action-gh-release",
+        ):
+            pattern = re.compile(
+                rf"uses:\s*{re.escape(action)}@([0-9a-f]{{40}})\s+#\s+(v\S+)"
+            )
+            release_pins = set(pattern.findall(release))
+            smoke_pins = pattern.findall(smoke)
+            with self.subTest(action=action):
+                self.assertEqual(len(release_pins), 1)
+                self.assertEqual(len(smoke_pins), 1)
+                self.assertEqual(smoke_pins[0], next(iter(release_pins)))
+
+    def test_release_action_smoke_verifies_sentinel_archive(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release-action-smoke.yml"
+        content = workflow.read_text(encoding="utf-8")
+        expected_archive = (
+            "raw-artifacts/release-action-smoke/release-action-smoke.zip"
+        )
+
+        for required in (
+            "id: upload_sentinel",
+            f"name: {RELEASE_SMOKE_ARTIFACT}",
+            f"path: sentinel/{RELEASE_SMOKE_SENTINEL}",
+            "if-no-files-found: error",
+            "retention-days: 1",
+            "needs: upload-sentinel",
+            "path: raw-artifacts/release-action-smoke",
+            "skip-decompress: true",
+            "digest-mismatch: error",
+            "${{ needs.upload-sentinel.outputs.artifact_digest }}",
+            expected_archive,
+            RELEASE_SMOKE_PAYLOAD_SHA256,
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, content)
+        self.assertNotIn("archive: true", content)
+
+        create_script = _workflow_run_script(content, "Create sentinel")
+        verify_script = _workflow_run_script(
+            content,
+            "Verify sentinel archive and bytes",
+        )
+        with tempfile.TemporaryDirectory() as temp_directory:
+            root = Path(temp_directory)
+            created = subprocess.run(
+                ["bash", "-c", create_script],
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(created.returncode, 0, created.stderr)
+            self.assertEqual(
+                (root / "sentinel" / RELEASE_SMOKE_SENTINEL).read_bytes(),
+                RELEASE_SMOKE_PAYLOAD,
+            )
+
+        cases = (
+            (
+                "valid",
+                {RELEASE_SMOKE_SENTINEL: RELEASE_SMOKE_PAYLOAD},
+                None,
+                0,
+                "",
+            ),
+            (
+                "wrong archive digest",
+                {RELEASE_SMOKE_SENTINEL: RELEASE_SMOKE_PAYLOAD},
+                "0" * 64,
+                1,
+                "Downloaded archive differs from the uploaded artifact",
+            ),
+            (
+                "altered sentinel bytes",
+                {RELEASE_SMOKE_SENTINEL: b"altered\n"},
+                None,
+                1,
+                "",
+            ),
+            (
+                "nested sentinel",
+                {f"nested/{RELEASE_SMOKE_SENTINEL}": RELEASE_SMOKE_PAYLOAD},
+                None,
+                1,
+                "Unexpected sentinel archive layout",
+            ),
+        )
+        for case, members, digest_override, expected_status, expected_error in cases:
+            with self.subTest(case=case):
+                with tempfile.TemporaryDirectory() as temp_directory:
+                    root = Path(temp_directory)
+                    _write_raw_artifact_archive(
+                        root,
+                        RELEASE_SMOKE_ARTIFACT,
+                        members,
+                    )
+                    archive = root / expected_archive
+                    environment = os.environ.copy()
+                    environment["EXPECTED_ARCHIVE_SHA256"] = (
+                        digest_override
+                        or hashlib.sha256(archive.read_bytes()).hexdigest()
+                    )
+                    result = subprocess.run(
+                        ["bash", "-c", verify_script],
+                        cwd=root,
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                        env=environment,
+                    )
+
+                if expected_status == 0:
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                else:
+                    self.assertNotEqual(result.returncode, 0)
+                if expected_error:
+                    self.assertIn(expected_error, result.stderr)
+
+        with tempfile.TemporaryDirectory() as temp_directory:
+            root = Path(temp_directory)
+            direct_archive = root / "raw-artifacts" / f"{RELEASE_SMOKE_ARTIFACT}.zip"
+            direct_archive.parent.mkdir(parents=True)
+            with zipfile.ZipFile(direct_archive, "w") as archive:
+                archive.writestr(RELEASE_SMOKE_SENTINEL, RELEASE_SMOKE_PAYLOAD)
+            environment = os.environ.copy()
+            environment["EXPECTED_ARCHIVE_SHA256"] = hashlib.sha256(
+                direct_archive.read_bytes()
+            ).hexdigest()
+            result = subprocess.run(
+                ["bash", "-c", verify_script],
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            f"Missing or empty sentinel archive: {expected_archive}",
+            result.stderr,
+        )
+
+    def test_release_action_smoke_requires_local_publisher_rejection(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release-action-smoke.yml"
+        content = workflow.read_text(encoding="utf-8")
+        publisher_marker = (
+            "      - name: Load publisher and reject before GitHub API access\n"
+        )
+        publisher_step = content[
+            content.index(publisher_marker):content.index(
+                "      - name: Assert the publisher rejected the probe\n"
+            )
+        ]
+
+        for required in (
+            "id: publisher_startup",
+            "continue-on-error: true",
+            "uses: softprops/action-gh-release@",
+            "GITHUB_TOKEN: gm2godot-release-smoke-invalid-token",
+            "repository: github/gm2godot-release-smoke-never-create",
+            "token: gm2godot-release-smoke-invalid-token",
+            "files: __gm2godot_release_smoke_missing__/"
+            "${{ github.run_id }}-${{ github.run_attempt }}/must-not-exist",
+            "fail_on_unmatched_files: true",
+            "overwrite_files: false",
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, publisher_step)
+        for forbidden in ("secrets.", "${{ github.token }}", "draft:"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, publisher_step)
+        self.assertEqual(content.count("continue-on-error: true"), 1)
+        self.assertIn("if: ${{ always() }}", content)
+        self.assertIn(
+            "PUBLISHER_OUTCOME: ${{ steps.publisher_startup.outcome }}",
+            content,
+        )
+        self.assertNotIn("publisher_startup.conclusion", content)
+
+        assertion_script = _workflow_run_script(
+            content,
+            "Assert the publisher rejected the probe",
+        )
+        for outcome, expected_status in (
+            ("failure", 0),
+            ("success", 1),
+            ("cancelled", 1),
+            ("", 1),
+        ):
+            with self.subTest(outcome=outcome):
+                environment = os.environ.copy()
+                environment["PUBLISHER_OUTCOME"] = outcome
+                result = subprocess.run(
+                    ["bash", "-c", assertion_script],
+                    cwd=PROJECT_ROOT,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    env=environment,
+                )
+                self.assertEqual(
+                    result.returncode == 0,
+                    expected_status == 0,
+                    result.stderr,
+                )
+
+    def test_release_action_smoke_proves_publisher_entrypoint_loaded(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release-action-smoke.yml"
+        content = workflow.read_text(encoding="utf-8")
+        receipt_job = content[content.index("  publisher-startup-receipt:"):]
+        expected_pattern = (
+            "__gm2godot_release_smoke_missing__/12345-2/must-not-exist"
+        )
+
+        for required in (
+            "name: publisher-startup-receipt",
+            "needs: publisher-startup",
+            "permissions:\n      actions: read",
+            "GH_TOKEN: ${{ github.token }}",
+            "jobs?per_page=100",
+            "select(.name == \"publisher-startup\") | .id",
+            "for retry in 1 2 3 4 5",
+            "actions/jobs/${job_id}/logs",
+            "Pattern '$EXPECTED_PATTERN' does not match any files.",
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, receipt_job)
+        for forbidden in ("contents: read", "contents: write", "actions/checkout"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, receipt_job)
+
+        script = _workflow_run_script(
+            content,
+            "Verify the action-originated publisher rejection",
+        )
+        for case, job_ids, log_text, expected_status in (
+            (
+                "action diagnostic",
+                "98765\n",
+                f"Error: Pattern '{expected_pattern}' does not match any files.\n",
+                0,
+            ),
+            (
+                "different failure",
+                "98765\n",
+                "Error: Unable to resolve action\n",
+                1,
+            ),
+            ("missing publisher job", "", "", 1),
+            ("duplicate publisher jobs", "98765\n98766\n", "", 1),
+        ):
+            with self.subTest(case=case):
+                with tempfile.TemporaryDirectory() as temp_directory:
+                    root = Path(temp_directory)
+                    tools_dir = root / "tools"
+                    tools_dir.mkdir()
+                    fake_gh = tools_dir / "gh"
+                    fake_gh.write_text(
+                        f"#!{sys.executable}\n"
+                        """import os
+import sys
+
+endpoint = next(
+    (argument for argument in sys.argv[1:] if argument.startswith("repos/")),
+    "",
+)
+if endpoint.endswith("jobs?per_page=100"):
+    print(os.environ["FAKE_JOB_IDS"], end="")
+    raise SystemExit(0)
+if endpoint.endswith("actions/jobs/98765/logs"):
+    print(os.environ["FAKE_PUBLISHER_LOG"], end="")
+    raise SystemExit(0)
+print(f"unexpected gh endpoint: {endpoint}", file=sys.stderr)
+raise SystemExit(97)
+""",
+                        encoding="utf-8",
+                    )
+                    fake_gh.chmod(0o755)
+                    environment = os.environ.copy()
+                    environment.update(
+                        {
+                            "EXPECTED_PATTERN": expected_pattern,
+                            "FAKE_JOB_IDS": job_ids,
+                            "FAKE_PUBLISHER_LOG": log_text,
+                            "GH_TOKEN": "read-only-test-token",
+                            "PATH": os.pathsep.join(
+                                (str(tools_dir), environment.get("PATH", ""))
+                            ),
+                            "REPOSITORY": "Infiland/GM2Godot",
+                            "RUN_ATTEMPT": "2",
+                            "RUN_ID": "12345",
+                            "RUNNER_TEMP": str(root),
+                        }
+                    )
+                    result = subprocess.run(
+                        ["bash", "-c", script],
+                        cwd=root,
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                        env=environment,
+                    )
+
+                self.assertEqual(
+                    result.returncode == 0,
+                    expected_status == 0,
+                    result.stderr,
+                )
+
     def test_release_preserves_digest_checks_without_deprecated_extraction(
         self,
     ) -> None:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_11(self) -> None:
-        self.assertEqual(get_version(), "0.7.11")
+    def test_release_version_is_0_7_12(self) -> None:
+        self.assertEqual(get_version(), "0.7.12")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- add a pull-request-only smoke for release workflow dependencies
- verify a deterministic cross-job artifact archive and payload through the production upload/download pins
- load the production publisher pin with zero permissions, stop before API access, and verify its exact action-originated diagnostic from a read-only receipt job
- bump GM2Godot to 0.7.12 and update versioned Wiki sources

## Validation

- 1,917 unit tests passed (39 skipped)
- 41 focused workflow, documentation, and version tests passed
- Pyright: 0 errors and 0 warnings
- Ruff: clean
- checksum-verified actionlint 1.7.12: clean
- three independent security, Actions-runtime, and test-scope reviews found no blockers

Related to #748
