### PR TITLE
Reuse Included File publication receipts

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.23, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.24, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.24 - 2026-07-19
+
+- Reused attempt-local Included File receipts across asset-registry and manifest publication, reducing successful matching Included File validation from 12x payload reads to at most 6x while binding reuse to the exact source, generated output, assigned path, and output generation.
+- Preserved final SHA-256 and path-versus-handle identity checks, with Win32 read handles denying concurrent write/delete sharing while the final receipts are hashed, so content mutation, path replacement, hard-link substitution, redirected paths, and directory swaps still fail closed.
+
 ## 0.7.23 - 2026-07-19
 
 - Replaced read-only generated text outputs on Windows through identity-bound handles, no-replace quarantine moves, and POSIX-style read-only disposition without path-level chmod or cleanup races.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.23`.
+Current source version: `0.7.24`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.23 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.24 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.23 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.24 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.23 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.24 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.23 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.24 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.23 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.24 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.23;
+- GM2Godot 0.7.24;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.23 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.24 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -46,7 +46,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.23`.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.24`.
 
 ## Run from source
 
@@ -133,6 +133,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.23`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.24`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.23 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.24 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.23 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.24 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/src/conversion/asset_registry.py
+++ b/src/conversion/asset_registry.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+import ctypes
 import hashlib
 import json
 import os
 import posixpath
 import stat
 from dataclasses import dataclass, field
-from typing import BinaryIO, Callable, ClassVar, Iterable, cast
+from functools import lru_cache
+from typing import Any, BinaryIO, Callable, ClassVar, Iterable, cast
 
 from src.conversion.atomic_generated_text import (
     atomic_write_confined_generated_text,
@@ -67,6 +69,18 @@ ASSET_REGISTRY_RESOURCE_PATH = "res://gm2godot/gml_asset_registry.gd"
 GROUP_COMPATIBILITY_REPORT_RELATIVE_PATH = os.path.join("gm2godot", "group_compatibility_report.json")
 STATIC_ASSET_ID_MASK = 0x3FFFFFFF
 
+_IncludedFilePathIdentity = tuple[int, int]
+_IncludedFilePathFingerprint = tuple[int, int, int, int, int, int, int]
+_IncludedFilePathHandleBinding = tuple[int, int, int, int, int, int]
+_IncludedFileHandleState = tuple[int, int, int, int, int, int, int]
+_IncludedFileDirectoryIdentity = tuple[str, _IncludedFilePathIdentity]
+
+_WINDOWS_GENERIC_READ = 0x80000000
+_WINDOWS_FILE_SHARE_READ = 0x00000001
+_WINDOWS_OPEN_EXISTING = 3
+_WINDOWS_FILE_ATTRIBUTE_NORMAL = 0x00000080
+_WINDOWS_FILE_FLAG_SEQUENTIAL_SCAN = 0x08000000
+
 
 def _empty_int_list() -> list[int]:
     return []
@@ -103,6 +117,136 @@ def _uses_windows_included_file_path_handle_semantics() -> bool:
     return os.name == "nt"
 
 
+def _included_file_path_fingerprint(
+    file_stat: os.stat_result,
+) -> _IncludedFilePathFingerprint:
+    """Return exact path metadata retained across publication boundaries."""
+
+    return (
+        file_stat.st_dev,
+        file_stat.st_ino,
+        file_stat.st_mode,
+        file_stat.st_size,
+        file_stat.st_mtime_ns,
+        file_stat.st_ctime_ns,
+        file_stat.st_nlink,
+    )
+
+
+def _included_file_path_handle_binding(
+    file_stat: os.stat_result,
+) -> _IncludedFilePathHandleBinding:
+    """Return metadata portable between path and handle stat on Windows."""
+
+    return (
+        file_stat.st_dev,
+        file_stat.st_ino,
+        stat.S_IFMT(file_stat.st_mode),
+        file_stat.st_size,
+        file_stat.st_mtime_ns,
+        file_stat.st_nlink,
+    )
+
+
+def _included_file_handle_state(
+    file_stat: os.stat_result,
+) -> _IncludedFileHandleState:
+    """Return exact metadata used to bind one open regular-file handle."""
+
+    return (
+        file_stat.st_dev,
+        file_stat.st_ino,
+        file_stat.st_mode,
+        file_stat.st_size,
+        file_stat.st_mtime_ns,
+        file_stat.st_ctime_ns,
+        file_stat.st_nlink,
+    )
+
+
+def _read_included_file_validation_chunk(opened_file: BinaryIO) -> bytes:
+    """Read one validation chunk through a deterministic accounting seam."""
+
+    return opened_file.read(1024 * 1024)
+
+
+@lru_cache(maxsize=1)
+def _windows_included_file_read_api() -> Any:
+    if os.name != "nt":
+        raise OSError("Windows Included File read handles are unavailable")
+    win_dll = cast(Callable[..., Any], getattr(ctypes, "WinDLL"))
+    kernel32 = win_dll("kernel32", use_last_error=True)
+    kernel32.CreateFileW.argtypes = (
+        ctypes.c_wchar_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+    )
+    kernel32.CreateFileW.restype = ctypes.c_void_p
+    kernel32.CloseHandle.argtypes = (ctypes.c_void_p,)
+    kernel32.CloseHandle.restype = ctypes.c_int
+    return kernel32
+
+
+def _open_included_file_validation_stream(
+    path: str,
+    *,
+    deny_writes: bool,
+) -> BinaryIO:
+    """Open a binary stream, denying Win32 writes at the final boundary."""
+
+    if not deny_writes or os.name != "nt":
+        return open(path, "rb")
+
+    kernel32 = _windows_included_file_read_api()
+    handle_value = kernel32.CreateFileW(
+        os.path.abspath(path),
+        _WINDOWS_GENERIC_READ,
+        _WINDOWS_FILE_SHARE_READ,
+        None,
+        _WINDOWS_OPEN_EXISTING,
+        _WINDOWS_FILE_ATTRIBUTE_NORMAL
+        | _WINDOWS_FILE_FLAG_SEQUENTIAL_SCAN,
+        None,
+    )
+    invalid_handle = ctypes.c_void_p(-1).value
+    if handle_value is None or handle_value == invalid_handle:
+        get_last_error = cast(
+            Callable[[], int],
+            getattr(ctypes, "get_last_error"),
+        )
+        error_number = get_last_error()
+        format_error = cast(
+            Callable[[int], str],
+            getattr(ctypes, "FormatError"),
+        )
+        raise OSError(
+            error_number,
+            format_error(error_number).strip(),
+            path,
+        )
+
+    handle = cast(int, handle_value)
+    try:
+        import msvcrt
+
+        file_descriptor = msvcrt.open_osfhandle(
+            handle,
+            os.O_RDONLY | getattr(os, "O_BINARY", 0),
+        )
+    except BaseException:
+        kernel32.CloseHandle(handle)
+        raise
+    try:
+        return os.fdopen(file_descriptor, "rb")
+    except BaseException:
+        os.close(file_descriptor)
+        raise
+
+
 def _included_file_streams_match(
     source_file: BinaryIO,
     output_file: BinaryIO,
@@ -110,8 +254,8 @@ def _included_file_streams_match(
     source_digest = hashlib.sha256()
     output_digest = hashlib.sha256()
     while True:
-        source_chunk = source_file.read(1024 * 1024)
-        output_chunk = output_file.read(1024 * 1024)
+        source_chunk = _read_included_file_validation_chunk(source_file)
+        output_chunk = _read_included_file_validation_chunk(output_file)
         source_digest.update(source_chunk)
         output_digest.update(output_chunk)
         if source_chunk != output_chunk:
@@ -128,39 +272,63 @@ def _included_file_streams_match(
             )
 
 
-def _included_file_stream_sha256(opened_file: BinaryIO) -> str:
+def _included_file_stream_sha256(opened_file: BinaryIO) -> tuple[int, str]:
     digest = hashlib.sha256()
+    byte_count = 0
     while True:
-        chunk = opened_file.read(1024 * 1024)
+        chunk = _read_included_file_validation_chunk(opened_file)
         if not chunk:
-            return digest.hexdigest()
+            return byte_count, digest.hexdigest()
         digest.update(chunk)
+        byte_count += len(chunk)
+
+
+@dataclass(frozen=True)
+class _IncludedFileStreamReceipt:
+    source_byte_count: int
+    source_sha256: str
+    output_byte_count: int
+    output_sha256: str
 
 
 def _included_file_streams_match_stably(
     source_file: BinaryIO,
     output_file: BinaryIO,
     output_path: str,
-) -> bool:
+) -> _IncludedFileStreamReceipt | None:
     matches, source_sha256, output_sha256 = _included_file_streams_match(
         source_file,
         output_file,
     )
     if not matches:
-        return False
+        return None
+
+    source_byte_count = source_file.tell()
+    output_byte_count = output_file.tell()
 
     source_file.seek(0)
-    if _included_file_stream_sha256(source_file) != source_sha256:
+    if _included_file_stream_sha256(source_file) != (
+        source_byte_count,
+        source_sha256,
+    ):
         raise OSError(
             "Asset-registry Included File source changed during validation"
         )
     output_file.seek(0)
-    if _included_file_stream_sha256(output_file) != output_sha256:
+    if _included_file_stream_sha256(output_file) != (
+        output_byte_count,
+        output_sha256,
+    ):
         raise OSError(
             "Asset-registry Included File output changed during validation: "
             f"{output_path}"
         )
-    return True
+    return _IncludedFileStreamReceipt(
+        source_byte_count=source_byte_count,
+        source_sha256=source_sha256,
+        output_byte_count=output_byte_count,
+        output_sha256=output_sha256,
+    )
 
 
 @dataclass(frozen=True)
@@ -197,6 +365,55 @@ class AssetRegistryEntry:
 class _UnavailablePublishedIncludedFile:
     entry: AssetRegistryEntry
     reason: str
+
+
+@dataclass(frozen=True)
+class _IncludedFileOutputReceipt:
+    path: str
+    components: tuple[str, ...]
+    directory_identities: tuple[_IncludedFileDirectoryIdentity, ...]
+    path_fingerprint: _IncludedFilePathFingerprint
+    handle_state: _IncludedFileHandleState
+    byte_count: int
+    sha256: str
+
+    @property
+    def generation_identity(self) -> _IncludedFilePathIdentity:
+        if len(self.directory_identities) < 2:
+            raise OSError(
+                "Asset-registry Included Files generation identity is missing"
+            )
+        return self.directory_identities[1][1]
+
+
+@dataclass(frozen=True)
+class _IncludedFileSourceReceipt:
+    filesystem_path: str
+    canonical_path: str
+    directory_identities: tuple[_IncludedFileDirectoryIdentity, ...]
+    lexical_fingerprint: _IncludedFilePathFingerprint
+    path_fingerprint: _IncludedFilePathFingerprint
+    handle_state: _IncludedFileHandleState
+
+
+@dataclass(frozen=True)
+class _IncludedFileContentReceipt:
+    entry: AssetRegistryEntry
+    source: _IncludedFileSourceReceipt
+    source_byte_count: int
+    source_sha256: str
+    output: _IncludedFileOutputReceipt
+
+
+@dataclass(frozen=True)
+class AssetRegistryPublication:
+    """Immutable Included File receipts for one publication attempt."""
+
+    entries: tuple[AssetRegistryEntry, ...]
+    planned_included_files: tuple[AssetRegistryEntry, ...]
+    included_file_receipts: tuple[_IncludedFileContentReceipt, ...]
+    unavailable_included_files: tuple[_UnavailablePublishedIncludedFile, ...]
+    included_files_generation: _IncludedFilePathIdentity | None
 
 
 @dataclass(frozen=True)
@@ -390,25 +607,34 @@ class AssetRegistryConverter(BaseConverter):
 
         ``build_entries()`` remains the source-planning API used by converters
         that need the complete deterministic asset namespace before outputs
-        exist. Artifact publishers use this method so they never advertise an
-        absent, redirected, stale, or otherwise mismatched Included File.
+        exist. This compatibility query filters absent, redirected, or stale
+        Included Files, but does not retain cross-boundary identity receipts.
+        Artifact publishers must use ``prepare_published_entries()`` together
+        with ``revalidate_publication()``.
         """
+
+        return self.prepare_published_entries().entries
+
+    def prepare_published_entries(self) -> AssetRegistryPublication:
+        """Capture immutable receipts for one artifact publication attempt."""
 
         plan = self._conversion_plan()
         entries, _processed_count = self._build_entries_from_resources(
             plan.resources,
             included_file_logical_paths=plan.included_file_logical_paths,
         )
-        published, _unavailable = self._filter_published_included_file_entries(
-            entries
-        )
-        return published
+        return self._prepare_published_entries(entries)
 
     def revalidate_published_entries(
         self,
         expected_entries: tuple[AssetRegistryEntry, ...],
     ) -> None:
-        """Fail if current published Included Files differ from the plan."""
+        """Compatibility check for logical Included File availability.
+
+        This method cannot bind a prior file identity because its legacy input
+        contains entries only. Receipt-sensitive publishers must use
+        ``revalidate_publication()``.
+        """
 
         expected_included_files = tuple(
             entry
@@ -426,6 +652,142 @@ class AssetRegistryConverter(BaseConverter):
                 "planning."
             )
 
+    def revalidate_publication(
+        self,
+        publication: AssetRegistryPublication,
+        *,
+        validate_content: bool,
+    ) -> None:
+        """Revalidate one receipt-bound publication phase.
+
+        The pre-publication phase deliberately performs only path, handle,
+        generation, and deterministic planning checks. The post-publication
+        phase additionally hashes each source and generated output once and
+        compares both to the immutable receipt captured during selection.
+        """
+
+        try:
+            current_plan = self._conversion_plan()
+            current_entries, _processed_count = self._build_entries_from_resources(
+                current_plan.resources,
+                included_file_logical_paths=(
+                    current_plan.included_file_logical_paths
+                ),
+            )
+            current_included_files = tuple(
+                entry
+                for entry in current_entries
+                if entry.kind == "included_files"
+            )
+            if current_included_files != publication.planned_included_files:
+                raise OSError("deterministic Included File planning changed")
+
+            published_included_files = tuple(
+                entry
+                for entry in publication.entries
+                if entry.kind == "included_files"
+            )
+            receipt_entries = tuple(
+                receipt.entry
+                for receipt in publication.included_file_receipts
+            )
+            unavailable_entries = tuple(
+                unavailable.entry
+                for unavailable in publication.unavailable_included_files
+            )
+            if (
+                receipt_entries != published_included_files
+                or tuple(
+                    sorted(
+                        (*receipt_entries, *unavailable_entries),
+                        key=self._included_file_publication_sort_key,
+                    )
+                )
+                != tuple(
+                    sorted(
+                        publication.planned_included_files,
+                        key=self._included_file_publication_sort_key,
+                    )
+                )
+            ):
+                raise OSError("Included File publication receipt set changed")
+
+            generation = self._included_file_publication_generation(
+                publication.included_file_receipts
+            )
+            if generation != publication.included_files_generation:
+                raise OSError("Included Files generation receipt changed")
+
+            for receipt in publication.included_file_receipts:
+                self._revalidate_included_file_receipt(
+                    receipt,
+                    validate_content=validate_content,
+                )
+        except (OSError, ProjectSourcePathError, ValueError) as error:
+            raise OSError(
+                "Asset-registry Included File publication inputs changed after "
+                "planning."
+            ) from error
+
+    def _prepare_published_entries(
+        self,
+        entries: tuple[AssetRegistryEntry, ...],
+    ) -> AssetRegistryPublication:
+        published: list[AssetRegistryEntry] = []
+        unavailable: list[_UnavailablePublishedIncludedFile] = []
+        receipts: list[_IncludedFileContentReceipt] = []
+        planned_included_files: list[AssetRegistryEntry] = []
+        for entry in entries:
+            if entry.kind != "included_files":
+                published.append(entry)
+                continue
+            planned_included_files.append(entry)
+            receipt, reason = self._included_file_content_receipt(entry)
+            if receipt is None:
+                unavailable.append(
+                    _UnavailablePublishedIncludedFile(
+                        entry=entry,
+                        reason=reason,
+                    )
+                )
+                continue
+            published.append(entry)
+            receipts.append(receipt)
+
+        receipt_tuple = tuple(receipts)
+        return AssetRegistryPublication(
+            entries=tuple(published),
+            planned_included_files=tuple(planned_included_files),
+            included_file_receipts=receipt_tuple,
+            unavailable_included_files=tuple(unavailable),
+            included_files_generation=(
+                self._included_file_publication_generation(receipt_tuple)
+            ),
+        )
+
+    @staticmethod
+    def _included_file_publication_sort_key(
+        entry: AssetRegistryEntry,
+    ) -> tuple[str, str, str]:
+        return (entry.source_path, entry.godot_path, entry.name)
+
+    @staticmethod
+    def _included_file_publication_generation(
+        receipts: tuple[_IncludedFileContentReceipt, ...],
+    ) -> _IncludedFilePathIdentity | None:
+        if not receipts:
+            return None
+        generation = receipts[0].output.generation_identity
+        if any(
+            receipt.output.generation_identity != generation
+            for receipt in receipts[1:]
+        ):
+            raise OSError(
+                "Asset-registry Included Files changed generations during "
+                "receipt capture"
+            )
+        return generation
+
     def _filter_published_included_file_entries(
         self,
         entries: tuple[AssetRegistryEntry, ...],
@@ -433,28 +795,20 @@ class AssetRegistryConverter(BaseConverter):
         tuple[AssetRegistryEntry, ...],
         tuple[_UnavailablePublishedIncludedFile, ...],
     ]:
-        published: list[AssetRegistryEntry] = []
-        unavailable: list[_UnavailablePublishedIncludedFile] = []
-        for entry in entries:
-            if entry.kind != "included_files":
-                published.append(entry)
-                continue
-            matches, reason = self._included_file_output_matches_source(entry)
-            if matches:
-                published.append(entry)
-            else:
-                unavailable.append(
-                    _UnavailablePublishedIncludedFile(
-                        entry=entry,
-                        reason=reason,
-                    )
-                )
-        return tuple(published), tuple(unavailable)
+        publication = self._prepare_published_entries(entries)
+        return publication.entries, publication.unavailable_included_files
 
     def _included_file_output_matches_source(
         self,
         entry: AssetRegistryEntry,
     ) -> tuple[bool, str]:
+        receipt, reason = self._included_file_content_receipt(entry)
+        return receipt is not None, reason
+
+    def _included_file_content_receipt(
+        self,
+        entry: AssetRegistryEntry,
+    ) -> tuple[_IncludedFileContentReceipt | None, str]:
         source_file: BinaryIO | None = None
         try:
             source_file, source_stat = self._open_pinned_included_file_source(
@@ -462,45 +816,69 @@ class AssetRegistryConverter(BaseConverter):
             )
             output_path, components = self._included_file_output_path(entry)
             with source_file:
-                self._verify_pinned_included_file_source(
+                source_receipt = self._capture_pinned_included_file_source(
                     entry,
                     source_file,
                     source_stat,
                 )
                 if _confined_asset_output_supported():
-                    matches = self._included_file_output_matches_at(
+                    output_receipt = self._included_file_output_receipt_at(
                         output_path,
                         components,
                         source_file,
                     )
                 else:
-                    matches = self._included_file_output_matches_fallback(
-                        output_path,
-                        components,
-                        source_file,
+                    output_receipt = (
+                        self._included_file_output_receipt_fallback(
+                            output_path,
+                            components,
+                            source_file,
+                        )
                     )
-                self._verify_pinned_included_file_source(
+                final_source_receipt = self._capture_pinned_included_file_source(
                     entry,
                     source_file,
                     source_stat,
                 )
+                if source_receipt != final_source_receipt:
+                    raise OSError(
+                        "Asset-registry Included File source changed during "
+                        f"validation: {entry.source_path}"
+                    )
+                if output_receipt is None:
+                    return (
+                        None,
+                        "the generated output bytes differ from the source file",
+                    )
+                return (
+                    _IncludedFileContentReceipt(
+                        entry=entry,
+                        source=source_receipt,
+                        source_byte_count=output_receipt.byte_count,
+                        source_sha256=output_receipt.sha256,
+                        output=output_receipt,
+                    ),
+                    "",
+                )
         except (OSError, ProjectSourcePathError, ValueError) as error:
             if source_file is not None and not source_file.closed:
                 source_file.close()
-            return False, str(error)
-        if not matches:
-            return False, "the generated output bytes differ from the source file"
-        return True, ""
+            return None, str(error)
 
     def _open_pinned_included_file_source(
         self,
         entry: AssetRegistryEntry,
+        *,
+        deny_writes: bool = False,
     ) -> tuple[BinaryIO, os.stat_result]:
         resolved = resolve_project_source_path(
             self.gm_project_path,
             entry.source_path,
         )
-        source_file = open(resolved.filesystem_path, "rb")
+        source_file = _open_included_file_validation_stream(
+            resolved.filesystem_path,
+            deny_writes=deny_writes,
+        )
         try:
             source_stat = os.fstat(source_file.fileno())
             if not stat.S_ISREG(source_stat.st_mode):
@@ -524,22 +902,108 @@ class AssetRegistryConverter(BaseConverter):
         source_file: BinaryIO,
         expected_stat: os.stat_result,
     ) -> None:
+        self._capture_pinned_included_file_source(
+            entry,
+            source_file,
+            expected_stat,
+        )
+
+    def _capture_pinned_included_file_source(
+        self,
+        entry: AssetRegistryEntry,
+        source_file: BinaryIO,
+        expected_stat: os.stat_result,
+    ) -> _IncludedFileSourceReceipt:
         resolved = resolve_project_source_path(
             self.gm_project_path,
             entry.source_path,
         )
+        lexical_stat = os.lstat(resolved.filesystem_path)
         current_path_stat = os.stat(resolved.filesystem_path)
         current_open_stat = os.fstat(source_file.fileno())
         if (
             not stat.S_ISREG(current_open_stat.st_mode)
             or not os.path.samestat(expected_stat, current_path_stat)
-            or _included_file_content_fingerprint(current_open_stat)
-            != _included_file_content_fingerprint(expected_stat)
+            or _included_file_handle_state(current_open_stat)
+            != _included_file_handle_state(expected_stat)
+            or _included_file_path_handle_binding(current_path_stat)
+            != _included_file_path_handle_binding(current_open_stat)
         ):
             raise OSError(
                 "Asset-registry Included File source changed during validation: "
                 f"{entry.source_path}"
             )
+        canonical_path, directory_identities = (
+            self._included_file_source_directory_identities(
+                resolved.project_root,
+                resolved.filesystem_path,
+            )
+        )
+        return _IncludedFileSourceReceipt(
+            filesystem_path=os.path.normcase(
+                os.path.abspath(resolved.filesystem_path)
+            ),
+            canonical_path=canonical_path,
+            directory_identities=directory_identities,
+            lexical_fingerprint=_included_file_path_fingerprint(
+                lexical_stat
+            ),
+            path_fingerprint=_included_file_path_fingerprint(
+                current_path_stat
+            ),
+            handle_state=_included_file_handle_state(current_open_stat),
+        )
+
+    @staticmethod
+    def _included_file_source_directory_identities(
+        project_root: str,
+        source_path: str,
+    ) -> tuple[str, tuple[_IncludedFileDirectoryIdentity, ...]]:
+        canonical_root = os.path.normcase(os.path.realpath(project_root))
+        canonical_path = os.path.normcase(os.path.realpath(source_path))
+        try:
+            contained = (
+                os.path.commonpath((canonical_root, canonical_path))
+                == canonical_root
+            )
+        except ValueError:
+            contained = False
+        if not contained or canonical_path == canonical_root:
+            raise OSError(
+                "Asset-registry Included File source escapes the selected "
+                f"project: {source_path}"
+            )
+
+        directory_path = canonical_root
+        identities: list[_IncludedFileDirectoryIdentity] = []
+        relative_directory = os.path.relpath(
+            os.path.dirname(canonical_path),
+            canonical_root,
+        )
+        components = (
+            ()
+            if relative_directory == os.curdir
+            else tuple(relative_directory.split(os.sep))
+        )
+        for component in (None, *components):
+            if component is not None:
+                directory_path = os.path.join(directory_path, component)
+            directory_stat = os.lstat(directory_path)
+            if (
+                _path_is_redirected(directory_path, directory_stat)
+                or not stat.S_ISDIR(directory_stat.st_mode)
+            ):
+                raise OSError(
+                    "Asset-registry Included File source directory is "
+                    f"redirected or invalid: {directory_path}"
+                )
+            identities.append(
+                (
+                    directory_path,
+                    (directory_stat.st_dev, directory_stat.st_ino),
+                )
+            )
+        return canonical_path, tuple(identities)
 
     def _included_file_output_path(
         self,
@@ -583,6 +1047,21 @@ class AssetRegistryConverter(BaseConverter):
         components: tuple[str, ...],
         source_file: BinaryIO,
     ) -> bool:
+        return (
+            self._included_file_output_receipt_at(
+                output_path,
+                components,
+                source_file,
+            )
+            is not None
+        )
+
+    def _included_file_output_receipt_at(
+        self,
+        output_path: str,
+        components: tuple[str, ...],
+        source_file: BinaryIO,
+    ) -> _IncludedFileOutputReceipt | None:
         project_root = os.path.abspath(self.godot_project_path)
         directory_flags = os.O_RDONLY
         directory_flags |= getattr(os, "O_DIRECTORY", 0)
@@ -591,12 +1070,21 @@ class AssetRegistryConverter(BaseConverter):
         project_fd = os.open(project_root, directory_flags)
         current_fd = project_fd
         output_fd = -1
+        directory_identities: list[_IncludedFileDirectoryIdentity] = []
         try:
             _verify_open_asset_output_directory(
                 project_root,
                 project_root,
                 project_fd,
             )
+            project_stat = os.fstat(project_fd)
+            directory_identities.append(
+                (
+                    project_root,
+                    (project_stat.st_dev, project_stat.st_ino),
+                )
+            )
+            directory_path = project_root
             for component in components[:-1]:
                 child_fd = os.open(
                     component,
@@ -606,6 +1094,19 @@ class AssetRegistryConverter(BaseConverter):
                 if current_fd != project_fd:
                     os.close(current_fd)
                 current_fd = child_fd
+                directory_path = os.path.join(directory_path, component)
+                _verify_open_asset_output_directory(
+                    project_root,
+                    directory_path,
+                    current_fd,
+                )
+                directory_stat = os.fstat(current_fd)
+                directory_identities.append(
+                    (
+                        directory_path,
+                        (directory_stat.st_dev, directory_stat.st_ino),
+                    )
+                )
 
             output_directory = os.path.dirname(output_path)
             _verify_open_asset_output_directory(
@@ -627,11 +1128,15 @@ class AssetRegistryConverter(BaseConverter):
             expected_fingerprint = _included_file_content_fingerprint(
                 opened_stat
             )
+            path_fingerprint = _included_file_path_fingerprint(path_stat)
+            handle_state = _included_file_handle_state(opened_stat)
             if (
                 _path_is_redirected(output_path, path_stat)
                 or not stat.S_ISREG(opened_stat.st_mode)
                 or not stat.S_ISREG(path_stat.st_mode)
                 or not os.path.samestat(opened_stat, path_stat)
+                or _included_file_path_handle_binding(path_stat)
+                != _included_file_path_handle_binding(opened_stat)
             ):
                 raise OSError(
                     "Asset-registry Included File output is redirected or "
@@ -639,7 +1144,7 @@ class AssetRegistryConverter(BaseConverter):
                 )
             with os.fdopen(output_fd, "rb") as output_file:
                 output_fd = -1
-                matches = _included_file_streams_match_stably(
+                stream_receipt = _included_file_streams_match_stably(
                     source_file,
                     output_file,
                     output_path,
@@ -663,12 +1168,26 @@ class AssetRegistryConverter(BaseConverter):
                 != expected_fingerprint
                 or _included_file_content_fingerprint(final_path_stat)
                 != expected_fingerprint
+                or _included_file_path_fingerprint(final_path_stat)
+                != path_fingerprint
+                or _included_file_handle_state(final_open_stat)
+                != handle_state
             ):
                 raise OSError(
                     "Asset-registry Included File output changed during "
                     f"validation: {output_path}"
                 )
-            return matches
+            if stream_receipt is None:
+                return None
+            return _IncludedFileOutputReceipt(
+                path=os.path.normcase(os.path.abspath(output_path)),
+                components=components,
+                directory_identities=tuple(directory_identities),
+                path_fingerprint=path_fingerprint,
+                handle_state=handle_state,
+                byte_count=stream_receipt.output_byte_count,
+                sha256=stream_receipt.output_sha256,
+            )
         finally:
             if output_fd >= 0:
                 os.close(output_fd)
@@ -682,10 +1201,25 @@ class AssetRegistryConverter(BaseConverter):
         components: tuple[str, ...],
         source_file: BinaryIO,
     ) -> bool:
+        return (
+            self._included_file_output_receipt_fallback(
+                output_path,
+                components,
+                source_file,
+            )
+            is not None
+        )
+
+    def _included_file_output_receipt_fallback(
+        self,
+        output_path: str,
+        components: tuple[str, ...],
+        source_file: BinaryIO,
+    ) -> _IncludedFileOutputReceipt | None:
         project_root = os.path.abspath(self.godot_project_path)
         project_real = os.path.normcase(os.path.realpath(project_root))
         directory_path = project_root
-        directory_identities: list[tuple[str, tuple[int, int]]] = []
+        directory_identities: list[_IncludedFileDirectoryIdentity] = []
         for component in (None, *components[:-1]):
             if component is not None:
                 directory_path = os.path.join(directory_path, component)
@@ -733,14 +1267,18 @@ class AssetRegistryConverter(BaseConverter):
                 f"non-regular: {output_path}"
             )
         expected_fingerprint = _included_file_content_fingerprint(output_stat)
+        path_fingerprint = _included_file_path_fingerprint(output_stat)
         with open(output_path, "rb") as output_file:
             opened_stat = os.fstat(output_file.fileno())
             opened_fingerprint = _included_file_content_fingerprint(
                 opened_stat
             )
+            handle_state = _included_file_handle_state(opened_stat)
             if (
                 not stat.S_ISREG(opened_stat.st_mode)
                 or not os.path.samestat(opened_stat, output_stat)
+                or _included_file_path_handle_binding(output_stat)
+                != _included_file_path_handle_binding(opened_stat)
             ):
                 raise OSError(
                     "Asset-registry Included File output changed before "
@@ -751,7 +1289,7 @@ class AssetRegistryConverter(BaseConverter):
                 output_path,
                 expected_fingerprint,
             )
-            matches = _included_file_streams_match_stably(
+            stream_receipt = _included_file_streams_match_stably(
                 source_file,
                 output_file,
                 output_path,
@@ -769,12 +1307,25 @@ class AssetRegistryConverter(BaseConverter):
                 expected_fingerprint,
                 _included_file_content_fingerprint(final_open_stat),
             )
+            or _included_file_path_fingerprint(os.lstat(output_path))
+            != path_fingerprint
+            or _included_file_handle_state(final_open_stat) != handle_state
         ):
             raise OSError(
                 "Asset-registry Included File output changed during "
                 f"validation: {output_path}"
             )
-        return matches
+        if stream_receipt is None:
+            return None
+        return _IncludedFileOutputReceipt(
+            path=os.path.normcase(os.path.abspath(output_path)),
+            components=components,
+            directory_identities=tuple(directory_identities),
+            path_fingerprint=path_fingerprint,
+            handle_state=handle_state,
+            byte_count=stream_receipt.output_byte_count,
+            sha256=stream_receipt.output_sha256,
+        )
 
     @staticmethod
     def _verify_included_file_output_fallback(
@@ -804,6 +1355,355 @@ class AssetRegistryConverter(BaseConverter):
             raise OSError(
                 "Asset-registry Included File output changed during "
                 f"validation: {output_path}"
+            )
+
+    def _revalidate_included_file_receipt(
+        self,
+        receipt: _IncludedFileContentReceipt,
+        *,
+        validate_content: bool,
+    ) -> None:
+        source_file, source_stat = self._open_pinned_included_file_source(
+            receipt.entry,
+            deny_writes=validate_content,
+        )
+        with source_file:
+            source_receipt = self._capture_pinned_included_file_source(
+                receipt.entry,
+                source_file,
+                source_stat,
+            )
+            if source_receipt != receipt.source:
+                raise OSError(
+                    "Asset-registry Included File source receipt changed: "
+                    f"{receipt.entry.source_path}"
+                )
+            output_path, components = self._included_file_output_path(
+                receipt.entry
+            )
+            if (
+                os.path.normcase(os.path.abspath(output_path))
+                != receipt.output.path
+                or components != receipt.output.components
+            ):
+                raise OSError(
+                    "Asset-registry Included File assigned output path changed: "
+                    f"{receipt.entry.godot_path}"
+                )
+            if _confined_asset_output_supported():
+                self._revalidate_included_file_output_at(
+                    receipt,
+                    source_file,
+                    validate_content=validate_content,
+                )
+            else:
+                self._revalidate_included_file_output_fallback(
+                    receipt,
+                    source_file,
+                    validate_content=validate_content,
+                )
+
+    def _revalidate_included_file_output_at(
+        self,
+        receipt: _IncludedFileContentReceipt,
+        source_file: BinaryIO,
+        *,
+        validate_content: bool,
+    ) -> None:
+        output_receipt = receipt.output
+        project_root = os.path.abspath(self.godot_project_path)
+        directory_flags = os.O_RDONLY
+        directory_flags |= getattr(os, "O_DIRECTORY", 0)
+        directory_flags |= getattr(os, "O_NOFOLLOW", 0)
+        file_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        project_fd = os.open(project_root, directory_flags)
+        current_fd = project_fd
+        output_fd = -1
+        directory_identities: list[_IncludedFileDirectoryIdentity] = []
+        try:
+            _verify_open_asset_output_directory(
+                project_root,
+                project_root,
+                project_fd,
+            )
+            project_stat = os.fstat(project_fd)
+            directory_identities.append(
+                (
+                    project_root,
+                    (project_stat.st_dev, project_stat.st_ino),
+                )
+            )
+            directory_path = project_root
+            for component in output_receipt.components[:-1]:
+                child_fd = os.open(
+                    component,
+                    directory_flags,
+                    dir_fd=current_fd,
+                )
+                if current_fd != project_fd:
+                    os.close(current_fd)
+                current_fd = child_fd
+                directory_path = os.path.join(directory_path, component)
+                _verify_open_asset_output_directory(
+                    project_root,
+                    directory_path,
+                    current_fd,
+                )
+                directory_stat = os.fstat(current_fd)
+                directory_identities.append(
+                    (
+                        directory_path,
+                        (directory_stat.st_dev, directory_stat.st_ino),
+                    )
+                )
+            if tuple(directory_identities) != output_receipt.directory_identities:
+                raise OSError(
+                    "Asset-registry Included Files generation changed during "
+                    "publication validation"
+                )
+
+            output_fd = os.open(
+                output_receipt.components[-1],
+                file_flags,
+                dir_fd=current_fd,
+            )
+            opened_stat = os.fstat(output_fd)
+            path_stat = os.stat(
+                output_receipt.components[-1],
+                dir_fd=current_fd,
+                follow_symlinks=False,
+            )
+            if (
+                _path_is_redirected(output_receipt.path, path_stat)
+                or not stat.S_ISREG(opened_stat.st_mode)
+                or not stat.S_ISREG(path_stat.st_mode)
+                or not os.path.samestat(opened_stat, path_stat)
+                or _included_file_path_handle_binding(path_stat)
+                != _included_file_path_handle_binding(opened_stat)
+                or _included_file_path_fingerprint(path_stat)
+                != output_receipt.path_fingerprint
+                or _included_file_handle_state(opened_stat)
+                != output_receipt.handle_state
+            ):
+                raise OSError(
+                    "Asset-registry Included File output receipt changed: "
+                    f"{output_receipt.path}"
+                )
+
+            with os.fdopen(output_fd, "rb") as output_file:
+                output_fd = -1
+                if validate_content:
+                    self._verify_included_file_receipt_content(
+                        receipt,
+                        source_file,
+                        output_file,
+                    )
+                final_open_stat = os.fstat(output_file.fileno())
+                _verify_open_asset_output_directory(
+                    project_root,
+                    os.path.dirname(output_receipt.path),
+                    current_fd,
+                )
+                final_path_stat = os.stat(
+                    output_receipt.components[-1],
+                    dir_fd=current_fd,
+                    follow_symlinks=False,
+                )
+                if (
+                    _path_is_redirected(output_receipt.path, final_path_stat)
+                    or _included_file_path_fingerprint(final_path_stat)
+                    != output_receipt.path_fingerprint
+                    or _included_file_handle_state(final_open_stat)
+                    != output_receipt.handle_state
+                    or not os.path.samestat(final_path_stat, final_open_stat)
+                ):
+                    raise OSError(
+                        "Asset-registry Included File output changed during "
+                        f"publication validation: {output_receipt.path}"
+                    )
+                self._verify_included_file_directory_identities(
+                    output_receipt.directory_identities
+                )
+                current_source = self._capture_pinned_included_file_source(
+                    receipt.entry,
+                    source_file,
+                    os.fstat(source_file.fileno()),
+                )
+                if current_source != receipt.source:
+                    raise OSError(
+                        "Asset-registry Included File source changed during "
+                        "publication validation: "
+                        f"{receipt.entry.source_path}"
+                    )
+        finally:
+            if output_fd >= 0:
+                os.close(output_fd)
+            if current_fd != project_fd:
+                os.close(current_fd)
+            os.close(project_fd)
+
+    def _revalidate_included_file_output_fallback(
+        self,
+        receipt: _IncludedFileContentReceipt,
+        source_file: BinaryIO,
+        *,
+        validate_content: bool,
+    ) -> None:
+        output_receipt = receipt.output
+        project_root = os.path.abspath(self.godot_project_path)
+        project_real = os.path.normcase(os.path.realpath(project_root))
+        directory_path = project_root
+        directory_identities: list[_IncludedFileDirectoryIdentity] = []
+        for component in (None, *output_receipt.components[:-1]):
+            if component is not None:
+                directory_path = os.path.join(directory_path, component)
+            directory_stat = os.lstat(directory_path)
+            directory_real = os.path.normcase(os.path.realpath(directory_path))
+            try:
+                contained = (
+                    os.path.commonpath((project_real, directory_real))
+                    == project_real
+                )
+            except ValueError:
+                contained = False
+            if (
+                _path_is_redirected(directory_path, directory_stat)
+                or not stat.S_ISDIR(directory_stat.st_mode)
+                or not contained
+            ):
+                raise OSError(
+                    "Asset-registry Included File output directory is "
+                    f"redirected or invalid: {directory_path}"
+                )
+            directory_identities.append(
+                (
+                    directory_path,
+                    (directory_stat.st_dev, directory_stat.st_ino),
+                )
+            )
+        if tuple(directory_identities) != output_receipt.directory_identities:
+            raise OSError(
+                "Asset-registry Included Files generation changed during "
+                "publication validation"
+            )
+
+        output_stat = os.lstat(output_receipt.path)
+        output_real = os.path.normcase(os.path.realpath(output_receipt.path))
+        try:
+            output_contained = (
+                os.path.commonpath((project_real, output_real)) == project_real
+            )
+        except ValueError:
+            output_contained = False
+        if (
+            _path_is_redirected(output_receipt.path, output_stat)
+            or not stat.S_ISREG(output_stat.st_mode)
+            or not output_contained
+            or _included_file_path_fingerprint(output_stat)
+            != output_receipt.path_fingerprint
+        ):
+            raise OSError(
+                "Asset-registry Included File output receipt changed: "
+                f"{output_receipt.path}"
+            )
+
+        with _open_included_file_validation_stream(
+            output_receipt.path,
+            deny_writes=validate_content,
+        ) as output_file:
+            opened_stat = os.fstat(output_file.fileno())
+            if (
+                not stat.S_ISREG(opened_stat.st_mode)
+                or not os.path.samestat(opened_stat, output_stat)
+                or _included_file_path_handle_binding(output_stat)
+                != _included_file_path_handle_binding(opened_stat)
+                or _included_file_handle_state(opened_stat)
+                != output_receipt.handle_state
+            ):
+                raise OSError(
+                    "Asset-registry Included File output changed before "
+                    f"publication validation: {output_receipt.path}"
+                )
+            self._verify_included_file_directory_identities(
+                output_receipt.directory_identities
+            )
+            if validate_content:
+                self._verify_included_file_receipt_content(
+                    receipt,
+                    source_file,
+                    output_file,
+                )
+            final_open_stat = os.fstat(output_file.fileno())
+            final_path_stat = os.lstat(output_receipt.path)
+            self._verify_included_file_directory_identities(
+                output_receipt.directory_identities
+            )
+            if (
+                _path_is_redirected(output_receipt.path, final_path_stat)
+                or _included_file_path_fingerprint(final_path_stat)
+                != output_receipt.path_fingerprint
+                or _included_file_handle_state(final_open_stat)
+                != output_receipt.handle_state
+                or not os.path.samestat(final_path_stat, final_open_stat)
+            ):
+                raise OSError(
+                    "Asset-registry Included File output changed during "
+                    f"publication validation: {output_receipt.path}"
+                )
+            current_source = self._capture_pinned_included_file_source(
+                receipt.entry,
+                source_file,
+                os.fstat(source_file.fileno()),
+            )
+            if current_source != receipt.source:
+                raise OSError(
+                    "Asset-registry Included File source changed during "
+                    f"publication validation: {receipt.entry.source_path}"
+                )
+
+    @staticmethod
+    def _verify_included_file_directory_identities(
+        directory_identities: tuple[_IncludedFileDirectoryIdentity, ...],
+    ) -> None:
+        for directory_path, expected_identity in directory_identities:
+            directory_stat = os.lstat(directory_path)
+            if (
+                _path_is_redirected(directory_path, directory_stat)
+                or not stat.S_ISDIR(directory_stat.st_mode)
+                or (directory_stat.st_dev, directory_stat.st_ino)
+                != expected_identity
+            ):
+                raise OSError(
+                    "Asset-registry Included File directory changed during "
+                    f"publication validation: {directory_path}"
+                )
+
+    @staticmethod
+    def _verify_included_file_receipt_content(
+        receipt: _IncludedFileContentReceipt,
+        source_file: BinaryIO,
+        output_file: BinaryIO,
+    ) -> None:
+        source_file.seek(0)
+        source_content = _included_file_stream_sha256(source_file)
+        output_file.seek(0)
+        output_content = _included_file_stream_sha256(output_file)
+        expected_source = (
+            receipt.source_byte_count,
+            receipt.source_sha256,
+        )
+        expected_output = (
+            receipt.output.byte_count,
+            receipt.output.sha256,
+        )
+        if (
+            source_content != expected_source
+            or output_content != expected_output
+            or source_content != output_content
+        ):
+            raise OSError(
+                "Asset-registry Included File content receipt changed: "
+                f"{receipt.entry.godot_path}"
             )
 
     def _ordered_project_resources(self) -> tuple[_ProjectResource, ...]:
@@ -1389,9 +2289,9 @@ class AssetRegistryConverter(BaseConverter):
         if processed_count < len(resources) or not self.conversion_running():
             return registry_path
 
-        entries, unavailable_outputs = self._filter_published_included_file_entries(
-            entries
-        )
+        publication = self._prepare_published_entries(entries)
+        entries = publication.entries
+        unavailable_outputs = publication.unavailable_included_files
         unavailable_output_keys = {
             self._entry_outcome_resource_key(unavailable.entry)
             for unavailable in unavailable_outputs
@@ -1435,8 +2335,8 @@ class AssetRegistryConverter(BaseConverter):
                 registry_path,
                 registry_script,
                 confinement_root=self.godot_project_path,
-                publication_validator=lambda: self.revalidate_published_entries(
-                    entries
+                publication_validator=(
+                    self._included_file_publication_validator(publication)
                 ),
             )
         except Exception:
@@ -1482,6 +2382,27 @@ class AssetRegistryConverter(BaseConverter):
             confinement_root=confinement_root or output_directory,
             publication_validator=publication_validator,
         )
+
+    def _included_file_publication_validator(
+        self,
+        publication: AssetRegistryPublication,
+    ) -> Callable[[], None]:
+        phases = iter((False, True))
+
+        def validate() -> None:
+            try:
+                validate_content = next(phases)
+            except StopIteration as error:
+                raise OSError(
+                    "Asset-registry publication validator was called outside "
+                    "its pre/post boundary contract"
+                ) from error
+            self.revalidate_publication(
+                publication,
+                validate_content=validate_content,
+            )
+
+        return validate
 
     @staticmethod
     def _outcome_resource_key(resource: _ProjectResource) -> str:

--- a/src/conversion/conversion_manifest.py
+++ b/src/conversion/conversion_manifest.py
@@ -11,7 +11,11 @@ from dataclasses import dataclass
 from typing import TypeAlias, cast
 
 from src.conversion.architecture_policy import build_architecture_policy_report
-from src.conversion.asset_registry import AssetRegistryConverter, AssetRegistryEntry
+from src.conversion.asset_registry import (
+    AssetRegistryConverter,
+    AssetRegistryEntry,
+    AssetRegistryPublication,
+)
 from src.conversion.conversion_outcome import ConversionOutcome
 from src.conversion.conversion_plan import build_conversion_plan, conversion_step_map
 from src.conversion.generated_paths import (
@@ -152,15 +156,15 @@ def write_conversion_artifacts(
 
     manifest_content: bytes | None = None
     manifest_asset_converter: AssetRegistryConverter | None = None
-    manifest_asset_entries: tuple[AssetRegistryEntry, ...] = ()
+    manifest_asset_publication: AssetRegistryPublication | None = None
     if manifest_outcome is not None:
         manifest_asset_converter = _asset_registry_converter(
             gm_project_path,
             godot_project_path,
             macro_configuration=target_platform,
         )
-        manifest_asset_entries = (
-            manifest_asset_converter.build_published_entries()
+        manifest_asset_publication = (
+            manifest_asset_converter.prepare_published_entries()
         )
         manifest_payload = _build_conversion_manifest(
             gm_project_path,
@@ -169,7 +173,7 @@ def write_conversion_artifacts(
             enabled_converter_keys=enabled_converter_keys,
             output_snapshot=output_snapshot,
             conversion_outcome=manifest_outcome,
-            asset_entries=manifest_asset_entries,
+            asset_entries=manifest_asset_publication.entries,
         )
         manifest_content = _serialize_json(manifest_payload)
         manifest_status = "updated"
@@ -286,9 +290,11 @@ def write_conversion_artifacts(
                 if (
                     target_path == manifest_path
                     and manifest_asset_converter is not None
+                    and manifest_asset_publication is not None
                 ):
-                    manifest_asset_converter.revalidate_published_entries(
-                        manifest_asset_entries
+                    manifest_asset_converter.revalidate_publication(
+                        manifest_asset_publication,
+                        validate_content=False,
                     )
                 staged_artifact = staged[target_path]
                 backup = backups[target_path]
@@ -314,9 +320,11 @@ def write_conversion_artifacts(
                 if (
                     target_path == manifest_path
                     and manifest_asset_converter is not None
+                    and manifest_asset_publication is not None
                 ):
-                    manifest_asset_converter.revalidate_published_entries(
-                        manifest_asset_entries
+                    manifest_asset_converter.revalidate_publication(
+                        manifest_asset_publication,
+                        validate_content=True,
                     )
             _verify_artifact_directory(
                 godot_project_path,
@@ -1525,7 +1533,7 @@ def _asset_registry_entries(
         godot_project_path,
         macro_configuration=macro_configuration,
     )
-    return converter.build_published_entries()
+    return converter.prepare_published_entries().entries
 
 
 def _asset_registry_converter(

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.23"
+VERSION = "0.7.24"
 
 
 def get_version():

--- a/tests/test_asset_registry.py
+++ b/tests/test_asset_registry.py
@@ -10,7 +10,7 @@ import tempfile
 import threading
 import unittest
 from typing import BinaryIO, Iterable, cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
@@ -18,8 +18,8 @@ if PROJECT_ROOT not in sys.path:
 
 from src.conversion.asset_registry import (
     ASSET_REGISTRY_RELATIVE_PATH,
-    AssetRegistryEntry,
     AssetRegistryConverter,
+    AssetRegistryPublication,
     GROUP_COMPATIBILITY_REPORT_RELATIVE_PATH,
     _ProjectResource,
 )
@@ -2405,6 +2405,462 @@ class TestAssetRegistryConverter(unittest.TestCase):
             )
         )
 
+    def test_convert_all_reads_matching_64_mib_payload_exactly_six_times(
+        self,
+    ) -> None:
+        payload_size = 64 * 1024 * 1024
+        payload = bytes(range(256)) * (payload_size // 256)
+        self._write_included_source("payload.bin", payload)
+        self._write_included_output("payload.bin", payload)
+        del payload
+        source_path = os.path.join(
+            self.gm_dir,
+            "datafiles",
+            "payload.bin",
+        )
+        output_path = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "payload.bin",
+        )
+        source_stat = os.stat(source_path)
+        output_stat = os.stat(output_path)
+        source_identity = source_stat.st_dev, source_stat.st_ino
+        output_identity = output_stat.st_dev, output_stat.st_ino
+        self.assertNotEqual(source_identity, output_identity)
+        converter = self._converter()
+        real_read = asset_registry_module._read_included_file_validation_chunk
+        bytes_by_identity = {
+            source_identity: 0,
+            output_identity: 0,
+        }
+
+        def counting_read(opened_file: BinaryIO) -> bytes:
+            chunk = real_read(opened_file)
+            opened_stat = os.fstat(opened_file.fileno())
+            identity = opened_stat.st_dev, opened_stat.st_ino
+            self.assertIn(identity, bytes_by_identity)
+            bytes_by_identity[identity] += len(chunk)
+            return chunk
+
+        with patch.object(
+            asset_registry_module,
+            "_read_included_file_validation_chunk",
+            side_effect=counting_read,
+        ):
+            registry_path = converter.convert_all()
+
+        self.assertEqual(bytes_by_identity[source_identity], 3 * payload_size)
+        self.assertEqual(bytes_by_identity[output_identity], 3 * payload_size)
+        with open(registry_path, "r", encoding="utf-8") as registry_file:
+            self.assertIn('"name": "payload.bin"', registry_file.read())
+
+    def test_publication_receipts_reject_same_byte_path_replacements(
+        self,
+    ) -> None:
+        payload = b"matching payload"
+        for endpoint in ("source", "output"):
+            with self.subTest(endpoint=endpoint):
+                relative_path = f"{endpoint}-replacement.bin"
+                self._write_included_source(relative_path, payload)
+                self._write_included_output(relative_path, payload)
+                converter = self._converter()
+                publication = converter.prepare_published_entries()
+                target_path = os.path.join(
+                    self.gm_dir if endpoint == "source" else self.godot_dir,
+                    "datafiles" if endpoint == "source" else "included_files",
+                    relative_path,
+                )
+                target_stat = os.lstat(target_path)
+                replacement_path = os.path.join(
+                    self.gm_dir if endpoint == "source" else self.godot_dir,
+                    f".{endpoint}-replacement.bin",
+                )
+                with open(replacement_path, "wb") as replacement_file:
+                    replacement_file.write(payload)
+                os.utime(
+                    replacement_path,
+                    ns=(target_stat.st_atime_ns, target_stat.st_mtime_ns),
+                )
+
+                os.replace(replacement_path, target_path)
+
+                replacement_stat = os.lstat(target_path)
+                self.assertNotEqual(
+                    (replacement_stat.st_dev, replacement_stat.st_ino),
+                    (target_stat.st_dev, target_stat.st_ino),
+                )
+                self.assertEqual(replacement_stat.st_size, target_stat.st_size)
+                self.assertEqual(
+                    replacement_stat.st_mtime_ns,
+                    target_stat.st_mtime_ns,
+                )
+                with self.assertRaisesRegex(
+                    OSError,
+                    "publication inputs changed",
+                ):
+                    converter.revalidate_publication(
+                        publication,
+                        validate_content=False,
+                    )
+
+    def test_publication_receipt_rejects_output_hardlink_substitution(
+        self,
+    ) -> None:
+        payload = b"matching payload"
+        self._write_included_source("payload.bin", payload)
+        self._write_included_output("payload.bin", payload)
+        output_path = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "payload.bin",
+        )
+        output_stat = os.lstat(output_path)
+        referent_path = os.path.join(self.godot_dir, "payload-referent.bin")
+        converter = self._converter()
+        publication = converter.prepare_published_entries()
+        with open(referent_path, "wb") as referent_file:
+            referent_file.write(payload)
+        os.utime(
+            referent_path,
+            ns=(output_stat.st_atime_ns, output_stat.st_mtime_ns),
+        )
+        os.unlink(output_path)
+        try:
+            os.link(referent_path, output_path)
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Hard links are unavailable: {error}")
+
+        substituted_stat = os.stat(output_path)
+        self.assertEqual(
+            (substituted_stat.st_dev, substituted_stat.st_ino),
+            (os.stat(referent_path).st_dev, os.stat(referent_path).st_ino),
+        )
+        self.assertNotEqual(
+            (substituted_stat.st_dev, substituted_stat.st_ino),
+            (output_stat.st_dev, output_stat.st_ino),
+        )
+        self.assertEqual(substituted_stat.st_size, output_stat.st_size)
+        self.assertEqual(substituted_stat.st_mtime_ns, output_stat.st_mtime_ns)
+        with self.assertRaisesRegex(OSError, "publication inputs changed"):
+            converter.revalidate_publication(
+                publication,
+                validate_content=False,
+            )
+
+    def test_publication_receipt_rejects_included_files_generation_swap(
+        self,
+    ) -> None:
+        payload = b"matching payload"
+        self._write_included_source("nested/payload.bin", payload)
+        self._write_included_output("nested/payload.bin", payload)
+        converter = self._converter()
+        publication = converter.prepare_published_entries()
+        included_files_root = os.path.join(self.godot_dir, "included_files")
+        prior_generation = os.path.join(
+            self.godot_dir,
+            "included_files-prior-generation",
+        )
+        original_identity = (
+            os.stat(included_files_root).st_dev,
+            os.stat(included_files_root).st_ino,
+        )
+
+        os.rename(included_files_root, prior_generation)
+        shutil.copytree(prior_generation, included_files_root)
+
+        replacement_identity = (
+            os.stat(included_files_root).st_dev,
+            os.stat(included_files_root).st_ino,
+        )
+        self.assertNotEqual(replacement_identity, original_identity)
+        with open(
+            os.path.join(included_files_root, "nested", "payload.bin"),
+            "rb",
+        ) as replacement_file:
+            self.assertEqual(replacement_file.read(), payload)
+        with self.assertRaisesRegex(OSError, "publication inputs changed"):
+            converter.revalidate_publication(
+                publication,
+                validate_content=False,
+            )
+
+    def test_publication_receipt_rejects_output_symlink_inserted_after_prepare(
+        self,
+    ) -> None:
+        payload = b"matching payload"
+        self._write_included_source("payload.bin", payload)
+        self._write_included_output("payload.bin", payload)
+        output_path = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "payload.bin",
+        )
+        referent_path = os.path.join(self.godot_dir, "payload-referent.bin")
+        with open(referent_path, "wb") as referent_file:
+            referent_file.write(payload)
+        converter = self._converter()
+        publication = converter.prepare_published_entries()
+        replacement_link = output_path + ".replacement"
+        try:
+            os.symlink(referent_path, replacement_link)
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+
+        os.replace(replacement_link, output_path)
+
+        self.assertTrue(os.path.islink(output_path))
+        with self.assertRaisesRegex(OSError, "publication inputs changed"):
+            converter.revalidate_publication(
+                publication,
+                validate_content=False,
+            )
+
+    def test_publication_receipt_rejects_nested_output_directory_swap(
+        self,
+    ) -> None:
+        payload = b"matching payload"
+        self._write_included_source("nested/payload.bin", payload)
+        self._write_included_output("nested/payload.bin", payload)
+        converter = self._converter()
+        publication = converter.prepare_published_entries()
+        included_files_root = os.path.join(self.godot_dir, "included_files")
+        nested_directory = os.path.join(included_files_root, "nested")
+        prior_directory = os.path.join(
+            self.godot_dir,
+            "nested-prior-generation",
+        )
+        root_identity = (
+            os.stat(included_files_root).st_dev,
+            os.stat(included_files_root).st_ino,
+        )
+        original_nested_identity = (
+            os.stat(nested_directory).st_dev,
+            os.stat(nested_directory).st_ino,
+        )
+
+        os.rename(nested_directory, prior_directory)
+        shutil.copytree(prior_directory, nested_directory)
+
+        self.assertEqual(
+            (
+                os.stat(included_files_root).st_dev,
+                os.stat(included_files_root).st_ino,
+            ),
+            root_identity,
+        )
+        self.assertNotEqual(
+            (
+                os.stat(nested_directory).st_dev,
+                os.stat(nested_directory).st_ino,
+            ),
+            original_nested_identity,
+        )
+        with open(
+            os.path.join(nested_directory, "payload.bin"),
+            "rb",
+        ) as replacement_file:
+            self.assertEqual(replacement_file.read(), payload)
+        with self.assertRaisesRegex(OSError, "publication inputs changed"):
+            converter.revalidate_publication(
+                publication,
+                validate_content=False,
+            )
+
+    def test_publication_receipt_rejects_collision_driven_path_change(
+        self,
+    ) -> None:
+        payload = b"matching payload"
+        self._write_included_source("Read Me.txt", payload)
+        self._write_included_output("read_me.txt", payload)
+        converter = self._converter()
+        publication = converter.prepare_published_entries()
+        self.assertEqual(
+            publication.included_file_receipts[0].entry.godot_path,
+            "res://included_files/read_me.txt",
+        )
+
+        self._write_included_source("read_me.txt", b"new collider")
+
+        current_paths = {
+            entry.name: entry.godot_path
+            for entry in converter.build_entries()
+            if entry.kind == "included_files"
+        }
+        self.assertEqual(
+            current_paths,
+            {
+                "Read Me.txt": "res://included_files/read_me_2.txt",
+                "read_me.txt": "res://included_files/read_me.txt",
+            },
+        )
+        with self.assertRaisesRegex(OSError, "publication inputs changed"):
+            converter.revalidate_publication(
+                publication,
+                validate_content=False,
+            )
+
+    def test_windows_validation_stream_denies_writes_and_transfers_handle(
+        self,
+    ) -> None:
+        kernel32 = MagicMock()
+        kernel32.CreateFileW.return_value = 1234
+        msvcrt = MagicMock()
+        msvcrt.open_osfhandle.return_value = 5678
+        binary_stream = MagicMock()
+        path = os.path.join(self.gm_dir, "payload.bin")
+
+        with (
+            patch.object(asset_registry_module.os, "name", "nt"),
+            patch.object(
+                asset_registry_module,
+                "_windows_included_file_read_api",
+                return_value=kernel32,
+            ),
+            patch.dict(sys.modules, {"msvcrt": msvcrt}),
+            patch.object(
+                asset_registry_module.os,
+                "fdopen",
+                return_value=binary_stream,
+            ) as fdopen,
+        ):
+            opened_stream = (
+                asset_registry_module._open_included_file_validation_stream(
+                    path,
+                    deny_writes=True,
+                )
+            )
+
+        self.assertIs(opened_stream, binary_stream)
+        kernel32.CreateFileW.assert_called_once_with(
+            os.path.abspath(path),
+            asset_registry_module._WINDOWS_GENERIC_READ,
+            asset_registry_module._WINDOWS_FILE_SHARE_READ,
+            None,
+            asset_registry_module._WINDOWS_OPEN_EXISTING,
+            asset_registry_module._WINDOWS_FILE_ATTRIBUTE_NORMAL
+            | asset_registry_module._WINDOWS_FILE_FLAG_SEQUENTIAL_SCAN,
+            None,
+        )
+        msvcrt.open_osfhandle.assert_called_once_with(
+            1234,
+            os.O_RDONLY | getattr(os, "O_BINARY", 0),
+        )
+        fdopen.assert_called_once_with(5678, "rb")
+        kernel32.CloseHandle.assert_not_called()
+
+    def test_windows_validation_stream_closes_fd_when_wrapping_fails(
+        self,
+    ) -> None:
+        kernel32 = MagicMock()
+        kernel32.CreateFileW.return_value = 1234
+        msvcrt = MagicMock()
+        msvcrt.open_osfhandle.return_value = 5678
+
+        with (
+            patch.object(asset_registry_module.os, "name", "nt"),
+            patch.object(
+                asset_registry_module,
+                "_windows_included_file_read_api",
+                return_value=kernel32,
+            ),
+            patch.dict(sys.modules, {"msvcrt": msvcrt}),
+            patch.object(
+                asset_registry_module.os,
+                "fdopen",
+                side_effect=MemoryError("injected wrapper failure"),
+            ),
+            patch.object(asset_registry_module.os, "close") as close,
+            self.assertRaisesRegex(MemoryError, "injected wrapper failure"),
+        ):
+            asset_registry_module._open_included_file_validation_stream(
+                os.path.join(self.gm_dir, "payload.bin"),
+                deny_writes=True,
+            )
+
+        close.assert_called_once_with(5678)
+        kernel32.CloseHandle.assert_not_called()
+
+    @unittest.skipUnless(os.name == "nt", "requires native Windows semantics")
+    def test_native_windows_final_receipt_denies_writes_while_hashing(
+        self,
+    ) -> None:
+        payload = b"matching payload"
+        self._write_included_source("payload.bin", payload)
+        self._write_included_output("payload.bin", payload)
+        source_path = os.path.join(
+            self.gm_dir,
+            "datafiles",
+            "payload.bin",
+        )
+        output_path = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "payload.bin",
+        )
+        converter = self._converter()
+        publication = converter.prepare_published_entries()
+        real_read = asset_registry_module._read_included_file_validation_chunk
+        blocked_paths: list[str] = []
+
+        def assert_write_sharing_is_denied(opened_file: BinaryIO) -> bytes:
+            if not blocked_paths:
+                for path in (source_path, output_path):
+                    with self.assertRaises(OSError) as raised:
+                        with open(path, "r+b"):
+                            pass
+                    self.assertEqual(
+                        getattr(raised.exception, "winerror", None),
+                        32,
+                    )
+                    blocked_paths.append(path)
+            return real_read(opened_file)
+
+        with patch.object(
+            asset_registry_module,
+            "_read_included_file_validation_chunk",
+            side_effect=assert_write_sharing_is_denied,
+        ):
+            converter.revalidate_publication(
+                publication,
+                validate_content=True,
+            )
+
+        self.assertEqual(blocked_paths, [source_path, output_path])
+
+    def test_unavailable_receipts_are_not_rehashed_at_boundaries(self) -> None:
+        self._write_included_source("payload.bin", b"expected payload")
+        self._write_included_output("payload.bin", b"stale____payload")
+        converter = self._converter()
+        publication = converter.prepare_published_entries()
+        self.assertEqual(publication.included_file_receipts, ())
+        self.assertEqual(len(publication.unavailable_included_files), 1)
+
+        payload_bytes_read = 0
+        real_read = asset_registry_module._read_included_file_validation_chunk
+
+        def counting_read(opened_file: BinaryIO) -> bytes:
+            nonlocal payload_bytes_read
+            chunk = real_read(opened_file)
+            payload_bytes_read += len(chunk)
+            return chunk
+
+        with patch.object(
+            asset_registry_module,
+            "_read_included_file_validation_chunk",
+            side_effect=counting_read,
+        ):
+            converter.revalidate_publication(
+                publication,
+                validate_content=False,
+            )
+            converter.revalidate_publication(
+                publication,
+                validate_content=True,
+            )
+
+        self.assertEqual(payload_bytes_read, 0)
+
     def test_windows_path_handle_fingerprint_match_ignores_only_ctime(
         self,
     ) -> None:
@@ -2656,22 +3112,26 @@ class TestAssetRegistryConverter(unittest.TestCase):
             ASSET_REGISTRY_RELATIVE_PATH,
         )
         converter = self._converter()
-        real_revalidate = converter.revalidate_published_entries
-        validation_calls = 0
+        real_revalidate = converter.revalidate_publication
+        validation_phases: list[bool] = []
 
         def delete_then_revalidate(
-            entries: tuple[AssetRegistryEntry, ...],
+            publication: AssetRegistryPublication,
+            *,
+            validate_content: bool,
         ) -> None:
-            nonlocal validation_calls
-            validation_calls += 1
-            if validation_calls == 1:
+            validation_phases.append(validate_content)
+            if not validate_content:
                 os.unlink(output_path)
-            real_revalidate(entries)
+            real_revalidate(
+                publication,
+                validate_content=validate_content,
+            )
 
         with (
             patch.object(
                 converter,
-                "revalidate_published_entries",
+                "revalidate_publication",
                 side_effect=delete_then_revalidate,
             ),
             self.assertRaisesRegex(
@@ -2681,7 +3141,7 @@ class TestAssetRegistryConverter(unittest.TestCase):
         ):
             converter.convert_all()
 
-        self.assertEqual(validation_calls, 1)
+        self.assertEqual(validation_phases, [False])
         self.assertFalse(os.path.exists(registry_path))
         self.assertEqual(
             converter.conversion_step_result(
@@ -2694,11 +3154,83 @@ class TestAssetRegistryConverter(unittest.TestCase):
             ),
         )
 
+    def test_source_same_size_change_before_registry_publish_fails_closed(
+        self,
+    ) -> None:
+        payload = b"matching payload"
+        replacement = b"tampered payload"
+        self.assertEqual(len(replacement), len(payload))
+        self._write_included_source("payload.bin", payload)
+        self._write_included_output("payload.bin", payload)
+        source_path = os.path.join(
+            self.gm_dir,
+            "datafiles",
+            "payload.bin",
+        )
+        registry_path = os.path.join(
+            self.godot_dir,
+            ASSET_REGISTRY_RELATIVE_PATH,
+        )
+        source_stat = os.lstat(source_path)
+        source_identity = source_stat.st_dev, source_stat.st_ino
+        converter = self._converter()
+        real_revalidate = converter.revalidate_publication
+        validation_phases: list[bool] = []
+        mutated = False
+
+        def mutate_then_revalidate(
+            publication: AssetRegistryPublication,
+            *,
+            validate_content: bool,
+        ) -> None:
+            nonlocal mutated
+            validation_phases.append(validate_content)
+            if not validate_content and not mutated:
+                with open(source_path, "r+b", buffering=0) as source_file:
+                    source_file.write(replacement)
+                    os.fsync(source_file.fileno())
+                os.utime(
+                    source_path,
+                    ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns),
+                )
+                self.assertEqual(
+                    (os.lstat(source_path).st_dev, os.lstat(source_path).st_ino),
+                    source_identity,
+                )
+                self.assertEqual(os.lstat(source_path).st_size, len(payload))
+                self.assertEqual(
+                    os.lstat(source_path).st_mtime_ns,
+                    source_stat.st_mtime_ns,
+                )
+                mutated = True
+            real_revalidate(
+                publication,
+                validate_content=validate_content,
+            )
+
+        with (
+            patch.object(
+                converter,
+                "revalidate_publication",
+                side_effect=mutate_then_revalidate,
+            ),
+            self.assertRaisesRegex(OSError, "publication inputs changed"),
+        ):
+            converter.convert_all()
+
+        self.assertTrue(mutated)
+        self.assertEqual(validation_phases[0], False)
+        self.assertIn(validation_phases, ([False], [False, True]))
+        self.assertFalse(os.path.exists(registry_path))
+
     def test_output_byte_change_after_registry_publish_removes_registry(
         self,
     ) -> None:
-        self._write_included_source("payload.bin", b"matching payload")
-        self._write_included_output("payload.bin", b"matching payload")
+        payload = b"matching payload"
+        replacement = b"tampered payload"
+        self.assertEqual(len(replacement), len(payload))
+        self._write_included_source("payload.bin", payload)
+        self._write_included_output("payload.bin", payload)
         output_path = os.path.join(
             self.godot_dir,
             "included_files",
@@ -2708,24 +3240,44 @@ class TestAssetRegistryConverter(unittest.TestCase):
             self.godot_dir,
             ASSET_REGISTRY_RELATIVE_PATH,
         )
+        output_stat = os.lstat(output_path)
+        output_identity = output_stat.st_dev, output_stat.st_ino
         converter = self._converter()
-        real_revalidate = converter.revalidate_published_entries
-        validation_calls = 0
+        real_revalidate = converter.revalidate_publication
+        validation_phases: list[bool] = []
 
         def mutate_then_revalidate(
-            entries: tuple[AssetRegistryEntry, ...],
+            publication: AssetRegistryPublication,
+            *,
+            validate_content: bool,
         ) -> None:
-            nonlocal validation_calls
-            validation_calls += 1
-            if validation_calls == 2:
-                with open(output_path, "wb") as output_file:
-                    output_file.write(b"changed after publication")
-            real_revalidate(entries)
+            validation_phases.append(validate_content)
+            if validate_content:
+                with open(output_path, "r+b", buffering=0) as output_file:
+                    output_file.write(replacement)
+                    os.fsync(output_file.fileno())
+                os.utime(
+                    output_path,
+                    ns=(output_stat.st_atime_ns, output_stat.st_mtime_ns),
+                )
+                self.assertEqual(
+                    (os.lstat(output_path).st_dev, os.lstat(output_path).st_ino),
+                    output_identity,
+                )
+                self.assertEqual(os.lstat(output_path).st_size, len(payload))
+                self.assertEqual(
+                    os.lstat(output_path).st_mtime_ns,
+                    output_stat.st_mtime_ns,
+                )
+            real_revalidate(
+                publication,
+                validate_content=validate_content,
+            )
 
         with (
             patch.object(
                 converter,
-                "revalidate_published_entries",
+                "revalidate_publication",
                 side_effect=mutate_then_revalidate,
             ),
             self.assertRaisesRegex(
@@ -2735,7 +3287,7 @@ class TestAssetRegistryConverter(unittest.TestCase):
         ):
             converter.convert_all()
 
-        self.assertEqual(validation_calls, 2)
+        self.assertEqual(validation_phases, [False, True])
         self.assertFalse(os.path.exists(registry_path))
         self.assertEqual(
             converter.conversion_step_result(
@@ -2771,24 +3323,28 @@ class TestAssetRegistryConverter(unittest.TestCase):
         previous_stat = os.lstat(registry_path)
         previous_identity = previous_stat.st_dev, previous_stat.st_ino
         converter = self._converter()
-        real_revalidate = converter.revalidate_published_entries
-        validation_calls = 0
+        real_revalidate = converter.revalidate_publication
+        validation_phases: list[bool] = []
 
         def mutate_then_revalidate(
-            entries: tuple[AssetRegistryEntry, ...],
+            publication: AssetRegistryPublication,
+            *,
+            validate_content: bool,
         ) -> None:
-            nonlocal validation_calls
-            validation_calls += 1
-            if validation_calls == 2:
+            validation_phases.append(validate_content)
+            if validate_content:
                 with open(output_path, "wb") as output_file:
                     output_file.write(b"changed after publication")
-            real_revalidate(entries)
+            real_revalidate(
+                publication,
+                validate_content=validate_content,
+            )
 
         try:
             with (
                 patch.object(
                     converter,
-                    "revalidate_published_entries",
+                    "revalidate_publication",
                     side_effect=mutate_then_revalidate,
                 ),
                 self.assertRaisesRegex(
@@ -2798,7 +3354,7 @@ class TestAssetRegistryConverter(unittest.TestCase):
             ):
                 converter.convert_all()
 
-            self.assertEqual(validation_calls, 2)
+            self.assertEqual(validation_phases, [False, True])
             current_stat = os.lstat(registry_path)
             self.assertEqual(
                 (current_stat.st_dev, current_stat.st_ino),

--- a/tests/test_asset_registry.py
+++ b/tests/test_asset_registry.py
@@ -1,6 +1,7 @@
 # pyright: reportPrivateUsage=false
 from __future__ import annotations
 
+import errno
 import json
 import os
 import shutil
@@ -2809,9 +2810,13 @@ class TestAssetRegistryConverter(unittest.TestCase):
                     with self.assertRaises(OSError) as raised:
                         with open(path, "r+b"):
                             pass
+                    self.assertIsInstance(
+                        raised.exception,
+                        PermissionError,
+                    )
                     self.assertEqual(
-                        getattr(raised.exception, "winerror", None),
-                        32,
+                        raised.exception.errno,
+                        errno.EACCES,
                     )
                     blocked_paths.append(path)
             return real_read(opened_file)

--- a/tests/test_conversion_manifest.py
+++ b/tests/test_conversion_manifest.py
@@ -13,9 +13,14 @@ from typing import Any, cast
 from unittest.mock import patch
 
 from src import cli
+from src.conversion import asset_registry as asset_registry_module
 from src.conversion import conversion_manifest as conversion_manifest_module
 from src.conversion.architecture_policy import ARCHITECTURE_POLICY_RELATIVE_PATH
-from src.conversion.asset_registry import AssetRegistryConverter, AssetRegistryEntry
+from src.conversion.asset_registry import (
+    AssetRegistryConverter,
+    AssetRegistryEntry,
+    AssetRegistryPublication,
+)
 from src.conversion.conversion_manifest import (
     CONVERSION_ATTEMPT_RELATIVE_PATH,
     CONVERSION_MANIFEST_RELATIVE_PATH,
@@ -955,23 +960,28 @@ class TestConversionManifest(unittest.TestCase):
             manifest_before,
             attempt_before,
         ) = self._included_publication_fixture("delete-boundary")
-        real_revalidate = AssetRegistryConverter.revalidate_published_entries
-        validation_calls = 0
+        real_revalidate = AssetRegistryConverter.revalidate_publication
+        validation_phases: list[bool] = []
 
         def delete_then_revalidate(
             converter: AssetRegistryConverter,
-            entries: tuple[AssetRegistryEntry, ...],
+            publication: AssetRegistryPublication,
+            *,
+            validate_content: bool,
         ) -> None:
-            nonlocal validation_calls
-            validation_calls += 1
-            if validation_calls == 1:
+            validation_phases.append(validate_content)
+            if not validate_content:
                 output_path.unlink()
-            real_revalidate(converter, entries)
+            real_revalidate(
+                converter,
+                publication,
+                validate_content=validate_content,
+            )
 
         with (
             patch.object(
                 AssetRegistryConverter,
-                "revalidate_published_entries",
+                "revalidate_publication",
                 new=delete_then_revalidate,
             ),
             self.assertRaisesRegex(
@@ -991,7 +1001,7 @@ class TestConversionManifest(unittest.TestCase):
                 attempt_outcome=self._successful_outcome(),
             )
 
-        self.assertEqual(validation_calls, 1)
+        self.assertEqual(validation_phases, [False])
         self.assertEqual(manifest_path.read_bytes(), manifest_before)
         self.assertEqual(attempt_path.read_bytes(), attempt_before)
         self.assertEqual(self._temporary_artifact_files(godot_dir), [])
@@ -1008,23 +1018,40 @@ class TestConversionManifest(unittest.TestCase):
             manifest_before,
             attempt_before,
         ) = self._included_publication_fixture("change-after-publish")
-        real_revalidate = AssetRegistryConverter.revalidate_published_entries
-        validation_calls = 0
+        output_stat = output_path.stat()
+        replacement = b"tampered included payload"
+        self.assertEqual(len(replacement), output_stat.st_size)
+        real_revalidate = AssetRegistryConverter.revalidate_publication
+        validation_phases: list[bool] = []
 
         def mutate_then_revalidate(
             converter: AssetRegistryConverter,
-            entries: tuple[AssetRegistryEntry, ...],
+            publication: AssetRegistryPublication,
+            *,
+            validate_content: bool,
         ) -> None:
-            nonlocal validation_calls
-            validation_calls += 1
-            if validation_calls == 2:
-                output_path.write_bytes(b"changed after manifest publication")
-            real_revalidate(converter, entries)
+            validation_phases.append(validate_content)
+            if validate_content:
+                with output_path.open("r+b", buffering=0) as output_file:
+                    output_file.write(replacement)
+                    os.fsync(output_file.fileno())
+                os.utime(
+                    output_path,
+                    ns=(output_stat.st_atime_ns, output_stat.st_mtime_ns),
+                )
+                mutated_stat = output_path.stat()
+                self.assertEqual(mutated_stat.st_size, output_stat.st_size)
+                self.assertEqual(mutated_stat.st_mtime_ns, output_stat.st_mtime_ns)
+            real_revalidate(
+                converter,
+                publication,
+                validate_content=validate_content,
+            )
 
         with (
             patch.object(
                 AssetRegistryConverter,
-                "revalidate_published_entries",
+                "revalidate_publication",
                 new=mutate_then_revalidate,
             ),
             self.assertRaisesRegex(
@@ -1044,10 +1071,84 @@ class TestConversionManifest(unittest.TestCase):
                 attempt_outcome=self._successful_outcome(),
             )
 
-        self.assertEqual(validation_calls, 2)
+        self.assertEqual(validation_phases, [False, True])
         self.assertEqual(manifest_path.read_bytes(), manifest_before)
         self.assertEqual(attempt_path.read_bytes(), attempt_before)
         self.assertEqual(self._temporary_artifact_files(godot_dir), [])
+
+    def test_included_file_manifest_publication_reads_payload_six_times(
+        self,
+    ) -> None:
+        (
+            gm_dir,
+            godot_dir,
+            output_path,
+            _manifest_path,
+            _attempt_path,
+            _manifest_before,
+            _attempt_before,
+        ) = self._included_publication_fixture("read-budget")
+        payload_size = output_path.stat().st_size
+        real_read_chunk = cast(
+            Callable[[Any], bytes],
+            getattr(
+                asset_registry_module,
+                "_read_included_file_validation_chunk",
+            ),
+        )
+        real_revalidate = AssetRegistryConverter.revalidate_publication
+        payload_bytes_read = 0
+        phase_reads: list[tuple[bool, int]] = []
+
+        def count_payload_bytes(opened_file: Any) -> bytes:
+            nonlocal payload_bytes_read
+            chunk = real_read_chunk(opened_file)
+            payload_bytes_read += len(chunk)
+            return chunk
+
+        def record_phase_reads(
+            converter: AssetRegistryConverter,
+            publication: AssetRegistryPublication,
+            *,
+            validate_content: bool,
+        ) -> None:
+            before = payload_bytes_read
+            real_revalidate(
+                converter,
+                publication,
+                validate_content=validate_content,
+            )
+            phase_reads.append((validate_content, payload_bytes_read - before))
+
+        with (
+            patch.object(
+                asset_registry_module,
+                "_read_included_file_validation_chunk",
+                new=count_payload_bytes,
+            ),
+            patch.object(
+                AssetRegistryConverter,
+                "revalidate_publication",
+                new=record_phase_reads,
+            ),
+        ):
+            write_conversion_artifacts(
+                str(gm_dir),
+                str(godot_dir),
+                target_platform="windows",
+                enabled_converters=(),
+                output_snapshot=capture_conversion_output_snapshot(
+                    str(godot_dir)
+                ),
+                manifest_outcome=self._successful_outcome(),
+                attempt_outcome=self._successful_outcome(),
+            )
+
+        self.assertEqual(
+            phase_reads,
+            [(False, 0), (True, 2 * payload_size)],
+        )
+        self.assertEqual(payload_bytes_read, 6 * payload_size)
 
     def test_outcome_steps_must_match_enabled_conversion_plan(self) -> None:
         godot_dir = self.temp_dir / "godot"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_23(self) -> None:
-        self.assertEqual(get_version(), "0.7.23")
+    def test_release_version_is_0_7_24(self) -> None:
+        self.assertEqual(get_version(), "0.7.24")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #731

Wiki source tracking: #712

## Summary

- carry immutable Included File content receipts through one asset-registry or manifest publication attempt, bound to the exact source, generated output, assigned Godot path, and Included Files generation
- reduce a successful matching Included File from 12 payload passes to exactly 6: four during stable receipt capture, zero at pre-publication identity validation, and two final SHA-256 passes
- fail closed on same-size/restored-mtime mutation, path replacement, hard-link substitution, symlink redirection, deterministic path drift, and root or nested directory replacement
- use overlapping Win32 read handles that deny write/delete sharing during the final hashes while preserving path-versus-handle metadata compatibility and correct handle ownership cleanup
- apply the same receipt lifecycle to conversion-manifest publication and bump the GameMaker LTS 2026 / Godot 4.7.1 release surface to 0.7.24

## Validation

- `./venv/bin/pyright --warnings` (0 errors, 0 warnings)
- `./venv/bin/ruff check .`
- actionlint and `git diff --check`
- `./venv/bin/python -m unittest` (2,140 tests, 47 skipped)
- focused registry, manifest, and version suite (159 tests, 4 platform skips)
- deterministic 64 MiB probe proving three source passes plus three output passes
- exact Godot `4.7.1.stable.official.a13da4feb` smoke suite (69 tests, no skips)

Native Windows sharing behavior and the GameMaker LTS 2026 conversion gate remain mandatory PR checks before merge.
