### PR TITLE
Validate packaged Linux GUI and Qt/XCB dependencies

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.21, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.22, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -793,6 +793,28 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
+      - name: Install Linux GUI build and smoke dependencies
+        if: matrix.name == 'linux'
+        run: |
+          package_manifest="packaging/linux/qt-xcb-runtime-packages.txt"
+          mapfile -t qt_packages < <(
+            sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' "$package_manifest"
+          )
+          if [ "${#qt_packages[@]}" -ne 9 ]; then
+            echo "::error::Expected exactly nine reviewed Qt/XCB runtime packages; found ${#qt_packages[@]}." >&2
+            exit 1
+          fi
+          for package in "${qt_packages[@]}"; do
+            if [[ ! "$package" =~ ^[a-z0-9][a-z0-9+.-]*$ ]]; then
+              echo "::error::Invalid package name in $package_manifest: $package" >&2
+              exit 1
+            fi
+          done
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            "${qt_packages[@]}" \
+            xvfb
+
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
@@ -851,16 +873,22 @@ jobs:
       - name: Build executable
         if: matrix.name != 'macos'
         run: |
+          additional_hooks=()
           if [ "$RUNNER_OS" = "Windows" ]; then
             SEP=";"
           else
             SEP=":"
           fi
+          if [ "${{ matrix.name }}" = "linux" ]; then
+            additional_hooks=(--additional-hooks-dir packaging/linux/hooks)
+          fi
+          pyinstaller_log="$RUNNER_TEMP/release-${{ matrix.name }}-pyinstaller.log"
           python -m PyInstaller ${{ matrix.pyinstaller_mode }} \
             --windowed \
             --clean \
             --name GM2Godot \
             --icon img/Logo.png \
+            "${additional_hooks[@]}" \
             --hidden-import markdown2 \
             --hidden-import PIL \
             --hidden-import PySide6.QtWidgets \
@@ -870,11 +898,65 @@ jobs:
             --add-data "src${SEP}src" \
             --add-data "Languages${SEP}Languages" \
             --add-data "Current Language${SEP}." \
-            main.py
+            main.py 2>&1 | tee "$pyinstaller_log"
+          if [ "${{ matrix.name }}" = "linux" ]; then
+            warning_status=0
+            grep -Fq "WARNING: Library not found:" "$pyinstaller_log" || warning_status=$?
+            if [ "$warning_status" -eq 0 ]; then
+              echo "::error::The Linux PyInstaller analysis reported an unresolved shared library." >&2
+              exit 1
+            fi
+            if [ "$warning_status" -ne 1 ]; then
+              echo "::error::Unable to inspect the Linux PyInstaller warning log." >&2
+              exit 1
+            fi
+          fi
 
       - name: Build macOS app bundle
         if: matrix.name == 'macos'
         run: python -m PyInstaller --clean packaging/macos/GM2Godot.spec
+
+      - name: Verify Linux bundled Qt runtime
+        if: matrix.name == 'linux'
+        run: |
+          inventory="$RUNNER_TEMP/release-linux-archive-inventory.txt"
+          normalized_inventory="$RUNNER_TEMP/release-linux-archive-members.txt"
+          pyi-archive_viewer --list --recursive --brief dist/GM2Godot > "$inventory"
+          sed -n -e 's/^ //p' "$inventory" > "$normalized_inventory"
+          for required in \
+            PySide6/Qt/plugins/platforms/libqxcb.so \
+            libxkbcommon-x11.so.0 \
+            libxcb-cursor.so.0 \
+            libxcb-icccm.so.4 \
+            libxcb-image.so.0 \
+            libxcb-keysyms.so.1 \
+            libxcb-render-util.so.0 \
+            libxcb-shape.so.0 \
+            libxcb-util.so.1 \
+            libxcb-xkb.so.1
+          do
+            member_status=0
+            grep -Fxq -- "$required" "$normalized_inventory" || member_status=$?
+            if [ "$member_status" -eq 1 ]; then
+              echo "::error::The Linux one-file archive is missing required Qt/XCB member: $required" >&2
+              exit 1
+            fi
+            if [ "$member_status" -ne 0 ]; then
+              echo "::error::Unable to inspect the Linux one-file archive inventory." >&2
+              exit 1
+            fi
+          done
+          tiff_status=0
+          grep -Fxq -- "PySide6/Qt/plugins/imageformats/libqtiff.so" \
+            "$normalized_inventory" || tiff_status=$?
+          if [ "$tiff_status" -eq 0 ]; then
+            echo "::error::The unsupported Qt TIFF plugin remained in the Linux one-file archive." >&2
+            exit 1
+          fi
+          if [ "$tiff_status" -ne 1 ]; then
+            echo "::error::Unable to inspect the Linux one-file archive inventory." >&2
+            exit 1
+          fi
 
       - name: Package build
         run: |
@@ -890,6 +972,12 @@ jobs:
         run: |
           cd release
           7z a ../GM2Godot-${{ matrix.name }}.zip .
+
+      - name: Verify packaged Linux GUI
+        if: matrix.name == 'linux'
+        run: |
+          python -I scripts/verify_linux_gui_artifact.py \
+            --archive "$GITHUB_WORKSPACE/GM2Godot-linux.zip"
 
       - name: Create macOS DMG
         if: matrix.name == 'macos'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -800,8 +800,8 @@ jobs:
           mapfile -t qt_packages < <(
             sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' "$package_manifest"
           )
-          if [ "${#qt_packages[@]}" -ne 9 ]; then
-            echo "::error::Expected exactly nine reviewed Qt/XCB runtime packages; found ${#qt_packages[@]}." >&2
+          if [ "${#qt_packages[@]}" -ne 11 ]; then
+            echo "::error::Expected exactly eleven reviewed Qt GUI/XCB runtime packages; found ${#qt_packages[@]}." >&2
             exit 1
           fi
           for package in "${qt_packages[@]}"; do

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install Qt system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends libegl1
+          sudo apt-get install --yes --no-install-recommends libegl1 libgl1
 
       - name: Run unit tests
         run: python -m unittest discover tests/ -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.22 - 2026-07-19
 
-- Declared Ubuntu 24.04 x86_64 as the packaged Linux baseline, supplied Qt's required XCB libraries during dependency analysis, and intentionally excluded the unused Qt TIFF plugin whose obsolete `libtiff.so.5` ABI is unavailable on that baseline.
+- Declared Ubuntu 24.04 x86_64 as the packaged Linux baseline, supplied QtGui's required EGL/GL providers and XCB libraries during dependency analysis, and intentionally excluded the unused Qt TIFF plugin whose obsolete `libtiff.so.5` ABI is unavailable on that baseline.
 - Made the release build fail on unresolved shared-library warnings and validate the extracted Linux archive under the real `qxcb` platform in Xvfb, including bundled-library inventory, executable permissions, GUI readiness, fatal loader diagnostics, and bounded process cleanup.
 
 ## 0.7.21 - 2026-07-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.22 - 2026-07-19
+
+- Declared Ubuntu 24.04 x86_64 as the packaged Linux baseline, supplied Qt's required XCB libraries during dependency analysis, and intentionally excluded the unused Qt TIFF plugin whose obsolete `libtiff.so.5` ABI is unavailable on that baseline.
+- Made the release build fail on unresolved shared-library warnings and validate the extracted Linux archive under the real `qxcb` platform in Xvfb, including bundled-library inventory, executable permissions, GUI readiness, fatal loader diagnostics, and bounded process cleanup.
+
 ## 0.7.21 - 2026-07-19
 
 - Forwarded exact terminal conversion outcomes through the GUI worker so partial, failed, and cancelled runs no longer collapse into the green success state.

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.21`.
+Current source version: `0.7.22`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
+The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system and X11 libraries. The release job bundles the Qt/XCB client libraries discovered on the baseline, rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.
 Releases starting with 0.7.14 include `SHA256SUMS` for the four platform payloads so downloaded bytes can be checked independently.
 When an exact version tag already exists, a release-workflow rerun now audits the published release, exact five-asset inventory, GitHub digests, downloaded bytes, checksum manifest, and stable tag/release receipt before accepting the run as a build-and-publication no-op.
 
@@ -85,6 +86,12 @@ Use the exact interpreter from the table above. After activation, `python --vers
 Linux x64:
 
 ```bash
+mapfile -t qt_packages < <(
+  sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' \
+    packaging/linux/qt-xcb-runtime-packages.txt
+)
+sudo apt-get update
+sudo apt-get install --yes --no-install-recommends "${qt_packages[@]}"
 python3.12 -m venv venv
 source venv/bin/activate
 python --version  # Python 3.12.13

--- a/README.md
+++ b/README.md
@@ -51,7 +51,18 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 Current source version: `0.7.22`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
-The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system and X11 libraries. The release job bundles the Qt/XCB client libraries discovered on the baseline, rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.
+The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.
+
+On a minimal Ubuntu 24.04 installation, install the reviewed host libraries before launching the downloaded Linux executable:
+
+```bash
+sudo apt-get update
+sudo apt-get install --yes --no-install-recommends \
+  libegl1 libgl1 libxkbcommon-x11-0 libxcb-cursor0 libxcb-icccm4 \
+  libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-shape0 \
+  libxcb-util1 libxcb-xkb1
+```
+
 Releases starting with 0.7.14 include `SHA256SUMS` for the four platform payloads so downloaded bytes can be checked independently.
 When an exact version tag already exists, a release-workflow rerun now audits the published release, exact five-asset inventory, GitHub digests, downloaded bytes, checksum manifest, and stable tag/release receipt before accepting the run as a build-and-publication no-op.
 

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.21 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.22 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -47,7 +47,7 @@ Three separate platform questions are easy to confuse:
 
 | Question | Current contract |
 | --- | --- |
-| **Where can GM2Godot run?** | Release artifacts and source execution are supported on Windows, macOS, and Linux. This is the **conversion host**. |
+| **Where can GM2Godot run?** | Release artifacts and source execution are supported on Windows, macOS, and Linux. Ubuntu 24.04 x86_64 is the only validated packaged-Linux baseline. Its glibc 2.39 requirement is necessary, while other distributions remain unverified and also need compatible system and X11 libraries. This is the **conversion host**. |
 | **What does `--target-platform` select?** | The CLI accepts `windows`, `macos`, or `linux`. This is a **GameMaker source/configuration filter** used for target-specific project options, conditional GML and macros, and capability-report context. It does not filter the project's resource inventory. It defaults from the conversion host. |
 | **Where can the generated game be exported?** | The generated project targets Godot 4.7.1, but GM2Godot does not certify a complete export for a platform. Godot export templates and presets, signing, permissions, SDKs, native extensions, store services, and target-device tests remain separate work. |
 
@@ -59,6 +59,8 @@ Selecting `--target-platform windows`, for example, does **not** create or valid
 - The output and automated smoke-test target is the official **[Godot 4.7.1](https://godotengine.org/article/maintenance-release-godot-4-7-1/)** build at commit `a13da4feb`. Other Godot versions may parse the project, but they are not the compatibility target for this release.
 - GM2Godot expects an editable GameMaker project with a `.yyp` and its `.yy`, GML, and asset files. Compiled executables are not supported input.
 - A generated project is a migration starting point. Keep the original GameMaker project, convert into a separate destination, and compare behavior before replacing any production workflow.
+
+The packaged Linux GUI intentionally excludes Qt's optional TIFF image-format plugin because the pinned Qt wheel requests the obsolete `libtiff.so.5` ABI, while Ubuntu 24.04 provides ABI-major 6. GM2Godot's interface loads its committed PNG assets and does not use that Qt plugin; GameMaker sprite and icon conversion continues through Pillow and is unaffected. The release build fails if this exclusion drifts or any required Qt/XCB library remains unresolved.
 
 ## Known limitation areas
 

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -60,7 +60,7 @@ Selecting `--target-platform windows`, for example, does **not** create or valid
 - GM2Godot expects an editable GameMaker project with a `.yyp` and its `.yy`, GML, and asset files. Compiled executables are not supported input.
 - A generated project is a migration starting point. Keep the original GameMaker project, convert into a separate destination, and compare behavior before replacing any production workflow.
 
-The packaged Linux GUI intentionally excludes Qt's optional TIFF image-format plugin because the pinned Qt wheel requests the obsolete `libtiff.so.5` ABI, while Ubuntu 24.04 provides ABI-major 6. GM2Godot's interface loads its committed PNG assets and does not use that Qt plugin; GameMaker sprite and icon conversion continues through Pillow and is unaffected. The release build fails if this exclusion drifts or any required Qt/XCB library remains unresolved.
+The packaged Linux GUI intentionally excludes Qt's optional TIFF image-format plugin because the pinned Qt wheel requests the obsolete `libtiff.so.5` ABI, while Ubuntu 24.04 provides ABI-major 6. GM2Godot's interface loads its committed PNG assets and does not use that Qt plugin; GameMaker sprite and icon conversion continues through Pillow and is unaffected. Ubuntu's `libegl1` and `libgl1` packages remain required because the pinned QtGui library links directly to EGL and GL. The release build fails if the TIFF exclusion drifts or any required Qt GUI/XCB library remains unresolved.
 
 ## Known limitation areas
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.21 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.22 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.21 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.22 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.21 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.22 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.21 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.22 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.21;
+- GM2Godot 0.7.22;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -18,7 +18,17 @@ Download the asset for your operating system from [GitHub Releases](https://gith
 | macOS | `GM2Godot-macos.dmg` or `GM2Godot-macos.zip` | Open the DMG and copy `GM2Godot.app` to Applications, or extract the ZIP and launch the app. |
 | Linux | `GM2Godot-linux.zip` | On the validated Ubuntu 24.04 x86_64 baseline, extract the archive and run `./GM2Godot`. If the executable bit was lost during download or extraction, run `chmod +x GM2Godot` once. |
 
-Ubuntu 24.04 x86_64 is the only validated packaged-Linux baseline. PyInstaller does not bundle glibc, so glibc 2.39 is necessary; it is not by itself a portability guarantee for other distributions, which remain unverified and must also provide compatible system and X11 libraries. The build supplies and collects Qt's required XCB client libraries, rejects unresolved shared-library warnings, and launches the executable extracted from the final ZIP through Qt's real `qxcb` platform under Xvfb before upload. A normal graphical X11 session, or XWayland when using a Wayland desktop, is still required at runtime.
+Ubuntu 24.04 x86_64 is the only validated packaged-Linux baseline. PyInstaller does not bundle glibc, so glibc 2.39 is necessary; it is not by itself a portability guarantee for other distributions, which remain unverified and must also provide compatible system, OpenGL/EGL, and X11 libraries. The reviewed package manifest installs Ubuntu's `libegl1` and `libgl1` providers required by QtGui together with the XCB client libraries. The build rejects unresolved shared-library warnings and launches the executable extracted from the final ZIP through Qt's real `qxcb` platform under Xvfb before upload. A normal graphical X11 session, or XWayland when using a Wayland desktop, is still required at runtime.
+
+On a minimal installation of that baseline, install the reviewed host libraries before launching the downloaded executable:
+
+```bash
+sudo apt-get update
+sudo apt-get install --yes --no-install-recommends \
+  libegl1 libgl1 libxkbcommon-x11-0 libxcb-cursor0 libxcb-icccm4 \
+  libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-shape0 \
+  libxcb-util1 libxcb-xkb1
+```
 
 ### Verify a release download
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.21 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.22 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -16,7 +16,9 @@ Download the asset for your operating system from [GitHub Releases](https://gith
 | --- | --- | --- |
 | Windows | `GM2Godot-windows.zip` | Extract the archive, then run `GM2Godot.exe`. |
 | macOS | `GM2Godot-macos.dmg` or `GM2Godot-macos.zip` | Open the DMG and copy `GM2Godot.app` to Applications, or extract the ZIP and launch the app. |
-| Linux | `GM2Godot-linux.zip` | Extract the archive and run `./GM2Godot`. If the executable bit was lost during download or extraction, run `chmod +x GM2Godot` once. |
+| Linux | `GM2Godot-linux.zip` | On the validated Ubuntu 24.04 x86_64 baseline, extract the archive and run `./GM2Godot`. If the executable bit was lost during download or extraction, run `chmod +x GM2Godot` once. |
+
+Ubuntu 24.04 x86_64 is the only validated packaged-Linux baseline. PyInstaller does not bundle glibc, so glibc 2.39 is necessary; it is not by itself a portability guarantee for other distributions, which remain unverified and must also provide compatible system and X11 libraries. The build supplies and collects Qt's required XCB client libraries, rejects unresolved shared-library warnings, and launches the executable extracted from the final ZIP through Qt's real `qxcb` platform under Xvfb before upload. A normal graphical X11 session, or XWayland when using a Wayland desktop, is still required at runtime.
 
 ### Verify a release download
 
@@ -34,7 +36,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.21`.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.22`.
 
 ## Run from source
 
@@ -91,6 +93,12 @@ python main.py
 ```bash
 git clone https://github.com/Infiland/GM2Godot.git
 cd GM2Godot
+mapfile -t qt_packages < <(
+  sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' \
+    packaging/linux/qt-xcb-runtime-packages.txt
+)
+sudo apt-get update
+sudo apt-get install --yes --no-install-recommends "${qt_packages[@]}"
 python3.12 -m venv venv
 source venv/bin/activate
 python --version  # Python 3.12.13
@@ -115,6 +123,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.21`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.22`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.21 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.22 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -36,6 +36,10 @@ Before artifact upload, `scripts/verify_macos_bundle_metadata.py` checks the sou
 
 This policy does not select the macOS architecture tracked in issue #736 and does not sign or notarize the app tracked in issue #737.
 
+## Linux packaged-GUI gate
+
+The packaged Linux baseline is Ubuntu 24.04 x86_64. The Linux build installs the exact XCB runtime-package inventory in `packaging/linux/qt-xcb-runtime-packages.txt` before PyInstaller analysis and uses the reviewed hook under `packaging/linux/hooks/` to exclude only Qt's unused TIFF plugin. Any `Library not found` warning fails the build. Before upload, the workflow inspects the one-file archive for the `qxcb` plugin and all required XCB SONAMEs, rejects the TIFF plugin, and runs `scripts/verify_linux_gui_artifact.py` against the extracted final ZIP under Xvfb with `QT_QPA_PLATFORM=xcb`. Success requires the main window to reach the Qt event loop and write the exact one-use readiness receipt before a bounded clean exit; missing loaders, platform-plugin failures, unsafe archive metadata, an immediate crash, a timeout, or fatal captured diagnostics fail the matrix job.
+
 ## Versioned-change checklist
 
 Before opening the pull request:
@@ -54,6 +58,7 @@ Before merging:
 - [ ] Confirm `refs/tags/v<version>` does not already exist on the GitHub remote; do not rely only on a local checkout's tag list.
 - [ ] Confirm all pull-request checks pass, including exact Godot 4.7.1 smoke and current GameMaker LTS conversion gates.
 - [ ] Confirm Linux, macOS, and Windows build jobs produce non-empty artifacts.
+- [ ] Confirm the Linux build reports no unresolved shared libraries and its extracted-ZIP `qxcb` GUI smoke passes with the required bundled XCB inventory and excluded TIFF plugin.
 - [ ] Confirm the macOS build verifies the exact bundle identifier and source release version in the `.app`, ZIP, and DMG before upload.
 - [ ] Confirm the pull request references the intended issue, uses the correct closure timing, and does not absorb unrelated work.
 

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -38,7 +38,7 @@ This policy does not select the macOS architecture tracked in issue #736 and doe
 
 ## Linux packaged-GUI gate
 
-The packaged Linux baseline is Ubuntu 24.04 x86_64. The Linux build installs the exact XCB runtime-package inventory in `packaging/linux/qt-xcb-runtime-packages.txt` before PyInstaller analysis and uses the reviewed hook under `packaging/linux/hooks/` to exclude only Qt's unused TIFF plugin. Any `Library not found` warning fails the build. Before upload, the workflow inspects the one-file archive for the `qxcb` plugin and all required XCB SONAMEs, rejects the TIFF plugin, and runs `scripts/verify_linux_gui_artifact.py` against the extracted final ZIP under Xvfb with `QT_QPA_PLATFORM=xcb`. Success requires the main window to reach the Qt event loop and write the exact one-use readiness receipt before a bounded clean exit; missing loaders, platform-plugin failures, unsafe archive metadata, an immediate crash, a timeout, or fatal captured diagnostics fail the matrix job.
+The packaged Linux baseline is Ubuntu 24.04 x86_64. The Linux build installs the exact Qt GUI/XCB runtime-package inventory in `packaging/linux/qt-xcb-runtime-packages.txt` before PyInstaller analysis, including Ubuntu's `libegl1` and `libgl1` providers required directly by QtGui, and uses the reviewed hook under `packaging/linux/hooks/` to exclude only Qt's unused TIFF plugin. Any `Library not found` warning fails the build. Before upload, the workflow inspects the one-file archive for the `qxcb` plugin and all required XCB SONAMEs, rejects the TIFF plugin, and runs `scripts/verify_linux_gui_artifact.py` against the extracted final ZIP under Xvfb with `QT_QPA_PLATFORM=xcb`. Success requires the main window to reach the Qt event loop and write the exact one-use readiness receipt before a bounded clean exit; missing loaders, platform-plugin failures, unsafe archive metadata, an immediate crash, a timeout, or unresolved captured diagnostics fail the matrix job.
 
 ## Versioned-change checklist
 
@@ -58,7 +58,7 @@ Before merging:
 - [ ] Confirm `refs/tags/v<version>` does not already exist on the GitHub remote; do not rely only on a local checkout's tag list.
 - [ ] Confirm all pull-request checks pass, including exact Godot 4.7.1 smoke and current GameMaker LTS conversion gates.
 - [ ] Confirm Linux, macOS, and Windows build jobs produce non-empty artifacts.
-- [ ] Confirm the Linux build reports no unresolved shared libraries and its extracted-ZIP `qxcb` GUI smoke passes with the required bundled XCB inventory and excluded TIFF plugin.
+- [ ] Confirm the Linux build reports no unresolved shared libraries and its extracted-ZIP `qxcb` GUI smoke passes with the required Qt GUI/XCB runtime inventory and excluded TIFF plugin.
 - [ ] Confirm the macOS build verifies the exact bundle identifier and source release version in the `.app`, ZIP, and DMG before upload.
 - [ ] Confirm the pull request references the intended issue, uses the correct closure timing, and does not absorb unrelated work.
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.21 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.22 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/main.py
+++ b/main.py
@@ -1,7 +1,56 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
 import sys
 
 CLI_COMMANDS = {"analyze", "convert", "list-converters", "report", "validate"}
 CLI_GLOBAL_FLAGS = {"--help", "-h", "--version"}
+GUI_SMOKE_RECEIPT_ENV = "GM2GODOT_GUI_SMOKE_RECEIPT"
+GUI_SMOKE_RECEIPT = "GM2Godot packaged GUI ready\n"
+
+
+def _configured_gui_smoke_receipt() -> Path | None:
+    raw_path = os.environ.get(GUI_SMOKE_RECEIPT_ENV)
+    if raw_path is None:
+        return None
+    if not raw_path:
+        raise ValueError(f"{GUI_SMOKE_RECEIPT_ENV} must not be empty")
+
+    receipt_path = Path(raw_path)
+    if not receipt_path.is_absolute():
+        raise ValueError(f"{GUI_SMOKE_RECEIPT_ENV} must be an absolute path")
+    return receipt_path
+
+
+def _write_gui_smoke_receipt(receipt_path: Path) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    no_follow = getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(receipt_path, flags | no_follow, 0o600)
+    created: os.stat_result | None = None
+    try:
+        created = os.fstat(descriptor)
+        if os.name != "nt":
+            os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(GUI_SMOKE_RECEIPT)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except BaseException:
+        try:
+            os.close(descriptor)
+        except OSError:
+            pass
+        try:
+            current = receipt_path.lstat()
+            if created is not None and (current.st_dev, current.st_ino) == (
+                created.st_dev,
+                created.st_ino,
+            ):
+                receipt_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
 
 
 def main() -> None:
@@ -10,6 +59,13 @@ def main() -> None:
 
         sys.exit(cli_main(sys.argv[1:]))
 
+    try:
+        smoke_receipt = _configured_gui_smoke_receipt()
+    except ValueError as error:
+        print(f"GUI startup smoke configuration error: {error}", file=sys.stderr)
+        raise SystemExit(2) from error
+
+    from PySide6.QtCore import QTimer
     from PySide6.QtWidgets import QApplication
 
     from src.gui.main_window import MainWindow
@@ -18,8 +74,23 @@ def main() -> None:
     app = QApplication(sys.argv)
     app.setStyleSheet(generate_stylesheet())
 
-    window = MainWindow()
+    window = MainWindow(check_for_updates_on_startup=smoke_receipt is None)
     window.show()
+
+    if smoke_receipt is not None:
+
+        def complete_gui_smoke() -> None:
+            try:
+                if not window.isVisible():
+                    raise RuntimeError("main window did not become visible")
+                _write_gui_smoke_receipt(smoke_receipt)
+            except Exception as error:
+                print(f"GUI startup smoke failed: {error}", file=sys.stderr)
+                app.exit(1)
+                return
+            app.quit()
+
+        QTimer.singleShot(0, complete_gui_smoke)
 
     sys.exit(app.exec())
 

--- a/packaging/linux/hooks/hook-PySide6.QtGui.py
+++ b/packaging/linux/hooks/hook-PySide6.QtGui.py
@@ -1,0 +1,36 @@
+from collections.abc import Callable
+from pathlib import Path
+from typing import cast
+
+from PyInstaller.utils.hooks.qt import add_qt6_dependencies  # pyright: ignore[reportMissingImports, reportUnknownVariableType]
+
+
+QtBinary = tuple[str, str]
+QtData = tuple[str, str]
+AddQtDependencies = Callable[[str], tuple[list[str], list[QtBinary], list[QtData]]]
+
+
+def _is_unsupported_tiff_plugin(binary: QtBinary) -> bool:
+    source, destination = binary
+    normalized_destination = destination.replace("\\", "/").rstrip("/")
+    return (
+        Path(source).name == "libqtiff.so"
+        and normalized_destination.endswith("/plugins/imageformats")
+    )
+
+
+typed_add_qt6_dependencies = cast(AddQtDependencies, add_qt6_dependencies)
+hiddenimports, binaries, datas = typed_add_qt6_dependencies(__file__)
+
+unsupported_tiff_plugins = [
+    binary for binary in binaries if _is_unsupported_tiff_plugin(binary)
+]
+if len(unsupported_tiff_plugins) != 1:
+    raise RuntimeError(
+        "Expected exactly one PySide6 Qt TIFF image-format plugin; "
+        f"found {len(unsupported_tiff_plugins)}."
+    )
+
+binaries = [
+    binary for binary in binaries if not _is_unsupported_tiff_plugin(binary)
+]

--- a/packaging/linux/qt-xcb-runtime-packages.txt
+++ b/packaging/linux/qt-xcb-runtime-packages.txt
@@ -1,0 +1,10 @@
+# Ubuntu 24.04 x86_64 packages collected for Qt 6's xcb platform plugin.
+libxkbcommon-x11-0
+libxcb-cursor0
+libxcb-icccm4
+libxcb-image0
+libxcb-keysyms1
+libxcb-render-util0
+libxcb-shape0
+libxcb-util1
+libxcb-xkb1

--- a/packaging/linux/qt-xcb-runtime-packages.txt
+++ b/packaging/linux/qt-xcb-runtime-packages.txt
@@ -1,4 +1,6 @@
-# Ubuntu 24.04 x86_64 packages collected for Qt 6's xcb platform plugin.
+# Ubuntu 24.04 x86_64 packages required by pinned QtGui and its xcb platform.
+libegl1
+libgl1
 libxkbcommon-x11-0
 libxcb-cursor0
 libxcb-icccm4

--- a/scripts/verify_linux_gui_artifact.py
+++ b/scripts/verify_linux_gui_artifact.py
@@ -32,6 +32,7 @@ MAX_EXECUTABLE_BYTES = 512 * 1024 * 1024
 MAX_README_BYTES = 4 * 1024 * 1024
 MAX_TOTAL_UNCOMPRESSED_BYTES = MAX_EXECUTABLE_BYTES + MAX_README_BYTES
 MAX_PROCESS_OUTPUT_BYTES = 4 * 1024 * 1024
+MAX_DIAGNOSTIC_LINE_CHARACTERS = 1000
 PROCESS_TIMEOUT_SECONDS = 60.0
 PROCESS_POLL_SECONDS = 0.2
 PROCESS_CLEANUP_TIMEOUT_SECONDS = 5.0
@@ -256,6 +257,15 @@ def _read_process_output(stream: object) -> bytes:
             "packaged GUI output exceeded the bounded verification limit"
         )
     return content
+
+
+def _matching_output_excerpt(content: str, signature: str) -> str:
+    for line in content.splitlines():
+        if signature in line.casefold():
+            if len(line) > MAX_DIAGNOSTIC_LINE_CHARACTERS:
+                line = line[:MAX_DIAGNOSTIC_LINE_CHARACTERS] + "..."
+            return repr(line)
+    return repr(signature)
 
 
 def _process_group_exists(process: subprocess.Popen[bytes]) -> bool:
@@ -526,7 +536,8 @@ def _run_packaged_gui(
     for signature in _FATAL_OUTPUT_SIGNATURES:
         if signature in folded_output:
             raise LinuxGuiArtifactVerificationError(
-                f"packaged GUI emitted fatal loader/platform diagnostic: {signature}"
+                f"packaged GUI emitted fatal loader/platform diagnostic: {signature}; "
+                f"matching output: {_matching_output_excerpt(decoded_output, signature)}"
             )
     if returncode != 0:
         raise LinuxGuiArtifactVerificationError(

--- a/scripts/verify_linux_gui_artifact.py
+++ b/scripts/verify_linux_gui_artifact.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 import lzma
 import os
 from pathlib import Path
+import re
 import signal
 import stat
 import subprocess
@@ -259,13 +260,90 @@ def _read_process_output(stream: object) -> bytes:
     return content
 
 
-def _matching_output_excerpt(content: str, signature: str) -> str:
+def _bounded_output_excerpt(
+    line: str,
+    marker_start: int,
+    marker_end: int,
+) -> str:
+    escaped_prefix = (
+        line[:marker_start]
+        .encode("unicode_escape")
+        .decode("ascii")
+        .replace("'", r"\x27")
+    )
+    escaped_marker = (
+        line[marker_start:marker_end]
+        .encode("unicode_escape")
+        .decode("ascii")
+        .replace("'", r"\x27")
+    )
+    escaped_suffix = (
+        line[marker_end:]
+        .encode("unicode_escape")
+        .decode("ascii")
+        .replace("'", r"\x27")
+    )
+    escaped_line = escaped_prefix + escaped_marker + escaped_suffix
+    escaped_marker_start = len(escaped_prefix)
+    escaped_marker_end = escaped_marker_start + len(escaped_marker)
+    if len(escaped_line) <= MAX_DIAGNOSTIC_LINE_CHARACTERS:
+        return f"'{escaped_line}'"
+
+    marker_length = escaped_marker_end - escaped_marker_start
+    omitted_prefix = escaped_marker_start > 0
+    omitted_suffix = escaped_marker_end < len(escaped_line)
+    ellipsis_length = 3 * (int(omitted_prefix) + int(omitted_suffix))
+    content_budget = MAX_DIAGNOSTIC_LINE_CHARACTERS - ellipsis_length
+    if marker_length > content_budget:
+        marker_budget = MAX_DIAGNOSTIC_LINE_CHARACTERS - 3
+        return f"'{escaped_marker[:marker_budget]}...'"
+
+    remaining = content_budget - marker_length
+    left_available = escaped_marker_start
+    right_available = len(escaped_line) - escaped_marker_end
+    left_length = min(left_available, remaining // 2)
+    right_length = min(right_available, remaining - left_length)
+    remaining -= left_length + right_length
+    if remaining:
+        additional_left = min(left_available - left_length, remaining)
+        left_length += additional_left
+        remaining -= additional_left
+    if remaining:
+        right_length += min(right_available - right_length, remaining)
+
+    excerpt_start = escaped_marker_start - left_length
+    excerpt_end = escaped_marker_end + right_length
+    excerpt = escaped_line[excerpt_start:excerpt_end]
+    if excerpt_start:
+        excerpt = "..." + excerpt
+    if excerpt_end < len(escaped_line):
+        excerpt += "..."
+    return f"'{excerpt}'"
+
+
+def _fatal_output_diagnostic(content: str) -> tuple[str, str] | None:
     for line in content.splitlines():
-        if signature in line.casefold():
-            if len(line) > MAX_DIAGNOSTIC_LINE_CHARACTERS:
-                line = line[:MAX_DIAGNOSTIC_LINE_CHARACTERS] + "..."
-            return repr(line)
-    return repr(signature)
+        selected: tuple[int, int, str] | None = None
+        for signature in _FATAL_OUTPUT_SIGNATURES:
+            match = re.search(
+                re.escape(signature),
+                line,
+                flags=re.IGNORECASE | re.ASCII,
+            )
+            if match is None:
+                continue
+            candidate = (match.start(), match.end(), signature)
+            if selected is None or candidate[0] < selected[0]:
+                selected = candidate
+        if selected is None:
+            continue
+        marker_start, marker_end, signature = selected
+        return signature, _bounded_output_excerpt(
+            line,
+            marker_start,
+            marker_end,
+        )
+    return None
 
 
 def _process_group_exists(process: subprocess.Popen[bytes]) -> bool:
@@ -532,13 +610,13 @@ def _run_packaged_gui(
             _terminate_process_group(process)
 
     decoded_output = captured.decode("utf-8", errors="replace")
-    folded_output = decoded_output.casefold()
-    for signature in _FATAL_OUTPUT_SIGNATURES:
-        if signature in folded_output:
-            raise LinuxGuiArtifactVerificationError(
-                f"packaged GUI emitted fatal loader/platform diagnostic: {signature}; "
-                f"matching output: {_matching_output_excerpt(decoded_output, signature)}"
-            )
+    fatal_diagnostic = _fatal_output_diagnostic(decoded_output)
+    if fatal_diagnostic is not None:
+        signature, excerpt = fatal_diagnostic
+        raise LinuxGuiArtifactVerificationError(
+            f"packaged GUI emitted fatal loader/platform diagnostic: {signature}; "
+            f"matching output: {excerpt}"
+        )
     if returncode != 0:
         raise LinuxGuiArtifactVerificationError(
             f"packaged GUI exited with status {returncode}"

--- a/scripts/verify_linux_gui_artifact.py
+++ b/scripts/verify_linux_gui_artifact.py
@@ -1,0 +1,656 @@
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from collections.abc import Sequence
+import lzma
+import os
+from pathlib import Path
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import zipfile
+import zlib
+
+
+ARCHIVE_NAME = "GM2Godot-linux.zip"
+EXECUTABLE_NAME = "GM2Godot"
+README_NAME = "README.md"
+EXPECTED_MEMBER_MODES = {
+    EXECUTABLE_NAME: 0o755,
+    README_NAME: 0o644,
+}
+GUI_SMOKE_RECEIPT_ENV = "GM2GODOT_GUI_SMOKE_RECEIPT"
+GUI_SMOKE_RECEIPT = b"GM2Godot packaged GUI ready\n"
+XVFB_RUN_PATH = Path("/usr/bin/xvfb-run")
+
+MAX_ARCHIVE_BYTES = 512 * 1024 * 1024
+MAX_EXECUTABLE_BYTES = 512 * 1024 * 1024
+MAX_README_BYTES = 4 * 1024 * 1024
+MAX_TOTAL_UNCOMPRESSED_BYTES = MAX_EXECUTABLE_BYTES + MAX_README_BYTES
+MAX_PROCESS_OUTPUT_BYTES = 4 * 1024 * 1024
+PROCESS_TIMEOUT_SECONDS = 60.0
+PROCESS_POLL_SECONDS = 0.2
+PROCESS_CLEANUP_TIMEOUT_SECONDS = 5.0
+PROCESS_GROUP_GRACE_SECONDS = 2.0
+PROCESS_TERMINATION_GRACE_SECONDS = 2.0
+
+_FATAL_OUTPUT_SIGNATURES = (
+    "error while loading shared libraries",
+    "cannot open shared object file",
+    "could not find the qt platform plugin",
+    "could not load the qt platform plugin",
+    "no qt platform plugin could be initialized",
+)
+
+
+class LinuxGuiArtifactVerificationError(Exception):
+    """A deterministic validation failure suitable for CI output."""
+
+
+def _require_absolute_normalized_path(raw_path: str, description: str) -> Path:
+    path = Path(raw_path)
+    if not path.is_absolute():
+        raise LinuxGuiArtifactVerificationError(
+            f"{description} must be an absolute path: {raw_path!r}"
+        )
+    if Path(os.path.normpath(os.fspath(path))) != path:
+        raise LinuxGuiArtifactVerificationError(
+            f"{description} must be lexically normalized: {raw_path!r}"
+        )
+    return path
+
+
+def _required_open_flags(base: int, *names: str) -> int:
+    flags = base
+    for name in names:
+        value = getattr(os, name, None)
+        if type(value) is not int:
+            raise LinuxGuiArtifactVerificationError(
+                f"required no-follow filesystem flag {name} is unavailable"
+            )
+        flags |= value
+    return flags
+
+
+def _validate_archive_path(archive_path: Path) -> None:
+    if archive_path.name != ARCHIVE_NAME:
+        raise LinuxGuiArtifactVerificationError(
+            f"Linux release archive must be named {ARCHIVE_NAME}: {archive_path}"
+        )
+
+
+def _validate_members(
+    members: Sequence[zipfile.ZipInfo],
+) -> dict[str, zipfile.ZipInfo]:
+    expected_names = Counter(EXPECTED_MEMBER_MODES.keys())
+    observed_names = Counter(member.filename for member in members)
+    if len(members) != len(EXPECTED_MEMBER_MODES) or observed_names != expected_names:
+        raise LinuxGuiArtifactVerificationError(
+            "Linux release ZIP must contain exactly GM2Godot and README.md once each"
+        )
+
+    selected: dict[str, zipfile.ZipInfo] = {}
+    total_size = 0
+    for member in members:
+        if member.orig_filename != member.filename:
+            raise LinuxGuiArtifactVerificationError(
+                f"ZIP member has a NUL-truncated or aliased name: {member.orig_filename!r}"
+            )
+        if member.flag_bits & 0x1:
+            raise LinuxGuiArtifactVerificationError(
+                f"ZIP member is encrypted: {member.filename}"
+            )
+        if member.compress_type != zipfile.ZIP_DEFLATED:
+            raise LinuxGuiArtifactVerificationError(
+                f"ZIP member does not use the required DEFLATE compression: "
+                f"{member.filename}"
+            )
+        if member.create_system != 3:
+            raise LinuxGuiArtifactVerificationError(
+                f"ZIP member lacks Unix metadata: {member.filename}"
+            )
+
+        raw_mode = (member.external_attr >> 16) & 0xFFFF
+        expected_mode = EXPECTED_MEMBER_MODES[member.filename]
+        if stat.S_IFMT(raw_mode) != stat.S_IFREG:
+            raise LinuxGuiArtifactVerificationError(
+                f"ZIP member is not a regular file: {member.filename}"
+            )
+        if stat.S_IMODE(raw_mode) != expected_mode:
+            raise LinuxGuiArtifactVerificationError(
+                f"ZIP member {member.filename} has mode "
+                f"{stat.S_IMODE(raw_mode):04o}; expected {expected_mode:04o}"
+            )
+
+        maximum_size = (
+            MAX_EXECUTABLE_BYTES
+            if member.filename == EXECUTABLE_NAME
+            else MAX_README_BYTES
+        )
+        if member.file_size <= 0 or member.file_size > maximum_size:
+            raise LinuxGuiArtifactVerificationError(
+                f"ZIP member {member.filename} has an invalid declared size"
+            )
+        if member.compress_size < 0 or member.compress_size > MAX_ARCHIVE_BYTES:
+            raise LinuxGuiArtifactVerificationError(
+                f"ZIP member {member.filename} has an invalid compressed size"
+            )
+        total_size += member.file_size
+        selected[member.filename] = member
+
+    if total_size > MAX_TOTAL_UNCOMPRESSED_BYTES:
+        raise LinuxGuiArtifactVerificationError(
+            "Linux release ZIP exceeds the total uncompressed-size limit"
+        )
+    return selected
+
+
+def _write_all(descriptor: int, content: bytes) -> None:
+    offset = 0
+    while offset < len(content):
+        written = os.write(descriptor, content[offset:])
+        if written <= 0:
+            raise OSError("short write while extracting ZIP member")
+        offset += written
+
+
+def _extract_member(
+    archive: zipfile.ZipFile,
+    member: zipfile.ZipInfo,
+    destination: Path,
+    expected_mode: int,
+) -> None:
+    descriptor: int | None = None
+    extracted_size = 0
+    try:
+        descriptor = os.open(
+            destination,
+            _required_open_flags(
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                "O_CLOEXEC",
+                "O_NOFOLLOW",
+            ),
+            expected_mode,
+        )
+        with archive.open(member, "r") as source:
+            while True:
+                chunk = source.read(64 * 1024)
+                if not chunk:
+                    break
+                extracted_size += len(chunk)
+                if extracted_size > member.file_size:
+                    raise LinuxGuiArtifactVerificationError(
+                        f"ZIP member {member.filename} exceeded its declared size"
+                    )
+                _write_all(descriptor, chunk)
+        if extracted_size != member.file_size:
+            raise LinuxGuiArtifactVerificationError(
+                f"ZIP member {member.filename} differs from its declared size"
+            )
+        os.fchmod(descriptor, expected_mode)
+        os.fsync(descriptor)
+    except LinuxGuiArtifactVerificationError:
+        raise
+    except (
+        OSError,
+        EOFError,
+        RuntimeError,
+        NotImplementedError,
+        ValueError,
+        lzma.LZMAError,
+        zipfile.BadZipFile,
+        zlib.error,
+    ) as error:
+        raise LinuxGuiArtifactVerificationError(
+            f"unable to extract ZIP member {member.filename}: {error}"
+        ) from error
+    finally:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+
+def _validate_extracted_file(
+    path: Path,
+    expected_mode: int,
+    expected_size: int,
+) -> None:
+    try:
+        metadata = path.lstat()
+    except OSError as error:
+        raise LinuxGuiArtifactVerificationError(
+            f"unable to inspect extracted file {path.name}: {error}"
+        ) from error
+    if not stat.S_ISREG(metadata.st_mode):
+        raise LinuxGuiArtifactVerificationError(
+            f"extracted file is not regular: {path.name}"
+        )
+    if stat.S_IMODE(metadata.st_mode) != expected_mode:
+        raise LinuxGuiArtifactVerificationError(
+            f"extracted file {path.name} has the wrong mode"
+        )
+    if metadata.st_size != expected_size:
+        raise LinuxGuiArtifactVerificationError(
+            f"extracted file {path.name} has the wrong size"
+        )
+
+
+def _read_process_output(stream: object) -> bytes:
+    try:
+        stream.seek(0)  # type: ignore[attr-defined]
+        content = stream.read(MAX_PROCESS_OUTPUT_BYTES + 1)  # type: ignore[attr-defined]
+    except OSError as error:
+        raise LinuxGuiArtifactVerificationError(
+            f"unable to read packaged GUI output: {error}"
+        ) from error
+    if not isinstance(content, bytes):
+        raise LinuxGuiArtifactVerificationError("packaged GUI output was not bytes")
+    if len(content) > MAX_PROCESS_OUTPUT_BYTES:
+        raise LinuxGuiArtifactVerificationError(
+            "packaged GUI output exceeded the bounded verification limit"
+        )
+    return content
+
+
+def _process_group_exists(process: subprocess.Popen[bytes]) -> bool:
+    leader_returncode = process.poll()
+    try:
+        os.killpg(process.pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError as error:
+        # Darwin can report EPERM for a just-terminated group while its leader
+        # is becoming waitable. Do not risk signalling a recycled group ID;
+        # the direct child is still reaped with a separate bounded wait.
+        if sys.platform == "darwin" or leader_returncode is not None:
+            return False
+        raise LinuxGuiArtifactVerificationError(
+            f"unable to inspect packaged GUI process group: {error}"
+        ) from error
+    except OSError as error:
+        raise LinuxGuiArtifactVerificationError(
+            f"unable to inspect packaged GUI process group: {error}"
+        ) from error
+    return True
+
+
+def _signal_process_group(
+    process: subprocess.Popen[bytes],
+    selected_signal: signal.Signals,
+) -> bool:
+    try:
+        os.killpg(process.pid, selected_signal)
+    except ProcessLookupError:
+        return False
+    except OSError as error:
+        raise LinuxGuiArtifactVerificationError(
+            f"unable to signal packaged GUI process group with "
+            f"{selected_signal.name}: {error}"
+        ) from error
+    return True
+
+
+def _wait_for_group_disappearance(
+    process: subprocess.Popen[bytes],
+    timeout_seconds: float,
+) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while _process_group_exists(process):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        time.sleep(min(PROCESS_POLL_SECONDS, remaining))
+    return True
+
+
+def _terminate_process_group(process: subprocess.Popen[bytes]) -> None:
+    if _signal_process_group(process, signal.SIGTERM) and not _wait_for_group_disappearance(
+        process,
+        PROCESS_TERMINATION_GRACE_SECONDS,
+    ):
+        _signal_process_group(process, signal.SIGKILL)
+        if not _wait_for_group_disappearance(
+            process,
+            PROCESS_CLEANUP_TIMEOUT_SECONDS,
+        ):
+            raise LinuxGuiArtifactVerificationError(
+                "packaged GUI process group survived SIGKILL cleanup"
+            )
+
+    if process.poll() is None:
+        try:
+            process.wait(timeout=PROCESS_CLEANUP_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired as error:
+            raise LinuxGuiArtifactVerificationError(
+                "packaged GUI process group could not be reaped after termination"
+            ) from error
+
+
+def _process_output_size(output: object) -> int:
+    try:
+        return os.fstat(output.fileno()).st_size  # type: ignore[attr-defined]
+    except OSError as error:
+        raise LinuxGuiArtifactVerificationError(
+            f"unable to inspect packaged GUI output: {error}"
+        ) from error
+
+
+def _wait_for_process_group_exit(
+    process: subprocess.Popen[bytes],
+    output: object,
+) -> None:
+    deadline = time.monotonic() + PROCESS_GROUP_GRACE_SECONDS
+    while _process_group_exists(process):
+        if _process_output_size(output) > MAX_PROCESS_OUTPUT_BYTES:
+            raise LinuxGuiArtifactVerificationError(
+                "packaged GUI output exceeded the bounded verification limit"
+            )
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise LinuxGuiArtifactVerificationError(
+                "packaged GUI left a descendant process running after exit"
+            )
+        time.sleep(min(PROCESS_POLL_SECONDS, remaining))
+
+
+def _wait_for_process(
+    process: subprocess.Popen[bytes],
+    output: object,
+    timeout_seconds: float,
+) -> int:
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        output_size = _process_output_size(output)
+        if output_size > MAX_PROCESS_OUTPUT_BYTES:
+            raise LinuxGuiArtifactVerificationError(
+                "packaged GUI output exceeded the bounded verification limit"
+            )
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise LinuxGuiArtifactVerificationError(
+                f"packaged GUI timed out after {timeout_seconds:g} seconds"
+            )
+        try:
+            return process.wait(timeout=min(PROCESS_POLL_SECONDS, remaining))
+        except subprocess.TimeoutExpired:
+            continue
+
+
+def _validate_xvfb_run(path: Path) -> None:
+    if not path.is_absolute() or Path(os.path.normpath(os.fspath(path))) != path:
+        raise LinuxGuiArtifactVerificationError(
+            f"xvfb-run path must be absolute and normalized: {path}"
+        )
+    try:
+        metadata = path.lstat()
+    except OSError as error:
+        raise LinuxGuiArtifactVerificationError(
+            f"unable to inspect xvfb-run: {error}"
+        ) from error
+    if not stat.S_ISREG(metadata.st_mode) or not os.access(path, os.X_OK):
+        raise LinuxGuiArtifactVerificationError(
+            f"xvfb-run is not an executable regular file: {path}"
+        )
+
+
+def _validate_receipt(receipt_path: Path) -> None:
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            receipt_path,
+            _required_open_flags(os.O_RDONLY, "O_CLOEXEC", "O_NOFOLLOW"),
+        )
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise LinuxGuiArtifactVerificationError(
+                "packaged GUI readiness receipt is not a regular file"
+            )
+        if stat.S_IMODE(metadata.st_mode) != 0o600:
+            raise LinuxGuiArtifactVerificationError(
+                "packaged GUI readiness receipt does not have mode 0600"
+            )
+        content = os.read(descriptor, len(GUI_SMOKE_RECEIPT) + 1)
+    except LinuxGuiArtifactVerificationError:
+        raise
+    except OSError as error:
+        raise LinuxGuiArtifactVerificationError(
+            f"unable to read packaged GUI readiness receipt: {error}"
+        ) from error
+    finally:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+    if content != GUI_SMOKE_RECEIPT:
+        raise LinuxGuiArtifactVerificationError(
+            "packaged GUI readiness receipt content is invalid"
+        )
+
+
+def _runtime_environment(root: Path, receipt_path: Path) -> dict[str, str]:
+    runtime = root / "runtime"
+    temporary = root / "tmp"
+    config = root / "config"
+    cache = root / "cache"
+    data = root / "data"
+    for directory in (runtime, temporary, config, cache, data):
+        directory.mkdir(mode=0o700)
+        directory.chmod(0o700)
+
+    environment = dict(os.environ)
+    for key in (
+        "DISPLAY",
+        "LD_LIBRARY_PATH",
+        "LD_PRELOAD",
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "QT_PLUGIN_PATH",
+        "QT_QPA_PLATFORM_PLUGIN_PATH",
+    ):
+        environment.pop(key, None)
+    environment.update(
+        {
+            GUI_SMOKE_RECEIPT_ENV: os.fspath(receipt_path),
+            "QT_QPA_PLATFORM": "xcb",
+            "QT_DEBUG_PLUGINS": "1",
+            "XDG_RUNTIME_DIR": os.fspath(runtime),
+            "XDG_CONFIG_HOME": os.fspath(config),
+            "XDG_CACHE_HOME": os.fspath(cache),
+            "XDG_DATA_HOME": os.fspath(data),
+            "TMPDIR": os.fspath(temporary),
+        }
+    )
+    return environment
+
+
+def _run_packaged_gui(
+    root: Path,
+    executable: Path,
+    *,
+    xvfb_run_path: Path,
+    timeout_seconds: float,
+) -> None:
+    _validate_xvfb_run(xvfb_run_path)
+    receipt_path = root / "gui-ready.receipt"
+    if receipt_path.exists() or receipt_path.is_symlink():
+        raise LinuxGuiArtifactVerificationError(
+            "packaged GUI readiness receipt path already exists"
+        )
+
+    environment = _runtime_environment(root, receipt_path)
+    process: subprocess.Popen[bytes] | None = None
+    process_group_gone = False
+    try:
+        with tempfile.TemporaryFile(mode="w+b", dir=root) as output:
+            try:
+                process = subprocess.Popen(
+                    [
+                        os.fspath(xvfb_run_path),
+                        "--auto-servernum",
+                        "--error-file=/dev/stderr",
+                        "--server-args=-screen 0 1024x768x24",
+                        os.fspath(executable),
+                    ],
+                    cwd=root,
+                    stdin=subprocess.DEVNULL,
+                    stdout=output,
+                    stderr=subprocess.STDOUT,
+                    env=environment,
+                    close_fds=True,
+                    shell=False,
+                    start_new_session=True,
+                )
+            except OSError as error:
+                raise LinuxGuiArtifactVerificationError(
+                    f"unable to launch packaged GUI under Xvfb: {error}"
+                ) from error
+
+            returncode = _wait_for_process(process, output, timeout_seconds)
+            _wait_for_process_group_exit(process, output)
+            process_group_gone = True
+            captured = _read_process_output(output)
+    finally:
+        if process is not None and not process_group_gone:
+            _terminate_process_group(process)
+
+    decoded_output = captured.decode("utf-8", errors="replace")
+    folded_output = decoded_output.casefold()
+    for signature in _FATAL_OUTPUT_SIGNATURES:
+        if signature in folded_output:
+            raise LinuxGuiArtifactVerificationError(
+                f"packaged GUI emitted fatal loader/platform diagnostic: {signature}"
+            )
+    if returncode != 0:
+        raise LinuxGuiArtifactVerificationError(
+            f"packaged GUI exited with status {returncode}"
+        )
+    _validate_receipt(receipt_path)
+
+
+def verify_archive(
+    archive_path: Path,
+    *,
+    xvfb_run_path: Path = XVFB_RUN_PATH,
+    timeout_seconds: float = PROCESS_TIMEOUT_SECONDS,
+) -> None:
+    archive_path = _require_absolute_normalized_path(
+        os.fspath(archive_path),
+        "Linux release archive",
+    )
+    _validate_archive_path(archive_path)
+    if timeout_seconds <= 0:
+        raise LinuxGuiArtifactVerificationError("process timeout must be positive")
+
+    archive_descriptor: int | None = None
+    try:
+        try:
+            archive_descriptor = os.open(
+                archive_path,
+                _required_open_flags(os.O_RDONLY, "O_CLOEXEC", "O_NOFOLLOW"),
+            )
+            archive_metadata = os.fstat(archive_descriptor)
+        except OSError as error:
+            raise LinuxGuiArtifactVerificationError(
+                f"unable to open Linux release ZIP without following links: {error}"
+            ) from error
+        if not stat.S_ISREG(archive_metadata.st_mode):
+            raise LinuxGuiArtifactVerificationError(
+                "Linux release ZIP is not a regular file"
+            )
+        if archive_metadata.st_size <= 0 or archive_metadata.st_size > MAX_ARCHIVE_BYTES:
+            raise LinuxGuiArtifactVerificationError(
+                "Linux release ZIP has an invalid size"
+            )
+
+        with tempfile.TemporaryDirectory(
+            prefix="gm2godot-linux-gui-artifact-"
+        ) as raw_root:
+            root = Path(raw_root).resolve(strict=True)
+            root.chmod(0o700)
+            try:
+                with (
+                    os.fdopen(os.dup(archive_descriptor), "rb") as archive_stream,
+                    zipfile.ZipFile(archive_stream) as archive,
+                ):
+                    selected = _validate_members(archive.infolist())
+                    for name, expected_mode in EXPECTED_MEMBER_MODES.items():
+                        _extract_member(
+                            archive,
+                            selected[name],
+                            root / name,
+                            expected_mode,
+                        )
+            except LinuxGuiArtifactVerificationError:
+                raise
+            except (
+                OSError,
+                EOFError,
+                RuntimeError,
+                NotImplementedError,
+                ValueError,
+                lzma.LZMAError,
+                zipfile.BadZipFile,
+                zlib.error,
+            ) as error:
+                raise LinuxGuiArtifactVerificationError(
+                    f"unable to inspect Linux release ZIP: {error}"
+                ) from error
+
+            for name, expected_mode in EXPECTED_MEMBER_MODES.items():
+                _validate_extracted_file(
+                    root / name,
+                    expected_mode,
+                    selected[name].file_size,
+                )
+            executable = (root / EXECUTABLE_NAME).resolve(strict=True)
+            if executable.parent != root:
+                raise LinuxGuiArtifactVerificationError(
+                    "extracted executable escaped the private verification directory"
+                )
+            _run_packaged_gui(
+                root,
+                executable,
+                xvfb_run_path=xvfb_run_path,
+                timeout_seconds=timeout_seconds,
+            )
+    finally:
+        if archive_descriptor is not None:
+            try:
+                os.close(archive_descriptor)
+            except OSError:
+                pass
+
+
+def _parse_args(arguments: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify and launch the exact packaged Linux GUI under Xvfb."
+    )
+    parser.add_argument("--archive", required=True)
+    return parser.parse_args(arguments)
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    options = _parse_args(arguments)
+    try:
+        archive_path = _require_absolute_normalized_path(
+            options.archive,
+            "Linux release archive",
+        )
+        verify_archive(archive_path)
+    except LinuxGuiArtifactVerificationError as error:
+        print(f"Linux packaged GUI verification failed: {error}", file=sys.stderr)
+        return 1
+    print(f"Verified packaged Linux GUI under Xvfb: {archive_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -47,7 +47,7 @@ class UpdateCheckWorker(QObject):
 
 
 class MainWindow(QMainWindow):
-    def __init__(self) -> None:
+    def __init__(self, *, check_for_updates_on_startup: bool = True) -> None:
         super().__init__()
         self.setWindowTitle(get_localized("Menu_Title").format(version=get_version()))
         self.resize(800, 600)
@@ -69,7 +69,8 @@ class MainWindow(QMainWindow):
         self._release_notes = ReleaseNotesDialog(self)
         self._init_ui()
         self._create_menu()
-        self._check_for_updates_on_startup()
+        if check_for_updates_on_startup:
+            self._check_for_updates_on_startup()
 
         # Timer
         self._timer = QTimer(self)

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.21"
+VERSION = "0.7.22"
 
 
 def get_version():

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -4540,6 +4540,8 @@ class TestCIWorkflows(unittest.TestCase):
         self.assertEqual(
             packages,
             (
+                "libegl1",
+                "libgl1",
                 "libxkbcommon-x11-0",
                 "libxcb-cursor0",
                 "libxcb-icccm4",
@@ -4566,7 +4568,7 @@ class TestCIWorkflows(unittest.TestCase):
                 )
         for required in (
             'package_manifest="packaging/linux/qt-xcb-runtime-packages.txt"',
-            'if [ "${#qt_packages[@]}" -ne 9 ]; then',
+            'if [ "${#qt_packages[@]}" -ne 11 ]; then',
             "sudo apt-get update",
             "sudo apt-get install --yes --no-install-recommends",
             '"${qt_packages[@]}"',
@@ -4755,12 +4757,12 @@ class TestCIWorkflows(unittest.TestCase):
         )
         self.assertIn("python -m unittest discover tests/ -v", linux_job)
         self.assertIn(
-            "sudo apt-get install --yes --no-install-recommends libegl1",
+            "sudo apt-get install --yes --no-install-recommends libegl1 libgl1",
             linux_job,
         )
         self.assertLess(
             linux_job.index(
-                "sudo apt-get install --yes --no-install-recommends libegl1"
+                "sudo apt-get install --yes --no-install-recommends libegl1 libgl1"
             ),
             linux_job.index("python -m unittest discover tests/ -v"),
         )

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -4466,29 +4466,17 @@ class TestCIWorkflows(unittest.TestCase):
             "packaging/macos/GM2Godot.spec\n",
             release_build,
         )
-        self.assertEqual(
-            non_macos_build,
-            "if [ \"$RUNNER_OS\" = \"Windows\" ]; then\n"
-            '  SEP=";"\n'
-            "else\n"
-            '  SEP=":"\n'
-            "fi\n"
-            "python -m PyInstaller ${{ matrix.pyinstaller_mode }} \\\n"
-            "  --windowed \\\n"
-            "  --clean \\\n"
-            "  --name GM2Godot \\\n"
-            "  --icon img/Logo.png \\\n"
-            "  --hidden-import markdown2 \\\n"
-            "  --hidden-import PIL \\\n"
-            "  --hidden-import PySide6.QtWidgets \\\n"
-            "  --hidden-import PySide6.QtCore \\\n"
-            "  --hidden-import PySide6.QtGui \\\n"
-            '  --add-data "img${SEP}img" \\\n'
-            '  --add-data "src${SEP}src" \\\n'
-            '  --add-data "Languages${SEP}Languages" \\\n'
-            '  --add-data "Current Language${SEP}." \\\n'
-            "  main.py\n",
-        )
+        for required in (
+            "additional_hooks=()",
+            'if [ "$RUNNER_OS" = "Windows" ]; then',
+            "additional_hooks=(--additional-hooks-dir packaging/linux/hooks)",
+            "python -m PyInstaller ${{ matrix.pyinstaller_mode }}",
+            '"${additional_hooks[@]}"',
+            '--add-data "Current Language${SEP}."',
+            'main.py 2>&1 | tee "$pyinstaller_log"',
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, non_macos_build)
 
         self.assertIn(
             "      - name: Verify macOS bundle metadata\n"
@@ -4518,6 +4506,180 @@ class TestCIWorkflows(unittest.TestCase):
             release_build.index("      - name: Verify macOS bundle metadata\n"),
             release_build.index("      - name: Upload macOS artifacts\n"),
         )
+
+    def test_linux_release_build_proves_packaged_xcb_gui(self) -> None:
+        release = (
+            PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+        ).read_text(encoding="utf-8")
+        release_build = _workflow_job_section(release, "build")
+        dependency_install = _workflow_run_script(
+            release,
+            "Install Linux GUI build and smoke dependencies",
+        )
+        build_script = _workflow_run_script(release, "Build executable")
+        archive_check = _workflow_run_script(
+            release,
+            "Verify Linux bundled Qt runtime",
+        )
+        packaged_smoke = _workflow_run_script(
+            release,
+            "Verify packaged Linux GUI",
+        )
+
+        package_manifest = (
+            PROJECT_ROOT
+            / "packaging"
+            / "linux"
+            / "qt-xcb-runtime-packages.txt"
+        )
+        packages = tuple(
+            line.strip()
+            for line in package_manifest.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        )
+        self.assertEqual(
+            packages,
+            (
+                "libxkbcommon-x11-0",
+                "libxcb-cursor0",
+                "libxcb-icccm4",
+                "libxcb-image0",
+                "libxcb-keysyms1",
+                "libxcb-render-util0",
+                "libxcb-shape0",
+                "libxcb-util1",
+                "libxcb-xkb1",
+            ),
+        )
+        self.assertEqual(len(packages), len(set(packages)))
+
+        for step_name in (
+            "Install Linux GUI build and smoke dependencies",
+            "Verify Linux bundled Qt runtime",
+            "Verify packaged Linux GUI",
+        ):
+            with self.subTest(step_guard=step_name):
+                self.assertIn(
+                    f"      - name: {step_name}\n"
+                    "        if: matrix.name == 'linux'\n",
+                    release_build,
+                )
+        for required in (
+            'package_manifest="packaging/linux/qt-xcb-runtime-packages.txt"',
+            'if [ "${#qt_packages[@]}" -ne 9 ]; then',
+            "sudo apt-get update",
+            "sudo apt-get install --yes --no-install-recommends",
+            '"${qt_packages[@]}"',
+            "xvfb",
+        ):
+            with self.subTest(script="dependency install", required=required):
+                self.assertIn(required, dependency_install)
+
+        for required in (
+            "additional_hooks=(--additional-hooks-dir packaging/linux/hooks)",
+            '2>&1 | tee "$pyinstaller_log"',
+            "warning_status=0",
+            'grep -Fq "WARNING: Library not found:" "$pyinstaller_log" '
+            "|| warning_status=$?",
+            'if [ "$warning_status" -eq 0 ]; then',
+            'if [ "$warning_status" -ne 1 ]; then',
+            "Unable to inspect the Linux PyInstaller warning log.",
+        ):
+            with self.subTest(script="PyInstaller", required=required):
+                self.assertIn(required, build_script)
+
+        bundled_members = (
+            "PySide6/Qt/plugins/platforms/libqxcb.so",
+            "libxkbcommon-x11.so.0",
+            "libxcb-cursor.so.0",
+            "libxcb-icccm.so.4",
+            "libxcb-image.so.0",
+            "libxcb-keysyms.so.1",
+            "libxcb-render-util.so.0",
+            "libxcb-shape.so.0",
+            "libxcb-util.so.1",
+            "libxcb-xkb.so.1",
+        )
+        self.assertIn(
+            "pyi-archive_viewer --list --recursive --brief dist/GM2Godot",
+            archive_check,
+        )
+        self.assertIn(
+            "sed -n -e 's/^ //p' \"$inventory\" > "
+            '"$normalized_inventory"',
+            archive_check,
+        )
+        for member in bundled_members:
+            with self.subTest(archive_member=member):
+                self.assertIn(member, archive_check)
+        self.assertIn(
+            "PySide6/Qt/plugins/imageformats/libqtiff.so",
+            archive_check,
+        )
+        for required in (
+            'grep -Fxq -- "$required" "$normalized_inventory" || member_status=$?',
+            'if [ "$member_status" -eq 1 ]; then',
+            'if [ "$member_status" -ne 0 ]; then',
+            "missing required Qt/XCB member",
+            'grep -Fxq -- "PySide6/Qt/plugins/imageformats/libqtiff.so"',
+            'if [ "$tiff_status" -eq 0 ]; then',
+            'if [ "$tiff_status" -ne 1 ]; then',
+            "unsupported Qt TIFF plugin remained",
+            "exit 1",
+        ):
+            with self.subTest(archive_policy=required):
+                self.assertIn(required, archive_check)
+        self.assertNotIn("grep -Fq", archive_check)
+
+        linux_verifier = (
+            PROJECT_ROOT / "scripts" / "verify_linux_gui_artifact.py"
+        )
+        self.assertTrue(linux_verifier.is_file())
+        verifier_source = linux_verifier.read_text(encoding="utf-8")
+        for required in (
+            'Path("/usr/bin/xvfb-run")',
+            '"--error-file=/dev/stderr"',
+            '"QT_QPA_PLATFORM": "xcb"',
+            '"QT_DEBUG_PLUGINS": "1"',
+            "member.compress_type != zipfile.ZIP_DEFLATED",
+            "start_new_session=True",
+            "GM2Godot packaged GUI ready\\n",
+        ):
+            with self.subTest(verifier_policy=required):
+                self.assertIn(required, verifier_source)
+        self.assertEqual(
+            packaged_smoke,
+            "python -I scripts/verify_linux_gui_artifact.py \\\n"
+            '  --archive "$GITHUB_WORKSPACE/GM2Godot-linux.zip"\n',
+        )
+        self.assertNotIn("main.py", packaged_smoke)
+        self.assertNotIn("dist/GM2Godot", packaged_smoke)
+        self.assertNotIn("sleep ", packaged_smoke)
+
+        for earlier, later in (
+            (
+                "      - name: Install Linux GUI build and smoke dependencies\n",
+                "      - name: Build executable\n",
+            ),
+            (
+                "      - name: Build executable\n",
+                "      - name: Verify Linux bundled Qt runtime\n",
+            ),
+            (
+                "      - name: Verify Linux bundled Qt runtime\n",
+                "      - name: Package build\n",
+            ),
+            (
+                "      - name: Zip release\n",
+                "      - name: Verify packaged Linux GUI\n",
+            ),
+            (
+                "      - name: Verify packaged Linux GUI\n",
+                "      - name: Upload artifact\n",
+            ),
+        ):
+            with self.subTest(earlier=earlier.strip(), later=later.strip()):
+                self.assertLess(release_build.index(earlier), release_build.index(later))
 
     def test_windows_build_cleanup_guard_deletes_only_original_owned_directory(
         self,

--- a/tests/test_documentation_health.py
+++ b/tests/test_documentation_health.py
@@ -171,6 +171,16 @@ class TestDocumentationHealth(unittest.TestCase):
             "sha256sum --check --strict SHA256SUMS",
             installation,
         )
+        macos_source = installation.partition("### macOS\n")[2].partition(
+            "### Linux\n"
+        )[0]
+        linux_source = installation.partition("### Linux\n")[2].partition(
+            "## Verify the source installation\n"
+        )[0]
+        self.assertNotIn("packaging/linux/qt-xcb-runtime-packages.txt", macos_source)
+        self.assertIn("packaging/linux/qt-xcb-runtime-packages.txt", linux_source)
+        self.assertIn("sudo apt-get install", linux_source)
+        self.assertIn("only validated packaged-Linux baseline", installation)
         self.assertIn("not a signature or proof of publisher identity", installation)
         self.assertIn("exactly five unique, non-empty assets", release_maintenance)
         self.assertIn(

--- a/tests/test_documentation_health.py
+++ b/tests/test_documentation_health.py
@@ -180,6 +180,28 @@ class TestDocumentationHealth(unittest.TestCase):
         self.assertNotIn("packaging/linux/qt-xcb-runtime-packages.txt", macos_source)
         self.assertIn("packaging/linux/qt-xcb-runtime-packages.txt", linux_source)
         self.assertIn("sudo apt-get install", linux_source)
+        linux_release_readme = readme.partition(
+            "The packaged Linux artifact is validated"
+        )[2].partition("## Installation")[0]
+        linux_release_installation = installation.partition(
+            "Ubuntu 24.04 x86_64 is the only validated packaged-Linux baseline"
+        )[2].partition("### Verify a release download")[0]
+        runtime_packages = tuple(
+            line.strip()
+            for line in (
+                PROJECT_ROOT
+                / "packaging"
+                / "linux"
+                / "qt-xcb-runtime-packages.txt"
+            )
+            .read_text(encoding="utf-8")
+            .splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        )
+        for runtime_package in runtime_packages:
+            with self.subTest(runtime_package=runtime_package):
+                self.assertIn(runtime_package, linux_release_readme)
+                self.assertIn(runtime_package, linux_release_installation)
         self.assertIn("only validated packaged-Linux baseline", installation)
         self.assertIn("not a signature or proof of publisher identity", installation)
         self.assertIn("exactly five unique, non-empty assets", release_maintenance)

--- a/tests/test_gui_startup_smoke.py
+++ b/tests/test_gui_startup_smoke.py
@@ -1,0 +1,194 @@
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from main import (
+    GUI_SMOKE_RECEIPT,
+    GUI_SMOKE_RECEIPT_ENV,
+    _configured_gui_smoke_receipt,
+    _write_gui_smoke_receipt,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+class GuiStartupSmokeTests(unittest.TestCase):
+    def test_source_gui_reaches_event_loop_and_writes_exact_receipt(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gm2godot-gui-smoke-") as raw_root:
+            root = Path(raw_root)
+            runtime = root / "runtime"
+            runtime.mkdir(mode=0o700)
+            receipt = root / "ready.txt"
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "QT_QPA_PLATFORM": "offscreen",
+                    "XDG_RUNTIME_DIR": str(runtime),
+                    GUI_SMOKE_RECEIPT_ENV: str(receipt),
+                }
+            )
+
+            result = subprocess.run(
+                [sys.executable, "main.py"],
+                cwd=PROJECT_ROOT,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(receipt.read_text(encoding="utf-8"), GUI_SMOKE_RECEIPT)
+            self.assertEqual(stat.S_IMODE(receipt.stat().st_mode), 0o600)
+            self.assertNotIn("QThread: Destroyed", result.stderr)
+
+    def test_receipt_configuration_requires_a_nonempty_absolute_path(self) -> None:
+        original = os.environ.get(GUI_SMOKE_RECEIPT_ENV)
+        try:
+            os.environ.pop(GUI_SMOKE_RECEIPT_ENV, None)
+            self.assertIsNone(_configured_gui_smoke_receipt())
+
+            for invalid in ("", "relative/ready.txt"):
+                with self.subTest(invalid=invalid):
+                    os.environ[GUI_SMOKE_RECEIPT_ENV] = invalid
+                    with self.assertRaises(ValueError):
+                        _configured_gui_smoke_receipt()
+        finally:
+            if original is None:
+                os.environ.pop(GUI_SMOKE_RECEIPT_ENV, None)
+            else:
+                os.environ[GUI_SMOKE_RECEIPT_ENV] = original
+
+    def test_receipt_writer_refuses_to_overwrite_existing_file(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gm2godot-gui-smoke-") as raw_root:
+            receipt = Path(raw_root) / "ready.txt"
+            receipt.write_text("preserve\n", encoding="utf-8")
+
+            with self.assertRaises(FileExistsError):
+                _write_gui_smoke_receipt(receipt)
+
+            self.assertEqual(receipt.read_text(encoding="utf-8"), "preserve\n")
+
+    @unittest.skipIf(os.name == "nt", "POSIX receipt permissions are Linux policy")
+    def test_receipt_writer_forces_mode_0600_under_restrictive_umask(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gm2godot-gui-smoke-") as raw_root:
+            receipt = Path(raw_root) / "ready.txt"
+            original_umask = os.umask(0o700)
+            try:
+                _write_gui_smoke_receipt(receipt)
+            finally:
+                os.umask(original_umask)
+
+            self.assertEqual(stat.S_IMODE(receipt.stat().st_mode), 0o600)
+
+    def test_main_reports_invalid_configuration_with_exit_status_2(self) -> None:
+        environment = os.environ.copy()
+        environment[GUI_SMOKE_RECEIPT_ENV] = "relative/ready.txt"
+
+        result = subprocess.run(
+            [sys.executable, "main.py"],
+            cwd=PROJECT_ROOT,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("GUI startup smoke configuration error", result.stderr)
+        self.assertFalse((PROJECT_ROOT / "relative" / "ready.txt").exists())
+
+    def test_main_reports_receipt_write_failure_with_exit_status_1(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gm2godot-gui-smoke-") as raw_root:
+            root = Path(raw_root)
+            runtime = root / "runtime"
+            runtime.mkdir(mode=0o700)
+            receipt = root / "ready.txt"
+            receipt.write_text("preserve\n", encoding="utf-8")
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "QT_QPA_PLATFORM": "offscreen",
+                    "XDG_RUNTIME_DIR": str(runtime),
+                    GUI_SMOKE_RECEIPT_ENV: str(receipt),
+                }
+            )
+
+            result = subprocess.run(
+                [sys.executable, "main.py"],
+                cwd=PROJECT_ROOT,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("GUI startup smoke failed", result.stderr)
+            self.assertEqual(receipt.read_text(encoding="utf-8"), "preserve\n")
+
+    def test_smoke_window_deterministically_skips_update_check(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gm2godot-gui-smoke-") as raw_root:
+            runtime = Path(raw_root) / "runtime"
+            runtime.mkdir(mode=0o700)
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "QT_QPA_PLATFORM": "offscreen",
+                    "XDG_RUNTIME_DIR": str(runtime),
+                }
+            )
+            code = (
+                "from PySide6.QtWidgets import QApplication;"
+                "from src.gui.main_window import MainWindow;"
+                "app=QApplication([]);"
+                "calls=[];"
+                "MainWindow._check_for_updates_on_startup="
+                "lambda self: calls.append(True);"
+                "window=MainWindow(check_for_updates_on_startup=False);"
+                "import os as process_os;"
+                "process_os._exit(1 if calls else 0)"
+            )
+
+            result = subprocess.run(
+                [sys.executable, "-c", code],
+                cwd=PROJECT_ROOT,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    @unittest.skipUnless(hasattr(os, "symlink"), "symlinks unavailable")
+    def test_receipt_writer_refuses_a_symlink_target(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gm2godot-gui-smoke-") as raw_root:
+            root = Path(raw_root)
+            target = root / "target.txt"
+            target.write_text("preserve\n", encoding="utf-8")
+            receipt = root / "ready.txt"
+            receipt.symlink_to(target)
+
+            with self.assertRaises(FileExistsError):
+                _write_gui_smoke_receipt(receipt)
+
+            self.assertTrue(receipt.is_symlink())
+            self.assertEqual(target.read_text(encoding="utf-8"), "preserve\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_linux_gui_artifact_verifier.py
+++ b/tests/test_linux_gui_artifact_verifier.py
@@ -209,10 +209,25 @@ class LinuxGuiArtifactVerifierTests(unittest.TestCase):
                 ):
                     self.verify(body)
 
+    def test_missing_qtgui_graphics_loader_dependencies_are_rejected(self) -> None:
+        for library in ("libEGL.so.1", "libGL.so.1"):
+            with self.subTest(library=library):
+                body = _success_body(
+                    f"printf '%s\\n' 'ImportError: {library}: "
+                    "cannot open shared object file: No such file or directory' >&2\n"
+                )
+                with self.assertRaisesRegex(
+                    verifier.LinuxGuiArtifactVerificationError,
+                    library.replace(".", r"\."),
+                ):
+                    self.verify(body)
+
     def test_fatal_diagnostic_reports_one_bounded_matching_line(self) -> None:
         marker = "cannot open shared object file"
         body = _success_body(
-            f"printf '%s\\n' 'loader: {marker}: {'x' * 2000}' >&2\n"
+            "printf '%s\\n' 'before-line-sentinel' >&2\n"
+            f"printf '%s\\n' '{'p' * 2000}{marker}{'s' * 2000}' >&2\n"
+            "printf '%s\\n' 'after-line-sentinel' >&2\n"
         )
         with self.assertRaises(
             verifier.LinuxGuiArtifactVerificationError
@@ -220,9 +235,120 @@ class LinuxGuiArtifactVerifierTests(unittest.TestCase):
             self.verify(body)
 
         message = str(raised.exception)
-        self.assertIn(f"loader: {marker}", message)
-        self.assertTrue(message.endswith("...'"))
-        self.assertLess(len(message), verifier.MAX_DIAGNOSTIC_LINE_CHARACTERS + 200)
+        excerpt = message.partition("matching output: ")[2]
+        self.assertIn(marker, excerpt)
+        self.assertTrue(excerpt.startswith("'..."))
+        self.assertTrue(excerpt.endswith("...'"))
+        self.assertNotIn("before-line-sentinel", excerpt)
+        self.assertNotIn("after-line-sentinel", excerpt)
+        self.assertLessEqual(
+            len(excerpt),
+            verifier.MAX_DIAGNOSTIC_LINE_CHARACTERS + 2,
+        )
+
+    def test_first_fatal_output_line_is_reported(self) -> None:
+        first = "could not load the qt platform plugin"
+        later = "error while loading shared libraries"
+        body = _success_body(
+            f"printf '%s\\n' 'first: {first}' >&2\n"
+            f"printf '%s\\n' 'later: {later}' >&2\n"
+        )
+        with self.assertRaises(
+            verifier.LinuxGuiArtifactVerificationError
+        ) as raised:
+            self.verify(body)
+
+        message = str(raised.exception)
+        self.assertIn(f"matching output: 'first: {first}'", message)
+        self.assertNotIn(f"later: {later}", message)
+
+    def test_leftmost_fatal_signature_on_one_line_is_classified(self) -> None:
+        first = "could not load the qt platform plugin"
+        later = "error while loading shared libraries"
+        body = _success_body(
+            f"printf '%s\\n' 'first: {first}; later: {later}' >&2\n"
+        )
+        with self.assertRaises(
+            verifier.LinuxGuiArtifactVerificationError
+        ) as raised:
+            self.verify(body)
+
+        self.assertIn(
+            f"fatal loader/platform diagnostic: {first};",
+            str(raised.exception),
+        )
+
+    def test_non_ascii_prefix_does_not_shift_fatal_marker_excerpt(self) -> None:
+        marker = "cannot open shared object file"
+        body = _success_body(
+            f"printf '%s\\n' '{'ß' * 2000}{marker}{'x' * 2000}' >&2\n"
+        )
+        with self.assertRaises(
+            verifier.LinuxGuiArtifactVerificationError
+        ) as raised:
+            self.verify(body)
+
+        excerpt = str(raised.exception).partition("matching output: ")[2]
+        self.assertIn(marker, excerpt)
+        self.assertLessEqual(
+            len(excerpt),
+            verifier.MAX_DIAGNOSTIC_LINE_CHARACTERS + 2,
+        )
+
+    def test_escaped_prefix_does_not_expand_bounded_excerpt(self) -> None:
+        marker = "cannot open shared object file"
+        body = _success_body(
+            f"printf '%s\\n' '{chr(92) * 2000}{marker}{chr(92) * 2000}' >&2\n"
+        )
+        with self.assertRaises(
+            verifier.LinuxGuiArtifactVerificationError
+        ) as raised:
+            self.verify(body)
+
+        excerpt = str(raised.exception).partition("matching output: ")[2]
+        self.assertIn(marker, excerpt)
+        self.assertLessEqual(
+            len(excerpt),
+            verifier.MAX_DIAGNOSTIC_LINE_CHARACTERS + 2,
+        )
+
+    def test_quote_heavy_prefix_keeps_diagnostic_wrapper_unambiguous(self) -> None:
+        marker = "cannot open shared object file"
+        diagnostic_line = "'" * 2000 + "a" + marker + "x" * 2000
+        body = _success_body(
+            f'printf \'%s\\n\' "{diagnostic_line}" >&2\n'
+        )
+        with self.assertRaises(
+            verifier.LinuxGuiArtifactVerificationError
+        ) as raised:
+            self.verify(body)
+
+        excerpt = str(raised.exception).partition("matching output: ")[2]
+        self.assertIn(marker, excerpt)
+        self.assertEqual(excerpt.count("'"), 2)
+        self.assertNotRegex(excerpt, "[\\r\\n\\x00-\\x1f\\x7f]")
+        self.assertLessEqual(
+            len(excerpt),
+            verifier.MAX_DIAGNOSTIC_LINE_CHARACTERS + 2,
+        )
+
+    def test_bounded_excerpt_escapes_control_characters(self) -> None:
+        marker = "cannot open shared object file"
+        line = "\x00\t\x1b" * 1000 + marker + "\x7f\r" * 1000
+        marker_start = line.index(marker)
+        excerpt = verifier._bounded_output_excerpt(
+            line,
+            marker_start,
+            marker_start + len(marker),
+        )
+
+        self.assertIn(marker, excerpt)
+        self.assertEqual(excerpt.count("'"), 2)
+        self.assertNotRegex(excerpt, r"[\x00-\x1f\x7f]")
+        self.assertLessEqual(
+            len(excerpt),
+            verifier.MAX_DIAGNOSTIC_LINE_CHARACTERS + 2,
+        )
 
     def test_timeout_kills_the_isolated_process_group(self) -> None:
         child_receipt = self.root / "timeout-child.pid"

--- a/tests/test_linux_gui_artifact_verifier.py
+++ b/tests/test_linux_gui_artifact_verifier.py
@@ -1,0 +1,536 @@
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from contextlib import redirect_stderr
+from io import StringIO
+import os
+from pathlib import Path
+import shlex
+import stat
+import subprocess
+import tempfile
+import time
+from typing import cast
+import unittest
+from unittest import mock
+import warnings
+import zipfile
+
+from scripts import verify_linux_gui_artifact as verifier
+
+
+class _ReapAwareProcess:
+    pid = 24680
+
+    def __init__(self) -> None:
+        self.reaped = False
+
+    def poll(self) -> int:
+        self.reaped = True
+        return -9
+
+
+def _member(
+    name: str,
+    content: bytes,
+    *,
+    mode: int,
+    file_type: int = stat.S_IFREG,
+    create_system: int = 3,
+) -> tuple[zipfile.ZipInfo, bytes]:
+    member = zipfile.ZipInfo(name)
+    member.create_system = create_system
+    member.external_attr = (file_type | mode) << 16
+    member.compress_type = zipfile.ZIP_DEFLATED
+    return member, content
+
+
+def _executable_script(body: str) -> bytes:
+    return ("#!/bin/sh\nset -eu\n" + body).encode("utf-8")
+
+
+def _write_archive(
+    root: Path,
+    executable: bytes,
+    *,
+    members: list[tuple[zipfile.ZipInfo, bytes]] | None = None,
+) -> Path:
+    archive_path = root / verifier.ARCHIVE_NAME
+    selected = members
+    if selected is None:
+        selected = [
+            _member(
+                verifier.EXECUTABLE_NAME,
+                executable,
+                mode=0o755,
+            ),
+            _member(verifier.README_NAME, b"# GM2Godot\n", mode=0o644),
+        ]
+    with zipfile.ZipFile(
+        archive_path,
+        "w",
+        compression=zipfile.ZIP_DEFLATED,
+    ) as archive:
+        for member, content in selected:
+            archive.writestr(member, content, compress_type=zipfile.ZIP_DEFLATED)
+    return archive_path
+
+
+def _write_fake_xvfb_run(root: Path) -> Path:
+    path = root / "xvfb-run"
+    path.write_text(
+        "#!/bin/sh\n"
+        "set -eu\n"
+        "for argument in \"$@\"; do command=$argument; done\n"
+        "exec \"$command\"\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+    return path
+
+
+def _write_delayed_cleanup_xvfb_run(root: Path) -> Path:
+    path = root / "xvfb-run-delayed-cleanup"
+    path.write_text(
+        "#!/bin/sh\n"
+        "set -eu\n"
+        "for argument in \"$@\"; do command=$argument; done\n"
+        "/bin/sh -c 'trap \"exit 0\" TERM; /bin/sleep 0.4' &\n"
+        "helper=$!\n"
+        "cleanup() { kill \"$helper\" 2>/dev/null || :; }\n"
+        "trap cleanup EXIT\n"
+        '"$command"\n',
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+    return path
+
+
+def _assert_process_gone(test_case: unittest.TestCase, process_id: int) -> None:
+    deadline = time.monotonic() + 2.0
+    while True:
+        try:
+            os.kill(process_id, 0)
+        except ProcessLookupError:
+            return
+        if time.monotonic() >= deadline:
+            test_case.fail(f"descendant process {process_id} survived verifier cleanup")
+        time.sleep(0.02)
+
+
+def _success_body(extra: str = "") -> str:
+    return (
+        '[ "$QT_QPA_PLATFORM" = "xcb" ]\n'
+        '[ "$QT_DEBUG_PLUGINS" = "1" ]\n'
+        '[ -d "$XDG_RUNTIME_DIR" ]\n'
+        '[ -d "$TMPDIR" ]\n'
+        '[ "${LD_LIBRARY_PATH+x}" != "x" ]\n'
+        "umask 077\n"
+        f"{extra}"
+        f"printf '{verifier.GUI_SMOKE_RECEIPT.decode('ascii')}' "
+        f' > "${verifier.GUI_SMOKE_RECEIPT_ENV}"\n'
+        f'chmod 600 "${verifier.GUI_SMOKE_RECEIPT_ENV}"\n'
+    )
+
+
+@unittest.skipUnless(
+    os.name == "posix" and hasattr(os, "O_NOFOLLOW") and hasattr(os, "killpg"),
+    "Linux artifact verifier requires POSIX no-follow and process groups",
+)
+class LinuxGuiArtifactVerifierTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(
+            prefix="gm2godot-linux-verifier-test-"
+        )
+        self.root = Path(self.temporary.name).resolve()
+        self.xvfb_run = _write_fake_xvfb_run(self.root)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def verify(self, body: str, *, timeout_seconds: float = 3.0) -> None:
+        archive = _write_archive(self.root, _executable_script(body))
+        verifier.verify_archive(
+            archive,
+            xvfb_run_path=self.xvfb_run,
+            timeout_seconds=timeout_seconds,
+        )
+
+    def test_exact_archive_launches_under_xcb_and_writes_receipt(self) -> None:
+        self.verify(_success_body())
+
+    def test_zero_exit_without_receipt_is_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            verifier.LinuxGuiArtifactVerificationError,
+            "read packaged GUI readiness receipt",
+        ):
+            self.verify("exit 0\n")
+
+    def test_nonzero_exit_is_rejected_even_with_receipt(self) -> None:
+        body = _success_body() + "exit 7\n"
+        with self.assertRaisesRegex(
+            verifier.LinuxGuiArtifactVerificationError,
+            "exited with status 7",
+        ):
+            self.verify(body)
+
+    def test_wrong_receipt_content_and_mode_are_rejected(self) -> None:
+        cases = {
+            "content": (
+                f"printf 'wrong\\n' > \"${verifier.GUI_SMOKE_RECEIPT_ENV}\"\n"
+                f'chmod 600 "${verifier.GUI_SMOKE_RECEIPT_ENV}"\n',
+                "content is invalid",
+            ),
+            "mode": (
+                f"printf '{verifier.GUI_SMOKE_RECEIPT.decode('ascii')}' "
+                f' > "${verifier.GUI_SMOKE_RECEIPT_ENV}"\n'
+                f'chmod 644 "${verifier.GUI_SMOKE_RECEIPT_ENV}"\n',
+                "does not have mode 0600",
+            ),
+        }
+        for name, (body, message) in cases.items():
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(
+                    verifier.LinuxGuiArtifactVerificationError,
+                    message,
+                ):
+                    self.verify(body)
+
+    def test_fatal_loader_and_platform_diagnostics_are_rejected(self) -> None:
+        for signature in verifier._FATAL_OUTPUT_SIGNATURES:
+            with self.subTest(signature=signature):
+                body = _success_body(
+                    f"printf '%s\\n' '{signature.upper()}' >&2\n"
+                )
+                with self.assertRaisesRegex(
+                    verifier.LinuxGuiArtifactVerificationError,
+                    "fatal loader/platform diagnostic",
+                ):
+                    self.verify(body)
+
+    def test_timeout_kills_the_isolated_process_group(self) -> None:
+        child_receipt = self.root / "timeout-child.pid"
+        body = (
+            "/bin/sleep 30 &\n"
+            "child=$!\n"
+            f"printf '%s' \"$child\" > {shlex.quote(os.fspath(child_receipt))}\n"
+            "wait \"$child\"\n"
+        )
+        with self.assertRaisesRegex(
+            verifier.LinuxGuiArtifactVerificationError,
+            "timed out",
+        ):
+            self.verify(body, timeout_seconds=3.0)
+        _assert_process_gone(self, int(child_receipt.read_text(encoding="ascii")))
+
+    def test_normal_delayed_xvfb_teardown_is_given_a_bounded_grace(self) -> None:
+        archive = _write_archive(
+            self.root,
+            _executable_script(_success_body()),
+        )
+        delayed_wrapper = _write_delayed_cleanup_xvfb_run(self.root)
+
+        verifier.verify_archive(
+            archive,
+            xvfb_run_path=delayed_wrapper,
+            timeout_seconds=3,
+        )
+
+    def test_cleanup_escalates_when_process_group_ignores_sigterm(self) -> None:
+        process_receipt = self.root / "term-ignoring-process.pid"
+        body = (
+            "trap '' TERM\n"
+            f"printf '%s' \"$$\" > {shlex.quote(os.fspath(process_receipt))}\n"
+            "while :; do /bin/sleep 1; done\n"
+        )
+        with (
+            mock.patch.object(verifier, "PROCESS_TERMINATION_GRACE_SECONDS", 0.1),
+            self.assertRaisesRegex(
+                verifier.LinuxGuiArtifactVerificationError,
+                "timed out",
+            ),
+        ):
+            self.verify(body, timeout_seconds=3.0)
+        _assert_process_gone(self, int(process_receipt.read_text(encoding="ascii")))
+
+    def test_group_disappearance_probe_reaps_linux_zombie_first(self) -> None:
+        fake_process = _ReapAwareProcess()
+        process = cast(subprocess.Popen[bytes], fake_process)
+
+        def reject_probe_before_reap(process_id: int, selected_signal: int) -> None:
+            self.assertEqual(process_id, fake_process.pid)
+            self.assertEqual(selected_signal, 0)
+            self.assertTrue(fake_process.reaped)
+            raise ProcessLookupError
+
+        with mock.patch.object(
+            verifier.os,
+            "killpg",
+            side_effect=reject_probe_before_reap,
+        ):
+            self.assertTrue(verifier._wait_for_group_disappearance(process, 0.1))
+
+    def test_successful_leader_cannot_leave_a_descendant_running(self) -> None:
+        child_receipt = self.root / "leaked-child.pid"
+        body = (
+            _success_body()
+            + "/bin/sleep 30 &\n"
+            + "child=$!\n"
+            + f"printf '%s' \"$child\" > {shlex.quote(os.fspath(child_receipt))}\n"
+            + "exit 0\n"
+        )
+        with (
+            mock.patch.object(verifier, "PROCESS_GROUP_GRACE_SECONDS", 0.1),
+            self.assertRaisesRegex(
+                verifier.LinuxGuiArtifactVerificationError,
+                "left a descendant process",
+            ),
+        ):
+            self.verify(body)
+        _assert_process_gone(self, int(child_receipt.read_text(encoding="ascii")))
+
+    def test_oversized_output_is_rejected_without_pipe_deadlock(self) -> None:
+        child_receipt = self.root / "output-child.pid"
+        body = (
+            "/bin/sleep 30 &\n"
+            "child=$!\n"
+            f"printf '%s' \"$child\" > {shlex.quote(os.fspath(child_receipt))}\n"
+            "i=0\nwhile [ $i -lt 200 ]; do printf x; i=$((i + 1)); done\n"
+            "exit 0\n"
+        )
+        with (
+            mock.patch.object(verifier, "MAX_PROCESS_OUTPUT_BYTES", 64),
+            mock.patch.object(verifier, "PROCESS_GROUP_GRACE_SECONDS", 0.1),
+            self.assertRaisesRegex(
+                verifier.LinuxGuiArtifactVerificationError,
+                "output exceeded",
+            ),
+        ):
+            self.verify(body)
+        _assert_process_gone(self, int(child_receipt.read_text(encoding="ascii")))
+
+    def test_archive_path_symlink_is_rejected(self) -> None:
+        actual = self.root / "actual.zip"
+        archive = _write_archive(self.root, _executable_script(_success_body()))
+        archive.rename(actual)
+        archive.symlink_to(actual)
+
+        with self.assertRaisesRegex(
+            verifier.LinuxGuiArtifactVerificationError,
+            "without following links",
+        ):
+            verifier.verify_archive(
+                archive,
+                xvfb_run_path=self.xvfb_run,
+                timeout_seconds=1,
+            )
+
+    def test_xvfb_run_symlink_is_rejected(self) -> None:
+        real_wrapper = self.root / "real-wrapper"
+        self.xvfb_run.rename(real_wrapper)
+        self.xvfb_run.symlink_to(real_wrapper)
+        archive = _write_archive(
+            self.root,
+            _executable_script(_success_body()),
+        )
+
+        with self.assertRaisesRegex(
+            verifier.LinuxGuiArtifactVerificationError,
+            "executable regular file",
+        ):
+            verifier.verify_archive(
+                archive,
+                xvfb_run_path=self.xvfb_run,
+                timeout_seconds=1,
+            )
+
+    def test_corrupt_member_payload_is_rejected_cleanly(self) -> None:
+        archive = _write_archive(
+            self.root,
+            _executable_script(_success_body()),
+        )
+        content = bytearray(archive.read_bytes())
+        local_header = content.find(b"PK\x03\x04")
+        self.assertGreaterEqual(local_header, 0)
+        name_length = int.from_bytes(content[local_header + 26 : local_header + 28], "little")
+        extra_length = int.from_bytes(content[local_header + 28 : local_header + 30], "little")
+        payload_offset = local_header + 30 + name_length + extra_length
+        content[payload_offset] ^= 0xFF
+        archive.write_bytes(content)
+
+        with self.assertRaises(verifier.LinuxGuiArtifactVerificationError):
+            verifier.verify_archive(
+                archive,
+                xvfb_run_path=self.xvfb_run,
+                timeout_seconds=1,
+            )
+
+    def test_cli_rejects_relative_and_wrong_basename_paths(self) -> None:
+        for argument, message in (
+            ("GM2Godot-linux.zip", "absolute path"),
+            (os.fspath(self.root / "renamed.zip"), "must be named"),
+        ):
+            with self.subTest(argument=argument):
+                stderr = StringIO()
+                with redirect_stderr(stderr):
+                    result = verifier.main(["--archive", argument])
+                self.assertEqual(result, 1)
+                self.assertIn(message, stderr.getvalue())
+
+
+class LinuxGuiArtifactMemberPolicyTests(unittest.TestCase):
+    def exact_members(self) -> list[zipfile.ZipInfo]:
+        executable, _ = _member(
+            verifier.EXECUTABLE_NAME,
+            b"binary",
+            mode=0o755,
+        )
+        executable.file_size = 6
+        executable.compress_size = 6
+        readme, _ = _member(verifier.README_NAME, b"readme", mode=0o644)
+        readme.file_size = 6
+        readme.compress_size = 6
+        return [executable, readme]
+
+    def test_exact_member_contract_is_accepted(self) -> None:
+        selected = verifier._validate_members(self.exact_members())
+        self.assertEqual(set(selected), set(verifier.EXPECTED_MEMBER_MODES))
+
+    def test_missing_extra_duplicate_case_and_path_aliases_are_rejected(self) -> None:
+        cases: list[list[zipfile.ZipInfo]] = []
+        exact = self.exact_members()
+        cases.append(exact[:1])
+
+        extra = self.exact_members()
+        extra_member, _ = _member("extra", b"x", mode=0o644)
+        extra_member.file_size = 1
+        extra_member.compress_size = 1
+        cases.append([*extra, extra_member])
+
+        duplicate = self.exact_members()
+        cases.append([duplicate[0], duplicate[0]])
+
+        for alias in ("gm2godot", "./GM2Godot", "folder/GM2Godot"):
+            aliased = self.exact_members()
+            aliased[0].filename = alias
+            aliased[0].orig_filename = alias
+            cases.append(aliased)
+
+        for members in cases:
+            with self.subTest(names=[member.filename for member in members]):
+                with self.assertRaises(
+                    verifier.LinuxGuiArtifactVerificationError
+                ):
+                    verifier._validate_members(members)
+
+    def test_nul_alias_encryption_and_non_unix_metadata_are_rejected(self) -> None:
+        cases: list[list[zipfile.ZipInfo]] = []
+
+        nul_alias = self.exact_members()
+        nul_alias[0].orig_filename = "GM2Godot\x00alias"
+        cases.append(nul_alias)
+
+        encrypted = self.exact_members()
+        encrypted[0].flag_bits |= 0x1
+        cases.append(encrypted)
+
+        non_unix = self.exact_members()
+        non_unix[0].create_system = 0
+        cases.append(non_unix)
+
+        for members in cases:
+            with self.subTest(member=members[0].orig_filename):
+                with self.assertRaises(
+                    verifier.LinuxGuiArtifactVerificationError
+                ):
+                    verifier._validate_members(members)
+
+    def test_non_deflate_compression_is_rejected_before_extraction(self) -> None:
+        for compression in (zipfile.ZIP_STORED, zipfile.ZIP_BZIP2, zipfile.ZIP_LZMA):
+            with self.subTest(compression=compression):
+                members = self.exact_members()
+                members[0].compress_type = compression
+                with self.assertRaisesRegex(
+                    verifier.LinuxGuiArtifactVerificationError,
+                    "required DEFLATE compression",
+                ):
+                    verifier._validate_members(members)
+
+    def test_nonregular_types_and_wrong_modes_are_rejected(self) -> None:
+        for file_type in (
+            stat.S_IFDIR,
+            stat.S_IFLNK,
+            stat.S_IFIFO,
+            stat.S_IFCHR,
+            stat.S_IFBLK,
+            stat.S_IFSOCK,
+            0,
+        ):
+            with self.subTest(file_type=file_type):
+                members = self.exact_members()
+                members[0].external_attr = (file_type | 0o755) << 16
+                with self.assertRaisesRegex(
+                    verifier.LinuxGuiArtifactVerificationError,
+                    "not a regular file",
+                ):
+                    verifier._validate_members(members)
+
+        for index, mode in ((0, 0o644), (0, 0o4755), (1, 0o755)):
+            with self.subTest(index=index, mode=mode):
+                members = self.exact_members()
+                members[index].external_attr = (stat.S_IFREG | mode) << 16
+                with self.assertRaisesRegex(
+                    verifier.LinuxGuiArtifactVerificationError,
+                    "has mode",
+                ):
+                    verifier._validate_members(members)
+
+    def test_zero_and_oversized_declared_members_are_rejected(self) -> None:
+        cases = (
+            (0, 0),
+            (0, verifier.MAX_EXECUTABLE_BYTES + 1),
+            (1, verifier.MAX_README_BYTES + 1),
+        )
+        for index, size in cases:
+            with self.subTest(index=index, size=size):
+                members = self.exact_members()
+                members[index].file_size = size
+                with self.assertRaisesRegex(
+                    verifier.LinuxGuiArtifactVerificationError,
+                    "invalid declared size",
+                ):
+                    verifier._validate_members(members)
+
+    def test_duplicate_archive_entries_are_not_hidden_by_a_dictionary(self) -> None:
+        executable, executable_content = _member(
+            verifier.EXECUTABLE_NAME,
+            b"first",
+            mode=0o755,
+        )
+        duplicate, duplicate_content = _member(
+            verifier.EXECUTABLE_NAME,
+            b"second",
+            mode=0o755,
+        )
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                archive = _write_archive(
+                    root,
+                    b"unused",
+                    members=[
+                        (executable, executable_content),
+                        (duplicate, duplicate_content),
+                    ],
+                )
+            with zipfile.ZipFile(archive) as opened:
+                with self.assertRaises(
+                    verifier.LinuxGuiArtifactVerificationError
+                ):
+                    verifier._validate_members(opened.infolist())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_linux_gui_artifact_verifier.py
+++ b/tests/test_linux_gui_artifact_verifier.py
@@ -209,6 +209,21 @@ class LinuxGuiArtifactVerifierTests(unittest.TestCase):
                 ):
                     self.verify(body)
 
+    def test_fatal_diagnostic_reports_one_bounded_matching_line(self) -> None:
+        marker = "cannot open shared object file"
+        body = _success_body(
+            f"printf '%s\\n' 'loader: {marker}: {'x' * 2000}' >&2\n"
+        )
+        with self.assertRaises(
+            verifier.LinuxGuiArtifactVerificationError
+        ) as raised:
+            self.verify(body)
+
+        message = str(raised.exception)
+        self.assertIn(f"loader: {marker}", message)
+        self.assertTrue(message.endswith("...'"))
+        self.assertLess(len(message), verifier.MAX_DIAGNOSTIC_LINE_CHARACTERS + 200)
+
     def test_timeout_kills_the_isolated_process_group(self) -> None:
         child_receipt = self.root / "timeout-child.pid"
         body = (

--- a/tests/test_linux_packaging_policy.py
+++ b/tests/test_linux_packaging_policy.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from pathlib import Path
+import runpy
+import sys
+from types import ModuleType
+import unittest
+from unittest.mock import patch
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+HOOK_PATH = (
+    PROJECT_ROOT / "packaging" / "linux" / "hooks" / "hook-PySide6.QtGui.py"
+)
+
+
+def _run_hook(
+    binaries: list[tuple[str, str]],
+) -> tuple[dict[str, object], list[str]]:
+    calls: list[str] = []
+    pyinstaller = ModuleType("PyInstaller")
+    utils = ModuleType("PyInstaller.utils")
+    hooks = ModuleType("PyInstaller.utils.hooks")
+    qt = ModuleType("PyInstaller.utils.hooks.qt")
+
+    def add_qt6_dependencies(hook_file: str):
+        calls.append(hook_file)
+        return ["qt-hidden-import"], list(binaries), [("qt-data", "qt-data")]
+
+    qt.add_qt6_dependencies = add_qt6_dependencies  # type: ignore[attr-defined]
+    modules = {
+        "PyInstaller": pyinstaller,
+        "PyInstaller.utils": utils,
+        "PyInstaller.utils.hooks": hooks,
+        "PyInstaller.utils.hooks.qt": qt,
+    }
+    with patch.dict(sys.modules, modules):
+        namespace = runpy.run_path(str(HOOK_PATH))
+    return namespace, calls
+
+
+class LinuxQtHookPolicyTests(unittest.TestCase):
+    def test_hook_preserves_qt_dependencies_and_excludes_only_tiff(self) -> None:
+        tiff = (
+            "/wheel/PySide6/Qt/plugins/imageformats/libqtiff.so",
+            "PySide6/Qt/plugins/imageformats",
+        )
+        qxcb = (
+            "/wheel/PySide6/Qt/plugins/platforms/libqxcb.so",
+            "PySide6/Qt/plugins/platforms",
+        )
+        png = (
+            "/wheel/PySide6/Qt/plugins/imageformats/libqpng.so",
+            "PySide6/Qt/plugins/imageformats",
+        )
+
+        namespace, calls = _run_hook([qxcb, tiff, png])
+
+        self.assertEqual(calls, [str(HOOK_PATH)])
+        self.assertEqual(namespace["hiddenimports"], ["qt-hidden-import"])
+        self.assertEqual(namespace["datas"], [("qt-data", "qt-data")])
+        self.assertEqual(namespace["binaries"], [qxcb, png])
+        self.assertEqual(namespace["unsupported_tiff_plugins"], [tiff])
+
+    def test_hook_accepts_windows_style_plugin_destination(self) -> None:
+        tiff = (
+            "/wheel/PySide6/Qt/plugins/imageformats/libqtiff.so",
+            "PySide6\\Qt\\plugins\\imageformats",
+        )
+
+        namespace, _ = _run_hook([tiff])
+
+        self.assertEqual(namespace["binaries"], [])
+
+    def test_hook_fails_closed_when_tiff_plugin_is_missing(self) -> None:
+        qxcb = (
+            "/wheel/PySide6/Qt/plugins/platforms/libqxcb.so",
+            "PySide6/Qt/plugins/platforms",
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "found 0"):
+            _run_hook([qxcb])
+
+    def test_hook_fails_closed_when_tiff_plugin_is_duplicated(self) -> None:
+        plugins = [
+            (
+                "/wheel-a/PySide6/Qt/plugins/imageformats/libqtiff.so",
+                "PySide6/Qt/plugins/imageformats",
+            ),
+            (
+                "/wheel-b/PySide6/Qt/plugins/imageformats/libqtiff.so",
+                "PySide6/Qt/plugins/imageformats",
+            ),
+        ]
+
+        with self.assertRaisesRegex(RuntimeError, "found 2"):
+            _run_hook(plugins)
+
+    def test_same_basename_outside_qt_imageformats_is_not_silently_removed(
+        self,
+    ) -> None:
+        unrelated = ("/vendor/libqtiff.so", "vendor")
+
+        with self.assertRaisesRegex(RuntimeError, "found 0"):
+            _run_hook([unrelated])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_21(self) -> None:
-        self.assertEqual(get_version(), "0.7.21")
+    def test_release_version_is_0_7_22(self) -> None:
+        self.assertEqual(get_version(), "0.7.22")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
@@ -28,8 +28,13 @@ class TestVersion(unittest.TestCase):
         )
         self.assertIn(f"Current source version: `{current_version}`.", readme)
         self.assertIn(
-            f"GM2Godot {current_version}, GameMaker LTS 2026",
+            f"GM2Godot {current_version}, GameMaker LTS 2026, Godot 4.7.1",
             issue_template,
+        )
+        self.assertIn(
+            "GM2Godot targets GameMaker LTS 2026 source projects and "
+            "Godot 4.7.1 output.",
+            readme,
         )
         self.assertIn("## 0.7.5 - 2026-07-18", changelog)
         self.assertIn("## 0.7.4 - 2026-07-18", changelog)


### PR DESCRIPTION
## Summary

- declare Ubuntu 24.04 x86_64 as the packaged Linux baseline and install the exact QtGui EGL/GL and XCB host dependencies
- exclude only the unused Qt TIFF plugin and fail on unresolved PyInstaller libraries or missing bundled XCB members
- extract the final Linux ZIP and launch its executable through real `qxcb` under Xvfb with bounded, fail-closed receipt and process cleanup
- add adversarial archive/process tests, startup-smoke coverage, documentation, and the 0.7.22 version bump

## Validation

- `./venv/bin/python -m unittest` (2116 passed, 39 skipped)
- `./venv/bin/pyright --warnings` (0 errors, 0 warnings)
- `./venv/bin/ruff check .`
- `actionlint` across all workflows
- `git diff --check`
- exact-head Linux, macOS, and Windows release builds, Godot 4.7.1 smoke, GameMaker LTS 2026 conversion, and TCC conversion

Closes #733