### PR TITLE
Publish verified release checksum manifest

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.13, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.14, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,6 +292,49 @@ jobs:
             unzip -q "$archive" -d "artifacts/$name"
           done
 
+      - name: Generate SHA256SUMS
+        shell: bash
+        run: |
+          set -euo pipefail
+          export LC_ALL=C
+
+          payloads=(
+            "artifacts/GM2Godot-linux/GM2Godot-linux.zip"
+            "artifacts/GM2Godot-macos/GM2Godot-macos.dmg"
+            "artifacts/GM2Godot-macos/GM2Godot-macos.zip"
+            "artifacts/GM2Godot-windows/GM2Godot-windows.zip"
+          )
+          if ! command -v sha256sum >/dev/null 2>&1; then
+            echo "::error::Required checksum tool is unavailable: sha256sum" >&2
+            exit 1
+          fi
+          for payload in "${payloads[@]}"; do
+            if [[ ! -f "$payload" || -L "$payload" || ! -s "$payload" ]]; then
+              echo "::error::Missing, non-regular, symlinked, or empty release payload: $payload" >&2
+              exit 1
+            fi
+          done
+
+          manifest_path="artifacts/SHA256SUMS"
+          if [[ -e "$manifest_path" || -L "$manifest_path" ]]; then
+            echo "::error::Checksum manifest path already exists: $manifest_path" >&2
+            exit 1
+          fi
+          manifest_tmp="$(mktemp "artifacts/.SHA256SUMS.XXXXXX")"
+          trap '[[ -z "$manifest_tmp" ]] || rm -f -- "$manifest_tmp"' EXIT
+          for payload in "${payloads[@]}"; do
+            digest_line="$(sha256sum -- "$payload")"
+            digest="${digest_line%% *}"
+            if [[ ! "$digest" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "::error::sha256sum returned an invalid digest for $payload" >&2
+              exit 1
+            fi
+            printf '%s  %s\n' "$digest" "${payload##*/}" >> "$manifest_tmp"
+          done
+          mv -- "$manifest_tmp" "$manifest_path"
+          manifest_tmp=""
+          trap - EXIT
+
       - name: Create release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
@@ -304,3 +347,4 @@ jobs:
             artifacts/GM2Godot-macos/GM2Godot-macos.zip
             artifacts/GM2Godot-macos/GM2Godot-macos.dmg
             artifacts/GM2Godot-linux/GM2Godot-linux.zip
+            artifacts/SHA256SUMS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.14 - 2026-07-18
+
+- Added a deterministic `SHA256SUMS` release asset for the four final platform payloads, with fail-closed file validation and executable manifest regression coverage.
+
 ## 0.7.13 - 2026-07-18
 
 - Upgraded archived GitHub Actions artifact transport to immutable `actions/upload-artifact` v7.0.1 across release builds, release smoke, and bounded LTS failure reports, preserving the verified nested archive layout consumed by the v8 downloader.

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.13`.
+Current source version: `0.7.14`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
+Releases starting with 0.7.14 include `SHA256SUMS` for the four platform payloads so downloaded bytes can be checked independently.
 
 To build a local macOS distributable (`.app` + `.dmg`), run `bash build_macos.sh` from the project root.
 

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.13 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.14 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.13 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.14 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.13 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.14 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.13 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.14 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.13 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.14 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.13;
+- GM2Godot 0.7.14;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.13 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.14 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -18,9 +18,23 @@ Download the asset for your operating system from [GitHub Releases](https://gith
 | macOS | `GM2Godot-macos.dmg` or `GM2Godot-macos.zip` | Open the DMG and copy `GM2Godot.app` to Applications, or extract the ZIP and launch the app. |
 | Linux | `GM2Godot-linux.zip` | Extract the archive and run `./GM2Godot`. If the executable bit was lost during download or extraction, run `chmod +x GM2Godot` once. |
 
+### Verify a release download
+
+Releases starting with 0.7.14 include `SHA256SUMS`, with one SHA-256 digest for each of the four platform payloads. To verify the complete release, download all four payloads and `SHA256SUMS` into one directory, then run one of these commands from that directory:
+
+```bash
+# Linux
+sha256sum --check --strict SHA256SUMS
+
+# macOS
+shasum -a 256 -c SHA256SUMS
+```
+
+On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in PowerShell and compare the result with the named `GM2Godot-windows.zip` line in `SHA256SUMS`. The manifest verifies the integrity of the published bytes; it is not a signature or proof of publisher identity.
+
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.13`.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.14`.
 
 ## Run from source
 
@@ -70,6 +84,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.13`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.14`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.13 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.14 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -8,7 +8,7 @@ This page documents the current maintainer path for a versioned release and for 
 
 ## Release model
 
-`src/version.py` is the release trigger and source version. A pull request that changes it starts cross-platform artifact builds; the merged change starts the `Build and Release` workflow on `main`. The workflow builds Linux, macOS, and Windows archives, creates the macOS DMG, and publishes the GitHub release/tag. Every new release must use a new version.
+`src/version.py` is the release trigger and source version. A pull request that changes it starts cross-platform artifact builds; the merged change starts the `Build and Release` workflow on `main`. The workflow builds Linux, macOS, and Windows archives, creates the macOS DMG, generates `SHA256SUMS` from those four final payloads, and publishes all five assets with the GitHub release/tag. Every new release must use a new version.
 
 Publication-capable push and manual-dispatch runs share one concurrency group across refs, covering the exact remote-tag check, builds, and publication. Pull-request validation remains independent. The active publisher is not cancelled and one additional publisher may remain pending; GitHub's default concurrency behavior can replace that pending run if a third publisher arrives, and it does not guarantee FIFO ordering. When the surviving waiter starts, it rechecks the exact remote tag. A present tag makes the run an intentional no-op; an absent tag after a clean prepublication failure lets it try the normal build and publication path. The release action is also configured not to overwrite same-named asset collisions.
 
@@ -41,7 +41,8 @@ Before merging:
 After merging:
 
 - [ ] Confirm the tag points to the intended `main` commit.
-- [ ] Confirm the release is neither draft nor prerelease and all expected assets are present.
+- [ ] Confirm the release is neither draft nor prerelease and has exactly five unique, non-empty assets: the four platform payloads and `SHA256SUMS`.
+- [ ] Download all five assets, run `sha256sum --check --strict SHA256SUMS`, and confirm each payload digest also matches the hexadecimal value after the `sha256:` prefix in GitHub's `assets[].digest` field.
 - [ ] Confirm post-merge tests, exact-LTS conversions, Godot smoke, and release jobs pass.
 - [ ] If `docs/wiki/` changed, publish the exact merged pages and verify the live Wiki before closing the documentation issue. Record the merged source SHA and published Wiki SHA on the issue before closing it.
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.13 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.14 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.13"
+VERSION = "0.7.14"
 
 
 def get_version():

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -65,6 +65,12 @@ RELEASE_SMOKE_PAYLOAD = b"GM2Godot release action smoke\n"
 RELEASE_SMOKE_PAYLOAD_SHA256 = (
     "f1efea0ac477ea11ec0fe4d13d9bfdcc2908ed8a6e2c71b91952388c1aaf48e6"
 )
+RELEASE_PAYLOADS = (
+    ("artifacts/GM2Godot-linux/GM2Godot-linux.zip", b"linux payload\n"),
+    ("artifacts/GM2Godot-macos/GM2Godot-macos.dmg", b"macOS DMG payload\n"),
+    ("artifacts/GM2Godot-macos/GM2Godot-macos.zip", b"macOS ZIP payload\n"),
+    ("artifacts/GM2Godot-windows/GM2Godot-windows.zip", b"windows payload\n"),
+)
 
 
 def _godot_env_lines(content: str) -> tuple[str, ...]:
@@ -329,6 +335,13 @@ def _write_raw_artifact_archive(
     ) as archive:
         for member_name, payload in members.items():
             archive.writestr(member_name, payload)
+
+
+def _write_release_payloads(root: Path) -> None:
+    for relative_path, payload in RELEASE_PAYLOADS:
+        destination = root / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(payload)
 
 
 class TestCIWorkflows(unittest.TestCase):
@@ -874,6 +887,264 @@ raise SystemExit(97)
             "raw-artifacts/GM2Godot-macos/GM2Godot-macos.zip",
             result.stderr,
         )
+
+    def test_release_generates_portable_sha256_manifest(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        content = workflow.read_text(encoding="utf-8")
+        script = _workflow_run_script(content, "Generate SHA256SUMS")
+        create_release_step = content[
+            content.index("      - name: Create release\n"):
+        ]
+
+        expected_lines = [
+            f"{hashlib.sha256(payload).hexdigest()}  {Path(relative_path).name}\n"
+            for relative_path, payload in RELEASE_PAYLOADS
+        ]
+        with tempfile.TemporaryDirectory() as temp_directory:
+            root = Path(temp_directory)
+            _write_release_payloads(root)
+
+            result = subprocess.run(
+                ["/bin/bash", "-c", script],
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            manifest = root / "artifacts" / "SHA256SUMS"
+            self.assertEqual(
+                manifest.read_bytes(),
+                "".join(expected_lines).encode("ascii"),
+            )
+
+            verification_root = root / "downloaded-release"
+            verification_root.mkdir()
+            for relative_path, _ in RELEASE_PAYLOADS:
+                source = root / relative_path
+                (verification_root / source.name).write_bytes(source.read_bytes())
+            (verification_root / manifest.name).write_bytes(manifest.read_bytes())
+            verification_commands = {
+                "linux": [
+                    "sha256sum",
+                    "--check",
+                    "--strict",
+                    manifest.name,
+                ],
+                "darwin": [
+                    "shasum",
+                    "-a",
+                    "256",
+                    "-c",
+                    manifest.name,
+                ],
+            }
+            verification_command = verification_commands.get(sys.platform)
+            if verification_command is not None:
+                verification = subprocess.run(
+                    verification_command,
+                    cwd=verification_root,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(verification.returncode, 0, verification.stderr)
+
+        self.assertLess(
+            content.index("      - name: Generate SHA256SUMS\n"),
+            content.index("      - name: Create release\n"),
+        )
+        files_marker = "          files: |\n"
+        _, separator, files_remainder = create_release_step.partition(files_marker)
+        self.assertTrue(separator)
+        release_files: list[str] = []
+        for line in files_remainder.splitlines():
+            if not line.startswith("            "):
+                break
+            release_files.append(line.strip())
+        self.assertEqual(
+            release_files,
+            [
+                "artifacts/GM2Godot-windows/GM2Godot-windows.zip",
+                "artifacts/GM2Godot-macos/GM2Godot-macos.zip",
+                "artifacts/GM2Godot-macos/GM2Godot-macos.dmg",
+                "artifacts/GM2Godot-linux/GM2Godot-linux.zip",
+                "artifacts/SHA256SUMS",
+            ],
+        )
+
+    def test_release_checksum_manifest_rejects_invalid_payloads(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        content = workflow.read_text(encoding="utf-8")
+        script = _workflow_run_script(content, "Generate SHA256SUMS")
+        invalid_cases = [
+            (Path(relative_path), invalid_kind)
+            for relative_path, _ in RELEASE_PAYLOADS
+            for invalid_kind in ("missing", "empty")
+        ]
+        invalid_cases.extend(
+            (
+                (Path(RELEASE_PAYLOADS[1][0]), "directory"),
+                (Path(RELEASE_PAYLOADS[1][0]), "symlink"),
+            )
+        )
+
+        for invalid_path, invalid_kind in invalid_cases:
+            if invalid_kind == "symlink" and os.name == "nt":
+                continue
+            with self.subTest(
+                invalid_path=invalid_path.as_posix(),
+                invalid_kind=invalid_kind,
+            ):
+                with tempfile.TemporaryDirectory() as temp_directory:
+                    root = Path(temp_directory)
+                    _write_release_payloads(root)
+                    target = root / invalid_path
+                    target.unlink()
+                    if invalid_kind == "empty":
+                        target.touch()
+                    elif invalid_kind == "directory":
+                        target.mkdir()
+                    elif invalid_kind == "symlink":
+                        referent = root / "symlink-referent"
+                        referent.write_bytes(b"not an accepted direct payload\n")
+                        target.symlink_to(referent)
+
+                    result = subprocess.run(
+                        ["/bin/bash", "-c", script],
+                        cwd=root,
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                    )
+
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(
+                        "Missing, non-regular, symlinked, or empty release "
+                        f"payload: {invalid_path.as_posix()}",
+                        result.stderr,
+                    )
+                    self.assertFalse((root / "artifacts" / "SHA256SUMS").exists())
+
+    def test_release_checksum_manifest_rejects_existing_destination(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        content = workflow.read_text(encoding="utf-8")
+        script = _workflow_run_script(content, "Generate SHA256SUMS")
+
+        with tempfile.TemporaryDirectory() as temp_directory:
+            root = Path(temp_directory)
+            _write_release_payloads(root)
+            manifest = root / "artifacts" / "SHA256SUMS"
+            manifest.write_bytes(b"preserve this unexpected file\n")
+
+            result = subprocess.run(
+                ["/bin/bash", "-c", script],
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "Checksum manifest path already exists: artifacts/SHA256SUMS",
+                result.stderr,
+            )
+            self.assertEqual(
+                manifest.read_bytes(),
+                b"preserve this unexpected file\n",
+            )
+
+    def test_release_checksum_manifest_rejects_malformed_digest_output(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        content = workflow.read_text(encoding="utf-8")
+        script = _workflow_run_script(content, "Generate SHA256SUMS")
+
+        with tempfile.TemporaryDirectory() as temp_directory:
+            root = Path(temp_directory)
+            _write_release_payloads(root)
+            tools_dir = root / "tools"
+            tools_dir.mkdir()
+            fake_sha256sum = tools_dir / "sha256sum"
+            fake_sha256sum.write_text(
+                "#!/bin/sh\nprintf 'not-a-digest  %s\\n' \"$2\"\n",
+                encoding="utf-8",
+            )
+            fake_sha256sum.chmod(0o755)
+            environment = os.environ.copy()
+            environment["PATH"] = os.pathsep.join(
+                (str(tools_dir), environment.get("PATH", ""))
+            )
+
+            result = subprocess.run(
+                ["/bin/bash", "-c", script],
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "sha256sum returned an invalid digest for "
+                "artifacts/GM2Godot-linux/GM2Godot-linux.zip",
+                result.stderr,
+            )
+            self.assertFalse((root / "artifacts" / "SHA256SUMS").exists())
+
+    def test_release_checksum_manifest_cleans_up_after_hash_failure(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        content = workflow.read_text(encoding="utf-8")
+        script = _workflow_run_script(content, "Generate SHA256SUMS")
+
+        with tempfile.TemporaryDirectory() as temp_directory:
+            root = Path(temp_directory)
+            _write_release_payloads(root)
+            tools_dir = root / "tools"
+            tools_dir.mkdir()
+            fake_sha256sum = tools_dir / "sha256sum"
+            fake_sha256sum.write_text(
+                "#!/bin/sh\n"
+                "count=0\n"
+                "if [ -f \"$FAKE_SHA256SUM_CALLS\" ]; then\n"
+                "  read -r count < \"$FAKE_SHA256SUM_CALLS\" || true\n"
+                "fi\n"
+                "count=$((count + 1))\n"
+                "printf '%s\\n' \"$count\" > \"$FAKE_SHA256SUM_CALLS\"\n"
+                "printf '%064d  %s\\n' 0 \"$2\"\n"
+                "if [ \"$count\" -eq 2 ]; then\n"
+                "  exit 73\n"
+                "fi\n",
+                encoding="utf-8",
+            )
+            fake_sha256sum.chmod(0o755)
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "FAKE_SHA256SUM_CALLS": str(root / "sha256sum-calls"),
+                    "PATH": os.pathsep.join(
+                        (str(tools_dir), environment.get("PATH", ""))
+                    ),
+                }
+            )
+
+            result = subprocess.run(
+                ["/bin/bash", "-c", script],
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+
+            self.assertEqual(result.returncode, 73, result.stderr)
+            self.assertFalse((root / "artifacts" / "SHA256SUMS").exists())
+            self.assertEqual(
+                list((root / "artifacts").glob(".SHA256SUMS.*")),
+                [],
+            )
 
     def test_release_tag_check_finds_exact_remote_tag_without_local_tags(
         self,

--- a/tests/test_documentation_health.py
+++ b/tests/test_documentation_health.py
@@ -143,6 +143,12 @@ class TestDocumentationHealth(unittest.TestCase):
         contributing = (PROJECT_ROOT / "CONTRIBUTING.md").read_text(
             encoding="utf-8"
         )
+        installation = (WIKI_SOURCE_DIR / "Installation.md").read_text(
+            encoding="utf-8"
+        )
+        release_maintenance = (
+            WIKI_SOURCE_DIR / "Maintainer-Release-and-Wiki.md"
+        ).read_text(encoding="utf-8")
         maintenance = (PROJECT_ROOT / "docs" / "WIKI_MAINTENANCE.md").read_text(
             encoding="utf-8"
         )
@@ -157,6 +163,20 @@ class TestDocumentationHealth(unittest.TestCase):
         self.assertNotIn("modern_widgets.py", contributing)
         self.assertNotIn("Add community links", readme + contributing)
         self.assertNotIn("Add link if available", readme + contributing)
+        self.assertIn(
+            "Releases starting with 0.7.14 include `SHA256SUMS`",
+            readme,
+        )
+        self.assertIn(
+            "sha256sum --check --strict SHA256SUMS",
+            installation,
+        )
+        self.assertIn("not a signature or proof of publisher identity", installation)
+        self.assertIn("exactly five unique, non-empty assets", release_maintenance)
+        self.assertIn(
+            "after the `sha256:` prefix in GitHub's `assets[].digest` field",
+            release_maintenance,
+        )
         self.assertIn("docs/wiki/", maintenance)
         self.assertIn("merged main-repository SHA", maintenance)
         self.assertIn("must not auto-close", maintenance)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_13(self) -> None:
-        self.assertEqual(get_version(), "0.7.13")
+    def test_release_version_is_0_7_14(self) -> None:
+        self.assertEqual(get_version(), "0.7.14")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- generate a deterministic `SHA256SUMS` from the four final extracted platform payloads before publication
- fail closed for missing, empty, non-regular, symlinked, pre-existing, or invalidly hashed release inputs
- publish the manifest exactly once as the fifth release asset and document portable verification
- execute the embedded workflow script against success and hostile fixtures
- bump GM2Godot to 0.7.14

## Validation

- 1,923 unit tests passed (39 skipped)
- 34 focused workflow tests passed
- Pyright: 0 errors and 0 warnings
- Ruff: clean
- checksum-verified actionlint 1.7.12: clean
- three independent design/diff reviews completed; all blockers resolved

Closes #734
Unblocks #740
Related: #750, #752