### PR TITLE
Stamp macOS bundle metadata from release version

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.19, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.20, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -849,6 +849,7 @@ jobs:
             --output "$RUNNER_TEMP/release-${{ matrix.name }}-dependencies.json"
 
       - name: Build executable
+        if: matrix.name != 'macos'
         run: |
           if [ "$RUNNER_OS" = "Windows" ]; then
             SEP=";"
@@ -870,6 +871,10 @@ jobs:
             --add-data "Languages${SEP}Languages" \
             --add-data "Current Language${SEP}." \
             main.py
+
+      - name: Build macOS app bundle
+        if: matrix.name == 'macos'
+        run: python -m PyInstaller --clean packaging/macos/GM2Godot.spec
 
       - name: Package build
         run: |
@@ -899,6 +904,16 @@ jobs:
             -ov \
             -format UDZO \
             GM2Godot-macos.dmg
+
+      - name: Verify macOS bundle metadata
+        if: matrix.name == 'macos'
+        run: |
+          /usr/bin/plutil -lint dist/GM2Godot.app/Contents/Info.plist
+          python -I scripts/verify_macos_bundle_metadata.py \
+            --source-root "$GITHUB_WORKSPACE" \
+            --app "$GITHUB_WORKSPACE/dist/GM2Godot.app" \
+            --zip "$GITHUB_WORKSPACE/GM2Godot-macos.zip" \
+            --dmg "$GITHUB_WORKSPACE/GM2Godot-macos.dmg"
 
       - name: Upload artifact
         if: matrix.name != 'macos'

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+!packaging/macos/GM2Godot.spec
 main.exe
 
 # Installer logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.20 - 2026-07-19
+
+- Stamped the macOS app bundle with the stable `land.infi.gm2godot` identifier and exact three-component release version from `src/version.py` for both its short and build versions.
+- Added fail-closed metadata checks for the source `.app`, release ZIP, and DMG so inconsistent, missing, malformed, or placeholder bundle metadata stops artifact publication.
+
 ## 0.7.19 - 2026-07-19
 
 - Pinned the complete CPython 3.12 runtime and tooling dependency graphs for the exact Linux x64, macOS arm64, and Windows x64 release tuples, with native pip-tools generation, self-hosted regeneration, strict installed-distribution receipts, `pip check`, and two fresh empty-cache installs per platform.

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.19`.
+Current source version: `0.7.20`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 Releases starting with 0.7.14 include `SHA256SUMS` for the four platform payloads so downloaded bytes can be checked independently.
 When an exact version tag already exists, a release-workflow rerun now audits the published release, exact five-asset inventory, GitHub digests, downloaded bytes, checksum manifest, and stable tag/release receipt before accepting the run as a build-and-publication no-op.
 
-To build a local macOS distributable (`.app` + `.dmg`), run `bash build_macos.sh` from the project root.
+To build local macOS distributables (`.app` + `.zip` + `.dmg`), run `bash build_macos.sh` from the project root. The macOS app uses the stable bundle identifier `land.infi.gm2godot`; its short and build versions both match the three-component release version in `src/version.py`.
 
 ## Installation
 

--- a/build_macos.sh
+++ b/build_macos.sh
@@ -8,6 +8,9 @@ readonly SCRIPT_DIRECTORY
 readonly PYTHON_BIN=python3
 readonly DEPENDENCY_CONSTRAINT=constraints/requirements-macos-py312.txt
 readonly DEPENDENCY_VERIFIER=scripts/verify_dependency_environment.py
+readonly MACOS_BUNDLE_SPEC=packaging/macos/GM2Godot.spec
+readonly MACOS_METADATA_POLICY=packaging/macos/bundle_metadata.py
+readonly MACOS_METADATA_VERIFIER=scripts/verify_macos_bundle_metadata.py
 export PIP_CONFIG_FILE=/dev/null
 readonly -a REPOSITORY_SENTINELS=(
   build_macos.sh
@@ -15,6 +18,9 @@ readonly -a REPOSITORY_SENTINELS=(
   requirements.txt
   "$DEPENDENCY_CONSTRAINT"
   "$DEPENDENCY_VERIFIER"
+  "$MACOS_BUNDLE_SPEC"
+  "$MACOS_METADATA_POLICY"
+  "$MACOS_METADATA_VERIFIER"
 )
 
 for repository_sentinel in "${REPOSITORY_SENTINELS[@]}"; do
@@ -136,21 +142,7 @@ rm -rf -- build dist release dmg
 rm -f -- GM2Godot-macos.zip GM2Godot-macos.dmg GM2Godot.spec
 
 echo "Building macOS app bundle..."
-"$VENV_PYTHON" -m PyInstaller --onedir \
-  --windowed \
-  --clean \
-  --name GM2Godot \
-  --icon img/Logo.png \
-  --hidden-import markdown2 \
-  --hidden-import PIL \
-  --hidden-import PySide6.QtWidgets \
-  --hidden-import PySide6.QtCore \
-  --hidden-import PySide6.QtGui \
-  --add-data "img:img" \
-  --add-data "src:src" \
-  --add-data "Languages:Languages" \
-  --add-data "Current Language:." \
-  main.py
+"$VENV_PYTHON" -m PyInstaller --clean "$MACOS_BUNDLE_SPEC"
 
 echo "Preparing release directory..."
 mkdir -p release
@@ -173,6 +165,14 @@ hdiutil create \
   -ov \
   -format UDZO \
   GM2Godot-macos.dmg
+
+echo "Verifying macOS bundle metadata..."
+/usr/bin/plutil -lint dist/GM2Godot.app/Contents/Info.plist
+"$VENV_PYTHON" -I "$MACOS_METADATA_VERIFIER" \
+  --source-root "$SCRIPT_DIRECTORY" \
+  --app "$SCRIPT_DIRECTORY/dist/GM2Godot.app" \
+  --zip "$SCRIPT_DIRECTORY/GM2Godot-macos.zip" \
+  --dmg "$SCRIPT_DIRECTORY/GM2Godot-macos.dmg"
 
 cleanup_build_temp
 

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.19 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.20 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.19 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.20 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.19 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.20 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.19 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.20 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.19 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.20 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.19;
+- GM2Godot 0.7.20;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.19 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.20 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -34,7 +34,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.19`.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.20`.
 
 ## Run from source
 
@@ -115,6 +115,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.19`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.20`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.19 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.20 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -28,6 +28,14 @@ The release workflow is canonical at [`.github/workflows/release.yml`](https://g
 
 Pull requests that change the release workflow, create-only publisher, or dedicated smoke workflow run [`.github/workflows/release-action-smoke.yml`](https://github.com/Infiland/GM2Godot/blob/main/.github/workflows/release-action-smoke.yml). The smoke is independent of the project version and remote tag state. It verifies a deterministic cross-job artifact round-trip through the exact production upload/download pins, loads the checked-out local publisher with an unusable token, and proves a guaranteed-missing local asset stops it before any API request while producing a failure receipt with zero mutation intents.
 
+## macOS bundle identity
+
+The checked-in `packaging/macos/GM2Godot.spec` is the only supported macOS release build definition. It loads the strict policy in `packaging/macos/bundle_metadata.py` and stamps `GM2Godot.app` with the stable reverse-domain identifier `land.infi.gm2godot`. Both `CFBundleShortVersionString` and `CFBundleVersion` equal the exact three-component numeric release version in `src/version.py`. GM2Godot produces one production macOS build for each source release version; do not substitute a workflow run number, timestamp, or mutable counter.
+
+Before artifact upload, `scripts/verify_macos_bundle_metadata.py` checks the source app, the app embedded in `GM2Godot-macos.zip`, and the app mounted read-only from `GM2Godot-macos.dmg`. All three copies must have the exact policy values and byte-identical `Info.plist` contents. A missing key, non-string value, placeholder, unsafe app/plist archive layout, malformed plist, or inconsistent digest fails the release.
+
+This policy does not select the macOS architecture tracked in issue #736 and does not sign or notarize the app tracked in issue #737.
+
 ## Versioned-change checklist
 
 Before opening the pull request:
@@ -46,6 +54,7 @@ Before merging:
 - [ ] Confirm `refs/tags/v<version>` does not already exist on the GitHub remote; do not rely only on a local checkout's tag list.
 - [ ] Confirm all pull-request checks pass, including exact Godot 4.7.1 smoke and current GameMaker LTS conversion gates.
 - [ ] Confirm Linux, macOS, and Windows build jobs produce non-empty artifacts.
+- [ ] Confirm the macOS build verifies the exact bundle identifier and source release version in the `.app`, ZIP, and DMG before upload.
 - [ ] Confirm the pull request references the intended issue, uses the correct closure timing, and does not absorb unrelated work.
 
 After merging:
@@ -54,6 +63,7 @@ After merging:
 - [ ] Confirm the release is neither draft nor prerelease and has exactly five unique, non-empty assets: the four platform payloads and `SHA256SUMS`.
 - [ ] Download the run's `release-publisher-receipt` Actions artifact and confirm it ends at `verified`, contains one accepted tag claim, one accepted draft creation, five accepted asset receipts, and one accepted finalization for the same release ID.
 - [ ] Download all five assets, run `sha256sum --check --strict SHA256SUMS`, and confirm each payload digest also matches the hexadecimal value after the `sha256:` prefix in GitHub's `assets[].digest` field.
+- [ ] Inspect the downloaded macOS ZIP and read-only mounted DMG and confirm their app bundle metadata and `Info.plist` digests match each other and the release policy.
 - [ ] Confirm post-merge tests, exact-LTS conversions, Godot smoke, and release jobs pass.
 - [ ] If `docs/wiki/` changed, publish the exact merged pages and verify the live Wiki before closing the documentation issue. Record the merged source SHA and published Wiki SHA on the issue before closing it.
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.19 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.20 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/packaging/macos/GM2Godot.spec
+++ b/packaging/macos/GM2Godot.spec
@@ -1,0 +1,77 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+_SPEC_FILE = Path(SPEC).resolve(strict=True)
+_SOURCE_ROOT = _SPEC_FILE.parents[2]
+_POLICY_FILE = _SPEC_FILE.with_name("bundle_metadata.py")
+_POLICY_SPEC = spec_from_file_location("_gm2godot_macos_bundle_metadata", _POLICY_FILE)
+if _POLICY_SPEC is None or _POLICY_SPEC.loader is None:
+    raise RuntimeError(f"Cannot load macOS bundle metadata policy from {_POLICY_FILE}.")
+_POLICY_MODULE = module_from_spec(_POLICY_SPEC)
+_POLICY_SPEC.loader.exec_module(_POLICY_MODULE)
+_BUNDLE_METADATA = _POLICY_MODULE.load_bundle_metadata(_SOURCE_ROOT)
+
+
+a = Analysis(
+    [str(_SOURCE_ROOT / "main.py")],
+    pathex=[],
+    binaries=[],
+    datas=[
+        (str(_SOURCE_ROOT / "img"), "img"),
+        (str(_SOURCE_ROOT / "src"), "src"),
+        (str(_SOURCE_ROOT / "Languages"), "Languages"),
+        (str(_SOURCE_ROOT / "Current Language"), "."),
+    ],
+    hiddenimports=[
+        "markdown2",
+        "PIL",
+        "PySide6.QtWidgets",
+        "PySide6.QtCore",
+        "PySide6.QtGui",
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="GM2Godot",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="GM2Godot",
+)
+app = BUNDLE(
+    coll,
+    name="GM2Godot.app",
+    icon=str(_SOURCE_ROOT / "img" / "Logo.png"),
+    bundle_identifier=_BUNDLE_METADATA["CFBundleIdentifier"],
+    version=_BUNDLE_METADATA["CFBundleShortVersionString"],
+    info_plist={"CFBundleVersion": _BUNDLE_METADATA["CFBundleVersion"]},
+)

--- a/packaging/macos/bundle_metadata.py
+++ b/packaging/macos/bundle_metadata.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import re
+import stat
+from typing import Final
+
+
+__all__ = ("BUNDLE_IDENTIFIER", "load_release_version", "load_bundle_metadata")
+
+BUNDLE_IDENTIFIER: Final = "land.infi.gm2godot"
+
+_MAX_VERSION_SOURCE_BYTES: Final = 16 * 1024
+_RELEASE_VERSION_PATTERN: Final = re.compile(r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)")
+_PLACEHOLDER_VERSION: Final = "0.0.0"
+
+
+class _BundleMetadataPolicyError(ValueError):
+    """Raised when the canonical release metadata is unsafe or ambiguous."""
+
+
+def _read_bounded_utf8(source_root: Path) -> tuple[str, Path]:
+    version_path = source_root / "src" / "version.py"
+    try:
+        file_status = version_path.lstat()
+    except OSError as error:
+        raise _BundleMetadataPolicyError(f"Cannot inspect canonical version source {version_path}: {error}.") from error
+
+    if stat.S_ISLNK(file_status.st_mode):
+        raise _BundleMetadataPolicyError(f"Canonical version source must not be a symbolic link: {version_path}.")
+    if not stat.S_ISREG(file_status.st_mode):
+        raise _BundleMetadataPolicyError(f"Canonical version source is not a regular file: {version_path}.")
+    if file_status.st_size > _MAX_VERSION_SOURCE_BYTES:
+        raise _BundleMetadataPolicyError(
+            f"Canonical version source exceeds the {_MAX_VERSION_SOURCE_BYTES}-byte limit: {version_path}."
+        )
+
+    try:
+        with version_path.open("rb") as version_file:
+            content = version_file.read(_MAX_VERSION_SOURCE_BYTES + 1)
+    except OSError as error:
+        raise _BundleMetadataPolicyError(f"Cannot read canonical version source {version_path}: {error}.") from error
+
+    if len(content) > _MAX_VERSION_SOURCE_BYTES:
+        raise _BundleMetadataPolicyError(
+            f"Canonical version source exceeds the {_MAX_VERSION_SOURCE_BYTES}-byte limit: {version_path}."
+        )
+    try:
+        return content.decode("utf-8"), version_path
+    except UnicodeDecodeError as error:
+        raise _BundleMetadataPolicyError(f"Canonical version source is not valid UTF-8: {version_path}.") from error
+
+
+def _is_module_docstring(statement: ast.stmt) -> bool:
+    return (
+        isinstance(statement, ast.Expr)
+        and isinstance(statement.value, ast.Constant)
+        and type(statement.value.value) is str
+    )
+
+
+def _is_annotations_future(statement: ast.stmt) -> bool:
+    return (
+        isinstance(statement, ast.ImportFrom)
+        and statement.module == "__future__"
+        and statement.level == 0
+        and len(statement.names) == 1
+        and statement.names[0].name == "annotations"
+        and statement.names[0].asname is None
+    )
+
+
+def _extract_literal_version(tree: ast.Module, version_path: Path) -> str:
+    statements = tree.body
+    index = 1 if statements and _is_module_docstring(statements[0]) else 0
+    if index < len(statements) and _is_annotations_future(statements[index]):
+        index += 1
+    maintained = statements[index:]
+    if len(maintained) != 2:
+        raise _BundleMetadataPolicyError(
+            "Canonical version source may only contain an optional module docstring, "
+            "an optional annotations future import, VERSION, and get_version: "
+            f"{version_path}."
+        )
+
+    assignment, getter = maintained
+    if not (
+        isinstance(assignment, ast.Assign)
+        and len(assignment.targets) == 1
+        and isinstance(assignment.targets[0], ast.Name)
+        and assignment.targets[0].id == "VERSION"
+        and assignment.type_comment is None
+        and isinstance(assignment.value, ast.Constant)
+        and type(assignment.value.value) is str
+    ):
+        raise _BundleMetadataPolicyError(
+            f"Canonical VERSION must be one simple top-level literal string assignment: {version_path}."
+        )
+
+    arguments = getter.args if isinstance(getter, ast.FunctionDef) else None
+    return_annotation = getter.returns if isinstance(getter, ast.FunctionDef) else None
+    if not (
+        isinstance(getter, ast.FunctionDef)
+        and getter.name == "get_version"
+        and not getter.decorator_list
+        and getter.type_comment is None
+        and arguments is not None
+        and not arguments.posonlyargs
+        and not arguments.args
+        and arguments.vararg is None
+        and not arguments.kwonlyargs
+        and arguments.kwarg is None
+        and not arguments.defaults
+        and (
+            return_annotation is None
+            or (
+                isinstance(return_annotation, ast.Name)
+                and return_annotation.id == "str"
+                and isinstance(return_annotation.ctx, ast.Load)
+            )
+        )
+        and len(getter.body) == 1
+        and isinstance(getter.body[0], ast.Return)
+        and isinstance(getter.body[0].value, ast.Name)
+        and getter.body[0].value.id == "VERSION"
+        and isinstance(getter.body[0].value.ctx, ast.Load)
+    ):
+        raise _BundleMetadataPolicyError(
+            "Canonical get_version must be undecorated, accept no arguments, optionally "
+            f"return str, and only return VERSION: {version_path}."
+        )
+    return assignment.value.value
+
+
+def load_release_version(source_root: Path) -> str:
+    """Load the canonical release version without importing or executing source code."""
+
+    source, version_path = _read_bounded_utf8(source_root)
+    try:
+        tree = ast.parse(source, filename=str(version_path), mode="exec", type_comments=True)
+    except (SyntaxError, ValueError) as error:
+        raise _BundleMetadataPolicyError(
+            f"Canonical version source is not valid Python syntax: {version_path}."
+        ) from error
+
+    version = _extract_literal_version(tree, version_path)
+    if version == _PLACEHOLDER_VERSION or _RELEASE_VERSION_PATTERN.fullmatch(version) is None:
+        raise _BundleMetadataPolicyError(
+            "Canonical VERSION must be a non-placeholder, canonical three-integer string "
+            f"such as '1.2.3'; got {version!r}."
+        )
+    return version
+
+
+def load_bundle_metadata(source_root: Path) -> dict[str, str]:
+    """Return the exact maintained metadata applied to the macOS app bundle."""
+
+    version = load_release_version(source_root)
+    return {
+        "CFBundleIdentifier": BUNDLE_IDENTIFIER,
+        "CFBundleShortVersionString": version,
+        "CFBundleVersion": version,
+    }

--- a/scripts/verify_macos_bundle_metadata.py
+++ b/scripts/verify_macos_bundle_metadata.py
@@ -1,0 +1,671 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import hashlib
+import os
+from pathlib import Path
+import plistlib
+import re
+import stat
+import subprocess
+import sys
+import tempfile
+from types import ModuleType
+from typing import cast
+import unicodedata
+from xml.parsers.expat import ExpatError
+import zipfile
+
+
+POLICY_COMPONENTS = ("packaging", "macos", "bundle_metadata.py")
+APP_PLIST_COMPONENTS = ("GM2Godot.app", "Contents", "Info.plist")
+ZIP_PLIST_PATH = "/".join(APP_PLIST_COMPONENTS)
+POLICY_KEYS = frozenset({"CFBundleIdentifier", "CFBundleShortVersionString", "CFBundleVersion"})
+MAX_POLICY_BYTES = 256 * 1024
+MAX_PLIST_BYTES = 1024 * 1024
+MAX_HDIUTIL_OUTPUT_BYTES = 1024 * 1024
+HDIUTIL_TIMEOUT_SECONDS = 120.0
+HDIUTIL_PATH = "/usr/bin/hdiutil"
+
+_BUNDLE_IDENTIFIER_PATTERN = re.compile(r"[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+){2,}\Z")
+_VERSION_PATTERN = re.compile(r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\Z")
+_DEVICE_PATTERN = re.compile(r"/dev/disk[0-9]+(?:s[0-9]+)*\Z")
+
+
+class MetadataVerificationError(Exception):
+    """A deterministic validation failure suitable for one-line CLI output."""
+
+
+@dataclass(frozen=True)
+class BundleMetadata:
+    identifier: str
+    short_version: str
+    build_version: str
+    plist_sha256: str
+
+
+@dataclass(frozen=True)
+class _CommandResult:
+    returncode: int
+    stdout: bytes
+    stderr: bytes
+
+
+def _require_absolute_path(raw_path: str, description: str) -> Path:
+    path = Path(raw_path)
+    if not path.is_absolute():
+        raise MetadataVerificationError(f"{description} must be an absolute path: {raw_path!r}")
+    if Path(os.path.normpath(os.fspath(path))) != path:
+        raise MetadataVerificationError(f"{description} must be lexically normalized: {raw_path!r}")
+    return path
+
+
+def _open_flags(*names: str) -> int:
+    if os.open not in os.supports_dir_fd:
+        raise MetadataVerificationError("descriptor-relative no-follow filesystem operations are unavailable")
+    flags = os.O_RDONLY
+    for name in names:
+        value = getattr(os, name, None)
+        if type(value) is not int:
+            raise MetadataVerificationError(f"required no-follow filesystem flag {name} is unavailable")
+        flags |= value
+    return flags
+
+
+def _read_fd_bounded(fd: int, maximum_bytes: int, description: str) -> bytes:
+    content = bytearray()
+    try:
+        while len(content) <= maximum_bytes:
+            remaining = maximum_bytes + 1 - len(content)
+            chunk = os.read(fd, min(64 * 1024, remaining))
+            if not chunk:
+                break
+            content.extend(chunk)
+    except OSError as error:
+        raise MetadataVerificationError(f"unable to read {description}: {error}") from error
+    if len(content) > maximum_bytes:
+        raise MetadataVerificationError(f"{description} exceeds the {maximum_bytes}-byte verification limit")
+    return bytes(content)
+
+
+def _read_regular_beneath(
+    root: Path,
+    components: Sequence[str],
+    maximum_bytes: int,
+    description: str,
+) -> bytes:
+    """Read one fixed regular file without following its root or path components."""
+
+    if not components or any(not component or component in {".", ".."} or "/" in component for component in components):
+        raise MetadataVerificationError(f"invalid fixed path for {description}")
+
+    descriptors: list[int] = []
+    try:
+        try:
+            current = os.open(
+                root,
+                _open_flags("O_CLOEXEC", "O_DIRECTORY", "O_NOFOLLOW"),
+            )
+            descriptors.append(current)
+            if not stat.S_ISDIR(os.fstat(current).st_mode):
+                raise MetadataVerificationError(f"{description} root is not a directory: {root}")
+            for component in components[:-1]:
+                current = os.open(
+                    component,
+                    _open_flags("O_CLOEXEC", "O_DIRECTORY", "O_NOFOLLOW"),
+                    dir_fd=current,
+                )
+                descriptors.append(current)
+                if not stat.S_ISDIR(os.fstat(current).st_mode):
+                    raise MetadataVerificationError(f"{description} component {component!r} is not a directory")
+            file_fd = os.open(
+                components[-1],
+                _open_flags("O_CLOEXEC", "O_NOFOLLOW"),
+                dir_fd=current,
+            )
+            descriptors.append(file_fd)
+            before = os.fstat(file_fd)
+        except OSError as error:
+            raise MetadataVerificationError(f"unable to open {description} without following links: {error}") from error
+
+        if not stat.S_ISREG(before.st_mode):
+            raise MetadataVerificationError(f"{description} is not a regular file")
+        if before.st_size > maximum_bytes:
+            raise MetadataVerificationError(f"{description} exceeds the {maximum_bytes}-byte verification limit")
+        return _read_fd_bounded(file_fd, maximum_bytes, description)
+    finally:
+        for descriptor in reversed(descriptors):
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+
+def _load_policy(source_root: Path) -> dict[str, str]:
+    """Execute only the helper at the canonical path (the CLI itself runs under ``-I``)."""
+
+    policy_path = source_root.joinpath(*POLICY_COMPONENTS)
+    source = _read_regular_beneath(
+        source_root,
+        POLICY_COMPONENTS,
+        MAX_POLICY_BYTES,
+        "macOS bundle metadata policy helper",
+    )
+    try:
+        code = compile(source, os.fspath(policy_path), "exec", dont_inherit=True)
+        module = ModuleType("_gm2godot_macos_bundle_metadata_policy")
+        module.__file__ = os.fspath(policy_path)
+        module.__package__ = ""
+        exec(code, module.__dict__)
+        loader = module.__dict__.get("load_bundle_metadata")
+        if not callable(loader):
+            raise MetadataVerificationError("bundle metadata policy does not define callable load_bundle_metadata")
+        raw_value = loader(source_root)
+    except MetadataVerificationError:
+        raise
+    except Exception as error:
+        raise MetadataVerificationError(f"bundle metadata policy failed: {error}") from error
+
+    if type(raw_value) is not dict:
+        raise MetadataVerificationError("bundle metadata policy must return dict[str, str]")
+    raw_policy = cast(dict[object, object], raw_value)
+    if any(type(key) is not str for key in raw_policy):
+        raise MetadataVerificationError("bundle metadata policy keys must be strings")
+    if frozenset(cast(str, key) for key in raw_policy) != POLICY_KEYS:
+        raise MetadataVerificationError("bundle metadata policy must return exactly the three required Info.plist keys")
+    if any(type(value) is not str for value in raw_policy.values()):
+        raise MetadataVerificationError("bundle metadata policy values must be strings")
+    policy = cast(dict[str, str], raw_policy)
+
+    identifier = policy["CFBundleIdentifier"]
+    if not _BUNDLE_IDENTIFIER_PATTERN.fullmatch(identifier):
+        raise MetadataVerificationError("bundle metadata policy has an invalid reverse-DNS identifier")
+    folded_identifier = identifier.casefold()
+    if folded_identifier == "gm2godot" or "example" in folded_identifier.split("."):
+        raise MetadataVerificationError("bundle metadata policy retains a placeholder identifier")
+    for key in ("CFBundleShortVersionString", "CFBundleVersion"):
+        value = policy[key]
+        if not _VERSION_PATTERN.fullmatch(value):
+            raise MetadataVerificationError(f"bundle metadata policy has an invalid {key}")
+        if value == "0.0.0":
+            raise MetadataVerificationError(f"bundle metadata policy retains placeholder {key}")
+    if policy["CFBundleShortVersionString"] != policy["CFBundleVersion"]:
+        raise MetadataVerificationError("bundle metadata policy requires matching release and build versions")
+    return policy
+
+
+def _parse_bundle_plist(
+    content: bytes,
+    expected: Mapping[str, str],
+    description: str,
+) -> BundleMetadata:
+    if len(content) > MAX_PLIST_BYTES:
+        raise MetadataVerificationError(f"{description} exceeds the {MAX_PLIST_BYTES}-byte verification limit")
+    try:
+        value = plistlib.loads(content)
+    except (
+        plistlib.InvalidFileException,
+        ExpatError,
+        ValueError,
+        TypeError,
+        OverflowError,
+    ) as error:
+        raise MetadataVerificationError(f"unable to parse {description}: {error}") from error
+    if type(value) is not dict:
+        raise MetadataVerificationError(f"{description} root must be a dictionary")
+    plist = cast(dict[object, object], value)
+    observed: dict[str, str] = {}
+    for key in sorted(POLICY_KEYS):
+        if key not in plist:
+            raise MetadataVerificationError(f"{description} is missing {key}")
+        item = plist[key]
+        if type(item) is not str:
+            raise MetadataVerificationError(f"{description} {key} must be a string")
+        expected_item = expected[key]
+        if item != expected_item:
+            raise MetadataVerificationError(f"{description} {key} is {item!r}; expected {expected_item!r}")
+        observed[key] = item
+    return BundleMetadata(
+        identifier=observed["CFBundleIdentifier"],
+        short_version=observed["CFBundleShortVersionString"],
+        build_version=observed["CFBundleVersion"],
+        plist_sha256=hashlib.sha256(content).hexdigest(),
+    )
+
+
+def inspect_app(app_path: Path, expected: Mapping[str, str]) -> BundleMetadata:
+    if app_path.name != APP_PLIST_COMPONENTS[0]:
+        raise MetadataVerificationError(f"direct app must be named {APP_PLIST_COMPONENTS[0]}: {app_path}")
+    content = _read_regular_beneath(
+        app_path.parent,
+        APP_PLIST_COMPONENTS,
+        MAX_PLIST_BYTES,
+        "direct app Info.plist",
+    )
+    return _parse_bundle_plist(content, expected, "direct app Info.plist")
+
+
+def _normalized_component(value: str) -> str:
+    return unicodedata.normalize("NFC", value).casefold()
+
+
+def _zip_member_type(member: zipfile.ZipInfo) -> int:
+    return stat.S_IFMT((member.external_attr >> 16) & 0xFFFF)
+
+
+def _zip_member_is_directory(member: zipfile.ZipInfo) -> bool:
+    member_type = _zip_member_type(member)
+    return member_type == stat.S_IFDIR or (member_type == 0 and member.is_dir())
+
+
+def _select_zip_plist(members: Sequence[zipfile.ZipInfo]) -> zipfile.ZipInfo:
+    """Select the exact plist and validate only paths that can alias its ancestors."""
+
+    canonical = APP_PLIST_COMPONENTS
+    normalized_canonical = tuple(_normalized_component(item) for item in canonical)
+    matches: list[zipfile.ZipInfo] = []
+    for member in members:
+        name = member.filename
+        if (
+            not name
+            or "\x00" in name
+            or "\\" in name
+            or name.startswith("/")
+            or re.match(r"[A-Za-z]:/", name) is not None
+        ):
+            raise MetadataVerificationError(f"ZIP contains an unsafe member path: {name!r}")
+        stripped = name[:-1] if name.endswith("/") else name
+        parts = tuple(stripped.split("/"))
+        if not parts or any(not part or part in {".", ".."} for part in parts):
+            raise MetadataVerificationError(f"ZIP contains an unsafe member path: {name!r}")
+        if not parts or _normalized_component(parts[0]) != normalized_canonical[0]:
+            continue
+
+        if parts[0] != canonical[0]:
+            raise MetadataVerificationError(f"ZIP contains a case or Unicode alias of {canonical[0]}: {name!r}")
+        if len(parts) == 1:
+            if not _zip_member_is_directory(member):
+                raise MetadataVerificationError("ZIP has an explicit non-directory or symlink GM2Godot.app ancestor")
+            continue
+
+        if _normalized_component(parts[1]) != normalized_canonical[1]:
+            continue
+        if parts[1] != canonical[1]:
+            raise MetadataVerificationError(f"ZIP contains a case or Unicode alias of GM2Godot.app/Contents: {name!r}")
+        if len(parts) == 2:
+            if not _zip_member_is_directory(member):
+                raise MetadataVerificationError("ZIP has an explicit non-directory or symlink Contents ancestor")
+            continue
+
+        if _normalized_component(parts[2]) != normalized_canonical[2]:
+            continue
+        if len(parts) != 3 or parts != canonical or name != ZIP_PLIST_PATH:
+            raise MetadataVerificationError(f"ZIP contains a case or Unicode alias of {ZIP_PLIST_PATH}: {name!r}")
+        matches.append(member)
+
+    if len(matches) != 1:
+        raise MetadataVerificationError(f"ZIP must contain exactly one {ZIP_PLIST_PATH}; found {len(matches)}")
+    target = matches[0]
+    target_type = _zip_member_type(target)
+    if target.is_dir() or target_type == stat.S_IFLNK or target_type not in {0, stat.S_IFREG}:
+        raise MetadataVerificationError("ZIP Info.plist is not a regular file")
+    if target.flag_bits & 0x1:
+        raise MetadataVerificationError("ZIP Info.plist is encrypted")
+    if target.file_size > MAX_PLIST_BYTES:
+        raise MetadataVerificationError(f"ZIP Info.plist exceeds the {MAX_PLIST_BYTES}-byte verification limit")
+    return target
+
+
+def inspect_zip(zip_path: Path, expected: Mapping[str, str]) -> BundleMetadata:
+    fd: int | None = None
+    try:
+        try:
+            fd = os.open(zip_path, _open_flags("O_CLOEXEC", "O_NOFOLLOW"))
+            archive_stat = os.fstat(fd)
+        except OSError as error:
+            raise MetadataVerificationError(f"unable to open ZIP without following links: {error}") from error
+        if not stat.S_ISREG(archive_stat.st_mode):
+            raise MetadataVerificationError("ZIP is not a regular file")
+
+        try:
+            with os.fdopen(os.dup(fd), "rb") as stream, zipfile.ZipFile(stream) as archive:
+                target = _select_zip_plist(archive.infolist())
+                with archive.open(target) as plist_stream:
+                    content = plist_stream.read(MAX_PLIST_BYTES + 1)
+        except (OSError, RuntimeError, NotImplementedError, zipfile.BadZipFile) as error:
+            raise MetadataVerificationError(f"unable to read ZIP: {error}") from error
+        if len(content) != target.file_size:
+            raise MetadataVerificationError("ZIP Info.plist size differs from its central-directory receipt")
+        return _parse_bundle_plist(content, expected, "ZIP Info.plist")
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _read_command_output(stream: object, label: str) -> bytes:
+    try:
+        stream.seek(0)  # type: ignore[attr-defined]
+        content = stream.read(MAX_HDIUTIL_OUTPUT_BYTES + 1)  # type: ignore[attr-defined]
+    except OSError as error:
+        raise MetadataVerificationError(f"unable to read {label} hdiutil output: {error}") from error
+    if not isinstance(content, bytes):
+        raise MetadataVerificationError(f"{label} hdiutil output was not bytes")
+    if len(content) > MAX_HDIUTIL_OUTPUT_BYTES:
+        raise MetadataVerificationError(f"{label} hdiutil output exceeds the bounded verification limit")
+    return content
+
+
+def _run_hdiutil_command(command: Sequence[str], label: str) -> _CommandResult:
+    environment = dict(os.environ)
+    environment["LC_ALL"] = "C"
+    try:
+        with tempfile.TemporaryFile() as stdout, tempfile.TemporaryFile() as stderr:
+            try:
+                completed = subprocess.run(
+                    list(command),
+                    check=False,
+                    stdin=subprocess.DEVNULL,
+                    stdout=stdout,
+                    stderr=stderr,
+                    env=environment,
+                    shell=False,
+                    timeout=HDIUTIL_TIMEOUT_SECONDS,
+                )
+            except subprocess.TimeoutExpired as error:
+                raise MetadataVerificationError(
+                    f"{label} hdiutil command timed out after {HDIUTIL_TIMEOUT_SECONDS:g} seconds"
+                ) from error
+            except OSError as error:
+                raise MetadataVerificationError(f"unable to run {label} hdiutil command: {error}") from error
+            return _CommandResult(
+                returncode=completed.returncode,
+                stdout=_read_command_output(stdout, label),
+                stderr=_read_command_output(stderr, label),
+            )
+    except MetadataVerificationError:
+        raise
+    except OSError as error:
+        raise MetadataVerificationError(f"unable to prepare {label} hdiutil output capture: {error}") from error
+
+
+def _receipt_entities(content: bytes, kind: str) -> list[dict[object, object]]:
+    try:
+        value = plistlib.loads(content)
+    except (
+        plistlib.InvalidFileException,
+        ExpatError,
+        ValueError,
+        TypeError,
+        OverflowError,
+    ) as error:
+        raise MetadataVerificationError(f"unable to parse hdiutil {kind} receipt: {error}") from error
+    if type(value) is not dict:
+        raise MetadataVerificationError(f"hdiutil {kind} receipt root must be a dictionary")
+    receipt = cast(dict[object, object], value)
+    entity_groups: list[object]
+    if kind == "attach":
+        entity_groups = [receipt.get("system-entities")]
+    elif kind == "info":
+        images_value = receipt.get("images")
+        if type(images_value) is not list:
+            raise MetadataVerificationError("hdiutil info receipt lacks an images list")
+        entity_groups = []
+        for image_value in cast(list[object], images_value):
+            if type(image_value) is not dict:
+                raise MetadataVerificationError("hdiutil info receipt contains a non-dictionary image")
+            image = cast(dict[object, object], image_value)
+            entity_groups.append(image.get("system-entities"))
+    else:
+        raise AssertionError(f"unsupported hdiutil receipt kind: {kind}")
+
+    entities: list[dict[object, object]] = []
+    for group in entity_groups:
+        if type(group) is not list:
+            raise MetadataVerificationError(f"hdiutil {kind} receipt lacks a system-entities list")
+        for entity_value in cast(list[object], group):
+            if type(entity_value) is not dict:
+                raise MetadataVerificationError(f"hdiutil {kind} receipt contains a non-dictionary entity")
+            entities.append(cast(dict[object, object], entity_value))
+    return entities
+
+
+def _receipt_device(content: bytes, kind: str, mountpoint: Path) -> str | None:
+    matches: list[str] = []
+    expected_mountpoint = os.fspath(mountpoint)
+    for entity in _receipt_entities(content, kind):
+        if entity.get("mount-point") != expected_mountpoint:
+            continue
+        device = entity.get("dev-entry")
+        if type(device) is not str or not _DEVICE_PATTERN.fullmatch(device):
+            raise MetadataVerificationError(f"hdiutil {kind} receipt has an invalid device for the exact mount point")
+        matches.append(device)
+    if len(matches) > 1:
+        raise MetadataVerificationError(f"hdiutil {kind} receipt has multiple devices for the exact mount point")
+    return matches[0] if matches else None
+
+
+def _command_failure(label: str, result: _CommandResult) -> MetadataVerificationError:
+    stderr = result.stderr.decode("utf-8", errors="replace").strip()
+    detail = f": {stderr}" if stderr else ""
+    return MetadataVerificationError(f"hdiutil {label} failed with status {result.returncode}{detail}")
+
+
+def _create_private_mountpoint() -> tuple[Path, Path]:
+    try:
+        raw_root = Path(tempfile.mkdtemp(prefix="gm2godot-dmg-metadata-"))
+    except OSError as error:
+        raise MetadataVerificationError(f"unable to create private DMG verification directory: {error}") from error
+
+    mountpoint: Path | None = None
+    try:
+        raw_stat = raw_root.lstat()
+        if not stat.S_ISDIR(raw_stat.st_mode) or stat.S_ISLNK(raw_stat.st_mode):
+            raise MetadataVerificationError(f"DMG verification root is not a physical directory: {raw_root}")
+        root = raw_root.resolve(strict=True)
+        os.chmod(root, 0o700)
+        mountpoint = root / "mount"
+        mountpoint.mkdir(mode=0o700)
+        return root, mountpoint
+    except (OSError, MetadataVerificationError) as error:
+        cleanup_error: OSError | None = None
+        try:
+            if mountpoint is not None and mountpoint.exists():
+                mountpoint.rmdir()
+            raw_root.rmdir()
+        except OSError as observed:
+            cleanup_error = observed
+        if isinstance(error, MetadataVerificationError):
+            message = str(error)
+        else:
+            message = f"unable to prepare private DMG verification directory: {error}"
+        if cleanup_error is not None:
+            message += f"; retaining {raw_root}: {cleanup_error}"
+        raise MetadataVerificationError(message) from error
+
+
+def _remove_empty_mount_root(root: Path, mountpoint: Path) -> None:
+    try:
+        mountpoint.rmdir()
+        root.rmdir()
+    except OSError as error:
+        raise MetadataVerificationError(
+            f"unable to remove detached DMG verification directory; retaining {root}: {error}"
+        ) from error
+
+
+def _hdiutil_info_device(mountpoint: Path) -> str | None:
+    result = _run_hdiutil_command((HDIUTIL_PATH, "info", "-plist"), "info")
+    if result.returncode != 0:
+        raise _command_failure("info", result)
+    return _receipt_device(result.stdout, "info", mountpoint)
+
+
+def _append_context(primary: MetadataVerificationError | None, cleanup: str) -> MetadataVerificationError:
+    if primary is None:
+        return MetadataVerificationError(cleanup)
+    return MetadataVerificationError(f"{primary}; {cleanup}")
+
+
+def inspect_dmg(dmg_path: Path, expected: Mapping[str, str]) -> BundleMetadata:
+    try:
+        fd = os.open(dmg_path, _open_flags("O_CLOEXEC", "O_NOFOLLOW"))
+        try:
+            dmg_stat = os.fstat(fd)
+        finally:
+            os.close(fd)
+    except OSError as error:
+        raise MetadataVerificationError(f"unable to open DMG without following links: {error}") from error
+    if not stat.S_ISREG(dmg_stat.st_mode):
+        raise MetadataVerificationError("DMG is not a regular file")
+
+    root, mountpoint = _create_private_mountpoint()
+    device: str | None = None
+    known_unmounted = False
+    primary_error: MetadataVerificationError | None = None
+    metadata: BundleMetadata | None = None
+    try:
+        try:
+            attach = _run_hdiutil_command(
+                (
+                    HDIUTIL_PATH,
+                    "attach",
+                    "-readonly",
+                    "-nobrowse",
+                    "-plist",
+                    "-mountpoint",
+                    os.fspath(mountpoint),
+                    os.fspath(dmg_path),
+                ),
+                "attach",
+            )
+            try:
+                device = _receipt_device(attach.stdout, "attach", mountpoint)
+                if device is None:
+                    primary_error = MetadataVerificationError(
+                        "hdiutil attach receipt has no device for the exact mount point"
+                    )
+            except MetadataVerificationError as error:
+                primary_error = error
+            if attach.returncode != 0:
+                primary_error = _command_failure("attach", attach)
+        except MetadataVerificationError as error:
+            primary_error = error
+
+        # An attach may partially succeed even after a nonzero status, timeout, or
+        # malformed receipt. Never infer safety from the command result alone.
+        if device is None:
+            try:
+                device = _hdiutil_info_device(mountpoint)
+                known_unmounted = device is None
+            except MetadataVerificationError as error:
+                primary_error = _append_context(
+                    primary_error,
+                    f"exact mounted device could not be recovered; retaining {root}: {error}",
+                )
+
+        if primary_error is None:
+            if device is None:
+                primary_error = MetadataVerificationError(
+                    "hdiutil reported attach success but the exact mount point is not mounted"
+                )
+            else:
+                content = _read_regular_beneath(
+                    mountpoint,
+                    APP_PLIST_COMPONENTS,
+                    MAX_PLIST_BYTES,
+                    "DMG Info.plist",
+                )
+                metadata = _parse_bundle_plist(content, expected, "DMG Info.plist")
+    except MetadataVerificationError as error:
+        primary_error = error
+    finally:
+        safe_to_clean = known_unmounted
+        if device is not None:
+            try:
+                detach = _run_hdiutil_command((HDIUTIL_PATH, "detach", device), "detach")
+                if detach.returncode != 0:
+                    raise _command_failure("detach", detach)
+                remaining_device = _hdiutil_info_device(mountpoint)
+                if remaining_device is not None or os.path.ismount(mountpoint):
+                    raise MetadataVerificationError(f"mount point remains attached to {remaining_device or device}")
+                safe_to_clean = True
+            except MetadataVerificationError as error:
+                safe_to_clean = False
+                primary_error = _append_context(
+                    primary_error,
+                    f"detach could not be confirmed for {device}; retaining {root}: {error}",
+                )
+
+        if safe_to_clean:
+            try:
+                _remove_empty_mount_root(root, mountpoint)
+            except MetadataVerificationError as error:
+                primary_error = _append_context(primary_error, str(error))
+
+    if primary_error is not None:
+        raise primary_error
+    if metadata is None:
+        raise MetadataVerificationError("DMG metadata verification produced no result")
+    return metadata
+
+
+def verify_artifacts(
+    source_root: Path,
+    app_path: Path,
+    zip_path: Path,
+    dmg_path: Path,
+) -> BundleMetadata:
+    expected = _load_policy(source_root)
+    observations = (
+        inspect_app(app_path, expected),
+        inspect_zip(zip_path, expected),
+        inspect_dmg(dmg_path, expected),
+    )
+    if len({observation.plist_sha256 for observation in observations}) != 1:
+        raise MetadataVerificationError("direct app, ZIP, and DMG Info.plist bytes are not identical")
+    return observations[0]
+
+
+def _argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify exact GM2Godot macOS bundle metadata across release artifacts."
+    )
+    parser.add_argument("--source-root", required=True)
+    parser.add_argument("--app", required=True)
+    parser.add_argument("--zip", required=True)
+    parser.add_argument("--dmg", required=True)
+    return parser
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    parsed = _argument_parser().parse_args(arguments)
+    try:
+        metadata = verify_artifacts(
+            _require_absolute_path(parsed.source_root, "source root"),
+            _require_absolute_path(parsed.app, "direct app"),
+            _require_absolute_path(parsed.zip, "ZIP"),
+            _require_absolute_path(parsed.dmg, "DMG"),
+        )
+        print(
+            "Verified identical macOS bundle metadata: "
+            f"identifier={metadata.identifier} "
+            f"version={metadata.short_version} "
+            f"build={metadata.build_version} "
+            f"plist_sha256={metadata.plist_sha256}"
+        )
+    except (MetadataVerificationError, OSError) as error:
+        print(
+            f"macOS bundle metadata verification failed: {error}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.19"
+VERSION = "0.7.20"
 
 
 def get_version():

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -4366,7 +4366,16 @@ class TestCIWorkflows(unittest.TestCase):
             '--constraint "$DEPENDENCY_CONSTRAINT"',
             f"pip=={PIP_VERSION}",
             f"PyInstaller=={PYINSTALLER_VERSION}",
-            '"$VENV_PYTHON" -m PyInstaller --onedir',
+            "readonly MACOS_BUNDLE_SPEC=packaging/macos/GM2Godot.spec",
+            "readonly MACOS_METADATA_POLICY=packaging/macos/bundle_metadata.py",
+            "readonly MACOS_METADATA_VERIFIER=scripts/verify_macos_bundle_metadata.py",
+            '"$VENV_PYTHON" -m PyInstaller --clean "$MACOS_BUNDLE_SPEC"',
+            "/usr/bin/plutil -lint dist/GM2Godot.app/Contents/Info.plist",
+            '"$VENV_PYTHON" -I "$MACOS_METADATA_VERIFIER"',
+            '--source-root "$SCRIPT_DIRECTORY"',
+            '--app "$SCRIPT_DIRECTORY/dist/GM2Godot.app"',
+            '--zip "$SCRIPT_DIRECTORY/GM2Godot-macos.zip"',
+            '--dmg "$SCRIPT_DIRECTORY/GM2Godot-macos.dmg"',
         ):
             with self.subTest(script="build_macos.sh", required=required):
                 self.assertIn(required, macos)
@@ -4383,6 +4392,14 @@ class TestCIWorkflows(unittest.TestCase):
         self.assertLess(
             macos.index('"$VENV_PYTHON" "$DEPENDENCY_VERIFIER"'),
             macos.index('echo "Cleaning old build artifacts..."'),
+        )
+        self.assertLess(
+            macos.index("hdiutil create"),
+            macos.index('"$VENV_PYTHON" -I "$MACOS_METADATA_VERIFIER"'),
+        )
+        self.assertLess(
+            macos.index('"$VENV_PYTHON" -I "$MACOS_METADATA_VERIFIER"'),
+            macos.rindex("\ncleanup_build_temp\n"),
         )
 
         for required in (
@@ -4424,6 +4441,82 @@ class TestCIWorkflows(unittest.TestCase):
         self.assertLess(
             windows.index('"%VENV_PYTHON%" "%DEPENDENCY_VERIFIER%"'),
             windows.index("echo Cleaning up old build files..."),
+        )
+
+    def test_macos_bundle_metadata_is_verified_in_app_zip_and_dmg(self) -> None:
+        release = (
+            PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        ).read_text(encoding="utf-8")
+        release_build = _workflow_job_section(release, "build")
+        non_macos_build = _workflow_run_script(release, "Build executable")
+        metadata_verification = _workflow_run_script(
+            release,
+            "Verify macOS bundle metadata",
+        )
+
+        self.assertIn(
+            "      - name: Build executable\n"
+            "        if: matrix.name != 'macos'\n",
+            release_build,
+        )
+        self.assertIn(
+            "      - name: Build macOS app bundle\n"
+            "        if: matrix.name == 'macos'\n"
+            "        run: python -m PyInstaller --clean "
+            "packaging/macos/GM2Godot.spec\n",
+            release_build,
+        )
+        self.assertEqual(
+            non_macos_build,
+            "if [ \"$RUNNER_OS\" = \"Windows\" ]; then\n"
+            '  SEP=";"\n'
+            "else\n"
+            '  SEP=":"\n'
+            "fi\n"
+            "python -m PyInstaller ${{ matrix.pyinstaller_mode }} \\\n"
+            "  --windowed \\\n"
+            "  --clean \\\n"
+            "  --name GM2Godot \\\n"
+            "  --icon img/Logo.png \\\n"
+            "  --hidden-import markdown2 \\\n"
+            "  --hidden-import PIL \\\n"
+            "  --hidden-import PySide6.QtWidgets \\\n"
+            "  --hidden-import PySide6.QtCore \\\n"
+            "  --hidden-import PySide6.QtGui \\\n"
+            '  --add-data "img${SEP}img" \\\n'
+            '  --add-data "src${SEP}src" \\\n'
+            '  --add-data "Languages${SEP}Languages" \\\n'
+            '  --add-data "Current Language${SEP}." \\\n'
+            "  main.py\n",
+        )
+
+        self.assertIn(
+            "      - name: Verify macOS bundle metadata\n"
+            "        if: matrix.name == 'macos'\n",
+            release_build,
+        )
+        for required in (
+            "/usr/bin/plutil -lint dist/GM2Godot.app/Contents/Info.plist",
+            "python -I scripts/verify_macos_bundle_metadata.py",
+            '--source-root "$GITHUB_WORKSPACE"',
+            '--app "$GITHUB_WORKSPACE/dist/GM2Godot.app"',
+            '--zip "$GITHUB_WORKSPACE/GM2Godot-macos.zip"',
+            '--dmg "$GITHUB_WORKSPACE/GM2Godot-macos.dmg"',
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, metadata_verification)
+        self.assertEqual(release_build.count("scripts/verify_macos_bundle_metadata.py"), 1)
+        self.assertLess(
+            release_build.index("      - name: Create macOS DMG\n"),
+            release_build.index("      - name: Verify macOS bundle metadata\n"),
+        )
+        self.assertLess(
+            release_build.index("      - name: Zip release\n"),
+            release_build.index("      - name: Verify macOS bundle metadata\n"),
+        )
+        self.assertLess(
+            release_build.index("      - name: Verify macOS bundle metadata\n"),
+            release_build.index("      - name: Upload macOS artifacts\n"),
         )
 
     def test_windows_build_cleanup_guard_deletes_only_original_owned_directory(

--- a/tests/test_macos_bundle_metadata.py
+++ b/tests/test_macos_bundle_metadata.py
@@ -1,0 +1,614 @@
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+import os
+from pathlib import Path
+import plistlib
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+import warnings
+import zipfile
+
+from scripts import verify_macos_bundle_metadata as verifier
+from src.version import VERSION
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+VERIFIER_PATH = PROJECT_ROOT / "scripts" / "verify_macos_bundle_metadata.py"
+SYNTHETIC_POLICY = {
+    "CFBundleIdentifier": "land.infi.gm2godot",
+    "CFBundleShortVersionString": "1.2.3",
+    "CFBundleVersion": "1.2.3",
+}
+
+
+def _policy_source(expression: str) -> str:
+    return (
+        "from pathlib import Path\n\n"
+        "def load_bundle_metadata(source_root: Path) -> dict[str, str]:\n"
+        "    if not source_root.is_absolute():\n"
+        "        raise ValueError('source root must be absolute')\n"
+        f"    return {expression}\n"
+    )
+
+
+def _write_policy(source_root: Path, expression: str | None = None) -> None:
+    helper = source_root.joinpath(*verifier.POLICY_COMPONENTS)
+    helper.parent.mkdir(parents=True, exist_ok=True)
+    helper.write_text(
+        _policy_source(repr(SYNTHETIC_POLICY) if expression is None else expression),
+        encoding="utf-8",
+    )
+
+
+def _plist_bytes(
+    values: Mapping[str, object] | None = None,
+    *,
+    binary: bool = False,
+) -> bytes:
+    selected = dict(SYNTHETIC_POLICY if values is None else values)
+    selected.setdefault("CFBundleExecutable", "GM2Godot")
+    return plistlib.dumps(
+        selected,
+        fmt=plistlib.FMT_BINARY if binary else plistlib.FMT_XML,
+        sort_keys=True,
+    )
+
+
+def _write_app(root: Path, content: bytes) -> Path:
+    app = root / "GM2Godot.app"
+    (app / "Contents").mkdir(parents=True, exist_ok=True)
+    (app / "Contents" / "Info.plist").write_bytes(content)
+    return app
+
+
+def _write_zip(path: Path, content: bytes) -> None:
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(verifier.ZIP_PLIST_PATH, content)
+        archive.writestr("unrelated/readme.txt", b"GM2Godot\n")
+
+
+def _remove_fake_app(mountpoint: Path) -> None:
+    plist_path = mountpoint.joinpath(*verifier.APP_PLIST_COMPONENTS)
+    plist_path.unlink()
+    plist_path.parent.rmdir()
+    plist_path.parent.parent.rmdir()
+
+
+class _TemporaryRootFactory:
+    def __init__(self, parent: Path) -> None:
+        self.parent = parent
+        self.paths: list[Path] = []
+
+    def __call__(self, *, prefix: str) -> str:
+        path = self.parent / f"{prefix}{len(self.paths)}"
+        path.mkdir(mode=0o700)
+        self.paths.append(path)
+        return os.fspath(path)
+
+
+class _FakeHdiutil:
+    def __init__(
+        self,
+        plist_content: bytes,
+        *,
+        attach_returncode: int = 0,
+        attach_receipt: str = "valid",
+        attach_error: bool = False,
+        mount_on_attach: bool = True,
+        info_returncode: int = 0,
+        info_receipt: str = "valid",
+        detach_returncode: int = 0,
+        unmount_on_detach: bool = True,
+    ) -> None:
+        self.plist_content = plist_content
+        self.attach_returncode = attach_returncode
+        self.attach_receipt = attach_receipt
+        self.attach_error = attach_error
+        self.mount_on_attach = mount_on_attach
+        self.info_returncode = info_returncode
+        self.info_receipt = info_receipt
+        self.detach_returncode = detach_returncode
+        self.unmount_on_detach = unmount_on_detach
+        self.device = "/dev/disk42s1"
+        self.mountpoint: Path | None = None
+        self.mounted = False
+        self.events: list[str] = []
+
+    def _attach_receipt_bytes(self) -> bytes:
+        if self.attach_receipt == "invalid":
+            return b"not a plist"
+        entities: list[dict[str, str]] = []
+        if self.attach_receipt == "valid" and self.mountpoint is not None:
+            entities.append(
+                {
+                    "dev-entry": self.device,
+                    "mount-point": os.fspath(self.mountpoint),
+                }
+            )
+        return plistlib.dumps({"system-entities": entities})
+
+    def _info_receipt_bytes(self) -> bytes:
+        if self.info_receipt == "invalid":
+            return b"not a plist"
+        entities: list[dict[str, str]] = []
+        if self.mounted and self.mountpoint is not None:
+            entities.append(
+                {
+                    "dev-entry": self.device,
+                    "mount-point": os.fspath(self.mountpoint),
+                }
+            )
+        return plistlib.dumps({"images": [{"system-entities": entities}]})
+
+    def __call__(self, command: object, label: str) -> verifier._CommandResult:
+        parts = tuple(str(part) for part in command)  # type: ignore[arg-type]
+        self.events.append(label)
+        if label == "attach":
+            self.mountpoint = Path(parts[parts.index("-mountpoint") + 1])
+            if self.mount_on_attach:
+                _write_app(self.mountpoint, self.plist_content)
+                self.mounted = True
+            if self.attach_error:
+                raise verifier.MetadataVerificationError("attach command timed out")
+            return verifier._CommandResult(
+                self.attach_returncode,
+                self._attach_receipt_bytes(),
+                b"attach failed detail" if self.attach_returncode else b"",
+            )
+        if label == "info":
+            return verifier._CommandResult(
+                self.info_returncode,
+                self._info_receipt_bytes(),
+                b"info failed detail" if self.info_returncode else b"",
+            )
+        if label == "detach":
+            if parts != (verifier.HDIUTIL_PATH, "detach", self.device):
+                raise AssertionError(f"unexpected detach command: {parts!r}")
+            if self.detach_returncode == 0 and self.unmount_on_detach:
+                if self.mounted and self.mountpoint is not None:
+                    _remove_fake_app(self.mountpoint)
+                self.mounted = False
+            return verifier._CommandResult(
+                self.detach_returncode,
+                b"",
+                b"detach failed detail" if self.detach_returncode else b"",
+            )
+        raise AssertionError(f"unexpected hdiutil label: {label}")
+
+
+class BundleMetadataFixture(unittest.TestCase):
+    def setUp(self) -> None:
+        self._temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self._temporary_directory.name).resolve()
+        self.source_root = self.root / "source"
+        self.source_root.mkdir()
+        _write_policy(self.source_root)
+        self.plist_content = _plist_bytes()
+        self.app_path = _write_app(self.root / "direct", self.plist_content)
+        self.zip_path = self.root / "GM2Godot-macos.zip"
+        _write_zip(self.zip_path, self.plist_content)
+        self.dmg_path = self.root / "GM2Godot-macos.dmg"
+        self.dmg_path.write_bytes(b"synthetic dmg")
+        self.root_factory = _TemporaryRootFactory(self.root)
+
+    def tearDown(self) -> None:
+        self._temporary_directory.cleanup()
+
+    def inspect_dmg_with(self, fake: _FakeHdiutil) -> verifier.BundleMetadata:
+        with (
+            mock.patch.object(verifier, "_run_hdiutil_command", side_effect=fake),
+            mock.patch.object(
+                verifier.tempfile,
+                "mkdtemp",
+                side_effect=self.root_factory,
+            ),
+        ):
+            return verifier.inspect_dmg(self.dmg_path, SYNTHETIC_POLICY)
+
+    def verify_with(self, fake: _FakeHdiutil) -> verifier.BundleMetadata:
+        with (
+            mock.patch.object(verifier, "_run_hdiutil_command", side_effect=fake),
+            mock.patch.object(
+                verifier.tempfile,
+                "mkdtemp",
+                side_effect=self.root_factory,
+            ),
+        ):
+            return verifier.verify_artifacts(
+                self.source_root,
+                self.app_path,
+                self.zip_path,
+                self.dmg_path,
+            )
+
+
+class MacOSBundleMetadataHappyPathTests(BundleMetadataFixture):
+    def test_xml_artifacts_match_and_cleanup_after_confirmed_detach(self) -> None:
+        fake = _FakeHdiutil(self.plist_content)
+        metadata = self.verify_with(fake)
+
+        self.assertEqual(metadata.identifier, SYNTHETIC_POLICY["CFBundleIdentifier"])
+        self.assertEqual(fake.events, ["attach", "detach", "info"])
+        self.assertFalse(self.root_factory.paths[0].exists())
+
+    def test_binary_plist_is_supported_in_all_artifacts(self) -> None:
+        binary = _plist_bytes(binary=True)
+        (self.app_path / "Contents" / "Info.plist").write_bytes(binary)
+        _write_zip(self.zip_path, binary)
+
+        metadata = self.verify_with(_FakeHdiutil(binary))
+
+        self.assertEqual(metadata.plist_sha256, verifier.hashlib.sha256(binary).hexdigest())
+
+    def test_byte_parity_rejects_semantically_equal_plists(self) -> None:
+        changed = dict(SYNTHETIC_POLICY)
+        changed["ExtraField"] = "different bytes"
+        with self.assertRaisesRegex(
+            verifier.MetadataVerificationError,
+            "Info.plist bytes are not identical",
+        ):
+            self.verify_with(_FakeHdiutil(_plist_bytes(changed)))
+
+
+class MacOSBundleMetadataStrictValueTests(BundleMetadataFixture):
+    def test_plist_missing_wrong_and_non_string_values_are_rejected(self) -> None:
+        cases: dict[str, dict[str, object]] = {}
+        for key in verifier.POLICY_KEYS:
+            missing: dict[str, object] = dict(SYNTHETIC_POLICY)
+            del missing[key]
+            cases[f"missing-{key}"] = missing
+            wrong: dict[str, object] = dict(SYNTHETIC_POLICY)
+            wrong[key] = "wrong"
+            cases[f"wrong-{key}"] = wrong
+            wrong_type: dict[str, object] = dict(SYNTHETIC_POLICY)
+            wrong_type[key] = 123
+            cases[f"type-{key}"] = wrong_type
+
+        for name, values in cases.items():
+            with self.subTest(name=name):
+                app = _write_app(self.root / name, _plist_bytes(values))
+                with self.assertRaises(verifier.MetadataVerificationError):
+                    verifier.inspect_app(app, SYNTHETIC_POLICY)
+
+    def test_malformed_plist_is_rejected_cleanly(self) -> None:
+        app = _write_app(self.root / "malformed", b"not a property list")
+
+        with self.assertRaisesRegex(
+            verifier.MetadataVerificationError,
+            "unable to parse direct app Info.plist",
+        ):
+            verifier.inspect_app(app, SYNTHETIC_POLICY)
+
+    def test_policy_contract_rejects_missing_extra_type_placeholder_and_mismatch(self) -> None:
+        cases = {
+            "missing": "{'CFBundleIdentifier': 'land.infi.gm2godot'}",
+            "extra": repr({**SYNTHETIC_POLICY, "extra": "value"}),
+            "type": repr({**SYNTHETIC_POLICY, "CFBundleVersion": 123}),
+            "placeholder-id": repr({**SYNTHETIC_POLICY, "CFBundleIdentifier": "com.example.gm2godot"}),
+            "placeholder-version": repr(
+                {
+                    **SYNTHETIC_POLICY,
+                    "CFBundleShortVersionString": "0.0.0",
+                    "CFBundleVersion": "0.0.0",
+                }
+            ),
+            "mismatch": repr({**SYNTHETIC_POLICY, "CFBundleVersion": "1.2.4"}),
+        }
+        for name, expression in cases.items():
+            with self.subTest(name=name):
+                root = self.root / f"policy-{name}"
+                root.mkdir()
+                _write_policy(root, expression)
+                with self.assertRaises(verifier.MetadataVerificationError):
+                    verifier._load_policy(root)
+
+    def test_repository_policy_is_tied_to_current_source_version(self) -> None:
+        self.assertEqual(
+            verifier._load_policy(PROJECT_ROOT),
+            {
+                "CFBundleIdentifier": "land.infi.gm2godot",
+                "CFBundleShortVersionString": VERSION,
+                "CFBundleVersion": VERSION,
+            },
+        )
+
+    def test_exact_policy_path_load_isolated_from_pythonpath_shadow(self) -> None:
+        shadow = self.root / "shadow"
+        shadow.mkdir()
+        sentinel = self.root / "shadow-imported"
+        (shadow / "bundle_metadata.py").write_text(
+            f"from pathlib import Path\nPath({os.fspath(sentinel)!r}).touch()\n",
+            encoding="utf-8",
+        )
+        code = (
+            "import pathlib,runpy,sys;"
+            "m=runpy.run_path(sys.argv[1]);"
+            "print(m['_load_policy'](pathlib.Path(sys.argv[2]))['CFBundleVersion'])"
+        )
+        environment = dict(os.environ)
+        environment["PYTHONPATH"] = os.fspath(shadow)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-I",
+                "-c",
+                code,
+                os.fspath(VERIFIER_PATH),
+                os.fspath(self.source_root),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=environment,
+            timeout=10,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "1.2.3")
+        self.assertFalse(sentinel.exists())
+
+
+class MacOSBundleMetadataZipTests(BundleMetadataFixture):
+    def _archive_with(self, members: list[tuple[str | zipfile.ZipInfo, bytes]]) -> Path:
+        path = self.root / f"case-{len(list(self.root.glob('case-*.zip')))}.zip"
+        with zipfile.ZipFile(path, "w") as archive:
+            for name, content in members:
+                archive.writestr(name, content)
+        return path
+
+    def test_duplicate_and_target_symlink_are_rejected(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            duplicate = self._archive_with(
+                [
+                    (verifier.ZIP_PLIST_PATH, self.plist_content),
+                    (verifier.ZIP_PLIST_PATH, self.plist_content),
+                ]
+            )
+        with self.assertRaises(verifier.MetadataVerificationError):
+            verifier.inspect_zip(duplicate, SYNTHETIC_POLICY)
+
+        target = zipfile.ZipInfo(verifier.ZIP_PLIST_PATH)
+        target.create_system = 3
+        target.external_attr = (stat.S_IFLNK | 0o777) << 16
+        symlink = self._archive_with([(target, b"outside")])
+        with self.assertRaisesRegex(verifier.MetadataVerificationError, "regular file"):
+            verifier.inspect_zip(symlink, SYNTHETIC_POLICY)
+
+    def test_explicit_ancestor_files_symlinks_and_aliases_are_rejected(self) -> None:
+        app_link = zipfile.ZipInfo("GM2Godot.app/")
+        app_link.create_system = 3
+        app_link.external_attr = (stat.S_IFLNK | 0o777) << 16
+        contents_link = zipfile.ZipInfo("GM2Godot.app/Contents")
+        contents_link.create_system = 3
+        contents_link.external_attr = (stat.S_IFLNK | 0o777) << 16
+        cases: list[tuple[str | zipfile.ZipInfo, bytes]] = [
+            ("GM2Godot.app", b"file"),
+            (app_link, b"elsewhere"),
+            ("GM2Godot.app/Contents", b"file"),
+            (contents_link, b"elsewhere"),
+            ("gm2godot.app/unrelated.txt", b"alias"),
+            ("GM2Godot.app/contents/unrelated.txt", b"alias"),
+            ("GM2Godot.app/Contentſ/unrelated.txt", b"unicode alias"),
+            ("GM2Godot.app/Contents/info.plist", self.plist_content),
+            ("GM2Godot.app/Contents/Info.plist/child", b"impossible child"),
+            ("./GM2Godot.app/Contents/Info.plist", b"dot alias"),
+            ("prefix/../GM2Godot.app/Contents/Info.plist", b"parent alias"),
+            ("/GM2Godot.app/Contents/Info.plist", b"absolute alias"),
+            ("C:/GM2Godot.app/Contents/Info.plist", b"drive alias"),
+        ]
+        for index, extra in enumerate(cases):
+            with self.subTest(index=index):
+                archive = self._archive_with([(verifier.ZIP_PLIST_PATH, self.plist_content), extra])
+                with self.assertRaises(verifier.MetadataVerificationError):
+                    verifier.inspect_zip(archive, SYNTHETIC_POLICY)
+
+    def test_exact_directory_ancestors_are_allowed_and_unrelated_members_are_ignored(self) -> None:
+        unrelated_link = zipfile.ZipInfo("unrelated/link")
+        unrelated_link.create_system = 3
+        unrelated_link.external_attr = (stat.S_IFLNK | 0o777) << 16
+        archive = self._archive_with(
+            [
+                ("GM2Godot.app/", b""),
+                ("GM2Godot.app/Contents/", b""),
+                (verifier.ZIP_PLIST_PATH, self.plist_content),
+                ("unrelated/readme.txt", b"ignored"),
+                (unrelated_link, b"../../outside"),
+            ]
+        )
+
+        metadata = verifier.inspect_zip(archive, SYNTHETIC_POLICY)
+
+        self.assertEqual(metadata.short_version, "1.2.3")
+
+
+class MacOSBundleMetadataDmgTests(BundleMetadataFixture):
+    def test_nonzero_attach_preserves_status_and_stderr_then_cleans_when_unmounted(self) -> None:
+        fake = _FakeHdiutil(
+            self.plist_content,
+            attach_returncode=7,
+            attach_receipt="missing",
+            mount_on_attach=False,
+        )
+        with self.assertRaisesRegex(
+            verifier.MetadataVerificationError,
+            "status 7: attach failed detail",
+        ):
+            self.inspect_dmg_with(fake)
+        self.assertEqual(fake.events, ["attach", "info"])
+        self.assertFalse(self.root_factory.paths[0].exists())
+
+    def test_nonzero_attach_with_exact_device_detaches_before_reporting_status(self) -> None:
+        fake = _FakeHdiutil(
+            self.plist_content,
+            attach_returncode=7,
+            attach_receipt="valid",
+        )
+
+        with self.assertRaisesRegex(
+            verifier.MetadataVerificationError,
+            "status 7: attach failed detail",
+        ):
+            self.inspect_dmg_with(fake)
+
+        self.assertEqual(fake.events, ["attach", "detach", "info"])
+        self.assertFalse(self.root_factory.paths[0].exists())
+
+    def test_invalid_receipt_recovers_device_and_detaches_before_error(self) -> None:
+        fake = _FakeHdiutil(self.plist_content, attach_receipt="invalid")
+        with self.assertRaisesRegex(
+            verifier.MetadataVerificationError,
+            "parse hdiutil attach receipt",
+        ):
+            self.inspect_dmg_with(fake)
+        self.assertEqual(fake.events, ["attach", "info", "detach", "info"])
+        self.assertFalse(self.root_factory.paths[0].exists())
+
+    def test_attach_command_error_still_recovers_partial_mount_and_detaches(self) -> None:
+        fake = _FakeHdiutil(self.plist_content, attach_error=True)
+        with self.assertRaisesRegex(
+            verifier.MetadataVerificationError,
+            "attach command timed out",
+        ):
+            self.inspect_dmg_with(fake)
+        self.assertEqual(fake.events, ["attach", "info", "detach", "info"])
+        self.assertFalse(self.root_factory.paths[0].exists())
+
+    def test_unknown_mount_after_failed_recovery_retains_root(self) -> None:
+        fake = _FakeHdiutil(
+            self.plist_content,
+            attach_receipt="invalid",
+            info_receipt="invalid",
+        )
+        with self.assertRaisesRegex(verifier.MetadataVerificationError, "retaining"):
+            self.inspect_dmg_with(fake)
+        self.assertEqual(fake.events, ["attach", "info"])
+        self.assertTrue(self.root_factory.paths[0].exists())
+
+    def test_detach_failure_and_confirmation_failure_retain_root(self) -> None:
+        detach_failure = _FakeHdiutil(self.plist_content, detach_returncode=9)
+        with self.assertRaisesRegex(verifier.MetadataVerificationError, "status 9"):
+            self.inspect_dmg_with(detach_failure)
+        self.assertTrue(self.root_factory.paths[0].exists())
+
+        confirmation_failure = _FakeHdiutil(
+            self.plist_content,
+            info_receipt="invalid",
+        )
+        with self.assertRaisesRegex(verifier.MetadataVerificationError, "retaining"):
+            self.inspect_dmg_with(confirmation_failure)
+        self.assertTrue(self.root_factory.paths[1].exists())
+
+    def test_temporary_setup_and_mounted_plist_read_errors_are_clean(self) -> None:
+        with (
+            mock.patch.object(
+                verifier.tempfile,
+                "mkdtemp",
+                side_effect=OSError("temp unavailable"),
+            ),
+            self.assertRaisesRegex(
+                verifier.MetadataVerificationError,
+                "temp unavailable",
+            ),
+        ):
+            verifier.inspect_dmg(self.dmg_path, SYNTHETIC_POLICY)
+
+        setup_root = self.root / "setup-failure"
+        setup_root.mkdir(mode=0o700)
+        with (
+            mock.patch.object(
+                verifier.tempfile,
+                "mkdtemp",
+                return_value=os.fspath(setup_root),
+            ),
+            mock.patch.object(
+                verifier.Path,
+                "mkdir",
+                side_effect=OSError("mountpoint unavailable"),
+            ),
+            self.assertRaisesRegex(
+                verifier.MetadataVerificationError,
+                "mountpoint unavailable",
+            ),
+        ):
+            verifier.inspect_dmg(self.dmg_path, SYNTHETIC_POLICY)
+        self.assertFalse(setup_root.exists())
+
+        fake = _FakeHdiutil(self.plist_content)
+        with (
+            mock.patch.object(verifier, "_run_hdiutil_command", side_effect=fake),
+            mock.patch.object(
+                verifier.tempfile,
+                "mkdtemp",
+                side_effect=self.root_factory,
+            ),
+            mock.patch.object(verifier.os, "read", side_effect=OSError("read failed")),
+            self.assertRaisesRegex(verifier.MetadataVerificationError, "read failed"),
+        ):
+            verifier.inspect_dmg(self.dmg_path, SYNTHETIC_POLICY)
+        self.assertEqual(fake.events, ["attach", "detach", "info"])
+        self.assertFalse(self.root_factory.paths[0].exists())
+
+
+class MacOSBundleMetadataCliTests(BundleMetadataFixture):
+    def test_main_reports_clean_validation_and_output_errors(self) -> None:
+        for error in (
+            verifier.MetadataVerificationError("bad metadata"),
+            OSError("output unavailable"),
+        ):
+            with self.subTest(error=type(error).__name__):
+                stderr = StringIO()
+                with (
+                    mock.patch.object(verifier, "verify_artifacts", side_effect=error),
+                    redirect_stderr(stderr),
+                ):
+                    status = verifier.main(
+                        [
+                            "--source-root",
+                            os.fspath(self.source_root),
+                            "--app",
+                            os.fspath(self.app_path),
+                            "--zip",
+                            os.fspath(self.zip_path),
+                            "--dmg",
+                            os.fspath(self.dmg_path),
+                        ]
+                    )
+                self.assertEqual(status, 1)
+                self.assertNotIn("Traceback", stderr.getvalue())
+
+    def test_main_prints_stable_success(self) -> None:
+        metadata = verifier.BundleMetadata("land.infi.gm2godot", "1.2.3", "1.2.3", "a" * 64)
+        stdout = StringIO()
+        with (
+            mock.patch.object(verifier, "verify_artifacts", return_value=metadata),
+            redirect_stdout(stdout),
+        ):
+            status = verifier.main(
+                [
+                    "--source-root",
+                    os.fspath(self.source_root),
+                    "--app",
+                    os.fspath(self.app_path),
+                    "--zip",
+                    os.fspath(self.zip_path),
+                    "--dmg",
+                    os.fspath(self.dmg_path),
+                ]
+            )
+        self.assertEqual(status, 0)
+        self.assertIn("identifier=land.infi.gm2godot", stdout.getvalue())
+        self.assertIn("plist_sha256=" + "a" * 64, stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_macos_bundle_policy.py
+++ b/tests/test_macos_bundle_policy.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import ast
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import re
+import runpy
+import shutil
+import sys
+import tempfile
+from typing import Protocol, cast
+import unittest
+from unittest import mock
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = PROJECT_ROOT / "packaging" / "macos" / "bundle_metadata.py"
+SPEC_PATH = PROJECT_ROOT / "packaging" / "macos" / "GM2Godot.spec"
+
+EXPECTED_METADATA_KEYS = {
+    "CFBundleIdentifier",
+    "CFBundleShortVersionString",
+    "CFBundleVersion",
+}
+EXPECTED_DATA_FILES = [
+    (PROJECT_ROOT / "img", "img"),
+    (PROJECT_ROOT / "src", "src"),
+    (PROJECT_ROOT / "Languages", "Languages"),
+    (PROJECT_ROOT / "Current Language", "."),
+]
+EXPECTED_HIDDEN_IMPORTS = [
+    "markdown2",
+    "PIL",
+    "PySide6.QtWidgets",
+    "PySide6.QtCore",
+    "PySide6.QtGui",
+]
+
+
+class _BundleMetadataPolicy(Protocol):
+    __all__: tuple[str, ...]
+    BUNDLE_IDENTIFIER: str
+
+    def load_release_version(self, source_root: Path) -> str: ...
+
+    def load_bundle_metadata(self, source_root: Path) -> dict[str, str]: ...
+
+
+def _load_policy(path: Path = POLICY_PATH) -> _BundleMetadataPolicy:
+    module_spec = spec_from_file_location("_gm2godot_test_macos_bundle_metadata", path)
+    if module_spec is None or module_spec.loader is None:
+        raise RuntimeError(f"Cannot load bundle metadata policy from {path}.")
+    module = module_from_spec(module_spec)
+    module_spec.loader.exec_module(module)
+    return cast(_BundleMetadataPolicy, module)
+
+
+POLICY = _load_policy()
+
+
+def canonical_version_source(version: str) -> str:
+    return f'VERSION = "{version}"\n\n\ndef get_version():\n    return VERSION\n'
+
+
+def write_version_source(source_root: Path, source: str) -> Path:
+    version_path = source_root / "src" / "version.py"
+    version_path.parent.mkdir(parents=True, exist_ok=True)
+    version_path.write_text(source, encoding="utf-8")
+    return version_path
+
+
+class _FakeTarget:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+
+class _FakeAnalysis(_FakeTarget):
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.pure = ("analysis-pure",)
+        self.scripts = ("analysis-scripts",)
+        self.binaries = ("analysis-binaries",)
+        self.datas = ("analysis-datas",)
+
+
+def _run_spec(spec_path: Path) -> dict[str, object]:
+    namespace = runpy.run_path(
+        str(spec_path),
+        init_globals={
+            "SPEC": str(spec_path),
+            "Analysis": _FakeAnalysis,
+            "PYZ": _FakeTarget,
+            "EXE": _FakeTarget,
+            "COLLECT": _FakeTarget,
+            "BUNDLE": _FakeTarget,
+        },
+    )
+    return cast(dict[str, object], namespace)
+
+
+class TestMacOSBundleMetadataPolicy(unittest.TestCase):
+    def test_repository_metadata_has_exact_public_contract(self) -> None:
+        version = POLICY.load_release_version(PROJECT_ROOT)
+        metadata = POLICY.load_bundle_metadata(PROJECT_ROOT)
+
+        self.assertEqual(POLICY.BUNDLE_IDENTIFIER, "land.infi.gm2godot")
+        self.assertEqual(
+            POLICY.__all__,
+            ("BUNDLE_IDENTIFIER", "load_release_version", "load_bundle_metadata"),
+        )
+        self.assertEqual(set(metadata), EXPECTED_METADATA_KEYS)
+        self.assertEqual(
+            metadata,
+            {
+                "CFBundleIdentifier": "land.infi.gm2godot",
+                "CFBundleShortVersionString": version,
+                "CFBundleVersion": version,
+            },
+        )
+        self.assertTrue(all(type(value) is str for value in metadata.values()))
+
+    def test_docstring_future_import_and_annotated_getter_are_accepted(self) -> None:
+        source = (
+            '"""Canonical application version."""\n'
+            "from __future__ import annotations\n\n"
+            'VERSION = "2.3.4"\n\n'
+            "def get_version() -> str:\n"
+            "    return VERSION\n\n"
+        )
+        with tempfile.TemporaryDirectory() as raw_root:
+            source_root = Path(raw_root)
+            write_version_source(source_root, source)
+
+            self.assertEqual(POLICY.load_release_version(source_root), "2.3.4")
+
+    def test_version_source_is_never_executed(self) -> None:
+        source = canonical_version_source("2.3.4") + 'raise AssertionError("source was executed")\n'
+        with tempfile.TemporaryDirectory() as raw_root:
+            source_root = Path(raw_root)
+            write_version_source(source_root, source)
+
+            with self.assertRaisesRegex(ValueError, "may only contain"):
+                POLICY.load_release_version(source_root)
+
+    def test_noncanonical_release_versions_are_rejected(self) -> None:
+        invalid_versions = (
+            "0.0.0",
+            "1.2",
+            "1.2.3.4",
+            "01.2.3",
+            "1.02.3",
+            "1.2.03",
+            "1.2.3-beta",
+            " 1.2.3",
+            "1.2.3 ",
+        )
+        for version in invalid_versions:
+            with self.subTest(version=version), tempfile.TemporaryDirectory() as raw_root:
+                source_root = Path(raw_root)
+                write_version_source(source_root, canonical_version_source(version))
+
+                with self.assertRaisesRegex(ValueError, "non-placeholder, canonical three-integer"):
+                    POLICY.load_release_version(source_root)
+
+    def test_missing_dynamic_duplicate_and_rebound_versions_are_rejected(self) -> None:
+        invalid_sources = {
+            "missing": 'OTHER = "1.2.3"\n',
+            "dynamic": 'VERSION = ".".join(("1", "2", "3"))\n\ndef get_version():\n    return VERSION\n',
+            "duplicate": canonical_version_source("1.2.3") + 'VERSION = "1.2.4"\n',
+            "annotated": 'VERSION: str = "1.2.3"\n\ndef get_version():\n    return VERSION\n',
+            "globals-rebind": canonical_version_source("1.2.3") + 'globals()["VERSION"] = "9.9.9"\n',
+            "wrong-getter": 'VERSION = "1.2.3"\n\ndef get_version():\n    return "9.9.9"\n',
+            "getter-default": 'VERSION = "1.2.3"\n\ndef get_version(value=VERSION):\n    return VERSION\n',
+            "getter-decorator": 'VERSION = "1.2.3"\n\n@staticmethod\ndef get_version():\n    return VERSION\n',
+        }
+        for label, source in invalid_sources.items():
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as raw_root:
+                source_root = Path(raw_root)
+                write_version_source(source_root, source)
+
+                with self.assertRaises(ValueError):
+                    POLICY.load_release_version(source_root)
+
+    def test_malformed_and_non_utf8_sources_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_root:
+            source_root = Path(raw_root)
+            write_version_source(source_root, "VERSION =\n")
+            with self.assertRaisesRegex(ValueError, "not valid Python syntax"):
+                POLICY.load_release_version(source_root)
+
+        with tempfile.TemporaryDirectory() as raw_root:
+            source_root = Path(raw_root)
+            version_path = write_version_source(source_root, 'VERSION = "1.2.3"\n')
+            version_path.write_bytes(b'VERSION = "\xff"\n')
+            with self.assertRaisesRegex(ValueError, "not valid UTF-8"):
+                POLICY.load_release_version(source_root)
+
+    def test_symlinked_version_source_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_root:
+            source_root = Path(raw_root)
+            source_directory = source_root / "src"
+            source_directory.mkdir()
+            real_version = source_root / "real_version.py"
+            real_version.write_text(canonical_version_source("1.2.3"), encoding="utf-8")
+            version_path = source_directory / "version.py"
+            try:
+                version_path.symlink_to(real_version)
+            except (NotImplementedError, OSError) as error:
+                self.skipTest(f"Symlinks are unavailable: {error}")
+
+            with self.assertRaisesRegex(ValueError, "must not be a symbolic link"):
+                POLICY.load_release_version(source_root)
+
+    def test_oversized_version_source_is_rejected_before_parsing(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_root:
+            source_root = Path(raw_root)
+            version_path = write_version_source(source_root, canonical_version_source("1.2.3"))
+            version_path.write_bytes(b"#" * (64 * 1024))
+
+            with self.assertRaisesRegex(ValueError, "exceeds the .*byte limit"):
+                POLICY.load_release_version(source_root)
+
+    def test_policy_uses_ast_without_dynamic_execution(self) -> None:
+        source = POLICY_PATH.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(POLICY_PATH))
+        imported_roots: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported_roots.update(alias.name.partition(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module is not None:
+                imported_roots.add(node.module.partition(".")[0])
+        forbidden_calls = {
+            node.func.id for node in ast.walk(tree) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        } & {"compile", "eval", "exec", "__import__"}
+
+        self.assertTrue({"ast", "pathlib", "re", "stat", "typing"} <= imported_roots)
+        self.assertTrue({"importlib", "runpy", "src"}.isdisjoint(imported_roots))
+        self.assertEqual(forbidden_calls, set())
+        self.assertIn(".lstat()", source)
+        self.assertIn('.open("rb")', source)
+        self.assertIn("ast.parse(", source)
+
+
+class TestMacOSPyInstallerSpec(unittest.TestCase):
+    def test_spec_is_the_only_tracked_spec_exception(self) -> None:
+        ignore_lines = (PROJECT_ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
+        spec_exceptions = [line for line in ignore_lines if line.startswith("!") and line.endswith(".spec")]
+
+        self.assertEqual(spec_exceptions, ["!packaging/macos/GM2Godot.spec"])
+        self.assertLess(
+            ignore_lines.index("*.spec"),
+            ignore_lines.index("!packaging/macos/GM2Godot.spec"),
+        )
+
+    def test_spec_anchors_from_exact_spec_and_avoids_module_search_paths(self) -> None:
+        source = SPEC_PATH.read_text(encoding="utf-8")
+        ast.parse(source, filename=str(SPEC_PATH))
+
+        self.assertIn("Path(SPEC).resolve(strict=True)", source)
+        self.assertIn('_POLICY_FILE = _SPEC_FILE.with_name("bundle_metadata.py")', source)
+        self.assertIn("spec_from_file_location(", source)
+        self.assertNotIn("SPECPATH", source)
+        self.assertNotIn("sys.path", source)
+        self.assertIsNone(re.search(r"[\"'](?:0|[1-9][0-9]*)\.[0-9]+\.[0-9]+[\"']", source))
+
+    def test_spec_preserves_onedir_inputs_and_routes_metadata_to_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_root:
+            source_root = Path(raw_root) / "checkout"
+            macos_directory = source_root / "packaging" / "macos"
+            macos_directory.mkdir(parents=True)
+            copied_policy = macos_directory / POLICY_PATH.name
+            copied_spec = macos_directory / SPEC_PATH.name
+            shutil.copyfile(POLICY_PATH, copied_policy)
+            shutil.copyfile(SPEC_PATH, copied_spec)
+            write_version_source(source_root, canonical_version_source("9.8.7"))
+
+            shadow_directory = Path(raw_root) / "shadow"
+            shadow_directory.mkdir()
+            (shadow_directory / "bundle_metadata.py").write_text(
+                "raise RuntimeError('module-search shadow was imported')\n",
+                encoding="utf-8",
+            )
+            with mock.patch.object(sys, "path", [str(shadow_directory), *sys.path]):
+                namespace = _run_spec(copied_spec)
+
+            resolved_source_root = source_root.resolve()
+
+        self.assertEqual(cast(Path, namespace["_SOURCE_ROOT"]), resolved_source_root)
+
+        analysis = cast(_FakeAnalysis, namespace["a"])
+        self.assertEqual(analysis.args, ([str(resolved_source_root / "main.py")],))
+        self.assertEqual(analysis.kwargs["pathex"], [])
+        self.assertEqual(analysis.kwargs["binaries"], [])
+        self.assertEqual(
+            analysis.kwargs["datas"],
+            [
+                (
+                    str(resolved_source_root / path.relative_to(PROJECT_ROOT)),
+                    destination,
+                )
+                for path, destination in EXPECTED_DATA_FILES
+            ],
+        )
+        self.assertEqual(analysis.kwargs["hiddenimports"], EXPECTED_HIDDEN_IMPORTS)
+        self.assertEqual(analysis.kwargs["hookspath"], [])
+        self.assertEqual(analysis.kwargs["hooksconfig"], {})
+        self.assertEqual(analysis.kwargs["runtime_hooks"], [])
+        self.assertEqual(analysis.kwargs["excludes"], [])
+        self.assertIs(analysis.kwargs["noarchive"], False)
+        self.assertEqual(analysis.kwargs["optimize"], 0)
+
+        executable = cast(_FakeTarget, namespace["exe"])
+        self.assertEqual(executable.args[1:], (("analysis-scripts",), []))
+        self.assertIs(executable.kwargs["exclude_binaries"], True)
+        self.assertEqual(executable.kwargs["name"], "GM2Godot")
+        self.assertIs(executable.kwargs["console"], False)
+        self.assertIs(executable.kwargs["argv_emulation"], False)
+        self.assertIsNone(executable.kwargs["target_arch"])
+        self.assertIsNone(executable.kwargs["codesign_identity"])
+        self.assertIsNone(executable.kwargs["entitlements_file"])
+
+        collection = cast(_FakeTarget, namespace["coll"])
+        self.assertEqual(
+            collection.args,
+            (executable, ("analysis-binaries",), ("analysis-datas",)),
+        )
+        self.assertEqual(collection.kwargs["name"], "GM2Godot")
+
+        bundle = cast(_FakeTarget, namespace["app"])
+        self.assertEqual(bundle.args, (collection,))
+        self.assertEqual(bundle.kwargs["name"], "GM2Godot.app")
+        self.assertEqual(
+            bundle.kwargs["icon"],
+            str(resolved_source_root / "img" / "Logo.png"),
+        )
+        self.assertEqual(bundle.kwargs["bundle_identifier"], "land.infi.gm2godot")
+        self.assertEqual(bundle.kwargs["version"], "9.8.7")
+        self.assertEqual(bundle.kwargs["info_plist"], {"CFBundleVersion": "9.8.7"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_19(self) -> None:
-        self.assertEqual(get_version(), "0.7.19")
+    def test_release_version_is_0_7_20(self) -> None:
+        self.assertEqual(get_version(), "0.7.20")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #735

## Summary
- build the macOS app from a maintained PyInstaller spec with the stable `land.infi.gm2godot` identifier and `0.7.20` source version
- verify exact app, ZIP, and read-only DMG plist values and bytes before upload
- document the build-version scheme and release checks

## Validation
- `./venv/bin/python -m unittest` (2054 tests, 39 skipped)
- `./venv/bin/pyright --warnings`
- `./venv/bin/ruff check .`
- `bash -n build_macos.sh`
- `actionlint .github/workflows/release.yml`
- native PyInstaller 6.21 and app/ZIP/DMG verifier smoke