### PR TITLE
Validate release artifact ZIP members

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.14, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.15, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,16 +279,175 @@ jobs:
           digest-mismatch: error
 
       - name: Extract verified artifact archives
+        shell: bash
         run: |
           set -euo pipefail
-          mkdir -p artifacts
+          if [[ -e artifacts || -L artifacts ]]; then
+            echo "::error::Release extraction root already exists: artifacts" >&2
+            exit 1
+          fi
           for name in GM2Godot-windows GM2Godot-macos GM2Godot-linux; do
             archive="raw-artifacts/$name/$name.zip"
-            if [[ ! -s "$archive" ]]; then
-              echo "::error::Missing or empty verified archive: $archive" >&2
+            if [[ ! -f "$archive" || -L "$archive" || ! -s "$archive" ]]; then
+              echo "::error::Missing, non-regular, symlinked, or empty verified archive: $archive" >&2
               exit 1
             fi
-            mkdir -p "artifacts/$name"
+          done
+
+          python3 - <<'PY'
+          from collections import Counter
+          from pathlib import Path, PurePosixPath, PureWindowsPath
+          import stat
+          import struct
+          import sys
+          import zipfile
+
+          local_header_struct = struct.Struct("<IHHHHHIIIHH")
+          local_header_signature = 0x04034B50
+          expected_by_artifact = {
+              "GM2Godot-windows": ("GM2Godot-windows.zip",),
+              "GM2Godot-macos": (
+                  "GM2Godot-macos.zip",
+                  "GM2Godot-macos.dmg",
+              ),
+              "GM2Godot-linux": ("GM2Godot-linux.zip",),
+          }
+
+
+          def fail(message: str) -> None:
+              print(f"::error::{message}", file=sys.stderr)
+              raise SystemExit(1)
+
+
+          for artifact_name, expected_members in expected_by_artifact.items():
+              archive_path = (
+                  Path("raw-artifacts")
+                  / artifact_name
+                  / f"{artifact_name}.zip"
+              )
+              try:
+                  with zipfile.ZipFile(archive_path) as archive:
+                      members = archive.infolist()
+                      for member in members:
+                          member_name = member.orig_filename
+                          if member.extra:
+                              fail(
+                                  "Unsupported archive member metadata in "
+                                  f"{archive_path}: {member_name!r} has "
+                                  "ZIP extra fields"
+                              )
+
+                          posix_path = PurePosixPath(member_name)
+                          windows_path = PureWindowsPath(member_name)
+                          if (
+                              member_name != member.filename
+                              or not member_name
+                              or "\\" in member_name
+                              or posix_path.is_absolute()
+                              or windows_path.is_absolute()
+                              or bool(windows_path.drive)
+                              or member_name != posix_path.name
+                              or member_name in {".", ".."}
+                          ):
+                              fail(
+                                  f"Unsafe archive member in {archive_path}: "
+                                  f"{member_name!r}"
+                              )
+
+                          unix_mode = (member.external_attr >> 16) & 0xFFFF
+                          if (
+                              member.create_system != 3
+                              or member.is_dir()
+                              or bool(member.external_attr & 0x10)
+                              or not stat.S_ISREG(unix_mode)
+                          ):
+                              fail(
+                                  "Non-regular archive member in "
+                                  f"{archive_path}: {member_name!r} "
+                                  f"(create_system={member.create_system}, "
+                                  f"mode={unix_mode:#o})"
+                              )
+
+                      actual_counts = Counter(
+                          member.orig_filename for member in members
+                      )
+                      expected_counts = Counter(expected_members)
+                      if actual_counts != expected_counts:
+                          fail(
+                              f"Unexpected archive members in {archive_path}: "
+                              f"expected {list(expected_members)!r}, "
+                              "found "
+                              f"{[member.orig_filename for member in members]!r}"
+                          )
+
+                      for member in members:
+                          archive_file = archive.fp
+                          if archive_file is None:
+                              fail(f"Verified archive closed unexpectedly: {archive_path}")
+                          archive_file.seek(member.header_offset)
+                          local_header = archive_file.read(local_header_struct.size)
+                          if len(local_header) != local_header_struct.size:
+                              fail(
+                                  "Cannot read local member metadata in "
+                                  f"{archive_path}: {member.orig_filename!r}"
+                              )
+                          local_fields = local_header_struct.unpack(local_header)
+                          local_signature = local_fields[0]
+                          local_flags = local_fields[2]
+                          local_compression = local_fields[3]
+                          local_name_length = local_fields[-2]
+                          local_extra_length = local_fields[-1]
+                          local_name = archive_file.read(local_name_length)
+                          local_extra = archive_file.read(local_extra_length)
+                          encoding = (
+                              "utf-8" if member.flag_bits & 0x800 else "cp437"
+                          )
+                          expected_local_name = member.orig_filename.encode(encoding)
+                          if (
+                              local_signature != local_header_signature
+                              or len(local_name) != local_name_length
+                              or len(local_extra) != local_extra_length
+                              or local_flags != member.flag_bits
+                              or local_compression != member.compress_type
+                              or local_name != expected_local_name
+                          ):
+                              fail(
+                                  "Inconsistent local member metadata in "
+                                  f"{archive_path}: {member.orig_filename!r}"
+                              )
+                          if local_extra:
+                              fail(
+                                  "Unsupported archive member metadata in "
+                                  f"{archive_path}: {member.orig_filename!r} has "
+                                  "local ZIP extra fields"
+                              )
+                          with archive.open(member):
+                              pass
+              except (
+                  OSError,
+                  RuntimeError,
+                  UnicodeError,
+                  NotImplementedError,
+                  zipfile.BadZipFile,
+              ) as error:
+                  fail(
+                      "Cannot read verified archive metadata for "
+                      f"{archive_path}: {error}"
+                  )
+          PY
+
+          mkdir -- artifacts
+          for name in GM2Godot-windows GM2Godot-macos GM2Godot-linux; do
+            destination="artifacts/$name"
+            mkdir -- "$destination"
+            if [[ ! -d "$destination" || -L "$destination" ]]; then
+              echo "::error::Unsafe release extraction directory: $destination" >&2
+              exit 1
+            fi
+          done
+
+          for name in GM2Godot-windows GM2Godot-macos GM2Godot-linux; do
+            archive="raw-artifacts/$name/$name.zip"
             unzip -q "$archive" -d "artifacts/$name"
           done
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.15 - 2026-07-18
+
+- Validated every release artifact ZIP member table against exact flat regular-file allowlists before extraction, rejecting unsafe or alternate-path metadata, duplicate, extra, symlink, directory, and special-file entries while preserving the verified payload bytes.
+
 ## 0.7.14 - 2026-07-18
 
 - Added a deterministic `SHA256SUMS` release asset for the four final platform payloads, with fail-closed file validation and executable manifest regression coverage.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.14`.
+Current source version: `0.7.15`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 Releases starting with 0.7.14 include `SHA256SUMS` for the four platform payloads so downloaded bytes can be checked independently.

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.14 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.15 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.14 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.15 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.14 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.15 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.14 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.15 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.14 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.15 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.14;
+- GM2Godot 0.7.15;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.14 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.15 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 
@@ -34,7 +34,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.14`.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.15`.
 
 ## Run from source
 
@@ -84,6 +84,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.14`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.15`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.14 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.15 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.14 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.15 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-18
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.14"
+VERSION = "0.7.15"
 
 
 def get_version():

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 import hashlib
 import json
 import os
 import re
+import stat
 import subprocess
 import sys
 import tempfile
 import unittest
+import warnings
 import zipfile
+import zlib
 from pathlib import Path
 
 
@@ -71,6 +75,14 @@ RELEASE_PAYLOADS = (
     ("artifacts/GM2Godot-macos/GM2Godot-macos.zip", b"macOS ZIP payload\n"),
     ("artifacts/GM2Godot-windows/GM2Godot-windows.zip", b"windows payload\n"),
 )
+RELEASE_ARCHIVE_MEMBERS = {
+    "GM2Godot-windows": (("GM2Godot-windows.zip", b"windows"),),
+    "GM2Godot-macos": (
+        ("GM2Godot-macos.dmg", b"macos-dmg"),
+        ("GM2Godot-macos.zip", b"macos-zip"),
+    ),
+    "GM2Godot-linux": (("GM2Godot-linux.zip", b"linux"),),
+}
 
 
 def _godot_env_lines(content: str) -> tuple[str, ...]:
@@ -324,7 +336,7 @@ raise SystemExit(int(os.environ["FAKE_GH_EXIT"]))
 def _write_raw_artifact_archive(
     root: Path,
     artifact_name: str,
-    members: dict[str, bytes],
+    members: Sequence[tuple[str | zipfile.ZipInfo, bytes]],
 ) -> None:
     artifact_dir = root / "raw-artifacts" / artifact_name
     artifact_dir.mkdir(parents=True)
@@ -333,8 +345,62 @@ def _write_raw_artifact_archive(
         "w",
         compression=zipfile.ZIP_DEFLATED,
     ) as archive:
-        for member_name, payload in members.items():
-            archive.writestr(member_name, payload)
+        for member_name, payload in members:
+            if isinstance(member_name, str):
+                member = zipfile.ZipInfo(member_name)
+                member.create_system = 3
+                member.external_attr = (stat.S_IFREG | 0o644) << 16
+                member.compress_type = zipfile.ZIP_DEFLATED
+            else:
+                member = member_name
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message=r"Duplicate name: .*",
+                    category=UserWarning,
+                )
+                archive.writestr(member, payload)
+
+
+def _strip_central_extra_field(archive_path: Path) -> None:
+    data = bytearray(archive_path.read_bytes())
+    central_offset = data.index(b"PK\x01\x02")
+    name_length = int.from_bytes(data[central_offset + 28 : central_offset + 30], "little")
+    extra_length = int.from_bytes(data[central_offset + 30 : central_offset + 32], "little")
+    if extra_length == 0:
+        raise AssertionError("test archive has no central extra field to strip")
+
+    extra_offset = central_offset + 46 + name_length
+    del data[extra_offset : extra_offset + extra_length]
+    data[central_offset + 30 : central_offset + 32] = b"\0\0"
+    end_offset = data.index(b"PK\x05\x06", central_offset)
+    central_size = int.from_bytes(data[end_offset + 12 : end_offset + 16], "little")
+    data[end_offset + 12 : end_offset + 16] = (central_size - extra_length).to_bytes(
+        4,
+        "little",
+    )
+    archive_path.write_bytes(data)
+
+
+def _fake_unzip_environment(root: Path) -> tuple[dict[str, str], Path]:
+    tools_dir = root / "tools"
+    tools_dir.mkdir()
+    call_log = root / "unzip-calls.log"
+    fake_unzip = tools_dir / "unzip"
+    fake_unzip.write_text(
+        "#!/bin/sh\n"
+        'printf "%s\\n" "$*" >> "$FAKE_UNZIP_CALL_LOG"\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_unzip.chmod(0o755)
+
+    environment = os.environ.copy()
+    environment["FAKE_UNZIP_CALL_LOG"] = str(call_log)
+    environment["PATH"] = os.pathsep.join(
+        (str(tools_dir), environment.get("PATH", ""))
+    )
+    return environment, call_log
 
 
 def _write_release_payloads(root: Path) -> None:
@@ -556,28 +622,28 @@ class TestCIWorkflows(unittest.TestCase):
         cases = (
             (
                 "valid",
-                {RELEASE_SMOKE_SENTINEL: RELEASE_SMOKE_PAYLOAD},
+                ((RELEASE_SMOKE_SENTINEL, RELEASE_SMOKE_PAYLOAD),),
                 None,
                 0,
                 "",
             ),
             (
                 "wrong archive digest",
-                {RELEASE_SMOKE_SENTINEL: RELEASE_SMOKE_PAYLOAD},
+                ((RELEASE_SMOKE_SENTINEL, RELEASE_SMOKE_PAYLOAD),),
                 "0" * 64,
                 1,
                 "Downloaded archive differs from the uploaded artifact",
             ),
             (
                 "altered sentinel bytes",
-                {RELEASE_SMOKE_SENTINEL: b"altered\n"},
+                ((RELEASE_SMOKE_SENTINEL, b"altered\n"),),
                 None,
                 1,
                 "",
             ),
             (
                 "nested sentinel",
-                {f"nested/{RELEASE_SMOKE_SENTINEL}": RELEASE_SMOKE_PAYLOAD},
+                ((f"nested/{RELEASE_SMOKE_SENTINEL}", RELEASE_SMOKE_PAYLOAD),),
                 None,
                 1,
                 "Unexpected sentinel archive layout",
@@ -822,19 +888,25 @@ raise SystemExit(97)
             content,
         )
         self.assertIn('archive="raw-artifacts/$name/$name.zip"', content)
-        self.assertIn('[[ ! -s "$archive" ]]', content)
+        self.assertIn(
+            '[[ ! -f "$archive" || -L "$archive" || ! -s "$archive" ]]',
+            content,
+        )
+        self.assertIn("with zipfile.ZipFile(archive_path) as archive:", content)
+        self.assertIn("members = archive.infolist()", content)
+        self.assertIn("member_name = member.orig_filename", content)
+        self.assertIn("member.create_system != 3", content)
+        self.assertIn("not stat.S_ISREG(unix_mode)", content)
+        self.assertIn('local_header_struct = struct.Struct("<IHHHHHIIIHH")', content)
+        self.assertIn("if local_extra:", content)
+        self.assertIn("actual_counts = Counter(", content)
+        self.assertIn("[[ -e artifacts || -L artifacts ]]", content)
+        self.assertIn('mkdir -- "$destination"', content)
         self.assertIn('unzip -q "$archive" -d "artifacts/$name"', content)
+        self.assertNotIn("unzip -Z", content)
 
-        expected_members = {
-            "GM2Godot-windows": {"GM2Godot-windows.zip": b"windows"},
-            "GM2Godot-macos": {
-                "GM2Godot-macos.zip": b"macos-zip",
-                "GM2Godot-macos.dmg": b"macos-dmg",
-            },
-            "GM2Godot-linux": {"GM2Godot-linux.zip": b"linux"},
-        }
-        for artifact_name, members in expected_members.items():
-            for member_name in members:
+        for artifact_name, members in RELEASE_ARCHIVE_MEMBERS.items():
+            for member_name, _ in members:
                 with self.subTest(release_file=member_name):
                     self.assertIn(
                         f"artifacts/{artifact_name}/{member_name}",
@@ -842,9 +914,11 @@ raise SystemExit(97)
                     )
 
         script = _workflow_run_script(content, "Extract verified artifact archives")
+        self.assertLess(script.index("python3 - <<'PY'"), script.index("mkdir -- artifacts"))
+        self.assertLess(script.index("members = archive.infolist()"), script.index("unzip -q"))
         with tempfile.TemporaryDirectory() as temp_directory:
             root = Path(temp_directory)
-            for artifact_name, members in expected_members.items():
+            for artifact_name, members in RELEASE_ARCHIVE_MEMBERS.items():
                 _write_raw_artifact_archive(root, artifact_name, members)
 
             result = subprocess.run(
@@ -855,11 +929,306 @@ raise SystemExit(97)
                 text=True,
             )
             self.assertEqual(result.returncode, 0, result.stderr)
-            for artifact_name, members in expected_members.items():
-                for member_name, payload in members.items():
+            for artifact_name, members in RELEASE_ARCHIVE_MEMBERS.items():
+                for member_name, payload in members:
                     with self.subTest(artifact=artifact_name, member=member_name):
                         extracted = root / "artifacts" / artifact_name / member_name
                         self.assertEqual(extracted.read_bytes(), payload)
+
+    def test_release_rejects_existing_extraction_roots_before_unzip(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        content = workflow.read_text(encoding="utf-8")
+        script = _workflow_run_script(content, "Extract verified artifact archives")
+
+        for root_kind in ("directory", "symlink", "broken-symlink"):
+            with self.subTest(root_kind=root_kind):
+                with (
+                    tempfile.TemporaryDirectory() as temp_directory,
+                    tempfile.TemporaryDirectory() as outside_directory,
+                ):
+                    root = Path(temp_directory)
+                    outside_root = Path(outside_directory)
+                    for artifact_name, members in RELEASE_ARCHIVE_MEMBERS.items():
+                        _write_raw_artifact_archive(root, artifact_name, members)
+
+                    extraction_root = root / "artifacts"
+                    broken_target = root / "missing-extraction-root"
+                    if root_kind == "directory":
+                        extraction_root.mkdir()
+                    elif root_kind == "symlink":
+                        extraction_root.symlink_to(
+                            outside_root,
+                            target_is_directory=True,
+                        )
+                    else:
+                        extraction_root.symlink_to(
+                            broken_target,
+                            target_is_directory=True,
+                        )
+                    environment, unzip_log = _fake_unzip_environment(root)
+
+                    result = subprocess.run(
+                        ["bash", "-c", script],
+                        cwd=root,
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                        env=environment,
+                    )
+
+                    self.assertNotEqual(result.returncode, 0, result.stderr)
+                    self.assertIn(
+                        "Release extraction root already exists: artifacts",
+                        result.stderr,
+                    )
+                    self.assertFalse(unzip_log.exists())
+                    self.assertEqual(list(outside_root.iterdir()), [])
+                    self.assertFalse(broken_target.exists())
+
+    def test_release_rejects_unsafe_or_unexpected_members_before_extraction(
+        self,
+    ) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        content = workflow.read_text(encoding="utf-8")
+        script = _workflow_run_script(content, "Extract verified artifact archives")
+        expected_linux = RELEASE_ARCHIVE_MEMBERS["GM2Godot-linux"][0]
+
+        def typed_member(file_type: int) -> zipfile.ZipInfo:
+            member = zipfile.ZipInfo("GM2Godot-linux.zip")
+            member.create_system = 3
+            member.external_attr = (file_type | 0o755) << 16
+            return member
+
+        def alternate_path_member() -> zipfile.ZipInfo:
+            member = typed_member(stat.S_IFREG)
+            encoded_member_name = b"GM2Godot-linux.zip"
+            unicode_path_payload = (
+                b"\x01"
+                + zlib.crc32(encoded_member_name).to_bytes(4, "little")
+                + b"../escape.bin"
+            )
+            member.extra = (
+                b"\x75\x70"
+                + len(unicode_path_payload).to_bytes(2, "little")
+                + unicode_path_payload
+            )
+            return member
+
+        dos_member = zipfile.ZipInfo("GM2Godot-linux.zip")
+        dos_member.create_system = 0
+        dos_member.external_attr = 0
+        dos_directory_member = typed_member(stat.S_IFREG)
+        dos_directory_member.external_attr |= 0x10
+
+        cases = (
+            (
+                "traversal",
+                (expected_linux, ("../escape.bin", b"escape")),
+                "Unsafe archive member",
+            ),
+            (
+                "posix-absolute",
+                (),
+                "Unsafe archive member",
+            ),
+            (
+                "windows-drive-absolute",
+                (expected_linux, ("C:/escape.bin", b"escape")),
+                "Unsafe archive member",
+            ),
+            (
+                "backslash-traversal",
+                (expected_linux, ("..\\escape.bin", b"escape")),
+                "Unsafe archive member",
+            ),
+            (
+                "duplicate",
+                (expected_linux, expected_linux),
+                "Unexpected archive members",
+            ),
+            (
+                "unexpected-extra",
+                (expected_linux, ("unexpected.bin", b"extra")),
+                "Unexpected archive members",
+            ),
+            (
+                "newline-name",
+                (expected_linux, ("unexpected\nmember.bin", b"extra")),
+                "Unexpected archive members",
+            ),
+            (
+                "missing-expected",
+                (),
+                "Unexpected archive members",
+            ),
+            (
+                "symlink",
+                ((typed_member(stat.S_IFLNK), b"target"),),
+                "Non-regular archive member",
+            ),
+            (
+                "directory",
+                ((typed_member(stat.S_IFDIR), b""),),
+                "Non-regular archive member",
+            ),
+            (
+                "special-file",
+                ((typed_member(stat.S_IFIFO), b""),),
+                "Non-regular archive member",
+            ),
+            (
+                "unsupported-origin-system",
+                ((dos_member, b"linux"),),
+                "Non-regular archive member",
+            ),
+            (
+                "dos-directory-attribute",
+                ((dos_directory_member, b"linux"),),
+                "Non-regular archive member",
+            ),
+            (
+                "alternate-path-extra-field",
+                ((alternate_path_member(), b"linux"),),
+                "Unsupported archive member metadata",
+            ),
+            (
+                "local-only-alternate-path-extra-field",
+                ((alternate_path_member(), b"linux"),),
+                "Unsupported archive member metadata",
+            ),
+        )
+
+        for case_name, invalid_members, error_fragment in cases:
+            with self.subTest(case=case_name):
+                with tempfile.TemporaryDirectory() as temp_directory:
+                    root = Path(temp_directory)
+                    absolute_escape = root.parent / f"{root.name}-absolute-escape.bin"
+                    self.assertFalse(absolute_escape.exists())
+                    members = (
+                        (expected_linux, (str(absolute_escape), b"escape"))
+                        if case_name == "posix-absolute"
+                        else invalid_members
+                    )
+                    for artifact_name in ("GM2Godot-windows", "GM2Godot-macos"):
+                        _write_raw_artifact_archive(
+                            root,
+                            artifact_name,
+                            RELEASE_ARCHIVE_MEMBERS[artifact_name],
+                        )
+                    _write_raw_artifact_archive(root, "GM2Godot-linux", members)
+                    if case_name == "local-only-alternate-path-extra-field":
+                        _strip_central_extra_field(
+                            root
+                            / "raw-artifacts"
+                            / "GM2Godot-linux"
+                            / "GM2Godot-linux.zip"
+                        )
+
+                    if case_name == "duplicate":
+                        archive_path = (
+                            root
+                            / "raw-artifacts"
+                            / "GM2Godot-linux"
+                            / "GM2Godot-linux.zip"
+                        )
+                        with zipfile.ZipFile(archive_path) as archive:
+                            self.assertEqual(
+                                [member.filename for member in archive.infolist()],
+                                ["GM2Godot-linux.zip", "GM2Godot-linux.zip"],
+                            )
+
+                    environment, unzip_log = _fake_unzip_environment(root)
+
+                    result = subprocess.run(
+                        ["bash", "-c", script],
+                        cwd=root,
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                        env=environment,
+                    )
+
+                    self.assertNotEqual(result.returncode, 0, result.stderr)
+                    self.assertIn(error_fragment, result.stderr)
+                    self.assertFalse(unzip_log.exists())
+                    self.assertFalse((root / "artifacts").exists())
+                    self.assertFalse(absolute_escape.exists())
+
+    def test_release_rejects_inconsistent_local_metadata_before_extraction(
+        self,
+    ) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        content = workflow.read_text(encoding="utf-8")
+        script = _workflow_run_script(content, "Extract verified artifact archives")
+        mutations = (
+            ("flags", 6, (0x800).to_bytes(2, "little")),
+            ("compression", 8, (0).to_bytes(2, "little")),
+            ("raw-name", 30, b"XM2Godot-linux.zip"),
+        )
+
+        for case_name, offset, replacement in mutations:
+            with self.subTest(case=case_name):
+                with tempfile.TemporaryDirectory() as temp_directory:
+                    root = Path(temp_directory)
+                    for artifact_name, members in RELEASE_ARCHIVE_MEMBERS.items():
+                        _write_raw_artifact_archive(root, artifact_name, members)
+                    linux_archive = (
+                        root
+                        / "raw-artifacts"
+                        / "GM2Godot-linux"
+                        / "GM2Godot-linux.zip"
+                    )
+                    archive_bytes = bytearray(linux_archive.read_bytes())
+                    archive_bytes[offset : offset + len(replacement)] = replacement
+                    linux_archive.write_bytes(archive_bytes)
+                    environment, unzip_log = _fake_unzip_environment(root)
+
+                    result = subprocess.run(
+                        ["bash", "-c", script],
+                        cwd=root,
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                        env=environment,
+                    )
+
+                    self.assertNotEqual(result.returncode, 0, result.stderr)
+                    self.assertIn("Inconsistent local member metadata", result.stderr)
+                    self.assertFalse(unzip_log.exists())
+                    self.assertFalse((root / "artifacts").exists())
+
+    def test_release_rejects_unreadable_zip_metadata_before_extraction(self) -> None:
+        workflow = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        content = workflow.read_text(encoding="utf-8")
+        script = _workflow_run_script(content, "Extract verified artifact archives")
+
+        with tempfile.TemporaryDirectory() as temp_directory:
+            root = Path(temp_directory)
+            for artifact_name, members in RELEASE_ARCHIVE_MEMBERS.items():
+                _write_raw_artifact_archive(root, artifact_name, members)
+            linux_archive = (
+                root
+                / "raw-artifacts"
+                / "GM2Godot-linux"
+                / "GM2Godot-linux.zip"
+            )
+            linux_archive.write_bytes(b"PK\x03\x04truncated")
+
+            environment, unzip_log = _fake_unzip_environment(root)
+
+            result = subprocess.run(
+                ["bash", "-c", script],
+                cwd=root,
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+
+            self.assertNotEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Cannot read verified archive metadata", result.stderr)
+            self.assertFalse(unzip_log.exists())
+            self.assertFalse((root / "artifacts").exists())
 
     def test_release_extraction_fails_when_verified_archive_is_missing(self) -> None:
         workflow = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
@@ -871,7 +1240,7 @@ raise SystemExit(97)
             _write_raw_artifact_archive(
                 root,
                 "GM2Godot-windows",
-                {"GM2Godot-windows.zip": b"windows"},
+                (("GM2Godot-windows.zip", b"windows"),),
             )
             result = subprocess.run(
                 ["bash", "-c", script],
@@ -883,7 +1252,7 @@ raise SystemExit(97)
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn(
-            "Missing or empty verified archive: "
+            "Missing, non-regular, symlinked, or empty verified archive: "
             "raw-artifacts/GM2Godot-macos/GM2Godot-macos.zip",
             result.stderr,
         )

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_14(self) -> None:
-        self.assertEqual(get_version(), "0.7.14")
+    def test_release_version_is_0_7_15(self) -> None:
+        self.assertEqual(get_version(), "0.7.15")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- validate all three upload-artifact transport ZIPs against exact flat Unix-regular-file allowlists before creating any extraction output
- reject traversal and absolute names, backslash paths, duplicates, extras, missing members, symlinks, directories, special files, alternate-name extra fields, and inconsistent central/local metadata
- require a fresh direct extraction root and destinations so pre-existing directories, live symlinks, and broken symlinks fail before the first `unzip`
- preserve the pinned v7/v8 artifact transport, deterministic `SHA256SUMS`, and exact five-asset release contract
- bump GM2Godot to 0.7.15

## Validation

- 1,927 unit tests passed (39 skipped)
- 51 focused workflow/version/documentation tests passed
- Pyright: 0 errors and 0 warnings
- Ruff: clean
- checksum-verified actionlint 1.7.12: clean
- exact validator accepted and byte-verified real Linux, macOS, and Windows `upload-artifact@v7.0.1` wrappers from PR #753
- independent security, test, release-contract, and acceptance reviews completed; all blockers resolved

Closes #752
Related: #734, #750, #740