### PR TITLE
Skip unchanged Included Files generations

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.24, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.25, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.25 - 2026-07-19
+
+- Skipped unchanged Included Files publication only after the complete planned output topology, rendered registry bytes, and two stable source-content receipts match the descriptor-captured public generation.
+- Kept the initial transaction at five full payload reads and bounded a deterministic 64 MiB unchanged generation to four, while pinned no-follow tree, registry, source-path, directory-identity, and final metadata checks make changed or concurrently mutated candidates use the normal transaction or fail closed without staging.
+
 ## 0.7.24 - 2026-07-19
 
 - Reused attempt-local Included File receipts across asset-registry and manifest publication, reducing successful matching Included File validation from 12x payload reads to at most 6x while binding reuse to the exact source, generated output, assigned path, and output generation.

--- a/Languages/de.json
+++ b/Languages/de.json
@@ -153,6 +153,7 @@
 "Console_Convertor_IncludedFiles_Complete" : "Konvertierung eingeschlossener Dateien abgeschlossen.",
 "Console_Convertor_IncludedFiles_Stopped" : "Konvertierung eingeschlossener Dateien gestoppt.",
 "Console_Convertor_IncludedFiles_Copied" : "Kopiert: {path}",
+"Console_Convertor_IncludedFiles_Unchanged" : "Unverändert: {path}",
 "Console_Convertor_IncludedFiles_Error_NotFound" : "Kein Ordner mit eingeschlossenen Dateien (datafiles) im GameMaker-Projekt gefunden.",
 
 "Icon_Error_PhotoImage" : "Fehler beim Setzen des Icons mit PhotoImage: {error}",

--- a/Languages/eng.json
+++ b/Languages/eng.json
@@ -153,6 +153,7 @@
 "Console_Convertor_IncludedFiles_Complete" : "Included files conversion completed.",
 "Console_Convertor_IncludedFiles_Stopped" : "Included files conversion stopped.",
 "Console_Convertor_IncludedFiles_Copied" : "Copied: {path}",
+"Console_Convertor_IncludedFiles_Unchanged" : "Unchanged: {path}",
 "Console_Convertor_IncludedFiles_Error_NotFound" : "No included files (datafiles) folder found in GameMaker project.",
 
 "Icon_Error_PhotoImage" : "Failed to set icon using PhotoImage: {error}",

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.24`.
+Current source version: `0.7.25`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.24 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.25 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.24 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.25 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.24 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.25 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.24 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.25 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.24 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.25 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.24;
+- GM2Godot 0.7.25;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.24 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.25 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -46,7 +46,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.24`.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.25`.
 
 ## Run from source
 
@@ -133,6 +133,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.24`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.25`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.24 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.25 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.24 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.25 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/src/conversion/included_files.py
+++ b/src/conversion/included_files.py
@@ -10,7 +10,8 @@ import sys
 import tempfile
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from typing import BinaryIO, Callable, cast
+from functools import lru_cache
+from typing import Any, BinaryIO, Callable, cast
 
 from src.localization import get_localized
 from src.conversion.atomic_generated_text import (
@@ -66,6 +67,7 @@ _PathFingerprint = tuple[int, int, int, int, int, int]
 _PathHandleBinding = tuple[int, int, int, int, int, int]
 _HandleState = tuple[int, int, int, int, int, int, int]
 _IncludedSourceFingerprint = tuple[int, int, int, int, int, int]
+_IncludedSourceDirectoryIdentity = tuple[str, _PathIdentity]
 _INCLUDED_FILES_ROOT_NAME = "included_files"
 _INCLUDED_FILES_STAGE_PREFIX = ".gm2godot-included-files-"
 
@@ -73,6 +75,23 @@ _INCLUDED_FILES_STAGE_PREFIX = ".gm2godot-included-files-"
 @dataclass(frozen=True)
 class _IncludedCopyReceipt:
     source_fingerprint: _IncludedSourceFingerprint
+    byte_count: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class _IncludedSourceBinding:
+    filesystem_path: str
+    canonical_path: str
+    directory_identities: tuple[_IncludedSourceDirectoryIdentity, ...]
+    lexical_state: _HandleState
+    path_state: _HandleState
+    handle_state: _HandleState
+
+
+@dataclass(frozen=True)
+class _IncludedNoOpSourceReceipt:
+    binding: _IncludedSourceBinding
     byte_count: int
     sha256: str
 
@@ -129,6 +148,13 @@ _DIRECTORY_OPEN_FLAGS = (
     | getattr(os, "O_DIRECTORY", 0)
     | getattr(os, "O_NOFOLLOW", 0)
 )
+
+_WINDOWS_GENERIC_READ = 0x80000000
+_WINDOWS_FILE_SHARE_READ = 0x00000001
+_WINDOWS_OPEN_EXISTING = 3
+_WINDOWS_FILE_ATTRIBUTE_NORMAL = 0x00000080
+_WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000
+_WINDOWS_FILE_FLAG_SEQUENTIAL_SCAN = 0x08000000
 
 
 def _included_descriptor_paths_supported() -> bool:
@@ -449,13 +475,110 @@ def _included_source_fingerprint(
     )
 
 
+def _read_included_validation_chunk(opened_file: BinaryIO) -> bytes:
+    """Read one validation chunk through a deterministic accounting seam."""
+
+    return opened_file.read(1024 * 1024)
+
+
+@lru_cache(maxsize=1)
+def _windows_included_file_read_api() -> Any:
+    if os.name != "nt":
+        raise OSError("Windows Included File read handles are unavailable")
+    win_dll = cast(Callable[..., Any], getattr(ctypes, "WinDLL"))
+    kernel32 = win_dll("kernel32", use_last_error=True)
+    kernel32.CreateFileW.argtypes = (
+        ctypes.c_wchar_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+    )
+    kernel32.CreateFileW.restype = ctypes.c_void_p
+    kernel32.CloseHandle.argtypes = (ctypes.c_void_p,)
+    kernel32.CloseHandle.restype = ctypes.c_int
+    return kernel32
+
+
+def _open_included_file_validation_stream(
+    path: str,
+    *,
+    deny_writes: bool,
+    no_follow: bool = False,
+) -> BinaryIO:
+    """Open a validation stream with requested sharing and link semantics."""
+
+    if os.name != "nt":
+        if no_follow:
+            file_descriptor = os.open(
+                path,
+                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            )
+            try:
+                return os.fdopen(file_descriptor, "rb")
+            except BaseException:
+                os.close(file_descriptor)
+                raise
+        return open(path, "rb")
+    if not deny_writes and not no_follow:
+        return open(path, "rb")
+
+    kernel32 = _windows_included_file_read_api()
+    handle_value = kernel32.CreateFileW(
+        os.path.abspath(path),
+        _WINDOWS_GENERIC_READ,
+        _WINDOWS_FILE_SHARE_READ,
+        None,
+        _WINDOWS_OPEN_EXISTING,
+        _WINDOWS_FILE_ATTRIBUTE_NORMAL
+        | (_WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT if no_follow else 0)
+        | _WINDOWS_FILE_FLAG_SEQUENTIAL_SCAN,
+        None,
+    )
+    invalid_handle = ctypes.c_void_p(-1).value
+    if handle_value is None or handle_value == invalid_handle:
+        get_last_error = cast(
+            Callable[[], int],
+            getattr(ctypes, "get_last_error"),
+        )
+        error_number = get_last_error()
+        format_error = cast(
+            Callable[[int], str],
+            getattr(ctypes, "FormatError"),
+        )
+        raise OSError(
+            error_number,
+            format_error(error_number).strip(),
+            path,
+        )
+
+    handle = cast(int, handle_value)
+    try:
+        import msvcrt
+
+        file_descriptor = msvcrt.open_osfhandle(
+            handle,
+            os.O_RDONLY | getattr(os, "O_BINARY", 0),
+        )
+    except BaseException:
+        kernel32.CloseHandle(handle)
+        raise
+    try:
+        return os.fdopen(file_descriptor, "rb")
+    except BaseException:
+        os.close(file_descriptor)
+        raise
+
+
 def _digest_open_included_file(
     opened_file: BinaryIO,
 ) -> tuple[int, str]:
     digest = hashlib.sha256()
     byte_count = 0
     while True:
-        chunk = opened_file.read(1024 * 1024)
+        chunk = _read_included_validation_chunk(opened_file)
         if not chunk:
             break
         digest.update(chunk)
@@ -470,41 +593,38 @@ def _digest_included_regular_file(
     expected_fingerprint = _included_path_fingerprint(expected_stat)
     expected_binding = _included_path_handle_binding(expected_stat)
     expected_ctime_ns = expected_stat.st_ctime_ns
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
-    file_descriptor = os.open(path, flags)
-    try:
-        opened_stat = os.fstat(file_descriptor)
+    with _open_included_file_validation_stream(
+        path,
+        deny_writes=True,
+        no_follow=True,
+    ) as opened_file:
+        opened_stat = os.fstat(opened_file.fileno())
         if (
             not stat.S_ISREG(opened_stat.st_mode)
             or _included_path_handle_binding(opened_stat) != expected_binding
         ):
             raise OSError(f"Included Files file changed before hashing: {path}")
         opened_state = _included_handle_state(opened_stat)
-        with os.fdopen(file_descriptor, "rb") as opened_file:
-            file_descriptor = -1
-            byte_count, content_sha256 = _digest_open_included_file(opened_file)
-            current_opened_stat = os.fstat(opened_file.fileno())
-            if (
-                _included_handle_state(current_opened_stat) != opened_state
-                or byte_count != expected_stat.st_size
-            ):
-                raise OSError(
-                    f"Included Files file changed while hashing: {path}"
-                )
+        byte_count, content_sha256 = _digest_open_included_file(opened_file)
+        current_opened_stat = os.fstat(opened_file.fileno())
+        if (
+            _included_handle_state(current_opened_stat) != opened_state
+            or byte_count != expected_stat.st_size
+        ):
+            raise OSError(
+                f"Included Files file changed while hashing: {path}"
+            )
 
-            current_stat = os.lstat(path)
-            if (
-                _included_output_path_is_redirected(path, current_stat)
-                or not stat.S_ISREG(current_stat.st_mode)
-                or _included_path_fingerprint(current_stat) != expected_fingerprint
-                or current_stat.st_ctime_ns != expected_ctime_ns
-            ):
-                raise OSError(
-                    f"Included Files file changed while hashing: {path}"
-                )
-    finally:
-        if file_descriptor >= 0:
-            os.close(file_descriptor)
+        current_stat = os.lstat(path)
+        if (
+            _included_output_path_is_redirected(path, current_stat)
+            or not stat.S_ISREG(current_stat.st_mode)
+            or _included_path_fingerprint(current_stat) != expected_fingerprint
+            or current_stat.st_ctime_ns != expected_ctime_ns
+        ):
+            raise OSError(
+                f"Included Files file changed while hashing: {path}"
+            )
     return content_sha256
 
 
@@ -564,6 +684,60 @@ def _verify_fallback_directory_ancestors(
             raise OSError(
                 f"Included Files directory ancestor changed: {directory_path}"
             )
+
+
+def _capture_included_source_directory_identities(
+    project_root: str,
+    source_path: str,
+) -> tuple[str, tuple[_IncludedSourceDirectoryIdentity, ...]]:
+    canonical_root = os.path.normcase(os.path.realpath(project_root))
+    canonical_path = os.path.normcase(os.path.realpath(source_path))
+    try:
+        contained = (
+            os.path.commonpath((canonical_root, canonical_path))
+            == canonical_root
+        )
+    except ValueError:
+        contained = False
+    if not contained or canonical_path == canonical_root:
+        raise OSError(
+            "GameMaker Included File source escapes the selected project: "
+            f"{source_path}"
+        )
+
+    directory_path = canonical_root
+    directory_identities: list[_IncludedSourceDirectoryIdentity] = []
+    relative_directory = os.path.relpath(
+        os.path.dirname(canonical_path),
+        canonical_root,
+    )
+    components = (
+        ()
+        if relative_directory == os.curdir
+        else tuple(relative_directory.split(os.sep))
+    )
+    for component in (None, *components):
+        if component is not None:
+            directory_path = os.path.join(directory_path, component)
+        directory_stat = os.lstat(directory_path)
+        if (
+            _included_output_path_is_redirected(
+                directory_path,
+                directory_stat,
+            )
+            or not stat.S_ISDIR(directory_stat.st_mode)
+        ):
+            raise OSError(
+                "GameMaker Included File source directory is redirected or "
+                f"invalid: {directory_path}"
+            )
+        directory_identities.append(
+            (
+                directory_path,
+                (directory_stat.st_dev, directory_stat.st_ino),
+            )
+        )
+    return canonical_path, tuple(directory_identities)
 
 
 def _included_directory_identity(path: str) -> _PathIdentity | None:
@@ -831,6 +1005,8 @@ def _capture_included_tree_from_fd(
     relative_directory: str,
     display_path: str,
     verify_binding: Callable[[], None],
+    *,
+    include_content: bool,
 ) -> list[_IncludedTreeEntry]:
     verify_binding()
     try:
@@ -882,6 +1058,7 @@ def _capture_included_tree_from_fd(
                         relative_path,
                         entry_path,
                         verify_child_binding,
+                        include_content=include_content,
                     )
                 )
             finally:
@@ -899,11 +1076,15 @@ def _capture_included_tree_from_fd(
         elif stat.S_ISREG(entry_stat.st_mode):
             kind = "file"
             ctime_ns = entry_stat.st_ctime_ns
-            content_sha256 = _digest_included_regular_file_at(
-                directory_fd,
-                name,
-                entry_stat,
-                entry_path,
+            content_sha256 = (
+                _digest_included_regular_file_at(
+                    directory_fd,
+                    name,
+                    entry_stat,
+                    entry_path,
+                )
+                if include_content
+                else None
             )
         else:
             raise OSError(
@@ -925,6 +1106,8 @@ def _capture_included_tree_from_fd(
 def _capture_included_tree_descriptor(
     root_path: str,
     expected_parent_identity: _PathIdentity | None,
+    *,
+    include_content: bool,
 ) -> _IncludedTreeSnapshot:
     parent_fd, root_name = _open_pinned_included_parent(root_path)
     parent_identity = _directory_identity_from_fd(parent_fd)
@@ -969,6 +1152,7 @@ def _capture_included_tree_descriptor(
                 "",
                 root_path,
                 verify_root_binding,
+                include_content=include_content,
             )
         finally:
             os.close(root_fd)
@@ -995,6 +1179,8 @@ def _after_included_fallback_tree_directory_scan(_path: str) -> None:
 def _capture_included_tree_fallback(
     root_path: str,
     expected_parent_identity: _PathIdentity | None,
+    *,
+    include_content: bool,
 ) -> _IncludedTreeSnapshot:
     root_parent_identities = _capture_fallback_directory_ancestors(
         os.path.dirname(os.path.abspath(root_path))
@@ -1063,9 +1249,13 @@ def _capture_included_tree_fallback(
                 kind = "file"
                 ctime_ns = entry_stat.st_ctime_ns
                 _verify_fallback_directory_ancestors(directory_identities)
-                content_sha256 = _digest_included_regular_file(
-                    entry_path,
-                    entry_stat,
+                content_sha256 = (
+                    _digest_included_regular_file(
+                        entry_path,
+                        entry_stat,
+                    )
+                    if include_content
+                    else None
                 )
             else:
                 raise OSError(
@@ -1106,15 +1296,18 @@ def _capture_included_tree(
     root_path: str,
     *,
     expected_parent_identity: _PathIdentity | None = None,
+    include_content: bool = True,
 ) -> _IncludedTreeSnapshot:
     if _included_descriptor_paths_supported():
         return _capture_included_tree_descriptor(
             root_path,
             expected_parent_identity,
+            include_content=include_content,
         )
     return _capture_included_tree_fallback(
         root_path,
         expected_parent_identity,
+        include_content=include_content,
     )
 
 
@@ -1132,6 +1325,89 @@ def _verify_included_tree_snapshot(
         != expected
     ):
         raise OSError(f"Included Files tree changed during conversion: {root_path}")
+
+
+def _included_tree_without_content(
+    snapshot: _IncludedTreeSnapshot,
+) -> _IncludedTreeSnapshot:
+    return _IncludedTreeSnapshot(
+        root_fingerprint=snapshot.root_fingerprint,
+        entries=tuple(
+            _IncludedTreeEntry(
+                relative_path=entry.relative_path,
+                kind=entry.kind,
+                fingerprint=entry.fingerprint,
+                ctime_ns=entry.ctime_ns,
+                content_sha256=None,
+            )
+            for entry in snapshot.entries
+        ),
+    )
+
+
+def _verify_included_tree_snapshot_metadata(
+    root_path: str,
+    expected: _IncludedTreeSnapshot,
+    *,
+    expected_parent_identity: _PathIdentity | None = None,
+) -> None:
+    current = _capture_included_tree(
+        root_path,
+        expected_parent_identity=expected_parent_identity,
+        include_content=False,
+    )
+    if current != _included_tree_without_content(expected):
+        raise OSError(
+            f"Included Files tree metadata changed during conversion: {root_path}"
+        )
+
+
+def _included_tree_matches_planned_paths(
+    snapshot: _IncludedTreeSnapshot,
+    assigned_paths: set[str],
+) -> bool:
+    if snapshot.identity is None:
+        return False
+    expected_directories = {
+        "/".join(path.split("/")[:component_count])
+        for path in assigned_paths
+        for component_count in range(1, len(path.split("/")))
+    }
+    actual_files = {
+        entry.relative_path
+        for entry in snapshot.entries
+        if entry.kind == "file"
+    }
+    actual_directories = {
+        entry.relative_path
+        for entry in snapshot.entries
+        if entry.kind == "directory"
+    }
+    if actual_files != assigned_paths or actual_directories != expected_directories:
+        return False
+    return all(
+        entry.content_sha256 is not None and entry.fingerprint[5] == 1
+        for entry in snapshot.entries
+        if entry.kind == "file"
+    )
+
+
+def _included_tree_matches_source_receipts(
+    snapshot: _IncludedTreeSnapshot,
+    assigned_receipts: dict[str, _IncludedNoOpSourceReceipt],
+) -> bool:
+    entries_by_path = {
+        entry.relative_path: entry
+        for entry in snapshot.entries
+        if entry.kind == "file"
+    }
+    return all(
+        assigned_path in entries_by_path
+        and entries_by_path[assigned_path].fingerprint[3]
+        == receipt.byte_count
+        and entries_by_path[assigned_path].content_sha256 == receipt.sha256
+        for assigned_path, receipt in assigned_receipts.items()
+    )
 
 
 def _verify_staged_included_inventory(
@@ -3536,6 +3812,18 @@ def _publish_confined_included_output(
     )
 
 
+def _before_included_unchanged_source_revalidation() -> None:
+    """Narrow test seam before the second stable source-content pass."""
+
+
+def _before_included_unchanged_public_revalidation() -> None:
+    """Narrow test seam before rehashing the candidate public generation."""
+
+
+def _before_included_unchanged_final_revalidation() -> None:
+    """Narrow test seam before final source and public identity checks."""
+
+
 class IncludedFilesConverter(BaseConverter):
     def __init__(self, gm_project_path: StrPath, godot_project_path: StrPath, log_callback: LogCallback = print,
                  progress_callback: ProgressCallback | None = None, conversion_running: ConversionRunning | None = None,
@@ -3625,6 +3913,7 @@ class IncludedFilesConverter(BaseConverter):
         *,
         owner_source_path: str,
         resource: str,
+        deny_writes: bool = False,
     ) -> tuple[BinaryIO, os.stat_result] | None:
         """Open a contained regular file and pin it against late path swaps."""
         resolved = self._resolve_discovered_project_source(
@@ -3638,7 +3927,10 @@ class IncludedFilesConverter(BaseConverter):
             return None
 
         try:
-            source_file = open(resolved.filesystem_path, "rb")
+            source_file = _open_included_file_validation_stream(
+                resolved.filesystem_path,
+                deny_writes=deny_writes,
+            )
         except OSError:
             return None
 
@@ -3675,6 +3967,253 @@ class IncludedFilesConverter(BaseConverter):
             source_file.close()
             return None
         return source_file, opened_stat
+
+    def _capture_pinned_included_source_binding(
+        self,
+        source: _IncludedFileSource,
+        source_file: BinaryIO,
+        expected_stat: os.stat_result,
+    ) -> _IncludedSourceBinding:
+        resolved = self._resolve_discovered_project_source(
+            source.filesystem_path,
+            owner_source_path=source.owner_source_path,
+            resource=source.relative_path,
+            resource_type="included_file",
+            field="discovered datafiles file",
+        )
+        if resolved is None:
+            raise OSError(
+                "GameMaker Included File source changed during unchanged-"
+                f"generation validation: {source.relative_path}"
+            )
+
+        lexical_stat = os.lstat(resolved.filesystem_path)
+        path_stat = os.stat(resolved.filesystem_path)
+        handle_stat = os.fstat(source_file.fileno())
+        if (
+            not stat.S_ISREG(path_stat.st_mode)
+            or not stat.S_ISREG(handle_stat.st_mode)
+            or not os.path.samestat(expected_stat, path_stat)
+            or not os.path.samestat(path_stat, handle_stat)
+            or _included_handle_state(handle_stat)
+            != _included_handle_state(expected_stat)
+            or _included_path_handle_binding(path_stat)
+            != _included_path_handle_binding(handle_stat)
+        ):
+            raise OSError(
+                "GameMaker Included File source changed during unchanged-"
+                f"generation validation: {source.relative_path}"
+            )
+        canonical_path, directory_identities = (
+            _capture_included_source_directory_identities(
+                self.gm_project_path,
+                resolved.filesystem_path,
+            )
+        )
+        _verify_fallback_directory_ancestors(directory_identities)
+        return _IncludedSourceBinding(
+            filesystem_path=os.path.normcase(
+                os.path.abspath(resolved.filesystem_path)
+            ),
+            canonical_path=canonical_path,
+            directory_identities=directory_identities,
+            lexical_state=_included_handle_state(lexical_stat),
+            path_state=_included_handle_state(path_stat),
+            handle_state=_included_handle_state(handle_stat),
+        )
+
+    def _capture_unchanged_source_receipt(
+        self,
+        source: _IncludedFileSource,
+        *,
+        deny_writes: bool,
+    ) -> _IncludedNoOpSourceReceipt:
+        if not self.conversion_running():
+            raise _IncludedOutputSetCancelled()
+        opened_source = self._open_confined_source_file(
+            source.filesystem_path,
+            owner_source_path=source.owner_source_path,
+            resource=source.relative_path,
+            deny_writes=deny_writes,
+        )
+        if opened_source is None:
+            raise OSError(
+                "GameMaker Included File source became unavailable during "
+                f"unchanged-generation validation: {source.relative_path}"
+            )
+        source_file, source_stat = opened_source
+        with source_file:
+            if source_file.tell() != 0:
+                raise OSError(
+                    "GameMaker Included File validation stream did not start "
+                    f"at offset zero: {source.relative_path}"
+                )
+            before_binding = self._capture_pinned_included_source_binding(
+                source,
+                source_file,
+                source_stat,
+            )
+            byte_count, sha256 = _digest_open_included_file(source_file)
+            after_binding = self._capture_pinned_included_source_binding(
+                source,
+                source_file,
+                source_stat,
+            )
+            if (
+                after_binding != before_binding
+                or byte_count != source_stat.st_size
+            ):
+                raise OSError(
+                    "GameMaker Included File source changed while validating "
+                    f"an unchanged generation: {source.relative_path}"
+                )
+        if not self.conversion_running():
+            raise _IncludedOutputSetCancelled()
+        return _IncludedNoOpSourceReceipt(
+            binding=before_binding,
+            byte_count=byte_count,
+            sha256=sha256,
+        )
+
+    def _collect_unchanged_source_receipts(
+        self,
+        sources: tuple[_IncludedFileSource, ...],
+        *,
+        deny_writes: bool,
+    ) -> dict[str, _IncludedNoOpSourceReceipt]:
+        receipts: dict[str, _IncludedNoOpSourceReceipt] = {}
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            futures: dict[
+                Future[_IncludedNoOpSourceReceipt],
+                _IncludedFileSource,
+            ] = {
+                executor.submit(
+                    self._capture_unchanged_source_receipt,
+                    source,
+                    deny_writes=deny_writes,
+                ): source
+                for source in sources
+            }
+            for future in as_completed(futures):
+                source = futures[future]
+                receipts[source.relative_path] = future.result()
+        return receipts
+
+    def _revalidate_unchanged_source_bindings(
+        self,
+        sources: tuple[_IncludedFileSource, ...],
+        receipts: dict[str, _IncludedNoOpSourceReceipt],
+    ) -> None:
+        for source in sources:
+            opened_source = self._open_confined_source_file(
+                source.filesystem_path,
+                owner_source_path=source.owner_source_path,
+                resource=source.relative_path,
+                deny_writes=True,
+            )
+            if opened_source is None:
+                raise OSError(
+                    "GameMaker Included File source became unavailable during "
+                    f"final unchanged-generation validation: {source.relative_path}"
+                )
+            source_file, source_stat = opened_source
+            with source_file:
+                current_binding = self._capture_pinned_included_source_binding(
+                    source,
+                    source_file,
+                    source_stat,
+                )
+            if current_binding != receipts[source.relative_path].binding:
+                raise OSError(
+                    "GameMaker Included File source changed during final "
+                    f"unchanged-generation validation: {source.relative_path}"
+                )
+
+    def _unchanged_included_generation_matches(
+        self,
+        sources: tuple[_IncludedFileSource, ...],
+        assignments_by_source: dict[str, IncludedFilePathAssignment],
+        expected_registry_content: bytes,
+        previous_root_snapshot: _IncludedTreeSnapshot,
+        previous_registry_snapshot: _IncludedRegistrySnapshot,
+        project_identity: _PathIdentity,
+        public_root_path: str,
+    ) -> bool:
+        assigned_paths = {
+            assignments_by_source[source.relative_path].assigned_output_path
+            for source in sources
+        }
+        if (
+            previous_registry_snapshot.directory_identity is None
+            or previous_registry_snapshot.file_identity is None
+            or previous_registry_snapshot.content != expected_registry_content
+            or not _included_tree_matches_planned_paths(
+                previous_root_snapshot,
+                assigned_paths,
+            )
+        ):
+            return False
+
+        first_receipts = self._collect_unchanged_source_receipts(
+            sources,
+            deny_writes=False,
+        )
+        assigned_receipts = {
+            assignments_by_source[source.relative_path].assigned_output_path:
+                first_receipts[source.relative_path]
+            for source in sources
+        }
+        if not _included_tree_matches_source_receipts(
+            previous_root_snapshot,
+            assigned_receipts,
+        ):
+            return False
+
+        _before_included_unchanged_source_revalidation()
+        second_receipts = self._collect_unchanged_source_receipts(
+            sources,
+            deny_writes=True,
+        )
+        if second_receipts != first_receipts:
+            raise OSError(
+                "GameMaker Included File sources changed during unchanged-"
+                "generation validation"
+            )
+
+        _before_included_unchanged_public_revalidation()
+        _verify_included_tree_snapshot(
+            public_root_path,
+            previous_root_snapshot,
+            expected_parent_identity=project_identity,
+        )
+        _verify_included_registry_snapshot(
+            self.godot_project_path,
+            previous_registry_snapshot,
+            expected_project_identity=project_identity,
+        )
+
+        _before_included_unchanged_final_revalidation()
+        self._revalidate_unchanged_source_bindings(
+            sources,
+            first_receipts,
+        )
+        _verify_included_tree_snapshot_metadata(
+            public_root_path,
+            previous_root_snapshot,
+            expected_parent_identity=project_identity,
+        )
+        _verify_included_registry_snapshot(
+            self.godot_project_path,
+            previous_registry_snapshot,
+            expected_project_identity=project_identity,
+        )
+        _verify_included_project_identity(
+            self.godot_project_path,
+            project_identity,
+        )
+        if not self.conversion_running():
+            raise _IncludedOutputSetCancelled()
+        return True
 
     def _list_confined_directory(
         self,
@@ -4208,6 +4747,14 @@ class IncludedFilesConverter(BaseConverter):
         all_files = list(plan.available_files)
         if path_assignments:
             self._report_included_file_path_collisions(path_assignments)
+        emitted_logical_paths = {
+            source.relative_path for source in all_files
+        }
+        staged_registry_text = render_included_file_registry(
+            path_assignments,
+            emitted_logical_paths,
+        )
+        expected_registry_content = staged_registry_text.encode("utf-8")
 
         project_identity = _ensure_included_output_project_root(
             self.godot_project_path
@@ -4246,6 +4793,33 @@ class IncludedFilesConverter(BaseConverter):
         active_error: BaseException | None = None
         transaction_committed = False
         try:
+            if self._unchanged_included_generation_matches(
+                tuple(all_files),
+                assignments_by_source,
+                expected_registry_content,
+                previous_root_snapshot,
+                previous_registry_snapshot,
+                project_identity,
+                public_root_path,
+            ):
+                for completed_count, source in enumerate(all_files, start=1):
+                    self._resource_started(source.relative_path)
+                    self._resource_completed(source.relative_path)
+                    if self.compact_logging:
+                        self._safe_log_progress(
+                            os.path.basename(source.relative_path),
+                            completed_count,
+                            len(all_files),
+                        )
+                    else:
+                        self._safe_log(
+                            get_localized(
+                                "Console_Convertor_IncludedFiles_Unchanged"
+                            ).format(path=source.relative_path)
+                        )
+                self._safe_progress(100)
+                return
+
             (
                 stage_container_path,
                 stage_container_identity,
@@ -4364,13 +4938,6 @@ class IncludedFilesConverter(BaseConverter):
                 assigned_receipts,
             )
 
-            emitted_logical_paths = {
-                source.relative_path for source in all_files
-            }
-            staged_registry_text = render_included_file_registry(
-                path_assignments,
-                emitted_logical_paths,
-            )
             staged_registry_path = os.path.join(
                 stage_container_path,
                 "gml_included_file_registry.gd",

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.24"
+VERSION = "0.7.25"
 
 
 def get_version():

--- a/tests/test_files_ini_json_godot.py
+++ b/tests/test_files_ini_json_godot.py
@@ -380,14 +380,34 @@ class TestFilesIniJsonGodotSmoke(unittest.TestCase):
             binary_source.parent.mkdir(parents=True, exist_ok=True)
             binary_source.write_bytes(bytes((0, 1, 127, 128, 255)))
 
-            IncludedFilesConverter(
+            included_files_converter = IncludedFilesConverter(
                 os.fspath(gm_project_dir),
                 os.fspath(project_dir),
                 log_callback=lambda _message: None,
                 progress_callback=lambda _value: None,
                 conversion_running=lambda: True,
                 max_workers=1,
-            ).convert_all()
+            )
+            included_files_converter.convert_all()
+            published_root = project_dir / "included_files"
+            published_registry = (
+                project_dir
+                / "gm2godot"
+                / "gml_included_file_registry.gd"
+            )
+            published_root_identity = published_root.stat().st_ino
+            published_registry_identity = published_registry.stat().st_ino
+            published_registry_content = published_registry.read_bytes()
+            included_files_converter.convert_all()
+            self.assertEqual(published_root.stat().st_ino, published_root_identity)
+            self.assertEqual(
+                published_registry.stat().st_ino,
+                published_registry_identity,
+            )
+            self.assertEqual(
+                published_registry.read_bytes(),
+                published_registry_content,
+            )
 
             self.assertEqual(
                 (

--- a/tests/test_included_files.py
+++ b/tests/test_included_files.py
@@ -10,6 +10,7 @@ import shutil
 import tempfile
 import threading
 import unittest
+from collections.abc import Collection, Iterable
 from types import SimpleNamespace
 from typing import BinaryIO, Callable
 from unittest.mock import MagicMock, patch
@@ -23,6 +24,7 @@ from src.conversion.included_files import IncludedFilesConverter
 from src.conversion.included_file_registry import (
     INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
 )
+from src.conversion.included_file_paths import IncludedFilePathAssignment
 from src.conversion.conversion_outcome import ConversionCounts
 from src.conversion.converter import Converter
 from src.conversion.diagnostics import ConversionDiagnostic, DiagnosticCollector
@@ -346,6 +348,564 @@ class TestIncludedFilesManagedRootTransaction(unittest.TestCase):
         self.assertEqual(project_debris, [])
         self.assertEqual(registry_debris, [])
 
+    def test_unchanged_generation_preserves_public_identity_without_writes(
+        self,
+    ) -> None:
+        self._write("nested/payload.txt", "stable payload")
+        converter = self._converter(max_workers=1)
+        converter.convert_all()
+        previous_pair = self._pair_snapshot()
+        output_path = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "nested",
+            "payload.txt",
+        )
+        previous_output_identity = os.lstat(output_path).st_ino
+
+        with (
+            patch.object(
+                included_files_module,
+                "_create_included_output_stage",
+                side_effect=AssertionError("unchanged conversion staged output"),
+            ) as create_stage,
+            patch.object(included_files_module.os, "fsync") as fsync,
+            patch.object(included_files_module.os, "replace") as replace,
+        ):
+            converter.convert_all()
+
+        create_stage.assert_not_called()
+        fsync.assert_not_called()
+        replace.assert_not_called()
+        self.assertEqual(self._pair_snapshot(), previous_pair)
+        self.assertEqual(os.lstat(output_path).st_ino, previous_output_identity)
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(
+                requested=1,
+                executed=1,
+                completed=1,
+            ),
+        )
+        self._assert_no_transaction_debris()
+
+    def test_64_mib_generation_has_bounded_initial_and_unchanged_reads(
+        self,
+    ) -> None:
+        payload_size = 64 * 1024 * 1024
+        source_path = os.path.join(self.datafiles_dir, "large.bin")
+        with open(source_path, "wb") as source_file:
+            source_file.truncate(payload_size)
+        converter = self._converter(max_workers=1)
+        original_payload_read = (
+            included_files_module._read_included_payload_chunk
+        )
+        original_validation_read = (
+            included_files_module._read_included_validation_chunk
+        )
+        read_bytes = 0
+
+        def count_payload_read(source_file: BinaryIO) -> bytes:
+            nonlocal read_bytes
+            chunk = original_payload_read(source_file)
+            read_bytes += len(chunk)
+            return chunk
+
+        def count_validation_read(source_file: BinaryIO) -> bytes:
+            nonlocal read_bytes
+            chunk = original_validation_read(source_file)
+            read_bytes += len(chunk)
+            return chunk
+
+        with (
+            patch.object(
+                included_files_module,
+                "_read_included_payload_chunk",
+                side_effect=count_payload_read,
+            ),
+            patch.object(
+                included_files_module,
+                "_read_included_validation_chunk",
+                side_effect=count_validation_read,
+            ),
+        ):
+            converter.convert_all()
+        self.assertEqual(read_bytes, 5 * payload_size)
+
+        read_bytes = 0
+        with (
+            patch.object(
+                included_files_module,
+                "_read_included_payload_chunk",
+                side_effect=count_payload_read,
+            ),
+            patch.object(
+                included_files_module,
+                "_read_included_validation_chunk",
+                side_effect=count_validation_read,
+            ),
+            patch.object(
+                included_files_module,
+                "_create_included_output_stage",
+                side_effect=AssertionError("unchanged conversion staged output"),
+            ),
+        ):
+            converter.convert_all()
+        self.assertEqual(read_bytes, 4 * payload_size)
+        self._assert_no_transaction_debris()
+
+    def test_changed_payload_uses_the_normal_output_transaction(self) -> None:
+        self._write("payload.txt", "BEFORE")
+        converter = self._converter(max_workers=1)
+        converter.convert_all()
+        previous_pair = self._pair_snapshot()
+        self._write("payload.txt", "AFTER!")
+        original_create_stage = (
+            included_files_module._create_included_output_stage
+        )
+
+        with patch.object(
+            included_files_module,
+            "_create_included_output_stage",
+            wraps=original_create_stage,
+        ) as create_stage:
+            converter.convert_all()
+
+        create_stage.assert_called_once()
+        current_pair = self._pair_snapshot()
+        self.assertNotEqual(current_pair[0], previous_pair[0])
+        self.assertEqual(current_pair[1], {"payload.txt": b"AFTER!"})
+        self._assert_no_transaction_debris()
+
+    def test_changed_path_uses_the_normal_output_transaction(
+        self,
+    ) -> None:
+        self._write("old.txt", "stable")
+        converter = self._converter(max_workers=1)
+        converter.convert_all()
+        os.rename(
+            os.path.join(self.datafiles_dir, "old.txt"),
+            os.path.join(self.datafiles_dir, "new.txt"),
+        )
+        original_create_stage = (
+            included_files_module._create_included_output_stage
+        )
+
+        with patch.object(
+            included_files_module,
+            "_create_included_output_stage",
+            wraps=original_create_stage,
+        ) as create_stage:
+            converter.convert_all()
+
+        create_stage.assert_called_once()
+        self.assertEqual(self._pair_snapshot()[1], {"new.txt": b"stable"})
+        self._assert_no_transaction_debris()
+
+    def test_changed_registry_rendering_uses_the_normal_output_transaction(
+        self,
+    ) -> None:
+        self._write("payload.txt", "stable")
+        converter = self._converter(max_workers=1)
+        converter.convert_all()
+        registry_path = os.path.join(
+            self.godot_dir,
+            INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+        )
+        original_render = included_files_module.render_included_file_registry
+        original_create_stage = (
+            included_files_module._create_included_output_stage
+        )
+
+        def changed_render(
+            assignments: Iterable[IncludedFilePathAssignment],
+            emitted_logical_paths: Collection[str],
+        ) -> str:
+            return (
+                original_render(assignments, emitted_logical_paths)
+                + "# changed rendering\n"
+            )
+
+        with (
+            patch.object(
+                included_files_module,
+                "render_included_file_registry",
+                side_effect=changed_render,
+            ),
+            patch.object(
+                included_files_module,
+                "_create_included_output_stage",
+                wraps=original_create_stage,
+            ) as create_stage,
+        ):
+            converter.convert_all()
+
+        create_stage.assert_called_once()
+        with open(registry_path, "rb") as registry_file:
+            self.assertTrue(registry_file.read().endswith(b"# changed rendering\n"))
+        self._assert_no_transaction_debris()
+
+    def test_hardlinked_public_payload_is_republished_normally(self) -> None:
+        self._write("payload.txt", "stable")
+        converter = self._converter(max_workers=1)
+        converter.convert_all()
+        output_path = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "payload.txt",
+        )
+        external_path = os.path.join(self.godot_dir, "external-hardlink.txt")
+        with open(external_path, "w", encoding="utf-8") as external_file:
+            external_file.write("stable")
+        os.unlink(output_path)
+        try:
+            os.link(external_path, output_path)
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Hard links are unavailable: {error}")
+        self.assertEqual(os.lstat(output_path).st_nlink, 2)
+        original_create_stage = (
+            included_files_module._create_included_output_stage
+        )
+
+        with patch.object(
+            included_files_module,
+            "_create_included_output_stage",
+            wraps=original_create_stage,
+        ) as create_stage:
+            converter.convert_all()
+
+        create_stage.assert_called_once()
+        self.assertEqual(os.lstat(output_path).st_nlink, 1)
+        with open(external_path, "r", encoding="utf-8") as external_file:
+            self.assertEqual(external_file.read(), "stable")
+        self._assert_no_transaction_debris()
+
+    def test_collision_and_availability_changes_use_normal_transactions(
+        self,
+    ) -> None:
+        self._write("Alpha Beta.txt", "first")
+        converter = self._converter(max_workers=1)
+        converter.convert_all()
+        self._write("alpha_beta.txt", "second")
+        original_create_stage = (
+            included_files_module._create_included_output_stage
+        )
+
+        with patch.object(
+            included_files_module,
+            "_create_included_output_stage",
+            wraps=original_create_stage,
+        ) as collision_stage:
+            converter.convert_all()
+        collision_stage.assert_called_once()
+        self.assertEqual(len(self._pair_snapshot()[1]), 2)
+
+        os.unlink(os.path.join(self.datafiles_dir, "Alpha Beta.txt"))
+        os.unlink(os.path.join(self.datafiles_dir, "alpha_beta.txt"))
+        with patch.object(
+            included_files_module,
+            "_create_included_output_stage",
+            wraps=original_create_stage,
+        ) as availability_stage:
+            converter.convert_all()
+        availability_stage.assert_called_once()
+        self.assertEqual(self._pair_snapshot()[1], {})
+        self._assert_no_transaction_debris()
+
+    def test_source_mutation_between_noop_receipts_fails_closed(self) -> None:
+        self._write("payload.txt", "ORIGINAL")
+        converter = self._converter(max_workers=1)
+        converter.convert_all()
+        previous_pair = self._pair_snapshot()
+        source_path = os.path.join(self.datafiles_dir, "payload.txt")
+        source_stat = os.stat(source_path)
+
+        def mutate_source() -> None:
+            with open(source_path, "r+b", buffering=0) as source_file:
+                source_file.write(b"MUTATED!")
+                os.fsync(source_file.fileno())
+            os.utime(
+                source_path,
+                ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns),
+            )
+
+        with (
+            patch.object(
+                included_files_module,
+                "_before_included_unchanged_source_revalidation",
+                side_effect=mutate_source,
+            ),
+            patch.object(
+                included_files_module,
+                "_create_included_output_stage",
+                side_effect=AssertionError("mutated no-op candidate staged output"),
+            ),
+            self.assertRaisesRegex(OSError, "sources changed"),
+        ):
+            converter.convert_all()
+
+        self.assertEqual(self._pair_snapshot(), previous_pair)
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(requested=1, executed=1, failed=1),
+        )
+        self._assert_no_transaction_debris()
+
+    def test_source_directory_swap_with_same_inode_fails_closed(self) -> None:
+        self._write("nested/payload.txt", "stable")
+        converter = self._converter(max_workers=1)
+        converter.convert_all()
+        previous_pair = self._pair_snapshot()
+        source_directory = os.path.join(self.datafiles_dir, "nested")
+        moved_directory = os.path.join(self.datafiles_dir, "nested-original")
+
+        def swap_source_directory() -> None:
+            os.rename(source_directory, moved_directory)
+            os.mkdir(source_directory)
+            os.link(
+                os.path.join(moved_directory, "payload.txt"),
+                os.path.join(source_directory, "payload.txt"),
+            )
+
+        with (
+            patch.object(
+                included_files_module,
+                "_before_included_unchanged_source_revalidation",
+                side_effect=swap_source_directory,
+            ),
+            patch.object(
+                included_files_module,
+                "_create_included_output_stage",
+                side_effect=AssertionError("swapped no-op candidate staged output"),
+            ),
+            self.assertRaisesRegex(OSError, "sources changed"),
+        ):
+            converter.convert_all()
+
+        self.assertEqual(self._pair_snapshot(), previous_pair)
+        self.assertEqual(
+            os.stat(
+                os.path.join(source_directory, "payload.txt")
+            ).st_ino,
+            os.stat(
+                os.path.join(moved_directory, "payload.txt")
+            ).st_ino,
+        )
+        self._assert_no_transaction_debris()
+
+    def test_public_root_symlink_swap_during_noop_is_preserved_and_rejected(
+        self,
+    ) -> None:
+        self._write("payload.txt", "stable")
+        converter = self._converter(max_workers=1)
+        converter.convert_all()
+        root_path = os.path.join(self.godot_dir, "included_files")
+        moved_root = os.path.join(self.godot_dir, "preserved-root")
+        replacement_root = tempfile.mkdtemp()
+        registry_path = os.path.join(
+            self.godot_dir,
+            INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+        )
+        registry_identity = os.lstat(registry_path).st_ino
+        with open(
+            os.path.join(replacement_root, "payload.txt"),
+            "wb",
+        ) as replacement_file:
+            replacement_file.write(b"replacement")
+
+        def swap_public_root() -> None:
+            os.rename(root_path, moved_root)
+            try:
+                os.symlink(replacement_root, root_path)
+            except (NotImplementedError, OSError) as error:
+                os.rename(moved_root, root_path)
+                self.skipTest(f"Symbolic links are unavailable: {error}")
+
+        try:
+            with (
+                patch.object(
+                    included_files_module,
+                    "_before_included_unchanged_public_revalidation",
+                    side_effect=swap_public_root,
+                ),
+                patch.object(
+                    included_files_module,
+                    "_create_included_output_stage",
+                    side_effect=AssertionError(
+                        "swapped no-op candidate staged output"
+                    ),
+                ),
+                self.assertRaisesRegex(OSError, "redirected|changed"),
+            ):
+                converter.convert_all()
+
+            self.assertTrue(os.path.islink(root_path))
+            with open(
+                os.path.join(moved_root, "payload.txt"),
+                "rb",
+            ) as preserved_file:
+                self.assertEqual(preserved_file.read(), b"stable")
+            with open(
+                os.path.join(root_path, "payload.txt"),
+                "rb",
+            ) as replacement_file:
+                self.assertEqual(replacement_file.read(), b"replacement")
+            self.assertEqual(os.lstat(registry_path).st_ino, registry_identity)
+            self._assert_no_transaction_debris()
+        finally:
+            shutil.rmtree(replacement_root)
+
+    def test_registry_mutation_during_noop_is_rejected_without_staging(
+        self,
+    ) -> None:
+        self._write("payload.txt", "stable")
+        converter = self._converter(max_workers=1)
+        converter.convert_all()
+        root_identity, root_files, registry_identity, registry_content = (
+            self._pair_snapshot()
+        )
+        registry_path = os.path.join(
+            self.godot_dir,
+            INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+        )
+
+        def mutate_registry() -> None:
+            with open(registry_path, "ab") as registry_file:
+                registry_file.write(b"# concurrent mutation\n")
+                registry_file.flush()
+                os.fsync(registry_file.fileno())
+
+        with (
+            patch.object(
+                included_files_module,
+                "_before_included_unchanged_public_revalidation",
+                side_effect=mutate_registry,
+            ),
+            patch.object(
+                included_files_module,
+                "_create_included_output_stage",
+                side_effect=AssertionError("mutated no-op candidate staged output"),
+            ),
+            self.assertRaisesRegex(OSError, "registry changed"),
+        ):
+            converter.convert_all()
+
+        current_pair = self._pair_snapshot()
+        self.assertEqual(current_pair[0], root_identity)
+        self.assertEqual(current_pair[1], root_files)
+        self.assertEqual(current_pair[2], registry_identity)
+        self.assertEqual(
+            current_pair[3],
+            registry_content + b"# concurrent mutation\n",
+        )
+        self._assert_no_transaction_debris()
+
+    def test_late_same_size_public_mutation_is_rejected_without_staging(
+        self,
+    ) -> None:
+        if os.name == "nt":
+            self.skipTest("Windows ctime does not portably expose content changes")
+        self._write("payload.txt", "ORIGINAL")
+        converter = self._converter(max_workers=1)
+        converter.convert_all()
+        output_path = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "payload.txt",
+        )
+        output_stat = os.stat(output_path)
+        registry_path = os.path.join(
+            self.godot_dir,
+            INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+        )
+        registry_identity = os.lstat(registry_path).st_ino
+
+        def mutate_public_payload() -> None:
+            with open(output_path, "r+b", buffering=0) as output_file:
+                output_file.write(b"MUTATED!")
+                os.fsync(output_file.fileno())
+            os.utime(
+                output_path,
+                ns=(output_stat.st_atime_ns, output_stat.st_mtime_ns),
+            )
+
+        with (
+            patch.object(
+                included_files_module,
+                "_before_included_unchanged_final_revalidation",
+                side_effect=mutate_public_payload,
+            ),
+            patch.object(
+                included_files_module,
+                "_create_included_output_stage",
+                side_effect=AssertionError("mutated no-op candidate staged output"),
+            ),
+            self.assertRaisesRegex(OSError, "tree metadata changed"),
+        ):
+            converter.convert_all()
+
+        with open(output_path, "rb") as output_file:
+            self.assertEqual(output_file.read(), b"MUTATED!")
+        self.assertEqual(os.lstat(registry_path).st_ino, registry_identity)
+        self._assert_no_transaction_debris()
+
+    def test_unchanged_generation_uses_the_pinned_fallback_verifier(self) -> None:
+        self._write("nested/payload.txt", "stable")
+        converter = self._converter(max_workers=1)
+        converter.convert_all()
+        previous_pair = self._pair_snapshot()
+
+        with (
+            patch.object(
+                included_files_module,
+                "_included_descriptor_paths_supported",
+                return_value=False,
+            ),
+            patch.object(
+                included_files_module,
+                "_create_included_output_stage",
+                side_effect=AssertionError("fallback no-op staged output"),
+            ),
+        ):
+            converter.convert_all()
+
+        self.assertEqual(self._pair_snapshot(), previous_pair)
+        self._assert_no_transaction_debris()
+
+    def test_unchanged_contained_source_symlink_keeps_copy_semantics(self) -> None:
+        target_path = os.path.join(self.datafiles_dir, "target.txt")
+        with open(target_path, "w", encoding="utf-8") as source_file:
+            source_file.write("contained target")
+        alias_path = os.path.join(self.datafiles_dir, "alias.txt")
+        try:
+            os.symlink(target_path, alias_path)
+        except (NotImplementedError, OSError) as error:
+            self.skipTest(f"Symbolic links are unavailable: {error}")
+        converter = self._converter(max_workers=2)
+        converter.convert_all()
+        previous_pair = self._pair_snapshot()
+
+        with patch.object(
+            included_files_module,
+            "_create_included_output_stage",
+            side_effect=AssertionError("symlink no-op candidate staged output"),
+        ):
+            converter.convert_all()
+
+        self.assertEqual(self._pair_snapshot(), previous_pair)
+        self.assertEqual(
+            previous_pair[1],
+            {
+                "alias.txt": b"contained target",
+                "target.txt": b"contained target",
+            },
+        )
+        self._assert_no_transaction_debris()
+
     @staticmethod
     def _modeled_handle_stat(
         path_stat: os.stat_result,
@@ -411,6 +971,122 @@ class TestIncludedFilesManagedRootTransaction(unittest.TestCase):
                 staged_path,
                 path_stat,
             )
+
+    def test_windows_validation_stream_denies_writes_and_reparse_following(
+        self,
+    ) -> None:
+        kernel32 = MagicMock()
+        kernel32.CreateFileW.return_value = 1234
+        msvcrt = MagicMock()
+        msvcrt.open_osfhandle.return_value = 5678
+        binary_stream = MagicMock()
+        path = os.path.join(self.godot_dir, "payload.bin")
+
+        with (
+            patch.object(included_files_module.os, "name", "nt"),
+            patch.object(
+                included_files_module,
+                "_windows_included_file_read_api",
+                return_value=kernel32,
+            ),
+            patch.dict(sys.modules, {"msvcrt": msvcrt}),
+            patch.object(
+                included_files_module.os,
+                "fdopen",
+                return_value=binary_stream,
+            ) as fdopen,
+        ):
+            opened_stream = (
+                included_files_module._open_included_file_validation_stream(
+                    path,
+                    deny_writes=True,
+                    no_follow=True,
+                )
+            )
+
+        self.assertIs(opened_stream, binary_stream)
+        kernel32.CreateFileW.assert_called_once_with(
+            os.path.abspath(path),
+            included_files_module._WINDOWS_GENERIC_READ,
+            included_files_module._WINDOWS_FILE_SHARE_READ,
+            None,
+            included_files_module._WINDOWS_OPEN_EXISTING,
+            included_files_module._WINDOWS_FILE_ATTRIBUTE_NORMAL
+            | included_files_module._WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT
+            | included_files_module._WINDOWS_FILE_FLAG_SEQUENTIAL_SCAN,
+            None,
+        )
+        msvcrt.open_osfhandle.assert_called_once_with(
+            1234,
+            os.O_RDONLY | getattr(os, "O_BINARY", 0),
+        )
+        fdopen.assert_called_once_with(5678, "rb")
+        kernel32.CloseHandle.assert_not_called()
+
+    def test_windows_validation_stream_closes_fd_when_wrapping_fails(
+        self,
+    ) -> None:
+        kernel32 = MagicMock()
+        kernel32.CreateFileW.return_value = 1234
+        msvcrt = MagicMock()
+        msvcrt.open_osfhandle.return_value = 5678
+
+        with (
+            patch.object(included_files_module.os, "name", "nt"),
+            patch.object(
+                included_files_module,
+                "_windows_included_file_read_api",
+                return_value=kernel32,
+            ),
+            patch.dict(sys.modules, {"msvcrt": msvcrt}),
+            patch.object(
+                included_files_module.os,
+                "fdopen",
+                side_effect=MemoryError("injected wrapper failure"),
+            ),
+            patch.object(included_files_module.os, "close") as close,
+            self.assertRaisesRegex(MemoryError, "injected wrapper failure"),
+        ):
+            included_files_module._open_included_file_validation_stream(
+                os.path.join(self.godot_dir, "payload.bin"),
+                deny_writes=True,
+                no_follow=True,
+            )
+
+        close.assert_called_once_with(5678)
+        kernel32.CloseHandle.assert_not_called()
+
+    @unittest.skipUnless(os.name == "nt", "requires native Windows semantics")
+    def test_native_windows_noop_hashes_deny_concurrent_writes(self) -> None:
+        self._write("payload.txt", "stable payload")
+        converter = self._converter(max_workers=1)
+        converter.convert_all()
+        source_path = os.path.join(self.datafiles_dir, "payload.txt")
+        output_path = os.path.join(
+            self.godot_dir,
+            "included_files",
+            "payload.txt",
+        )
+        original_read = included_files_module._read_included_validation_chunk
+        blocked_paths: set[str] = set()
+
+        def observe_write_sharing(opened_file: BinaryIO) -> bytes:
+            for path in (source_path, output_path):
+                try:
+                    with open(path, "r+b"):
+                        pass
+                except PermissionError:
+                    blocked_paths.add(path)
+            return original_read(opened_file)
+
+        with patch.object(
+            included_files_module,
+            "_read_included_validation_chunk",
+            side_effect=observe_write_sharing,
+        ):
+            converter.convert_all()
+
+        self.assertEqual(blocked_paths, {source_path, output_path})
 
     def test_descriptor_digest_rechecks_the_open_handle(self) -> None:
         if not included_files_module._included_descriptor_paths_supported():

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_24(self) -> None:
-        self.assertEqual(get_version(), "0.7.24")
+    def test_release_version_is_0_7_25(self) -> None:
+        self.assertEqual(get_version(), "0.7.25")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #729

Wiki source tracking: #712

## Summary

- skip an identical Included Files generation only when the complete planned topology, rendered registry bytes, and stable source size/SHA-256 receipts match the pinned public generation
- rehash every source twice and the public tree twice, with final metadata, ancestry, path/handle, no-follow, registry, and project-identity checks before returning without a stage, write, fsync, rename, cleanup, or inode replacement
- fall back to the normal transaction for changed payloads, paths, collision suffixes, availability, registry rendering, and hard-linked public files; fail closed on concurrent source/public/registry mutation and path or directory swaps
- deny Win32 write/delete sharing during final source and public hashes, retain contained source-symlink semantics, and bump the GameMaker LTS 2026 / Godot 4.7.1 release surface to 0.7.25

## Validation

- `./venv/bin/pyright --warnings` (0 errors, 0 warnings)
- `./venv/bin/python -m ruff check .`
- actionlint and `git diff --check`
- focused Included Files/version suite (88 tests, 1 native-Windows skip)
- `./venv/bin/python -m unittest` (2,157 tests, 48 expected skips)
- deterministic 64 MiB probe: exactly 5x payload bytes initially and 4x on an unchanged repeat
- exact Godot `4.7.1.stable.official.a13da4feb` smoke suite (69 tests, no skips), including an identity-stable repeat conversion before Included Files runtime validation

Native Windows sharing behavior and the GameMaker LTS 2026 conversion gate remain mandatory PR checks before merge.