### PR TITLE
Adopt verified upload-artifact v7 archives

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.12, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.13, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/.github/workflows/release-action-smoke.yml
+++ b/.github/workflows/release-action-smoke.yml
@@ -25,10 +25,11 @@ jobs:
 
       - name: Upload sentinel
         id: upload_sentinel
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-action-smoke
           path: sentinel/release-action-sentinel.txt
+          archive: true
           if-no-files-found: error
           retention-days: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,19 +246,21 @@ jobs:
 
       - name: Upload artifact
         if: matrix.name != 'macos'
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: GM2Godot-${{ matrix.name }}
           path: GM2Godot-${{ matrix.name }}.zip
+          archive: true
 
       - name: Upload macOS artifacts
         if: matrix.name == 'macos'
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: GM2Godot-${{ matrix.name }}
           path: |
             GM2Godot-${{ matrix.name }}.zip
             GM2Godot-${{ matrix.name }}.dmg
+          archive: true
 
   release:
     needs: [get-version, release-state-preflight, build]

--- a/.github/workflows/tcc-conversion-test.yml
+++ b/.github/workflows/tcc-conversion-test.yml
@@ -181,7 +181,7 @@ jobs:
 
       - name: Upload bounded current-LTS failure reports
         if: failure()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: lts-2026-fixture-reports
           path: |
@@ -192,5 +192,6 @@ jobs:
             ${{ runner.temp }}/gm2godot-lts-2026-output/*/gm2godot/conversion_attempt.json
             ${{ runner.temp }}/gm2godot-lts-2026-output/*/gm2godot/conversion_manifest.json
             ${{ runner.temp }}/gm2godot-lts-2026-output/*/gm2godot/godot_validation_report.json
+          archive: true
           if-no-files-found: ignore
           retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.13 - 2026-07-18
+
+- Upgraded archived GitHub Actions artifact transport to immutable `actions/upload-artifact` v7.0.1 across release builds, release smoke, and bounded LTS failure reports, preserving the verified nested archive layout consumed by the v8 downloader.
+
 ## 0.7.12 - 2026-07-18
 
 - Added a pull-request-only release-action smoke that round-trips and verifies a deterministic artifact through the production pins, then proves the release publisher loaded and stopped at a credentialless pre-network boundary without changing tags or releases.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.12`.
+Current source version: `0.7.13`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.12 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.13 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.12 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.13 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.12 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.13 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.12 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.13 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.12 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.13 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.12;
+- GM2Godot 0.7.13;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.12 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.13 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -20,7 +20,7 @@ Download the asset for your operating system from [GitHub Releases](https://gith
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.12`.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.13`.
 
 ## Run from source
 
@@ -70,6 +70,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.12`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.13`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.12 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.13 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.12 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.13 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.12"
+VERSION = "0.7.13"
 
 
 def get_version():

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -411,6 +411,91 @@ class TestCIWorkflows(unittest.TestCase):
                 self.assertEqual(len(smoke_pins), 1)
                 self.assertEqual(smoke_pins[0], next(iter(release_pins)))
 
+    def test_upload_artifact_calls_explicitly_preserve_archives(self) -> None:
+        uses_pattern = re.compile(
+            r"^(?P<indent> *)(?:-\s*)?(?P<key_quote>['\"]?)"
+            r"uses(?P=key_quote)\s*:\s*(?P<value>.*?)\s*$"
+        )
+        flow_uses_pattern = re.compile(
+            r"\{[^{}]*?(?:['\"]uses['\"]|uses)\s*:"
+            r"\s*(?P<value>[^,}]+)"
+        )
+        locations: list[str] = []
+        workflow_dir = PROJECT_ROOT / ".github" / "workflows"
+        workflows = (*workflow_dir.glob("*.yml"), *workflow_dir.glob("*.yaml"))
+        for workflow in sorted(workflows):
+            lines = workflow.read_text(encoding="utf-8").splitlines()
+            for index, line in enumerate(lines):
+                for flow_match in flow_uses_pattern.finditer(line):
+                    flow_value = flow_match.group("value").strip().strip("'\"")
+                    if flow_value.casefold().startswith("actions/upload-artifact@"):
+                        self.fail(
+                            f"{workflow.name}:{index + 1}: upload-artifact must "
+                            "use block style so with.archive can be verified"
+                        )
+
+                uses_match = uses_pattern.match(line)
+                if uses_match is None:
+                    continue
+                raw_value = uses_match.group("value").partition("#")[0].strip()
+                action_value = raw_value.strip("'\"")
+                if not action_value.casefold().startswith("actions/upload-artifact@"):
+                    continue
+
+                locations.append(f"{workflow.name}:{index + 1}")
+                uses_indent = len(uses_match.group("indent"))
+                step_indent = (
+                    uses_indent
+                    if line[uses_indent:].startswith("-")
+                    else uses_indent - 2
+                )
+                end = index + 1
+                while end < len(lines):
+                    candidate = lines[end]
+                    candidate_indent = len(candidate) - len(candidate.lstrip())
+                    if candidate.strip() and candidate_indent <= step_indent:
+                        break
+                    end += 1
+
+                property_indent = step_indent + 2
+                with_pattern = re.compile(
+                    rf"^ {{{property_indent}}}(?P<quote>['\"]?)"
+                    r"with(?P=quote)\s*:\s*(?:#.*)?$"
+                )
+                with_index = next(
+                    (
+                        candidate_index
+                        for candidate_index in range(index + 1, end)
+                        if with_pattern.match(lines[candidate_index])
+                    ),
+                    None,
+                )
+                archive_inputs: list[str] = []
+                if with_index is not None:
+                    input_indent = property_indent + 2
+                    with_end = with_index + 1
+                    while with_end < end:
+                        candidate = lines[with_end]
+                        candidate_indent = len(candidate) - len(candidate.lstrip())
+                        if candidate.strip() and candidate_indent <= property_indent:
+                            break
+                        with_end += 1
+                    archive_pattern = re.compile(
+                        rf"^ {{{input_indent}}}(?P<quote>['\"]?)"
+                        r"archive(?P=quote)\s*:\s*"
+                        r"(?P<value>[^#]*?)\s*(?:#.*)?$"
+                    )
+                    for candidate in lines[with_index + 1:with_end]:
+                        archive_match = archive_pattern.match(candidate)
+                        if archive_match is not None:
+                            archive_inputs.append(
+                                archive_match.group("value").strip().strip("'\"").casefold()
+                            )
+                with self.subTest(location=locations[-1]):
+                    self.assertEqual(archive_inputs, ["true"])
+
+        self.assertEqual(len(locations), 4, locations)
+
     def test_release_action_smoke_verifies_sentinel_archive(self) -> None:
         workflow = PROJECT_ROOT / ".github" / "workflows" / "release-action-smoke.yml"
         content = workflow.read_text(encoding="utf-8")
@@ -423,6 +508,7 @@ class TestCIWorkflows(unittest.TestCase):
             f"name: {RELEASE_SMOKE_ARTIFACT}",
             f"path: sentinel/{RELEASE_SMOKE_SENTINEL}",
             "if-no-files-found: error",
+            "archive: true",
             "retention-days: 1",
             "needs: upload-sentinel",
             "path: raw-artifacts/release-action-smoke",
@@ -434,8 +520,6 @@ class TestCIWorkflows(unittest.TestCase):
         ):
             with self.subTest(required=required):
                 self.assertIn(required, content)
-        self.assertNotIn("archive: true", content)
-
         create_script = _workflow_run_script(content, "Create sentinel")
         verify_script = _workflow_run_script(
             content,
@@ -1494,6 +1578,7 @@ raise SystemExit(97)
 
         self.assertIn("if: failure()", upload_step)
         self.assertIn("uses: actions/upload-artifact@", upload_step)
+        self.assertIn("archive: true", upload_step)
         self.assertIn("if-no-files-found: ignore", upload_step)
         self.assertIn("retention-days: 7", upload_step)
         for report_name in (

--- a/tests/test_documentation_health.py
+++ b/tests/test_documentation_health.py
@@ -48,7 +48,7 @@ APPROVED_NODE24_ACTION_MAJORS = {
     "actions/checkout": 5,
     "actions/setup-python": 6,
     "actions/cache": 5,
-    "actions/upload-artifact": 6,
+    "actions/upload-artifact": 7,
     "actions/download-artifact": 8,
     "softprops/action-gh-release": 3,
 }
@@ -304,7 +304,7 @@ class TestDocumentationHealth(unittest.TestCase):
                     self.assertIsNotNone(
                         approved_major,
                         f"{location}: review this action's runtime and add "
-                        "its smallest Node-24-native major to "
+                        "its reviewed Node-24-native major to "
                         "APPROVED_NODE24_ACTION_MAJORS",
                     )
                 if approved_major is None:
@@ -314,7 +314,7 @@ class TestDocumentationHealth(unittest.TestCase):
                     self.assertEqual(
                         int(pin_match.group("major")),
                         approved_major,
-                        f"{location}: use the approved smallest "
+                        f"{location}: use the approved "
                         f"Node-24-native major v{approved_major}",
                     )
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_12(self) -> None:
-        self.assertEqual(get_version(), "0.7.12")
+    def test_release_version_is_0_7_13(self) -> None:
+        self.assertEqual(get_version(), "0.7.13")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- move all four upload-artifact call sites to immutable v7.0.1
- make `archive: true` explicit for release, smoke, and bounded LTS-report artifacts
- record major 7 as the reviewed Node 24 policy and harden direct `with.archive` coverage
- bump GM2Godot to 0.7.13

## Validation

- 1,918 unit tests passed (39 skipped)
- 42 focused workflow, documentation, and version tests passed
- Pyright: 0 errors and 0 warnings
- Ruff: clean
- checksum-verified actionlint 1.7.12: clean
- three upstream/repository/Dependabot design reviews and three post-implementation reviews completed; all blockers resolved

Closes #750
Supersedes #745
Related: #748
