### PR TITLE
Anchor architecture-policy report transactions

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.27, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.28, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,6 +123,7 @@ jobs:
           tests.test_conversion_outcome
           tests.test_conversion_manifest
           tests.test_diagnostics
+          tests.test_anchored_artifacts
           tests.test_architecture_policy
           tests.test_converter
           tests.test_cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.28 - 2026-07-19
+
+- Anchored architecture-policy publication and restoration to one retained destination-directory binding, using descriptor-relative POSIX operations, no-delete-share Win32 handles, write-through Windows moves, and an explicit verified-path fallback.
+- Added a reusable ordered byte-artifact transaction with exact snapshots, receipts, modes, per-entry concurrency checks, reverse rollback continuation, recovery retention, cleanup, and write-through absence tombstones on Windows.
+- Added adversarial directory-replacement, rollback, receipt-drift, read-only hardlink, native junction, relocation, Unicode long-path, and exact Godot 4.7.1 validation coverage.
+
 ## 0.7.27 - 2026-07-19
 
 - Published the Included Files root and runtime registry as one journaled, recoverable generation: interruption before the durable commit marker restores the exact previous pair, while interruption after it verifies and finalizes the complete new pair on the next conversion.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.27`.
+Current source version: `0.7.28`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.27 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.28 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.27 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.28 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.27 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.28 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.27 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.28 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -204,6 +204,16 @@ Important trust rules:
 - `generated_files` describes files changed from the conversion’s initial output snapshot; it intentionally does not claim ownership of every unchanged pre-existing file.
 
 The exact schemas and transaction rules are defined by [`conversion_manifest.py`](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/conversion_manifest.py), [`conversion_outcome.py`](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/conversion_outcome.py), and their [manifest tests](https://github.com/Infiland/GM2Godot/blob/main/tests/test_conversion_manifest.py).
+
+### Architecture-policy publication confinement
+
+`architecture_policy.json` is staged, backed up, published, rolled back, recovered and cleaned through one destination-directory binding retained for the complete operation. On POSIX hosts with the required APIs, every child lookup and namespace mutation is relative to a no-follow directory descriptor and durability barriers call `fsync()` on that retained descriptor. Replacing the visible `gm2godot/` path therefore makes publication fail, but cannot redirect cleanup or rollback into the replacement directory.
+
+On Windows, GM2Godot opens both the destination project and the exact captured `gm2godot/` directory with reparse-point inspection and without delete sharing before it creates a stage. Child paths remain safe to resolve while those handles prevent either directory from being relocated; replacement requests use write-through completion. Publishing absence first moves the exact target behind a private write-through tombstone, then removes that tombstone on a best-effort basis. Windows has no documented general equivalent to POSIX directory `fsync`, so directory barriers revalidate the retained handle. This is a confinement and strongest-available write-through guarantee, not a claim of identical power-loss durability; a crash can leave hidden tombstone debris, but cannot restore its old public name.
+
+If a non-Windows host lacks descriptor-relative open, stat, mkdir, rename or unlink, `O_NOFOLLOW`, `O_DIRECTORY`, or descriptor chmod, the transaction selects a `verified_path` fallback before staging. That fallback verifies the root and destination identities before and after each full-path operation. It rejects links and changed directories but narrows rather than eliminates the final non-cooperating path-resolution race. The backend is fixed for the transaction and never downgrades after a stage exists.
+
+The retained directory binding does not lock individual artifact names against a non-cooperating writer. Exact inode, mode, byte and digest checks run after staging, before every ordered mutation, and again at the native replace/unlink boundary. A process that races the final system call can still win the remaining leaf-entry interval on platforms without a suitable handle-relative primitive. Close editors, games and other writers while conversion or recovery is running; unexpected exact-state changes fail the transaction and preserve verified recovery material instead of authorizing an overwrite.
 
 ## Extension mappings and platform bridges
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.27 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.28 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.27;
+- GM2Godot 0.7.28;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.27 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.28 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -46,7 +46,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.27`.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.28`.
 
 ## Run from source
 
@@ -133,6 +133,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.27`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.28`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.27 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.28 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.27 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.28 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/src/conversion/anchored_artifacts.py
+++ b/src/conversion/anchored_artifacts.py
@@ -1,0 +1,2328 @@
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import os
+import secrets
+import stat
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any, Callable, Literal, TypeAlias, cast
+
+
+FileFingerprint: TypeAlias = tuple[int, int, int, int, int]
+ReceiptFingerprint: TypeAlias = tuple[int, int, int, int]
+PathIdentity: TypeAlias = tuple[int, int]
+DirectoryStrategy: TypeAlias = Literal["posix_dir_fd", "windows_handle", "verified_path"]
+
+
+def _path_is_redirected(path: str, path_stat: os.stat_result) -> bool:
+    if stat.S_ISLNK(path_stat.st_mode):
+        return True
+    junction_candidate: object = getattr(os.path, "isjunction", None)
+    if not callable(junction_candidate):
+        return False
+    junction_checker = cast(Callable[[str], bool], junction_candidate)
+    return junction_checker(path)
+
+
+def _file_fingerprint(path_stat: os.stat_result) -> FileFingerprint:
+    return (
+        path_stat.st_dev,
+        path_stat.st_ino,
+        path_stat.st_size,
+        path_stat.st_mtime_ns,
+        path_stat.st_ctime_ns,
+    )
+
+
+def _stable_fingerprint(fingerprint: FileFingerprint) -> ReceiptFingerprint:
+    # Renaming the same inode aside and back can update ctime. Receipts retain
+    # exact identity, size, mtime, mode, bytes, and digest instead.
+    return fingerprint[:4]
+
+
+def _sha256_bytes(content: bytes) -> str:
+    return "sha256:" + hashlib.sha256(content).hexdigest()
+
+
+def _is_windows_platform() -> bool:
+    return os.name == "nt"
+
+
+def modes_match(actual: int, expected: int) -> bool:
+    if _is_windows_platform():
+        return bool(actual & stat.S_IWUSR) == bool(expected & stat.S_IWUSR)
+    return actual == expected
+
+
+def fingerprints_match(actual: FileFingerprint, expected: FileFingerprint) -> bool:
+    if _is_windows_platform():
+        # Windows path and handle stat APIs can expose different ctime values
+        # for the same file. Size, mtime, identity, bytes, and SHA remain exact.
+        return actual[:4] == expected[:4]
+    return actual == expected
+
+
+def _replaceable_mode(mode: int) -> int:
+    if not _is_windows_platform():
+        return mode
+    return mode | stat.S_IWUSR
+
+
+def _descriptor_relative_supported() -> bool:
+    return (
+        os.name != "nt"
+        and bool(getattr(os, "O_DIRECTORY", 0))
+        and bool(getattr(os, "O_NOFOLLOW", 0))
+        and os.chmod in os.supports_fd
+        and all(
+            operation in os.supports_dir_fd
+            for operation in (os.open, os.mkdir, os.stat, os.rename, os.unlink)
+        )
+    )
+
+
+def _safe_leaf(name: str) -> str:
+    windows_stem = name.rstrip(" .").split(".", 1)[0].upper()
+    windows_reserved = (
+        windows_stem in {"CON", "PRN", "AUX", "NUL", "CONIN$", "CONOUT$"}
+        or (
+            len(windows_stem) == 4
+            and windows_stem[:3] in {"COM", "LPT"}
+            and windows_stem[3] in "123456789"
+        )
+    )
+    if (
+        name in {"", ".", ".."}
+        or "\x00" in name
+        or os.path.basename(name) != name
+        or any(separator in name for separator in ("/", "\\"))
+        or (
+            os.name == "nt"
+            and (
+                ":" in name
+                or name.endswith((" ", "."))
+                or any(ord(character) < 32 for character in name)
+                or windows_reserved
+            )
+        )
+    ):
+        raise ValueError(f"Unsafe artifact transaction name: {name!r}")
+    return name
+
+
+_WINDOWS_FILE_READ_ATTRIBUTES = 0x00000080
+_WINDOWS_FILE_TRAVERSE = 0x00000020
+_WINDOWS_FILE_SHARE_READ = 0x00000001
+_WINDOWS_FILE_SHARE_WRITE = 0x00000002
+_WINDOWS_OPEN_EXISTING = 3
+_WINDOWS_FILE_FLAG_BACKUP_SEMANTICS = 0x02000000
+_WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000
+_WINDOWS_FILE_ATTRIBUTE_DIRECTORY = 0x00000010
+_WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
+_WINDOWS_FILE_TYPE_DISK = 1
+_WINDOWS_FILE_BASIC_INFO_CLASS = 0
+_WINDOWS_FILE_ID_INFO_CLASS = 18
+_WINDOWS_MOVEFILE_REPLACE_EXISTING = 0x00000001
+_WINDOWS_MOVEFILE_WRITE_THROUGH = 0x00000008
+
+
+class _WindowsFileId128(ctypes.Structure):
+    _fields_ = (("Identifier", ctypes.c_uint8 * 16),)
+
+
+class _WindowsFileIdInfo(ctypes.Structure):
+    _fields_ = (
+        ("VolumeSerialNumber", ctypes.c_uint64),
+        ("FileId", _WindowsFileId128),
+    )
+
+
+class _WindowsFileBasicInfo(ctypes.Structure):
+    _fields_ = (
+        ("CreationTime", ctypes.c_int64),
+        ("LastAccessTime", ctypes.c_int64),
+        ("LastWriteTime", ctypes.c_int64),
+        ("ChangeTime", ctypes.c_int64),
+        ("FileAttributes", ctypes.c_uint32),
+    )
+
+
+@lru_cache(maxsize=1)
+def _windows_file_api() -> Any:
+    if os.name != "nt":
+        raise OSError("Windows artifact transaction APIs are unavailable")
+    if (
+        ctypes.sizeof(_WindowsFileId128) != 16
+        or ctypes.sizeof(_WindowsFileIdInfo) != 24
+        or _WindowsFileIdInfo.FileId.offset != 8
+        or ctypes.sizeof(_WindowsFileBasicInfo) != 40
+        or _WindowsFileBasicInfo.FileAttributes.offset != 32
+    ):
+        raise OSError("Unsupported Windows artifact transaction ABI layout")
+    win_dll = cast(Callable[..., Any], getattr(ctypes, "WinDLL"))
+    kernel32 = win_dll("kernel32", use_last_error=True)
+    kernel32.CreateFileW.argtypes = (
+        ctypes.c_wchar_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+    )
+    kernel32.CreateFileW.restype = ctypes.c_void_p
+    kernel32.GetFileInformationByHandleEx.argtypes = (
+        ctypes.c_void_p,
+        ctypes.c_int,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+    )
+    kernel32.GetFileInformationByHandleEx.restype = ctypes.c_int
+    kernel32.GetFileType.argtypes = (ctypes.c_void_p,)
+    kernel32.GetFileType.restype = ctypes.c_uint32
+    kernel32.MoveFileExW.argtypes = (
+        ctypes.c_wchar_p,
+        ctypes.c_wchar_p,
+        ctypes.c_uint32,
+    )
+    kernel32.MoveFileExW.restype = ctypes.c_int
+    kernel32.CloseHandle.argtypes = (ctypes.c_void_p,)
+    kernel32.CloseHandle.restype = ctypes.c_int
+    return kernel32
+
+
+def _windows_api_error(operation: str, path: str) -> OSError:
+    get_last_error = cast(Callable[[], int], getattr(ctypes, "get_last_error"))
+    error_number = get_last_error()
+    format_error = cast(Callable[[int], str], getattr(ctypes, "FormatError"))
+    return OSError(
+        error_number,
+        f"{operation}: {format_error(error_number).strip()}",
+        path,
+    )
+
+
+def _windows_extended_path(path: str) -> str:
+    """Return an absolute Win32 path independent of MAX_PATH policy."""
+    absolute_path = os.path.abspath(path)
+    if absolute_path.startswith(("\\\\?\\", "\\\\.\\")):
+        return absolute_path
+    if absolute_path.startswith("\\\\"):
+        return "\\\\?\\UNC\\" + absolute_path[2:]
+    return "\\\\?\\" + absolute_path
+
+
+def _windows_handle_identity(kernel32: Any, handle: int, path: str) -> PathIdentity:
+    identity_info = _WindowsFileIdInfo()
+    if not kernel32.GetFileInformationByHandleEx(
+        handle,
+        _WINDOWS_FILE_ID_INFO_CLASS,
+        ctypes.byref(identity_info),
+        ctypes.sizeof(identity_info),
+    ):
+        raise _windows_api_error("Could not identify artifact directory handle", path)
+    return (
+        int(identity_info.VolumeSerialNumber),
+        int.from_bytes(bytes(identity_info.FileId.Identifier), "little"),
+    )
+
+
+def _windows_directory_attributes(kernel32: Any, handle: int, path: str) -> int:
+    basic_info = _WindowsFileBasicInfo()
+    if not kernel32.GetFileInformationByHandleEx(
+        handle,
+        _WINDOWS_FILE_BASIC_INFO_CLASS,
+        ctypes.byref(basic_info),
+        ctypes.sizeof(basic_info),
+    ):
+        raise _windows_api_error("Could not inspect artifact directory handle", path)
+    return int(basic_info.FileAttributes)
+
+
+def _open_windows_directory_handle(
+    path: str,
+    expected_identity: PathIdentity,
+) -> tuple[Any, int]:
+    kernel32 = _windows_file_api()
+    handle = kernel32.CreateFileW(
+        _windows_extended_path(path),
+        _WINDOWS_FILE_TRAVERSE | _WINDOWS_FILE_READ_ATTRIBUTES,
+        _WINDOWS_FILE_SHARE_READ | _WINDOWS_FILE_SHARE_WRITE,
+        None,
+        _WINDOWS_OPEN_EXISTING,
+        _WINDOWS_FILE_FLAG_BACKUP_SEMANTICS
+        | _WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT,
+        None,
+    )
+    invalid_handle = ctypes.c_void_p(-1).value
+    if handle is None or handle == invalid_handle:
+        raise _windows_api_error("Could not bind artifact transaction directory", path)
+    handle_value = cast(int, handle)
+    try:
+        path_stat = os.lstat(path)
+        attributes = _windows_directory_attributes(kernel32, handle_value, path)
+        if (
+            kernel32.GetFileType(handle_value) != _WINDOWS_FILE_TYPE_DISK
+            or not stat.S_ISDIR(path_stat.st_mode)
+            or (path_stat.st_dev, path_stat.st_ino) != expected_identity
+            or _windows_handle_identity(kernel32, handle_value, path)
+            != expected_identity
+            or not attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY
+            or attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT
+        ):
+            raise OSError(f"Artifact transaction directory changed: {path}")
+    except BaseException as error:
+        if not kernel32.CloseHandle(handle_value):
+            error.add_note(
+                f"Could not close rejected artifact directory handle: {path}"
+            )
+        raise
+    return kernel32, handle_value
+
+
+def _before_anchored_artifact_phase(
+    _phase: str,
+    _directory_path: str,
+    _name: str | None,
+) -> None:
+    """Narrow adversarial-test seam around namespace and durability phases."""
+
+
+@dataclass
+class VerifiedDirectory(AbstractContextManager["VerifiedDirectory"]):
+    """A directory whose namespace remains bound for a complete transaction.
+
+    POSIX operations are descriptor-relative. Windows retains a directory
+    handle opened without delete sharing, so path-based child operations cannot
+    be redirected by moving the directory. Other platforms use an explicitly
+    weaker verified-path strategy chosen before any staging begins.
+    """
+
+    path: str
+    identity: PathIdentity
+    description: str
+    strategy: DirectoryStrategy
+    descriptor: int = -1
+    windows_api: Any | None = None
+    windows_handle: int | None = None
+    closed: bool = False
+
+    @classmethod
+    def open(cls, path: str, *, description: str) -> "VerifiedDirectory":
+        absolute_path = os.path.abspath(path)
+        try:
+            path_stat = os.lstat(absolute_path)
+        except OSError as error:
+            raise OSError(f"{description.capitalize()} is unavailable: {path}") from error
+        if _path_is_redirected(absolute_path, path_stat) or not stat.S_ISDIR(
+            path_stat.st_mode
+        ):
+            raise OSError(f"Refusing redirected or non-directory {description}: {path}")
+        identity = (path_stat.st_dev, path_stat.st_ino)
+        if _descriptor_relative_supported():
+            flags = (
+                os.O_RDONLY
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_NOFOLLOW", 0)
+            )
+            descriptor = os.open(absolute_path, flags)
+            try:
+                opened_stat = os.fstat(descriptor)
+                if (
+                    not stat.S_ISDIR(opened_stat.st_mode)
+                    or (opened_stat.st_dev, opened_stat.st_ino) != identity
+                ):
+                    raise OSError(f"{description.capitalize()} changed: {path}")
+            except BaseException as error:
+                try:
+                    os.close(descriptor)
+                except BaseException as close_error:
+                    error.add_note(
+                        f"Could not close rejected {description} descriptor: "
+                        f"{close_error}"
+                    )
+                raise
+            binding = cls(
+                path=absolute_path,
+                identity=identity,
+                description=description,
+                strategy="posix_dir_fd",
+                descriptor=descriptor,
+            )
+        elif os.name == "nt":
+            kernel32, handle = _open_windows_directory_handle(
+                absolute_path,
+                identity,
+            )
+            binding = cls(
+                path=absolute_path,
+                identity=identity,
+                description=description,
+                strategy="windows_handle",
+                windows_api=kernel32,
+                windows_handle=handle,
+            )
+        else:
+            binding = cls(
+                path=absolute_path,
+                identity=identity,
+                description=description,
+                strategy="verified_path",
+            )
+        try:
+            binding.verify_path()
+        except BaseException as error:
+            try:
+                binding.close()
+            except BaseException as close_error:
+                error.add_note(
+                    f"Could not close rejected {description} binding: {close_error}"
+                )
+            raise
+        return binding
+
+    def __exit__(
+        self,
+        _exc_type: object,
+        active_error: BaseException | None,
+        _traceback: object,
+    ) -> bool | None:
+        try:
+            self.close()
+        except BaseException as close_error:
+            if active_error is None:
+                raise
+            active_error.add_note(
+                f"Could not close {self.description} binding: {close_error}"
+            )
+        return None
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        if self.descriptor >= 0:
+            descriptor = self.descriptor
+            self.descriptor = -1
+            os.close(descriptor)
+        if self.windows_handle is not None:
+            handle = self.windows_handle
+            self.windows_handle = None
+            assert self.windows_api is not None
+            if not self.windows_api.CloseHandle(handle):
+                raise _windows_api_error(
+                    "Could not close artifact transaction directory",
+                    self.path,
+                )
+
+    def verify_path(self) -> None:
+        if self.closed:
+            raise OSError(f"{self.description.capitalize()} binding is closed")
+        try:
+            path_stat = os.lstat(self.path)
+        except OSError as error:
+            raise OSError(f"{self.description.capitalize()} changed: {self.path}") from error
+        if (
+            _path_is_redirected(self.path, path_stat)
+            or not stat.S_ISDIR(path_stat.st_mode)
+            or (path_stat.st_dev, path_stat.st_ino) != self.identity
+        ):
+            raise OSError(f"{self.description.capitalize()} changed: {self.path}")
+        if self.strategy == "posix_dir_fd":
+            opened_stat = os.fstat(self.descriptor)
+            if (
+                not stat.S_ISDIR(opened_stat.st_mode)
+                or (opened_stat.st_dev, opened_stat.st_ino) != self.identity
+            ):
+                raise OSError(f"{self.description.capitalize()} changed: {self.path}")
+        elif self.strategy == "windows_handle":
+            assert self.windows_api is not None
+            assert self.windows_handle is not None
+            attributes = _windows_directory_attributes(
+                self.windows_api,
+                self.windows_handle,
+                self.path,
+            )
+            if (
+                _windows_handle_identity(
+                    self.windows_api,
+                    self.windows_handle,
+                    self.path,
+                )
+                != self.identity
+                or not attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY
+                or attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT
+            ):
+                raise OSError(f"{self.description.capitalize()} changed: {self.path}")
+
+    def child_path(self, name: str) -> str:
+        return os.path.join(self.path, _safe_leaf(name))
+
+    def open_child(
+        self,
+        name: str,
+        *,
+        expected_identity: PathIdentity,
+        description: str,
+    ) -> "VerifiedDirectory":
+        leaf = _safe_leaf(name)
+        child_path = self.child_path(leaf)
+        try:
+            child_stat = self.stat(leaf)
+        except OSError as error:
+            raise OSError(f"{description.capitalize()} is unavailable: {child_path}") from error
+        if _path_is_redirected(child_path, child_stat) or not stat.S_ISDIR(
+            child_stat.st_mode
+        ):
+            raise OSError(
+                f"Refusing redirected or non-directory {description}: {child_path}"
+            )
+        identity = (child_stat.st_dev, child_stat.st_ino)
+        if identity != expected_identity:
+            raise OSError(f"{description.capitalize()} changed: {child_path}")
+        if self.strategy == "posix_dir_fd":
+            flags = (
+                os.O_RDONLY
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_NOFOLLOW", 0)
+            )
+            descriptor = os.open(leaf, flags, dir_fd=self.descriptor)
+            try:
+                opened_stat = os.fstat(descriptor)
+                if (
+                    not stat.S_ISDIR(opened_stat.st_mode)
+                    or (opened_stat.st_dev, opened_stat.st_ino) != expected_identity
+                ):
+                    raise OSError(f"{description.capitalize()} changed: {child_path}")
+            except BaseException as error:
+                try:
+                    os.close(descriptor)
+                except BaseException as close_error:
+                    error.add_note(
+                        f"Could not close rejected {description} descriptor: "
+                        f"{close_error}"
+                    )
+                raise
+            binding = VerifiedDirectory(
+                path=child_path,
+                identity=expected_identity,
+                description=description,
+                strategy="posix_dir_fd",
+                descriptor=descriptor,
+            )
+            try:
+                self.verify_path()
+                binding.verify_path()
+            except BaseException as error:
+                try:
+                    binding.close()
+                except BaseException as close_error:
+                    error.add_note(
+                        f"Could not close rejected {description} binding: {close_error}"
+                    )
+                raise
+            return binding
+        if self.strategy == "windows_handle":
+            # The retained root handle prevents parent relocation while this
+            # second handle binds the exact child captured by the caller.
+            self.verify_path()
+            kernel32, handle = _open_windows_directory_handle(
+                child_path,
+                expected_identity,
+            )
+            binding = VerifiedDirectory(
+                path=child_path,
+                identity=expected_identity,
+                description=description,
+                strategy="windows_handle",
+                windows_api=kernel32,
+                windows_handle=handle,
+            )
+            try:
+                self.verify_path()
+                binding.verify_path()
+            except BaseException as error:
+                try:
+                    binding.close()
+                except BaseException as close_error:
+                    error.add_note(
+                        f"Could not close rejected {description} binding: {close_error}"
+                    )
+                raise
+            return binding
+        # The verified fallback repeats the full path guards and rejects a
+        # freshly captured replacement before returning it to the transaction.
+        self.verify_path()
+        binding = VerifiedDirectory.open(child_path, description=description)
+        try:
+            if binding.identity != expected_identity:
+                raise OSError(f"{description.capitalize()} changed: {child_path}")
+            self.verify_path()
+        except BaseException as error:
+            try:
+                binding.close()
+            except BaseException as close_error:
+                error.add_note(
+                    f"Could not close rejected {description} binding: {close_error}"
+                )
+            raise
+        return binding
+
+    def stat(self, name: str) -> os.stat_result:
+        leaf = _safe_leaf(name)
+        if self.strategy == "posix_dir_fd":
+            return os.stat(leaf, dir_fd=self.descriptor, follow_symlinks=False)
+        self.verify_path()
+        result = os.lstat(self.child_path(leaf))
+        self.verify_path()
+        return result
+
+    def lexists(self, name: str) -> bool:
+        try:
+            self.stat(name)
+        except FileNotFoundError:
+            return False
+        return True
+
+    def open_file(self, name: str, flags: int, mode: int = 0o600) -> int:
+        leaf = _safe_leaf(name)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        if self.strategy == "posix_dir_fd":
+            return os.open(leaf, flags, mode, dir_fd=self.descriptor)
+        self.verify_path()
+        descriptor = os.open(self.child_path(leaf), flags, mode)
+        try:
+            self.verify_path()
+        except BaseException:
+            os.close(descriptor)
+            raise
+        return descriptor
+
+    def mkdir(self, name: str, mode: int = 0o755) -> None:
+        leaf = _safe_leaf(name)
+        _before_anchored_artifact_phase("before_mkdir", self.path, leaf)
+        if self.strategy == "posix_dir_fd":
+            os.mkdir(leaf, mode, dir_fd=self.descriptor)
+        else:
+            self.verify_path()
+            os.mkdir(self.child_path(leaf), mode)
+            self.verify_path()
+        _before_anchored_artifact_phase("after_mkdir", self.path, leaf)
+
+    def replace(
+        self,
+        source: str,
+        destination: str,
+        *,
+        expected_source: PathIdentity,
+        expected_destination: PathIdentity | None,
+    ) -> BaseException | None:
+        source_leaf = _safe_leaf(source)
+        destination_leaf = _safe_leaf(destination)
+        _before_anchored_artifact_phase(
+            "before_replace",
+            self.path,
+            destination_leaf,
+        )
+        self.verify_regular_identity(source_leaf, expected_source)
+        if expected_destination is None:
+            if self.lexists(destination_leaf):
+                raise OSError(
+                    "Artifact transaction destination appeared: "
+                    f"{self.child_path(destination_leaf)}"
+                )
+        else:
+            self.verify_regular_identity(destination_leaf, expected_destination)
+        if self.strategy == "posix_dir_fd":
+            os.rename(
+                source_leaf,
+                destination_leaf,
+                src_dir_fd=self.descriptor,
+                dst_dir_fd=self.descriptor,
+            )
+        elif self.strategy == "windows_handle":
+            self.verify_path()
+            assert self.windows_api is not None
+            if not self.windows_api.MoveFileExW(
+                _windows_extended_path(self.child_path(source_leaf)),
+                _windows_extended_path(self.child_path(destination_leaf)),
+                _WINDOWS_MOVEFILE_REPLACE_EXISTING
+                | _WINDOWS_MOVEFILE_WRITE_THROUGH,
+            ):
+                raise _windows_api_error(
+                    "Could not replace artifact transaction file",
+                    self.child_path(destination_leaf),
+                )
+        else:
+            self.verify_path()
+            os.replace(
+                self.child_path(source_leaf),
+                self.child_path(destination_leaf),
+            )
+        try:
+            if self.strategy != "posix_dir_fd":
+                self.verify_path()
+            _before_anchored_artifact_phase(
+                "after_replace",
+                self.path,
+                destination_leaf,
+            )
+        except BaseException as error:
+            return error
+        return None
+
+    def unlink(
+        self,
+        name: str,
+        *,
+        expected_identity: PathIdentity,
+    ) -> BaseException | None:
+        leaf = _safe_leaf(name)
+        _before_anchored_artifact_phase("before_unlink", self.path, leaf)
+        self.verify_regular_identity(leaf, expected_identity)
+        if self.strategy == "posix_dir_fd":
+            os.unlink(leaf, dir_fd=self.descriptor)
+        else:
+            self.verify_path()
+            os.unlink(self.child_path(leaf))
+        try:
+            if self.strategy != "posix_dir_fd":
+                self.verify_path()
+            _before_anchored_artifact_phase("after_unlink", self.path, leaf)
+        except BaseException as error:
+            return error
+        return None
+
+    def chmod_exact(
+        self,
+        name: str,
+        identity: PathIdentity,
+        mode: int,
+        *,
+        require_single_link: bool = False,
+    ) -> int:
+        leaf = _safe_leaf(name)
+        current = self.stat(leaf)
+        if (
+            not stat.S_ISREG(current.st_mode)
+            or (current.st_dev, current.st_ino) != identity
+            or (require_single_link and current.st_nlink != 1)
+        ):
+            raise OSError(f"Artifact transaction file changed: {self.child_path(leaf)}")
+        current_mode = stat.S_IMODE(current.st_mode)
+        if modes_match(current_mode, mode):
+            return current_mode
+        descriptor = self.open_file(leaf, os.O_RDONLY)
+        try:
+            opened = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(opened.st_mode)
+                or (opened.st_dev, opened.st_ino) != identity
+                or (require_single_link and opened.st_nlink != 1)
+            ):
+                raise OSError(
+                    f"Artifact transaction file changed: {self.child_path(leaf)}"
+                )
+            fchmod_candidate: object = getattr(os, "fchmod", None)
+            if callable(fchmod_candidate):
+                fchmod = cast(Callable[[int, int], None], fchmod_candidate)
+                fchmod(descriptor, mode)
+            elif os.chmod in os.supports_fd:
+                os.chmod(descriptor, mode)
+            else:
+                self.verify_regular_identity(leaf, identity)
+                os.chmod(self.child_path(leaf), mode)
+                self.verify_regular_identity(leaf, identity)
+        finally:
+            os.close(descriptor)
+        self.verify_regular_identity(leaf, identity)
+        current_mode = stat.S_IMODE(self.stat(leaf).st_mode)
+        if not modes_match(current_mode, mode):
+            raise OSError(
+                f"Artifact transaction file mode did not update: {self.child_path(leaf)}"
+            )
+        return current_mode
+
+    def verify_regular_identity(self, name: str, identity: PathIdentity) -> None:
+        leaf = _safe_leaf(name)
+        try:
+            path_stat = self.stat(leaf)
+        except OSError as error:
+            raise OSError(
+                f"Artifact transaction file changed: {self.child_path(leaf)}"
+            ) from error
+        if (
+            not stat.S_ISREG(path_stat.st_mode)
+            or (path_stat.st_dev, path_stat.st_ino) != identity
+        ):
+            raise OSError(f"Artifact transaction file changed: {self.child_path(leaf)}")
+
+    def sync(self) -> None:
+        _before_anchored_artifact_phase("before_sync", self.path, None)
+        if self.strategy == "posix_dir_fd":
+            os.fsync(self.descriptor)
+        elif self.strategy == "windows_handle":
+            # Win32 has no documented unprivileged equivalent to POSIX
+            # directory fsync. File stages are fsynced and namespace moves use
+            # MOVEFILE_WRITE_THROUGH; this barrier verifies the pinned handle.
+            self.verify_path()
+        else:
+            self.verify_path()
+            flags = (
+                os.O_RDONLY
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_NOFOLLOW", 0)
+            )
+            descriptor = os.open(self.path, flags)
+            try:
+                opened = os.fstat(descriptor)
+                if (
+                    not stat.S_ISDIR(opened.st_mode)
+                    or (opened.st_dev, opened.st_ino) != self.identity
+                ):
+                    raise OSError(f"{self.description.capitalize()} changed: {self.path}")
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+        self.verify_path()
+        _before_anchored_artifact_phase("after_sync", self.path, None)
+
+
+@dataclass
+class AnchoredArtifactDirectory(
+    AbstractContextManager["AnchoredArtifactDirectory"]
+):
+    root: VerifiedDirectory
+    directory: VerifiedDirectory | None
+    relative_directory: str
+    description: str
+
+    @classmethod
+    def open(
+        cls,
+        root_path: str,
+        relative_directory: str,
+        *,
+        create: bool,
+        description: str,
+    ) -> "AnchoredArtifactDirectory":
+        child_name = _safe_leaf(relative_directory)
+        root = VerifiedDirectory.open(
+            root_path,
+            description=f"{description} root",
+        )
+        child_path = root.child_path(child_name)
+        directory: VerifiedDirectory | None = None
+        try:
+            try:
+                child_stat = root.stat(child_name)
+            except FileNotFoundError:
+                if not create:
+                    return cls(root, None, child_name, description)
+                try:
+                    root.mkdir(child_name)
+                except FileExistsError:
+                    pass
+                child_stat = root.stat(child_name)
+            if _path_is_redirected(child_path, child_stat) or not stat.S_ISDIR(
+                child_stat.st_mode
+            ):
+                raise OSError(
+                    f"Refusing redirected or non-directory {description}: {child_path}"
+                )
+            child_identity = (child_stat.st_dev, child_stat.st_ino)
+            directory = root.open_child(
+                child_name,
+                expected_identity=child_identity,
+                description=description,
+            )
+            if create:
+                # Repeat the parent durability barrier even for an existing child.
+                # A previous creation may have become visible before its parent
+                # sync failed, and a retry must not treat that entry as durable.
+                root.sync()
+                directory.verify_path()
+            root.verify_path()
+            return cls(root, directory, child_name, description)
+        except BaseException as error:
+            if directory is not None:
+                try:
+                    directory.close()
+                except OSError as close_error:
+                    error.add_note(f"Could not close artifact directory: {close_error}")
+            try:
+                root.close()
+            except OSError as close_error:
+                error.add_note(f"Could not close artifact root: {close_error}")
+            raise
+
+    @property
+    def path(self) -> str:
+        return self.root.child_path(self.relative_directory)
+
+    @property
+    def root_identity(self) -> PathIdentity:
+        return self.root.identity
+
+    @property
+    def directory_identity(self) -> PathIdentity | None:
+        return None if self.directory is None else self.directory.identity
+
+    @property
+    def strategy(self) -> DirectoryStrategy | None:
+        return None if self.directory is None else self.directory.strategy
+
+    def require_directory(self) -> VerifiedDirectory:
+        if self.directory is None:
+            raise OSError(f"{self.description.capitalize()} is unavailable: {self.path}")
+        return self.directory
+
+    def verify(self) -> None:
+        self.root.verify_path()
+        if self.directory is not None:
+            self.directory.verify_path()
+        self.root.verify_path()
+
+    def current_directory_path(self) -> str | None:
+        """Resolve the retained directory's current name when it stays in root."""
+        if self.directory is None:
+            return None
+        try:
+            self.directory.verify_path()
+        except OSError:
+            pass
+        else:
+            return self.directory.path
+        if self.root.strategy != "posix_dir_fd":
+            return None
+        try:
+            self.root.verify_path()
+            entries = os.listdir(self.root.descriptor)
+        except OSError:
+            return None
+        for entry in entries:
+            try:
+                leaf = _safe_leaf(entry)
+                entry_stat = self.root.stat(leaf)
+            except (OSError, ValueError):
+                continue
+            if (
+                stat.S_ISDIR(entry_stat.st_mode)
+                and (entry_stat.st_dev, entry_stat.st_ino) == self.directory.identity
+            ):
+                candidate = self.root.child_path(leaf)
+                try:
+                    candidate_stat = os.lstat(candidate)
+                except OSError:
+                    continue
+                if (
+                    stat.S_ISDIR(candidate_stat.st_mode)
+                    and (candidate_stat.st_dev, candidate_stat.st_ino)
+                    == self.directory.identity
+                ):
+                    return candidate
+        return None
+
+    def __exit__(
+        self,
+        _exc_type: object,
+        active_error: BaseException | None,
+        _traceback: object,
+    ) -> bool | None:
+        close_error: BaseException | None = None
+        try:
+            if self.directory is not None:
+                self.directory.close()
+        except BaseException as error:
+            close_error = error
+        try:
+            self.root.close()
+        except BaseException as error:
+            if close_error is None:
+                close_error = error
+            else:
+                close_error.add_note(f"Could not close artifact root: {error}")
+        if close_error is not None:
+            if active_error is None:
+                raise close_error
+            active_error.add_note(f"Could not close artifact bindings: {close_error}")
+        return None
+
+
+@dataclass(frozen=True)
+class ArtifactTargetState:
+    fingerprint: FileFingerprint | None
+    mode: int | None
+
+    @property
+    def present(self) -> bool:
+        return self.fingerprint is not None
+
+
+@dataclass(frozen=True)
+class StagedArtifact:
+    directory_path: str
+    name: str
+    identity: PathIdentity
+    content: bytes
+    # The temporary inode stays replaceable until its final transition.
+    mode: int
+    target_mode: int
+    sha256: str
+
+    @property
+    def path(self) -> str:
+        return os.path.join(self.directory_path, self.name)
+
+
+@dataclass(frozen=True)
+class ArtifactReceipt:
+    path: str
+    content: bytes
+    mode: int
+    fingerprint: ReceiptFingerprint
+    sha256: str
+
+
+@dataclass(frozen=True)
+class ArtifactSnapshot:
+    name: str
+    content: bytes | None
+    mode: int | None
+    fingerprint: FileFingerprint | None
+    sha256: str | None
+
+    @property
+    def present(self) -> bool:
+        return self.fingerprint is not None
+
+
+@dataclass(frozen=True)
+class ArtifactSpec:
+    name: str
+    content: bytes | None
+    # None preserves an existing mode and otherwise uses the private stage mode.
+    mode: int | None = None
+
+
+@dataclass
+class _PublishedMutation:
+    snapshot: ArtifactSnapshot
+    desired: StagedArtifact | None
+    backup: StagedArtifact | None
+
+
+@dataclass
+class _RestoreMutation:
+    snapshot: ArtifactSnapshot
+    receipt: ArtifactReceipt | None
+    restored: StagedArtifact | None
+    receipt_backup: StagedArtifact | None
+    restored_committed: bool
+
+
+@dataclass(frozen=True)
+class _ReplaceTarget:
+    identity: PathIdentity
+    mode: int
+    mode_changed: bool
+
+
+class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"]):
+    """Byte-oriented operations confined to one retained artifact directory.
+
+    The class intentionally owns no report schema or ordering policy. A caller
+    can compose one or many ordered present/absent targets while every stage,
+    backup, replacement, rollback, recovery, cleanup, and durability barrier
+    uses this same binding.
+    """
+
+    def __init__(self, anchored: AnchoredArtifactDirectory) -> None:
+        self.anchored = anchored
+
+    @classmethod
+    def open(
+        cls,
+        root_path: str,
+        relative_directory: str,
+        *,
+        create: bool,
+        description: str,
+    ) -> "ByteArtifactTransaction":
+        return cls(
+            AnchoredArtifactDirectory.open(
+                root_path,
+                relative_directory,
+                create=create,
+                description=description,
+            )
+        )
+
+    @property
+    def directory(self) -> VerifiedDirectory:
+        return self.anchored.require_directory()
+
+    @property
+    def path(self) -> str:
+        return self.anchored.path
+
+    @property
+    def root_identity(self) -> PathIdentity:
+        return self.anchored.root_identity
+
+    @property
+    def directory_identity(self) -> PathIdentity | None:
+        return self.anchored.directory_identity
+
+    @property
+    def strategy(self) -> DirectoryStrategy | None:
+        return self.anchored.strategy
+
+    @property
+    def available(self) -> bool:
+        return self.anchored.directory is not None
+
+    def __exit__(
+        self,
+        exc_type: object,
+        active_error: BaseException | None,
+        traceback: object,
+    ) -> bool | None:
+        return self.anchored.__exit__(exc_type, active_error, traceback)
+
+    def verify_directory(self) -> None:
+        self.anchored.verify()
+
+    def phase(self, phase: str, name: str | None = None) -> None:
+        _before_anchored_artifact_phase(phase, self.path, name)
+
+    def target_state(self, name: str) -> ArtifactTargetState:
+        leaf = _safe_leaf(name)
+        try:
+            path_stat = self.directory.stat(leaf)
+        except FileNotFoundError:
+            return ArtifactTargetState(fingerprint=None, mode=None)
+        path = self.directory.child_path(leaf)
+        if _path_is_redirected(path, path_stat) or not stat.S_ISREG(
+            path_stat.st_mode
+        ):
+            raise OSError(f"Refusing redirected or non-regular artifact: {path}")
+        return ArtifactTargetState(
+            fingerprint=_file_fingerprint(path_stat),
+            mode=stat.S_IMODE(path_stat.st_mode),
+        )
+
+    def verify_target_state(
+        self,
+        name: str,
+        expected: ArtifactTargetState,
+    ) -> None:
+        leaf = _safe_leaf(name)
+        try:
+            path_stat = self.directory.stat(leaf)
+        except FileNotFoundError:
+            if expected.fingerprint is None:
+                return
+            raise OSError(f"Artifact disappeared: {self.directory.child_path(leaf)}")
+        path = self.directory.child_path(leaf)
+        if (
+            expected.fingerprint is None
+            or _path_is_redirected(path, path_stat)
+            or not stat.S_ISREG(path_stat.st_mode)
+            or _file_fingerprint(path_stat) != expected.fingerprint
+            or expected.mode is None
+            or not modes_match(stat.S_IMODE(path_stat.st_mode), expected.mode)
+        ):
+            raise OSError(f"Artifact changed: {path}")
+
+    def read_target_bytes(
+        self,
+        name: str,
+        expected: ArtifactTargetState,
+    ) -> bytes:
+        leaf = _safe_leaf(name)
+        if expected.fingerprint is None:
+            raise ValueError("Cannot read an absent artifact.")
+        descriptor = self.directory.open_file(leaf, os.O_RDONLY)
+        try:
+            opened_before = os.fstat(descriptor)
+            path_before = self.directory.stat(leaf)
+            if (
+                not stat.S_ISREG(opened_before.st_mode)
+                or not fingerprints_match(
+                    _file_fingerprint(opened_before),
+                    expected.fingerprint,
+                )
+                or _file_fingerprint(path_before) != expected.fingerprint
+            ):
+                raise OSError(
+                    f"Artifact changed while reading: {self.directory.child_path(leaf)}"
+                )
+            with os.fdopen(descriptor, "rb") as artifact_file:
+                descriptor = -1
+                content = artifact_file.read()
+                opened_after = os.fstat(artifact_file.fileno())
+            if not fingerprints_match(
+                _file_fingerprint(opened_after),
+                expected.fingerprint,
+            ):
+                raise OSError(
+                    f"Artifact changed while reading: {self.directory.child_path(leaf)}"
+                )
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+        self.verify_target_state(leaf, expected)
+        return content
+
+    def stage_existing(
+        self,
+        name: str,
+        expected: ArtifactTargetState,
+        *,
+        suffix: str = ".backup",
+    ) -> StagedArtifact | None:
+        leaf = _safe_leaf(name)
+        if expected.fingerprint is None:
+            return None
+        self.phase("before_backup", leaf)
+        content = self.read_target_bytes(leaf, expected)
+        self.verify_target_state(leaf, expected)
+        staged = self.stage_bytes(
+            leaf,
+            content,
+            mode=expected.mode,
+            suffix=suffix,
+            phase_name="backup_stage",
+        )
+        self.phase("after_backup", leaf)
+        return staged
+
+    def stage_bytes(
+        self,
+        target_name: str,
+        content: bytes,
+        *,
+        mode: int | None,
+        suffix: str,
+        phase_name: str = "stage",
+    ) -> StagedArtifact:
+        target_leaf = _safe_leaf(target_name)
+        self.phase(f"before_{phase_name}", target_leaf)
+        descriptor = -1
+        staged_leaf = ""
+        identity: PathIdentity | None = None
+        for _attempt in range(100):
+            staged_leaf = (
+                f".{target_leaf}.{secrets.token_hex(8)}{suffix}"
+            )
+            try:
+                descriptor = self.directory.open_file(
+                    staged_leaf,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    0o600,
+                )
+                break
+            except FileExistsError:
+                continue
+        if descriptor < 0:
+            raise OSError(
+                f"Could not stage artifact transaction file: {target_leaf}"
+            )
+        initial_stat = os.fstat(descriptor)
+        identity = (initial_stat.st_dev, initial_stat.st_ino)
+        if not stat.S_ISREG(initial_stat.st_mode) or initial_stat.st_nlink != 1:
+            os.close(descriptor)
+            descriptor = -1
+            cleanup_error = self.unlink_if_identity(staged_leaf, identity)
+            if cleanup_error is not None:
+                cleanup_error.add_note(
+                    f"Rejected artifact stage remained: {self.directory.child_path(staged_leaf)}"
+                )
+            raise OSError(
+                f"Refusing non-regular or multiply-linked artifact stage: "
+                f"{self.directory.child_path(staged_leaf)}"
+            )
+        target_mode = stat.S_IMODE(initial_stat.st_mode) if mode is None else mode
+        staging_mode = _replaceable_mode(target_mode)
+        try:
+            with os.fdopen(descriptor, "wb") as staged_file:
+                descriptor = -1
+                staged_file.write(content)
+                staged_file.flush()
+                if not modes_match(
+                    stat.S_IMODE(os.fstat(staged_file.fileno()).st_mode),
+                    staging_mode,
+                ):
+                    fchmod_candidate: object = getattr(os, "fchmod", None)
+                    if callable(fchmod_candidate):
+                        fchmod = cast(Callable[[int, int], None], fchmod_candidate)
+                        fchmod(staged_file.fileno(), staging_mode)
+                    else:
+                        self.directory.chmod_exact(
+                            staged_leaf,
+                            identity,
+                            staging_mode,
+                        )
+                os.fsync(staged_file.fileno())
+            staged_stat = self.directory.stat(staged_leaf)
+            staged_mode = stat.S_IMODE(staged_stat.st_mode)
+            if (
+                not stat.S_ISREG(staged_stat.st_mode)
+                or staged_stat.st_nlink != 1
+                or (staged_stat.st_dev, staged_stat.st_ino) != identity
+                or not modes_match(staged_mode, staging_mode)
+            ):
+                raise OSError(
+                    f"Staged artifact changed: {self.directory.child_path(staged_leaf)}"
+                )
+            staged = StagedArtifact(
+                directory_path=self.path,
+                name=staged_leaf,
+                identity=identity,
+                content=content,
+                mode=staged_mode,
+                target_mode=target_mode,
+                sha256=_sha256_bytes(content),
+            )
+            self.verify_staged(staged)
+            self.phase(f"after_{phase_name}", target_leaf)
+            return staged
+        except BaseException as error:
+            if descriptor >= 0:
+                os.close(descriptor)
+            cleanup_error = self.unlink_if_identity(staged_leaf, identity)
+            if cleanup_error is not None:
+                error.add_note(
+                    "Failed to remove incomplete artifact transaction stage: "
+                    f"{cleanup_error}"
+                )
+            raise
+
+    def read_staged(
+        self,
+        staged: StagedArtifact,
+        *,
+        name: str | None = None,
+        verify_mode: bool = True,
+    ) -> bytes:
+        selected_name = staged.name if name is None else _safe_leaf(name)
+        expected_mode = (
+            staged.mode if selected_name == staged.name else staged.target_mode
+        )
+        descriptor = self.directory.open_file(selected_name, os.O_RDONLY)
+        try:
+            opened_before = os.fstat(descriptor)
+            fingerprint_before = _file_fingerprint(opened_before)
+            if (
+                not stat.S_ISREG(opened_before.st_mode)
+                or opened_before.st_nlink != 1
+                or (opened_before.st_dev, opened_before.st_ino) != staged.identity
+                or (
+                    verify_mode
+                    and not modes_match(
+                        stat.S_IMODE(opened_before.st_mode),
+                        expected_mode,
+                    )
+                )
+            ):
+                raise OSError(
+                    f"Staged artifact changed: {self.directory.child_path(selected_name)}"
+                )
+            with os.fdopen(descriptor, "rb") as staged_file:
+                descriptor = -1
+                content = staged_file.read()
+                opened_after = os.fstat(staged_file.fileno())
+            path_after = self.directory.stat(selected_name)
+            if (
+                not stat.S_ISREG(opened_after.st_mode)
+                or opened_after.st_nlink != 1
+                or path_after.st_nlink != 1
+                or (opened_after.st_dev, opened_after.st_ino) != staged.identity
+                or (path_after.st_dev, path_after.st_ino) != staged.identity
+                or (
+                    verify_mode
+                    and not modes_match(
+                        stat.S_IMODE(opened_after.st_mode),
+                        expected_mode,
+                    )
+                )
+                or (
+                    verify_mode
+                    and not modes_match(
+                        stat.S_IMODE(path_after.st_mode),
+                        expected_mode,
+                    )
+                )
+                or not fingerprints_match(
+                    _file_fingerprint(opened_after),
+                    fingerprint_before,
+                )
+                or not fingerprints_match(
+                    _file_fingerprint(path_after),
+                    fingerprint_before,
+                )
+                or content != staged.content
+                or _sha256_bytes(content) != staged.sha256
+            ):
+                raise OSError(
+                    "Staged artifact content changed: "
+                    f"{self.directory.child_path(selected_name)}"
+                )
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+        self.directory.verify_regular_identity(selected_name, staged.identity)
+        return content
+
+    def verify_staged(
+        self,
+        staged: StagedArtifact,
+        *,
+        name: str | None = None,
+    ) -> None:
+        self.read_staged(staged, name=name)
+
+    def path_matches_stage(self, name: str, staged: StagedArtifact) -> bool:
+        try:
+            self.read_staged(staged, name=name, verify_mode=False)
+        except OSError:
+            return False
+        return True
+
+    def _make_target_replaceable(self, name: str) -> _ReplaceTarget | None:
+        leaf = _safe_leaf(name)
+        try:
+            path_stat = self.directory.stat(leaf)
+        except FileNotFoundError:
+            return None
+        path = self.directory.child_path(leaf)
+        if _path_is_redirected(path, path_stat) or not stat.S_ISREG(
+            path_stat.st_mode
+        ):
+            raise OSError(f"Refusing redirected or non-regular artifact: {path}")
+        identity = (path_stat.st_dev, path_stat.st_ino)
+        mode = stat.S_IMODE(path_stat.st_mode)
+        mode_changed = _is_windows_platform() and not mode & stat.S_IWUSR
+        if mode_changed:
+            if path_stat.st_nlink != 1:
+                raise OSError(
+                    "Refusing to change a read-only multiply-linked artifact: "
+                    f"{path}"
+                )
+            self.directory.chmod_exact(
+                leaf,
+                identity,
+                _replaceable_mode(mode),
+                require_single_link=True,
+            )
+        return _ReplaceTarget(identity=identity, mode=mode, mode_changed=mode_changed)
+
+    def _restore_replace_target_mode(
+        self,
+        name: str,
+        target: _ReplaceTarget | None,
+        error: BaseException,
+    ) -> None:
+        if target is None or not target.mode_changed:
+            return
+        try:
+            self.directory.chmod_exact(name, target.identity, target.mode)
+        except Exception as mode_error:
+            error.add_note(
+                f"Failed to restore replaced artifact target mode: {mode_error}"
+            )
+
+    def replace_staged(
+        self,
+        staged: StagedArtifact,
+        target_name: str,
+    ) -> BaseException | None:
+        target_leaf = _safe_leaf(target_name)
+        self.phase("before_commit", target_leaf)
+        self.verify_staged(staged)
+        target_state = self._make_target_replaceable(target_leaf)
+        try:
+            self.directory.chmod_exact(
+                staged.name,
+                staged.identity,
+                staged.target_mode,
+            )
+            completion_error = self.directory.replace(
+                staged.name,
+                target_leaf,
+                expected_source=staged.identity,
+                expected_destination=(
+                    None if target_state is None else target_state.identity
+                ),
+            )
+        except BaseException as error:
+            if self.path_matches_stage(target_leaf, staged):
+                return error
+            try:
+                self.directory.chmod_exact(
+                    staged.name,
+                    staged.identity,
+                    staged.mode,
+                )
+            except Exception as mode_error:
+                error.add_note(
+                    f"Failed to restore replaceable artifact stage mode: {mode_error}"
+                )
+            self._restore_replace_target_mode(target_leaf, target_state, error)
+            raise
+        if completion_error is not None:
+            return completion_error
+        try:
+            self.verify_staged(staged, name=target_leaf)
+            self.phase("after_commit", target_leaf)
+        except BaseException as error:
+            return error
+        return None
+
+    def replace_target_with_stage_path(
+        self,
+        target_name: str,
+        staged_copy: StagedArtifact,
+        displaced_target: StagedArtifact,
+    ) -> BaseException | None:
+        target_leaf = _safe_leaf(target_name)
+        self.verify_staged(staged_copy)
+        target_state = self._make_target_replaceable(target_leaf)
+        if target_state is None:
+            raise OSError(
+                f"Artifact disappeared before displacement: "
+                f"{self.directory.child_path(target_leaf)}"
+            )
+        try:
+            completion_error = self.directory.replace(
+                target_leaf,
+                staged_copy.name,
+                expected_source=target_state.identity,
+                expected_destination=staged_copy.identity,
+            )
+        except BaseException as error:
+            if self.path_matches_stage(staged_copy.name, displaced_target):
+                return error
+            self._restore_replace_target_mode(target_leaf, target_state, error)
+            raise
+        if completion_error is not None:
+            return completion_error
+        try:
+            self.verify_staged(displaced_target)
+        except BaseException as error:
+            return error
+        return None
+
+    def unlink_finalized(
+        self,
+        staged: StagedArtifact,
+        name: str,
+    ) -> tuple[StagedArtifact | None, BaseException | None]:
+        leaf = _safe_leaf(name)
+        self.verify_staged(staged, name=leaf)
+        if self.strategy == "windows_handle":
+            # Win32 has no directory-fsync equivalent for an unlink. Move the
+            # exact public inode behind a private name with write-through first;
+            # best-effort cleanup may leave only that hidden tombstone after a
+            # power loss, never resurrect the public target.
+            placeholder = self.stage_bytes(
+                leaf,
+                staged.content,
+                mode=staged.target_mode,
+                suffix=".tombstone",
+                phase_name="tombstone_stage",
+            )
+            displaced = StagedArtifact(
+                directory_path=self.path,
+                name=placeholder.name,
+                identity=staged.identity,
+                content=staged.content,
+                mode=_replaceable_mode(staged.target_mode),
+                target_mode=staged.target_mode,
+                sha256=staged.sha256,
+            )
+            try:
+                completion_error = self.replace_target_with_stage_path(
+                    leaf,
+                    placeholder,
+                    displaced,
+                )
+            except BaseException as error:
+                cleanup_error = self.unlink_staged(placeholder)
+                if cleanup_error is not None:
+                    error.add_note(
+                        "Failed to remove unused artifact tombstone stage: "
+                        f"{cleanup_error}"
+                    )
+                raise
+            return displaced, completion_error
+        target_state = self._make_target_replaceable(leaf)
+        if target_state is None:
+            return None, None
+        try:
+            completion_error = self.directory.unlink(
+                leaf,
+                expected_identity=target_state.identity,
+            )
+        except BaseException as error:
+            if not self.directory.lexists(leaf):
+                return None, error
+            self._restore_replace_target_mode(leaf, target_state, error)
+            raise
+        if completion_error is not None:
+            return None, completion_error
+        if self.directory.lexists(leaf):
+            error = OSError(
+                f"Artifact remained after unlink: {self.directory.child_path(leaf)}"
+            )
+            return None, error
+        return None, None
+
+    def unlink_staged(self, staged: StagedArtifact) -> Exception | None:
+        try:
+            self.verify_staged(staged)
+            completion_error = self.directory.unlink(
+                staged.name,
+                expected_identity=staged.identity,
+            )
+            if completion_error is not None:
+                raise completion_error
+        except Exception as error:
+            return error
+        return None
+
+    def unlink_if_identity(
+        self,
+        name: str,
+        identity: PathIdentity | None,
+    ) -> Exception | None:
+        if identity is None:
+            return None
+        try:
+            self.directory.verify_regular_identity(name, identity)
+            completion_error = self.directory.unlink(
+                name,
+                expected_identity=identity,
+            )
+            if completion_error is not None:
+                raise completion_error
+        except Exception as error:
+            return error
+        return None
+
+    def cleanup(
+        self,
+        temporary_files: dict[str, StagedArtifact],
+    ) -> list[Exception]:
+        self.phase("before_cleanup", None)
+        errors: list[Exception] = []
+        removed = False
+        for temporary_name, staged in tuple(temporary_files.items()):
+            try:
+                if not self.directory.lexists(temporary_name):
+                    temporary_files.pop(temporary_name, None)
+                    continue
+                self.verify_staged(staged)
+                completion_error = self.directory.unlink(
+                    temporary_name,
+                    expected_identity=staged.identity,
+                )
+                temporary_files.pop(temporary_name, None)
+                removed = True
+                if completion_error is not None:
+                    raise completion_error
+            except Exception as error:
+                errors.append(error)
+        if removed:
+            try:
+                self.sync("cleanup_durability")
+            except Exception as error:
+                errors.append(error)
+        self.phase("after_cleanup", None)
+        return errors
+
+    def sync(self, phase: str = "durability") -> None:
+        self.phase(f"before_{phase}", None)
+        self.directory.sync()
+        self.anchored.root.verify_path()
+        self.phase(f"after_{phase}", None)
+
+    def receipt(self, name: str, staged: StagedArtifact) -> ArtifactReceipt:
+        leaf = _safe_leaf(name)
+        self.verify_staged(staged, name=leaf)
+        path_stat = self.directory.stat(leaf)
+        return ArtifactReceipt(
+            path=self.directory.child_path(leaf),
+            content=staged.content,
+            mode=stat.S_IMODE(path_stat.st_mode),
+            fingerprint=_stable_fingerprint(_file_fingerprint(path_stat)),
+            sha256=staged.sha256,
+        )
+
+    def verify_receipt(self, receipt: ArtifactReceipt) -> None:
+        expected_parent = os.path.normcase(os.path.abspath(self.path))
+        receipt_parent = os.path.normcase(os.path.abspath(os.path.dirname(receipt.path)))
+        if receipt_parent != expected_parent:
+            raise ValueError("Artifact receipt belongs to another directory.")
+        leaf = _safe_leaf(os.path.basename(receipt.path))
+        state = self.target_state(leaf)
+        if (
+            state.fingerprint is None
+            or _stable_fingerprint(state.fingerprint) != receipt.fingerprint
+            or state.mode is None
+            or not modes_match(state.mode, receipt.mode)
+            or _sha256_bytes(receipt.content) != receipt.sha256
+        ):
+            raise OSError(f"Artifact no longer matches its receipt: {receipt.path}")
+        content = self.read_target_bytes(leaf, state)
+        if content != receipt.content or _sha256_bytes(content) != receipt.sha256:
+            raise OSError(f"Artifact no longer matches its receipt: {receipt.path}")
+
+    def capture_snapshot(self, name: str) -> ArtifactSnapshot:
+        leaf = _safe_leaf(name)
+        state = self.target_state(leaf)
+        if state.fingerprint is None:
+            self.verify_directory()
+            self.verify_target_state(leaf, state)
+            return ArtifactSnapshot(
+                name=leaf,
+                content=None,
+                mode=None,
+                fingerprint=None,
+                sha256=None,
+            )
+        content = self.read_target_bytes(leaf, state)
+        return ArtifactSnapshot(
+            name=leaf,
+            content=content,
+            mode=state.mode,
+            fingerprint=state.fingerprint,
+            sha256=_sha256_bytes(content),
+        )
+
+    def capture_snapshots(
+        self,
+        names: tuple[str, ...],
+    ) -> tuple[ArtifactSnapshot, ...]:
+        self._validate_unique_names(names)
+        return tuple(self.capture_snapshot(name) for name in names)
+
+    def _verify_snapshot_current(self, snapshot: ArtifactSnapshot) -> None:
+        state = self._snapshot_state(snapshot)
+        self.verify_target_state(snapshot.name, state)
+        if not snapshot.present:
+            return
+        assert snapshot.content is not None
+        assert snapshot.sha256 is not None
+        content = self.read_target_bytes(snapshot.name, state)
+        if content != snapshot.content or _sha256_bytes(content) != snapshot.sha256:
+            raise OSError(
+                "Artifact content changed: "
+                f"{self.directory.child_path(snapshot.name)}"
+            )
+
+    def publish_specs(
+        self,
+        specs: tuple[ArtifactSpec, ...],
+    ) -> tuple[ArtifactReceipt | None, ...]:
+        """Publish an ordered present/absent set with reverse rollback."""
+        self._validate_unique_names(tuple(spec.name for spec in specs))
+        normalized_specs = tuple(
+            ArtifactSpec(
+                name=_safe_leaf(spec.name),
+                content=spec.content,
+                mode=spec.mode,
+            )
+            for spec in specs
+        )
+        snapshots = self.capture_snapshots(
+            tuple(spec.name for spec in normalized_specs)
+        )
+        desired_stages: dict[str, StagedArtifact | None] = {}
+        backups: dict[str, StagedArtifact | None] = {}
+        temporary_files: dict[str, StagedArtifact] = {}
+        active_error: BaseException | None = None
+        mutations: list[_PublishedMutation] = []
+        try:
+            for spec, snapshot in zip(normalized_specs, snapshots, strict=True):
+                desired = None
+                if spec.content is not None:
+                    desired = self.stage_bytes(
+                        spec.name,
+                        spec.content,
+                        mode=snapshot.mode if spec.mode is None else spec.mode,
+                        suffix=".tmp",
+                    )
+                    temporary_files[desired.name] = desired
+                desired_stages[spec.name] = desired
+            for spec, snapshot in zip(normalized_specs, snapshots, strict=True):
+                backup = self.stage_existing(
+                    spec.name,
+                    self._snapshot_state(snapshot),
+                )
+                backups[spec.name] = backup
+                if backup is not None:
+                    temporary_files[backup.name] = backup
+                if snapshot.present and (
+                    backup is None
+                    or backup.content != snapshot.content
+                    or backup.sha256 != snapshot.sha256
+                ):
+                    raise OSError(
+                        "Artifact backup no longer matches its snapshot: "
+                        f"{self.directory.child_path(snapshot.name)}"
+                    )
+                self._verify_snapshot_current(snapshot)
+
+            self.verify_directory()
+            for snapshot in snapshots:
+                self._verify_snapshot_current(snapshot)
+
+            for spec, snapshot in zip(normalized_specs, snapshots, strict=True):
+                desired = desired_stages[spec.name]
+                backup = backups[spec.name]
+                # Earlier ordered commits and their durability barriers can
+                # give another writer time to change a later target. Never
+                # overwrite that external state from the stale preflight.
+                self._verify_snapshot_current(snapshot)
+                mutation_started = False
+                completion_error: BaseException | None = None
+                if desired is not None:
+                    completion_error = self.replace_staged(desired, spec.name)
+                    mutation_started = True
+                    temporary_files.pop(desired.name, None)
+                elif snapshot.present:
+                    published_previous = self._snapshot_as_staged(
+                        snapshot,
+                        name=spec.name,
+                        storage_mode=cast(int, snapshot.mode),
+                    )
+                    tombstone, completion_error = self.unlink_finalized(
+                        published_previous,
+                        spec.name,
+                    )
+                    if tombstone is not None:
+                        temporary_files[tombstone.name] = tombstone
+                    mutation_started = True
+                if mutation_started:
+                    mutations.append(_PublishedMutation(snapshot, desired, backup))
+                    if completion_error is not None:
+                        raise completion_error
+                    self.phase("before_durability", spec.name)
+                    self.sync(f"commit_{spec.name}_durability")
+                    self.phase("after_durability", spec.name)
+
+            receipts = tuple(
+                None
+                if desired_stages[spec.name] is None
+                else self.receipt(spec.name, cast(StagedArtifact, desired_stages[spec.name]))
+                for spec in normalized_specs
+            )
+        except BaseException as error:
+            active_error = error
+            if mutations:
+                rollback_error = self._rollback_published_mutations(
+                    mutations,
+                    temporary_files,
+                )
+                if rollback_error is not None:
+                    error.add_note(f"Artifact publication rollback also failed: {rollback_error}")
+            raise
+        finally:
+            cleanup_errors = self.cleanup(temporary_files)
+            if active_error is not None and cleanup_errors:
+                active_error.add_note(
+                    "Artifact publication cleanup failed: "
+                    + "; ".join(str(error) for error in cleanup_errors)
+                )
+
+        self.verify_directory()
+        for spec, receipt in zip(normalized_specs, receipts, strict=True):
+            if receipt is None:
+                if self.directory.lexists(spec.name):
+                    raise OSError(
+                        f"Absent artifact reappeared after publication: {spec.name}"
+                    )
+            else:
+                self.verify_receipt(receipt)
+        return receipts
+
+    def restore_snapshots(
+        self,
+        snapshots: tuple[ArtifactSnapshot, ...],
+        receipts: tuple[ArtifactReceipt | None, ...],
+    ) -> None:
+        """Restore ordered snapshots while exact publication receipts remain live."""
+        if len(snapshots) != len(receipts):
+            raise ValueError("Artifact snapshots and receipts must have equal lengths.")
+        self._validate_unique_names(tuple(snapshot.name for snapshot in snapshots))
+        for snapshot in snapshots:
+            self._validate_snapshot(snapshot)
+        for snapshot, receipt in zip(snapshots, receipts, strict=True):
+            if receipt is None:
+                self.verify_target_state(
+                    snapshot.name,
+                    ArtifactTargetState(fingerprint=None, mode=None),
+                )
+            else:
+                if os.path.basename(receipt.path) != snapshot.name:
+                    raise ValueError("Artifact receipt belongs to another snapshot.")
+                self.verify_receipt(receipt)
+
+        receipt_copies: dict[str, StagedArtifact | None] = {}
+        restored_stages: dict[str, StagedArtifact | None] = {}
+        temporary_files: dict[str, StagedArtifact] = {}
+        mutations: list[_RestoreMutation] = []
+        active_error: BaseException | None = None
+        try:
+            for snapshot, receipt in zip(snapshots, receipts, strict=True):
+                receipt_copy = None
+                if receipt is not None:
+                    receipt_copy = self.stage_bytes(
+                        snapshot.name,
+                        receipt.content,
+                        mode=receipt.mode,
+                        suffix=".restore.backup",
+                    )
+                    temporary_files[receipt_copy.name] = receipt_copy
+                receipt_copies[snapshot.name] = receipt_copy
+
+                restored = None
+                if snapshot.present:
+                    assert snapshot.content is not None
+                    assert snapshot.mode is not None
+                    restored = self.stage_bytes(
+                        snapshot.name,
+                        snapshot.content,
+                        mode=snapshot.mode,
+                        suffix=".restore.tmp",
+                    )
+                    temporary_files[restored.name] = restored
+                restored_stages[snapshot.name] = restored
+
+            # Staging can run arbitrary filesystem work and is deliberately
+            # observable through the phase hook. Recheck every publication
+            # receipt immediately before the first namespace mutation so a
+            # target changed during preparation is left completely untouched.
+            self.verify_directory()
+            for snapshot, receipt in zip(snapshots, receipts, strict=True):
+                if receipt is None:
+                    self.verify_target_state(
+                        snapshot.name,
+                        ArtifactTargetState(fingerprint=None, mode=None),
+                    )
+                else:
+                    self.verify_receipt(receipt)
+
+            for snapshot, receipt in zip(snapshots, receipts, strict=True):
+                restored = restored_stages[snapshot.name]
+                receipt_copy = receipt_copies[snapshot.name]
+                # Preserve exact optimistic-concurrency semantics for every
+                # ordered entry, not only for the set-wide preflight.
+                if receipt is None:
+                    self.verify_target_state(
+                        snapshot.name,
+                        ArtifactTargetState(fingerprint=None, mode=None),
+                    )
+                else:
+                    self.verify_receipt(receipt)
+                displaced_receipt: StagedArtifact | None = None
+                mutation_started = False
+                recorded_mutation: _RestoreMutation | None = None
+                if receipt is not None:
+                    assert receipt_copy is not None
+                    displaced_receipt = self._receipt_as_staged(
+                        receipt,
+                        name=receipt_copy.name,
+                        storage_mode=receipt_copy.mode,
+                    )
+                    completion_error = self.replace_target_with_stage_path(
+                        snapshot.name,
+                        receipt_copy,
+                        displaced_receipt,
+                    )
+                    mutation_started = True
+                    temporary_files[displaced_receipt.name] = displaced_receipt
+                    recorded_mutation = _RestoreMutation(
+                        snapshot,
+                        receipt,
+                        restored,
+                        displaced_receipt,
+                        False,
+                    )
+                    mutations.append(recorded_mutation)
+                    if completion_error is not None:
+                        raise completion_error
+                if restored is not None:
+                    completion_error = self.replace_staged(restored, snapshot.name)
+                    mutation_started = True
+                    temporary_files.pop(restored.name, None)
+                    if recorded_mutation is None:
+                        recorded_mutation = _RestoreMutation(
+                            snapshot,
+                            receipt,
+                            restored,
+                            displaced_receipt,
+                            True,
+                        )
+                        mutations.append(recorded_mutation)
+                    else:
+                        recorded_mutation.restored_committed = True
+                    if completion_error is not None:
+                        raise completion_error
+                if mutation_started:
+                    self.phase("before_durability", snapshot.name)
+                    self.sync(f"restore_{snapshot.name}_durability")
+                    self.phase("after_durability", snapshot.name)
+                self._verify_restored_snapshot(snapshot, restored)
+        except BaseException as error:
+            active_error = error
+            if mutations:
+                rollback_error = self._rollback_restore_mutations(
+                    mutations,
+                    temporary_files,
+                )
+                if rollback_error is not None:
+                    error.add_note(f"Artifact snapshot rollback also failed: {rollback_error}")
+            raise
+        finally:
+            cleanup_errors = self.cleanup(temporary_files)
+            if active_error is not None and cleanup_errors:
+                active_error.add_note(
+                    "Artifact restore cleanup failed: "
+                    + "; ".join(str(error) for error in cleanup_errors)
+                )
+
+        self.verify_directory()
+        for snapshot in snapshots:
+            self._verify_restored_snapshot(
+                snapshot,
+                restored_stages[snapshot.name],
+            )
+
+    def _rollback_published_mutations(
+        self,
+        mutations: list[_PublishedMutation],
+        temporary_files: dict[str, StagedArtifact],
+    ) -> Exception | None:
+        errors: list[BaseException] = []
+        retained_paths: list[str] = []
+        try:
+            self.phase("before_rollback", None)
+        except BaseException as error:
+            errors.append(error)
+        for mutation in reversed(mutations):
+            name = mutation.snapshot.name
+            backup = mutation.backup
+            desired = mutation.desired
+            recovery: StagedArtifact | None = None
+            try:
+                if desired is not None:
+                    self.verify_staged(desired, name=name)
+                elif self.directory.lexists(name):
+                    raise OSError(f"Absent artifact changed before rollback: {name}")
+                if backup is None:
+                    assert desired is not None
+                    tombstone, completion_error = self.unlink_finalized(
+                        desired,
+                        name,
+                    )
+                    if tombstone is not None:
+                        temporary_files[tombstone.name] = tombstone
+                    if completion_error is not None:
+                        raise completion_error
+                else:
+                    recovery = self.stage_bytes(
+                        name,
+                        backup.content,
+                        mode=backup.target_mode,
+                        suffix=".recovery.backup",
+                    )
+                    temporary_files[recovery.name] = recovery
+                    completion_error = self.replace_staged(backup, name)
+                    temporary_files.pop(backup.name, None)
+                    if completion_error is not None:
+                        raise completion_error
+                self.sync(f"rollback_{name}_durability")
+                self._verify_snapshot_restored(mutation.snapshot, backup)
+                if recovery is not None:
+                    cleanup_error = self.unlink_staged(recovery)
+                    if cleanup_error is None:
+                        temporary_files.pop(recovery.name, None)
+                        self.sync(f"recovery_{name}_cleanup_durability")
+            except BaseException as error:
+                errors.append(error)
+                try:
+                    retained = self._retain_recovery(
+                        (recovery, backup),
+                        temporary_files,
+                    )
+                    if retained is not None:
+                        retained_paths.append(retained)
+                except BaseException as retention_error:
+                    errors.append(retention_error)
+        try:
+            self.phase("after_rollback", None)
+        except BaseException as error:
+            errors.append(error)
+        return self._combined_rollback_error(errors, retained_paths)
+
+    def _rollback_restore_mutations(
+        self,
+        mutations: list[_RestoreMutation],
+        temporary_files: dict[str, StagedArtifact],
+    ) -> Exception | None:
+        errors: list[BaseException] = []
+        retained_paths: list[str] = []
+        try:
+            self.phase("before_rollback", None)
+        except BaseException as error:
+            errors.append(error)
+        for mutation in reversed(mutations):
+            name = mutation.snapshot.name
+            recovery: StagedArtifact | None = None
+            try:
+                if mutation.restored_committed:
+                    self._verify_restored_snapshot(
+                        mutation.snapshot,
+                        mutation.restored,
+                    )
+                elif self.directory.lexists(name):
+                    raise OSError(
+                        f"Artifact changed after receipt displacement: {name}"
+                    )
+                if mutation.receipt is None:
+                    if mutation.restored is not None:
+                        tombstone, completion_error = self.unlink_finalized(
+                            mutation.restored,
+                            name,
+                        )
+                        if tombstone is not None:
+                            temporary_files[tombstone.name] = tombstone
+                        if completion_error is not None:
+                            raise completion_error
+                else:
+                    receipt_backup = mutation.receipt_backup
+                    if receipt_backup is None:
+                        raise OSError(f"Artifact receipt backup disappeared: {name}")
+                    recovery = self.stage_bytes(
+                        name,
+                        receipt_backup.content,
+                        mode=receipt_backup.target_mode,
+                        suffix=".recovery.backup",
+                    )
+                    temporary_files[recovery.name] = recovery
+                    completion_error = self.replace_staged(receipt_backup, name)
+                    temporary_files.pop(receipt_backup.name, None)
+                    if completion_error is not None:
+                        raise completion_error
+                self.sync(f"restore_rollback_{name}_durability")
+                if mutation.receipt is None:
+                    if self.directory.lexists(name):
+                        raise OSError(f"Absent receipt reappeared: {name}")
+                else:
+                    self.verify_receipt(mutation.receipt)
+                if recovery is not None:
+                    cleanup_error = self.unlink_staged(recovery)
+                    if cleanup_error is None:
+                        temporary_files.pop(recovery.name, None)
+                        self.sync(f"restore_recovery_{name}_cleanup_durability")
+            except BaseException as error:
+                errors.append(error)
+                try:
+                    retained = self._retain_recovery(
+                        (mutation.receipt_backup, recovery),
+                        temporary_files,
+                    )
+                    if retained is not None:
+                        retained_paths.append(retained)
+                except BaseException as retention_error:
+                    errors.append(retention_error)
+        try:
+            self.phase("after_rollback", None)
+        except BaseException as error:
+            errors.append(error)
+        return self._combined_rollback_error(errors, retained_paths)
+
+    @staticmethod
+    def _combined_rollback_error(
+        errors: list[BaseException],
+        retained_paths: list[str],
+    ) -> Exception | None:
+        if not errors:
+            return None
+        details = "; ".join(str(error) for error in errors)
+        if retained_paths:
+            details += "; verified recovery artifact preserved at: " + ", ".join(
+                retained_paths
+            )
+        wrapped = OSError(details)
+        wrapped.__cause__ = errors[0]
+        for additional_error in errors[1:]:
+            wrapped.add_note(f"Additional rollback failure: {additional_error}")
+        return wrapped
+
+    def _retain_recovery(
+        self,
+        candidates: tuple[StagedArtifact | None, ...],
+        temporary_files: dict[str, StagedArtifact],
+    ) -> str | None:
+        for candidate in candidates:
+            if candidate is None:
+                continue
+            try:
+                self.verify_staged(candidate)
+            except OSError:
+                continue
+            temporary_files.pop(candidate.name, None)
+            current_directory = self.anchored.current_directory_path()
+            if current_directory is not None:
+                return os.path.join(current_directory, candidate.name)
+            return (
+                f"{candidate.name!r} in retained directory identity "
+                f"{self.directory.identity!r}; original path {self.path!r} changed"
+            )
+        return None
+
+    def _verify_restored_snapshot(
+        self,
+        snapshot: ArtifactSnapshot,
+        restored: StagedArtifact | None,
+    ) -> None:
+        if not snapshot.present:
+            if self.directory.lexists(snapshot.name):
+                raise OSError(f"Artifact should have been absent: {snapshot.name}")
+            return
+        if restored is None:
+            raise ValueError("A present snapshot requires a staged artifact.")
+        self.verify_staged(restored, name=snapshot.name)
+
+    def _verify_snapshot_restored(
+        self,
+        snapshot: ArtifactSnapshot,
+        backup: StagedArtifact | None,
+    ) -> None:
+        if not snapshot.present:
+            if self.directory.lexists(snapshot.name):
+                raise OSError(f"Artifact should have rolled back to absence: {snapshot.name}")
+            return
+        if backup is None:
+            raise OSError(f"Artifact rollback backup disappeared: {snapshot.name}")
+        self.verify_staged(backup, name=snapshot.name)
+
+    def _snapshot_as_staged(
+        self,
+        snapshot: ArtifactSnapshot,
+        *,
+        name: str,
+        storage_mode: int,
+    ) -> StagedArtifact:
+        if (
+            snapshot.content is None
+            or snapshot.mode is None
+            or snapshot.fingerprint is None
+            or snapshot.sha256 is None
+        ):
+            raise ValueError("A present artifact snapshot is incomplete.")
+        return StagedArtifact(
+            directory_path=self.path,
+            name=_safe_leaf(name),
+            identity=(snapshot.fingerprint[0], snapshot.fingerprint[1]),
+            content=snapshot.content,
+            mode=storage_mode,
+            target_mode=snapshot.mode,
+            sha256=snapshot.sha256,
+        )
+
+    def _receipt_as_staged(
+        self,
+        receipt: ArtifactReceipt,
+        *,
+        name: str,
+        storage_mode: int,
+    ) -> StagedArtifact:
+        return StagedArtifact(
+            directory_path=self.path,
+            name=_safe_leaf(name),
+            identity=(receipt.fingerprint[0], receipt.fingerprint[1]),
+            content=receipt.content,
+            mode=storage_mode,
+            target_mode=receipt.mode,
+            sha256=receipt.sha256,
+        )
+
+    @staticmethod
+    def _snapshot_state(snapshot: ArtifactSnapshot) -> ArtifactTargetState:
+        return ArtifactTargetState(
+            fingerprint=snapshot.fingerprint,
+            mode=snapshot.mode,
+        )
+
+    @staticmethod
+    def _validate_snapshot(snapshot: ArtifactSnapshot) -> None:
+        _safe_leaf(snapshot.name)
+        if snapshot.present:
+            if (
+                snapshot.content is None
+                or snapshot.mode is None
+                or snapshot.sha256 is None
+            ):
+                raise ValueError("A present artifact snapshot is incomplete.")
+            assert snapshot.fingerprint is not None
+            if (
+                len(snapshot.content) != snapshot.fingerprint[2]
+                or _sha256_bytes(snapshot.content) != snapshot.sha256
+            ):
+                raise ValueError("Artifact snapshot content does not match its fingerprint.")
+            return
+        if (
+            snapshot.content is not None
+            or snapshot.mode is not None
+            or snapshot.sha256 is not None
+        ):
+            raise ValueError("An absent artifact snapshot cannot contain file data.")
+
+    @staticmethod
+    def _validate_unique_names(names: tuple[str, ...]) -> None:
+        normalized = tuple(_safe_leaf(name) for name in names)
+        comparison_names = (
+            tuple(name.casefold() for name in normalized)
+            if os.name == "nt"
+            else normalized
+        )
+        if len(set(comparison_names)) != len(comparison_names):
+            raise ValueError("Artifact transaction names must be unique.")
+
+
+def artifact_sha256(content: bytes) -> str:
+    return _sha256_bytes(content)
+
+
+def stable_artifact_fingerprint(
+    fingerprint: FileFingerprint,
+) -> ReceiptFingerprint:
+    return _stable_fingerprint(fingerprint)
+
+
+__all__ = [
+    "AnchoredArtifactDirectory",
+    "ArtifactReceipt",
+    "ArtifactSnapshot",
+    "ArtifactSpec",
+    "ArtifactTargetState",
+    "ByteArtifactTransaction",
+    "DirectoryStrategy",
+    "FileFingerprint",
+    "PathIdentity",
+    "ReceiptFingerprint",
+    "StagedArtifact",
+    "VerifiedDirectory",
+    "artifact_sha256",
+    "fingerprints_match",
+    "modes_match",
+    "stable_artifact_fingerprint",
+]

--- a/src/conversion/architecture_policy.py
+++ b/src/conversion/architecture_policy.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import re
-import stat
-import tempfile
 from dataclasses import dataclass
-from typing import Callable, Iterable, TypeAlias, cast
+from typing import Iterable, TypeAlias, cast
 
+from src.conversion.anchored_artifacts import (
+    ArtifactReceipt,
+    ArtifactSnapshot,
+    ArtifactSpec,
+    ByteArtifactTransaction,
+    artifact_sha256,
+)
 from src.conversion.resource_index import GameMakerResourceIndex, IndexedRoom
 from src.conversion.runtime_managers import runtime_manager_definitions
 from src.conversion.project_source_paths import (
@@ -19,6 +23,8 @@ from src.conversion.type_defs import JsonDict
 
 ARCHITECTURE_POLICY_RELATIVE_PATH = os.path.join("gm2godot", "architecture_policy.json")
 ARCHITECTURE_POLICY_VERSION = 1
+_ARCHITECTURE_POLICY_DIRECTORY = os.path.dirname(ARCHITECTURE_POLICY_RELATIVE_PATH)
+_ARCHITECTURE_POLICY_FILENAME = os.path.basename(ARCHITECTURE_POLICY_RELATIVE_PATH)
 
 ROOM_ROOT_POLICY_ID = "gm_room_node2d"
 LAYER_HIERARCHY_POLICY_ID = "gm_layer_depth_node2d"
@@ -44,7 +50,6 @@ _BUFFER_FILE_RE = re.compile(r"\b(buffer_|file_|ini_|json_)", re.IGNORECASE)
 
 FileFingerprint: TypeAlias = tuple[int, int, int, int, int]
 ReceiptFingerprint: TypeAlias = tuple[int, int, int, int]
-PathIdentity: TypeAlias = tuple[int, int]
 
 
 @dataclass(frozen=True)
@@ -69,32 +74,6 @@ class ArchitecturePolicyPublicationReceipt:
     content: bytes
     mode: int
     fingerprint: ReceiptFingerprint
-    sha256: str
-
-
-@dataclass(frozen=True)
-class _PolicyTargetState:
-    fingerprint: FileFingerprint | None
-    mode: int | None
-
-
-@dataclass(frozen=True)
-class _PolicyReplaceTarget:
-    identity: PathIdentity
-    mode: int
-    mode_changed: bool
-
-
-@dataclass(frozen=True)
-class _StagedPolicyFile:
-    path: str
-    identity: PathIdentity
-    content: bytes
-    # Temporary files remain replaceable on Windows even when the destination
-    # is read-only. ``mode`` describes the temporary inode while
-    # ``target_mode`` is applied immediately before its final replacement.
-    mode: int
-    target_mode: int
     sha256: str
 
 
@@ -171,92 +150,42 @@ def publish_architecture_policy_report(
     )
     content = (json.dumps(report, indent=2, sort_keys=True) + "\n").encode("utf-8")
     report_path = os.path.join(godot_project_path, ARCHITECTURE_POLICY_RELATIVE_PATH)
-    artifact_directory, initial_root_identity, initial_directory_identity = (
-        _inspect_policy_directory(godot_project_path)
-    )
-    initial_state = (
-        _policy_target_state(report_path)
-        if initial_directory_identity is not None
-        else _PolicyTargetState(fingerprint=None, mode=None)
-    )
-    prepared_directory, root_identity, directory_identity = _prepare_policy_directory(
-        godot_project_path
-    )
-    if (
-        prepared_directory != artifact_directory
-        or root_identity != initial_root_identity
-        or (
-            initial_directory_identity is not None
-            and directory_identity != initial_directory_identity
-        )
-    ):
-        raise OSError("Architecture-policy report directory changed before publication.")
-    _verify_policy_directory(
+    with ByteArtifactTransaction.open(
         godot_project_path,
-        root_identity,
-        artifact_directory,
-        directory_identity,
-    )
-    _verify_policy_target_state(report_path, initial_state)
-    return _publish_policy_content(
-        report_path,
-        content,
-        initial_state,
-        godot_project_path=godot_project_path,
-        root_identity=root_identity,
-        artifact_directory=artifact_directory,
-        directory_identity=directory_identity,
-    )
+        _ARCHITECTURE_POLICY_DIRECTORY,
+        create=True,
+        description="architecture-policy report directory",
+    ) as transaction:
+        receipts = transaction.publish_specs(
+            (ArtifactSpec(_ARCHITECTURE_POLICY_FILENAME, content),)
+        )
+        core_receipt = receipts[0]
+        if core_receipt is None:
+            raise OSError("Architecture-policy publication produced no receipt.")
+        return _architecture_receipt(core_receipt, path=report_path)
 
 
 def capture_architecture_policy_snapshot(
     godot_project_path: str,
 ) -> ArchitecturePolicySnapshot:
     """Capture exact report bytes, mode, and fingerprint without following links."""
-    report_path = os.path.join(godot_project_path, ARCHITECTURE_POLICY_RELATIVE_PATH)
-    artifact_directory, root_identity, directory_identity = _inspect_policy_directory(
-        godot_project_path
-    )
-    if directory_identity is None:
-        _verify_directory_path(
-            godot_project_path,
-            root_identity,
-            description="architecture-policy report root",
-        )
-        return ArchitecturePolicySnapshot(
-            content=None,
-            mode=None,
-            fingerprint=None,
-            sha256=None,
-        )
-    _verify_policy_directory(
+    with ByteArtifactTransaction.open(
         godot_project_path,
-        root_identity,
-        artifact_directory,
-        directory_identity,
-    )
-    state = _policy_target_state(report_path)
-    if state.fingerprint is None:
-        _verify_policy_directory(
-            godot_project_path,
-            root_identity,
-            artifact_directory,
-            directory_identity,
+        _ARCHITECTURE_POLICY_DIRECTORY,
+        create=False,
+        description="architecture-policy report directory",
+    ) as transaction:
+        if not transaction.available:
+            transaction.verify_directory()
+            return ArchitecturePolicySnapshot(
+                content=None,
+                mode=None,
+                fingerprint=None,
+                sha256=None,
+            )
+        return _architecture_snapshot(
+            transaction.capture_snapshot(_ARCHITECTURE_POLICY_FILENAME)
         )
-        _verify_policy_target_state(report_path, state)
-        return ArchitecturePolicySnapshot(
-            content=None,
-            mode=None,
-            fingerprint=None,
-            sha256=None,
-        )
-    content = _read_policy_target_bytes(report_path, state)
-    return ArchitecturePolicySnapshot(
-        content=content,
-        mode=state.mode,
-        fingerprint=state.fingerprint,
-        sha256=_sha256_bytes(content),
-    )
 
 
 def restore_architecture_policy_snapshot(
@@ -269,973 +198,80 @@ def restore_architecture_policy_snapshot(
     report_path = os.path.join(godot_project_path, ARCHITECTURE_POLICY_RELATIVE_PATH)
     if os.path.abspath(receipt.path) != os.path.abspath(report_path):
         raise ValueError("Architecture-policy publication receipt belongs to another path.")
-    artifact_directory, root_identity, directory_identity = _inspect_policy_directory(
-        godot_project_path
-    )
-    if directory_identity is None:
-        raise OSError("Architecture-policy report directory disappeared before restore.")
-    _verify_policy_directory(
+    with ByteArtifactTransaction.open(
         godot_project_path,
-        root_identity,
-        artifact_directory,
-        directory_identity,
-    )
-    _verify_policy_receipt(receipt)
-
-    restored_stage: _StagedPolicyFile | None = None
-    receipt_backup = _stage_policy_bytes(
-        report_path,
-        receipt.content,
-        mode=receipt.mode,
-        suffix=".restore.backup",
-    )
-    temporary_files: dict[str, _StagedPolicyFile] = {
-        receipt_backup.path: receipt_backup,
-    }
-    try:
-        if snapshot.present:
-            assert snapshot.content is not None
-            assert snapshot.mode is not None
-            restored_stage = _stage_policy_bytes(
-                report_path,
-                snapshot.content,
-                mode=snapshot.mode,
-                suffix=".restore.tmp",
-            )
-            temporary_files[restored_stage.path] = restored_stage
-    except BaseException as error:
-        cleanup_errors = _cleanup_policy_temporary_files(
-            temporary_files,
-            godot_project_path=godot_project_path,
-            root_identity=root_identity,
-            artifact_directory=artifact_directory,
-            directory_identity=directory_identity,
-        )
-        if cleanup_errors:
-            error.add_note(
-                "Architecture-policy restore preparation cleanup failed: "
-                + "; ".join(str(cleanup_error) for cleanup_error in cleanup_errors)
-            )
-        raise
-
-    displaced_receipt = _receipt_as_staged_file(
-        receipt,
-        path=receipt_backup.path,
-        storage_mode=receipt_backup.mode,
-    )
-    mutation_completed = False
-    active_error: BaseException | None = None
-    try:
-        _verify_policy_directory(
-            godot_project_path,
-            root_identity,
-            artifact_directory,
-            directory_identity,
-        )
-        _verify_policy_receipt(receipt)
-        try:
-            _replace_published_receipt_with_backup(
-                receipt,
-                receipt_backup,
-                displaced_receipt,
-            )
-            receipt_backup = displaced_receipt
-            temporary_files[receipt_backup.path] = receipt_backup
-            mutation_completed = True
-        except BaseException:
-            if _policy_path_matches_stage(
-                displaced_receipt.path,
-                displaced_receipt,
-            ):
-                receipt_backup = displaced_receipt
-                temporary_files[receipt_backup.path] = receipt_backup
-                mutation_completed = True
-            raise
-        if restored_stage is not None:
-            mutation_completed = _replace_staged_policy_file(
-                restored_stage,
-                report_path,
-            )
-            if mutation_completed:
-                temporary_files.pop(restored_stage.path, None)
-        _fsync_policy_directory(
-            godot_project_path,
-            root_identity,
-            artifact_directory,
-            directory_identity,
-        )
-        _verify_restored_snapshot(report_path, snapshot, restored_stage)
-    except BaseException as error:
-        active_error = error
-        if (
-            not mutation_completed
-            and restored_stage is not None
-            and _policy_path_matches_stage(report_path, restored_stage)
-        ):
-            mutation_completed = True
-            temporary_files.pop(restored_stage.path, None)
-        if mutation_completed:
-            rollback_error = _rollback_restore(
-                report_path,
-                snapshot,
-                restored_stage,
-                receipt_backup,
-                receipt,
-                temporary_files,
-                godot_project_path=godot_project_path,
-                root_identity=root_identity,
-                artifact_directory=artifact_directory,
-                directory_identity=directory_identity,
-            )
-            if rollback_error is not None:
-                error.add_note(
-                    "Architecture-policy snapshot restore rollback also failed: "
-                    f"{rollback_error}"
-                )
-        raise
-    finally:
-        cleanup_errors = _cleanup_policy_temporary_files(
-            temporary_files,
-            godot_project_path=godot_project_path,
-            root_identity=root_identity,
-            artifact_directory=artifact_directory,
-            directory_identity=directory_identity,
-        )
-        if active_error is not None and cleanup_errors:
-            active_error.add_note(
-                "Architecture-policy restore cleanup failed: "
-                + "; ".join(str(error) for error in cleanup_errors)
-            )
-
-    _verify_policy_directory(
-        godot_project_path,
-        root_identity,
-        artifact_directory,
-        directory_identity,
-    )
-    _verify_restored_snapshot(report_path, snapshot, restored_stage)
-    return report_path
-
-
-def _publish_policy_content(
-    report_path: str,
-    content: bytes,
-    initial_state: _PolicyTargetState,
-    *,
-    godot_project_path: str,
-    root_identity: PathIdentity,
-    artifact_directory: str,
-    directory_identity: PathIdentity,
-) -> ArchitecturePolicyPublicationReceipt:
-    staged = _stage_policy_bytes(
-        report_path,
-        content,
-        mode=initial_state.mode,
-        suffix=".tmp",
-    )
-    temporary_files: dict[str, _StagedPolicyFile] = {staged.path: staged}
-    backup: _StagedPolicyFile | None = None
-    publication_completed = False
-    active_error: BaseException | None = None
-    try:
-        backup = _stage_existing_policy_file(report_path, initial_state)
-        if backup is not None:
-            temporary_files[backup.path] = backup
-        _verify_policy_directory(
-            godot_project_path,
-            root_identity,
-            artifact_directory,
-            directory_identity,
-        )
-        _verify_policy_target_state(report_path, initial_state)
-        try:
-            _replace_staged_policy_file(staged, report_path)
-            publication_completed = True
-            temporary_files.pop(staged.path, None)
-        except BaseException:
-            if _policy_path_matches_stage(report_path, staged):
-                publication_completed = True
-                temporary_files.pop(staged.path, None)
-            raise
-        _fsync_policy_directory(
-            godot_project_path,
-            root_identity,
-            artifact_directory,
-            directory_identity,
-        )
-        _verify_staged_policy_file(staged, path=report_path)
-    except BaseException as error:
-        active_error = error
-        if publication_completed:
-            rollback_error = _rollback_policy_publication(
-                report_path,
-                staged,
-                backup,
-                temporary_files,
-                godot_project_path=godot_project_path,
-                root_identity=root_identity,
-                artifact_directory=artifact_directory,
-                directory_identity=directory_identity,
-            )
-            if rollback_error is not None:
-                error.add_note(
-                    "Architecture-policy report rollback also failed: "
-                    f"{rollback_error}"
-                )
-        raise
-    finally:
-        cleanup_errors = _cleanup_policy_temporary_files(
-            temporary_files,
-            godot_project_path=godot_project_path,
-            root_identity=root_identity,
-            artifact_directory=artifact_directory,
-            directory_identity=directory_identity,
-        )
-        if active_error is not None and cleanup_errors:
-            active_error.add_note(
-                "Architecture-policy report cleanup failed: "
-                + "; ".join(str(error) for error in cleanup_errors)
-            )
-
-    _verify_policy_directory(
-        godot_project_path,
-        root_identity,
-        artifact_directory,
-        directory_identity,
-    )
-    _verify_staged_policy_file(staged, path=report_path)
-    report_stat = os.lstat(report_path)
-    receipt = ArchitecturePolicyPublicationReceipt(
-        path=report_path,
-        content=content,
-        mode=stat.S_IMODE(report_stat.st_mode),
-        fingerprint=_receipt_fingerprint(report_stat),
-        sha256=staged.sha256,
-    )
-    _verify_policy_receipt(receipt)
-    return receipt
-
-
-def _rollback_policy_publication(
-    report_path: str,
-    published: _StagedPolicyFile,
-    backup: _StagedPolicyFile | None,
-    temporary_files: dict[str, _StagedPolicyFile],
-    *,
-    godot_project_path: str,
-    root_identity: PathIdentity,
-    artifact_directory: str,
-    directory_identity: PathIdentity,
-) -> Exception | None:
-    recovery: _StagedPolicyFile | None = None
-    try:
-        _verify_policy_directory(
-            godot_project_path,
-            root_identity,
-            artifact_directory,
-            directory_identity,
-        )
-        _verify_staged_policy_file(published, path=report_path)
-        if backup is None:
-            _unlink_finalized_policy_file(published, report_path)
-        else:
-            recovery = _stage_policy_bytes(
-                report_path,
-                backup.content,
-                mode=backup.mode,
-                suffix=".recovery.backup",
-            )
-            temporary_files[recovery.path] = recovery
-            _replace_staged_policy_file(backup, report_path)
-            temporary_files.pop(backup.path, None)
-        _fsync_policy_directory(
-            godot_project_path,
-            root_identity,
-            artifact_directory,
-            directory_identity,
-        )
-        if backup is None:
-            if os.path.lexists(report_path):
-                raise OSError(
-                    "Removed architecture-policy report reappeared during rollback."
-                )
-        else:
-            _verify_staged_policy_file(backup, path=report_path)
-        if recovery is not None:
-            cleanup_error = _unlink_staged_policy_file(recovery)
-            if cleanup_error is None:
-                temporary_files.pop(recovery.path, None)
-                _fsync_policy_directory(
-                    godot_project_path,
-                    root_identity,
-                    artifact_directory,
-                    directory_identity,
-                )
-                assert backup is not None
-                _verify_staged_policy_file(backup, path=report_path)
-        return None
-    except Exception as error:
-        recovery_path = _retain_policy_recovery(recovery, backup, temporary_files)
-        if recovery_path is None:
-            return error
-        wrapped = OSError(
-            f"{error}; previous architecture-policy report preserved at: "
-            f"{recovery_path}"
-        )
-        wrapped.__cause__ = error
-        return wrapped
-
-
-def _rollback_restore(
-    report_path: str,
-    snapshot: ArchitecturePolicySnapshot,
-    restored_stage: _StagedPolicyFile | None,
-    receipt_backup: _StagedPolicyFile,
-    receipt: ArchitecturePolicyPublicationReceipt,
-    temporary_files: dict[str, _StagedPolicyFile],
-    *,
-    godot_project_path: str,
-    root_identity: PathIdentity,
-    artifact_directory: str,
-    directory_identity: PathIdentity,
-) -> Exception | None:
-    recovery: _StagedPolicyFile | None = None
-    try:
-        _verify_policy_directory(
-            godot_project_path,
-            root_identity,
-            artifact_directory,
-            directory_identity,
-        )
-        _verify_restore_rollback_target(report_path, snapshot, restored_stage)
-        recovery = _stage_policy_bytes(
-            report_path,
-            receipt_backup.content,
-            mode=receipt_backup.mode,
-            suffix=".recovery.backup",
-        )
-        temporary_files[recovery.path] = recovery
-        _replace_staged_policy_file(receipt_backup, report_path)
-        temporary_files.pop(receipt_backup.path, None)
-        _fsync_policy_directory(
-            godot_project_path,
-            root_identity,
-            artifact_directory,
-            directory_identity,
-        )
-        _verify_policy_receipt(receipt)
-        cleanup_error = _unlink_staged_policy_file(recovery)
-        if cleanup_error is None:
-            temporary_files.pop(recovery.path, None)
-            _fsync_policy_directory(
-                godot_project_path,
-                root_identity,
-                artifact_directory,
-                directory_identity,
-            )
-            _verify_policy_receipt(receipt)
-        return None
-    except Exception as error:
-        recovery_path = _retain_policy_recovery(
-            recovery,
-            receipt_backup,
-            temporary_files,
-        )
-        if recovery_path is None:
-            return error
-        wrapped = OSError(
-            f"{error}; published architecture-policy report preserved at: "
-            f"{recovery_path}"
-        )
-        wrapped.__cause__ = error
-        return wrapped
-
-
-def _retain_policy_recovery(
-    recovery: _StagedPolicyFile | None,
-    backup: _StagedPolicyFile | None,
-    temporary_files: dict[str, _StagedPolicyFile],
-) -> str | None:
-    for candidate in (recovery, backup):
-        if candidate is None:
-            continue
-        try:
-            _verify_staged_policy_file(candidate)
-        except OSError:
-            continue
-        temporary_files.pop(candidate.path, None)
-        return candidate.path
-    return None
-
-
-def _inspect_policy_directory(
-    godot_project_path: str,
-) -> tuple[str, PathIdentity, PathIdentity | None]:
-    try:
-        root_stat = os.lstat(godot_project_path)
-    except OSError as error:
-        raise OSError(
-            f"Architecture-policy report root is unavailable: {godot_project_path}"
-        ) from error
-    if _path_is_redirected(godot_project_path, root_stat) or not stat.S_ISDIR(
-        root_stat.st_mode
-    ):
-        raise OSError(
-            "Refusing redirected or non-directory architecture-policy report root: "
-            f"{godot_project_path}"
-        )
-    root_identity = (root_stat.st_dev, root_stat.st_ino)
-    artifact_directory = os.path.join(
-        godot_project_path,
-        os.path.dirname(ARCHITECTURE_POLICY_RELATIVE_PATH),
-    )
-    try:
-        directory_stat = os.lstat(artifact_directory)
-    except FileNotFoundError:
-        return artifact_directory, root_identity, None
-    if _path_is_redirected(artifact_directory, directory_stat) or not stat.S_ISDIR(
-        directory_stat.st_mode
-    ):
-        raise OSError(
-            "Refusing redirected or non-directory architecture-policy report "
-            f"directory: {artifact_directory}"
-        )
-    directory_identity = (directory_stat.st_dev, directory_stat.st_ino)
-    _verify_policy_directory(
-        godot_project_path,
-        root_identity,
-        artifact_directory,
-        directory_identity,
-    )
-    return artifact_directory, root_identity, directory_identity
-
-
-def _prepare_policy_directory(
-    godot_project_path: str,
-) -> tuple[str, PathIdentity, PathIdentity]:
-    artifact_directory, root_identity, directory_identity = _inspect_policy_directory(
-        godot_project_path
-    )
-    if directory_identity is None:
-        _verify_directory_path(
-            godot_project_path,
-            root_identity,
-            description="architecture-policy report root",
-        )
-        try:
-            os.mkdir(artifact_directory)
-        except FileExistsError:
-            pass
-        directory_stat = os.lstat(artifact_directory)
-        if _path_is_redirected(
-            artifact_directory,
-            directory_stat,
-        ) or not stat.S_ISDIR(directory_stat.st_mode):
-            raise OSError(
-                "Refusing redirected or non-directory architecture-policy report "
-                f"directory: {artifact_directory}"
-            )
-        directory_identity = (directory_stat.st_dev, directory_stat.st_ino)
-    # Repeat the parent-directory durability barrier even when the managed
-    # directory already exists. A previous creation may have succeeded before
-    # its root fsync failed; a retry must not mistake that still-visible entry
-    # for one whose creation was durably committed.
-    _fsync_verified_directory(
-        godot_project_path,
-        root_identity,
-        description="architecture-policy report root",
-    )
-    _verify_policy_directory(
-        godot_project_path,
-        root_identity,
-        artifact_directory,
-        directory_identity,
-    )
-    return artifact_directory, root_identity, directory_identity
-
-
-def _verify_policy_directory(
-    godot_project_path: str,
-    root_identity: PathIdentity,
-    artifact_directory: str,
-    directory_identity: PathIdentity,
-) -> None:
-    _verify_directory_path(
-        godot_project_path,
-        root_identity,
-        description="architecture-policy report root",
-    )
-    _verify_directory_path(
-        artifact_directory,
-        directory_identity,
+        _ARCHITECTURE_POLICY_DIRECTORY,
+        create=False,
         description="architecture-policy report directory",
-    )
-
-
-def _verify_directory_path(
-    path: str,
-    expected_identity: PathIdentity,
-    *,
-    description: str,
-) -> None:
-    try:
-        path_stat = os.lstat(path)
-    except OSError as error:
-        raise OSError(f"{description.capitalize()} changed: {path}") from error
-    if (
-        _path_is_redirected(path, path_stat)
-        or not stat.S_ISDIR(path_stat.st_mode)
-        or (path_stat.st_dev, path_stat.st_ino) != expected_identity
-    ):
-        raise OSError(f"{description.capitalize()} changed: {path}")
-
-
-def _path_is_redirected(path: str, path_stat: os.stat_result) -> bool:
-    if stat.S_ISLNK(path_stat.st_mode):
-        return True
-    junction_candidate: object = getattr(os.path, "isjunction", None)
-    if not callable(junction_candidate):
-        return False
-    junction_checker = cast(Callable[[str], bool], junction_candidate)
-    return junction_checker(path)
-
-
-def _is_windows_platform() -> bool:
-    return os.name == "nt"
-
-
-def _policy_mode_is_writable(mode: int) -> bool:
-    return bool(mode & stat.S_IWUSR)
-
-
-def _policy_modes_match(actual: int, expected: int) -> bool:
-    if _is_windows_platform():
-        # Windows chmod exposes only the read-only attribute. Group/other and
-        # execute bits may be normalized by the filesystem and cannot be
-        # preserved independently.
-        return _policy_mode_is_writable(actual) == _policy_mode_is_writable(
-            expected
-        )
-    return actual == expected
-
-
-def _policy_fingerprints_match(
-    actual: FileFingerprint,
-    expected: FileFingerprint,
-) -> bool:
-    if _is_windows_platform():
-        # Windows path-stat and open-handle implementations can expose
-        # different st_ctime values for the same file. Keep the stable
-        # identity, size, and mtime guards. Callers use this only for
-        # descriptor parity or exact-content/SHA-backed staged files;
-        # path-to-path transaction guards remain exact.
-        return actual[:4] == expected[:4]
-    return actual == expected
-
-
-def _replaceable_policy_mode(mode: int) -> int:
-    if not _is_windows_platform():
-        return mode
-    return mode | stat.S_IWUSR
-
-
-def _set_policy_path_mode(
-    path: str,
-    expected_identity: PathIdentity,
-    mode: int,
-) -> int:
-    """Set a mode without following a changed or redirected path."""
-    _verify_regular_path_identity(path, expected_identity)
-    current_mode = stat.S_IMODE(os.lstat(path).st_mode)
-    if not _policy_modes_match(current_mode, mode):
-        os.chmod(path, mode)
-        _verify_regular_path_identity(path, expected_identity)
-        current_mode = stat.S_IMODE(os.lstat(path).st_mode)
-    if not _policy_modes_match(current_mode, mode):
-        raise OSError(f"Architecture-policy report mode did not update: {path}")
-    return current_mode
-
-
-def _make_policy_target_replaceable(
-    path: str,
-) -> _PolicyReplaceTarget | None:
-    """Clear a Windows read-only destination after capturing its identity."""
-    try:
-        path_stat = os.lstat(path)
-    except FileNotFoundError:
-        return None
-    if _path_is_redirected(path, path_stat) or not stat.S_ISREG(path_stat.st_mode):
-        raise OSError(
-            f"Refusing redirected or non-regular architecture-policy report: {path}"
-        )
-    identity = (path_stat.st_dev, path_stat.st_ino)
-    mode = stat.S_IMODE(path_stat.st_mode)
-    mode_changed = _is_windows_platform() and not _policy_mode_is_writable(mode)
-    if mode_changed:
-        _set_policy_path_mode(path, identity, _replaceable_policy_mode(mode))
-    return _PolicyReplaceTarget(
-        identity=identity,
-        mode=mode,
-        mode_changed=mode_changed,
-    )
-
-
-def _restore_replace_target_mode(
-    path: str,
-    target: _PolicyReplaceTarget | None,
-    error: BaseException,
-) -> None:
-    if target is None or not target.mode_changed:
-        return
-    try:
-        _set_policy_path_mode(path, target.identity, target.mode)
-    except Exception as mode_error:
-        error.add_note(
-            "Failed to restore the replaced architecture-policy target mode: "
-            f"{mode_error}"
-        )
-
-
-def _policy_target_state(path: str) -> _PolicyTargetState:
-    try:
-        path_stat = os.lstat(path)
-    except FileNotFoundError:
-        return _PolicyTargetState(fingerprint=None, mode=None)
-    if _path_is_redirected(path, path_stat) or not stat.S_ISREG(path_stat.st_mode):
-        raise OSError(
-            f"Refusing redirected or non-regular architecture-policy report: {path}"
-        )
-    return _PolicyTargetState(
-        fingerprint=_file_fingerprint(path_stat),
-        mode=stat.S_IMODE(path_stat.st_mode),
-    )
-
-
-def _verify_policy_target_state(path: str, expected: _PolicyTargetState) -> None:
-    try:
-        path_stat = os.lstat(path)
-    except FileNotFoundError:
-        if expected.fingerprint is None:
-            return
-        raise OSError(f"Architecture-policy report disappeared: {path}")
-    if (
-        expected.fingerprint is None
-        or _path_is_redirected(path, path_stat)
-        or not stat.S_ISREG(path_stat.st_mode)
-        or _file_fingerprint(path_stat) != expected.fingerprint
-        or expected.mode is None
-        or not _policy_modes_match(
-            stat.S_IMODE(path_stat.st_mode),
-            expected.mode,
-        )
-    ):
-        raise OSError(f"Architecture-policy report changed: {path}")
-
-
-def _read_policy_target_bytes(path: str, expected: _PolicyTargetState) -> bytes:
-    if expected.fingerprint is None:
-        raise ValueError("Cannot read an absent architecture-policy report.")
-    open_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
-    file_descriptor = os.open(path, open_flags)
-    try:
-        opened_before = os.fstat(file_descriptor)
-        path_before = os.lstat(path)
-        if (
-            not stat.S_ISREG(opened_before.st_mode)
-            or not _policy_fingerprints_match(
-                _file_fingerprint(opened_before),
-                expected.fingerprint,
-            )
-            or _file_fingerprint(path_before) != expected.fingerprint
-        ):
-            raise OSError(f"Architecture-policy report changed while reading: {path}")
-        with os.fdopen(file_descriptor, "rb") as report_file:
-            file_descriptor = -1
-            content = report_file.read()
-            opened_after = os.fstat(report_file.fileno())
-        if not _policy_fingerprints_match(
-            _file_fingerprint(opened_after),
-            expected.fingerprint,
-        ):
-            raise OSError(f"Architecture-policy report changed while reading: {path}")
-    finally:
-        if file_descriptor >= 0:
-            os.close(file_descriptor)
-    _verify_policy_target_state(path, expected)
-    return content
-
-
-def _stage_existing_policy_file(
-    path: str,
-    expected: _PolicyTargetState,
-) -> _StagedPolicyFile | None:
-    if expected.fingerprint is None:
-        return None
-    content = _read_policy_target_bytes(path, expected)
-    _verify_policy_target_state(path, expected)
-    return _stage_policy_bytes(
-        path,
-        content,
-        mode=expected.mode,
-        suffix=".backup",
-    )
-
-
-def _stage_policy_bytes(
-    path: str,
-    content: bytes,
-    *,
-    mode: int | None,
-    suffix: str,
-) -> _StagedPolicyFile:
-    artifact_directory = os.path.dirname(path) or os.curdir
-    file_descriptor, staged_path = tempfile.mkstemp(
-        dir=artifact_directory,
-        prefix=f".{os.path.basename(path)}.",
-        suffix=suffix,
-    )
-    initial_stat = os.fstat(file_descriptor)
-    identity = (initial_stat.st_dev, initial_stat.st_ino)
-    target_mode = stat.S_IMODE(initial_stat.st_mode) if mode is None else mode
-    staging_mode = _replaceable_policy_mode(target_mode)
-    try:
-        with os.fdopen(file_descriptor, "wb") as staged_file:
-            file_descriptor = -1
-            staged_file.write(content)
-            staged_file.flush()
-            if not _policy_modes_match(
-                stat.S_IMODE(os.fstat(staged_file.fileno()).st_mode),
-                staging_mode,
-            ):
-                fchmod_candidate: object = getattr(os, "fchmod", None)
-                if callable(fchmod_candidate):
-                    fchmod = cast(Callable[[int, int], None], fchmod_candidate)
-                    fchmod(staged_file.fileno(), staging_mode)
-                else:
-                    _verify_regular_path_identity(staged_path, identity)
-                    os.chmod(staged_path, staging_mode)
-                    _verify_regular_path_identity(staged_path, identity)
-            os.fsync(staged_file.fileno())
-        staged_stat = os.lstat(staged_path)
-        staged_mode = stat.S_IMODE(staged_stat.st_mode)
-        if not _policy_modes_match(staged_mode, staging_mode):
+    ) as transaction:
+        if not transaction.available:
             raise OSError(
-                f"Staged architecture-policy report mode changed: {staged_path}"
+                "Architecture-policy report directory disappeared before restore."
             )
-        staged = _StagedPolicyFile(
-            path=staged_path,
-            identity=identity,
-            content=content,
-            mode=staged_mode,
-            target_mode=target_mode,
-            sha256=_sha256_bytes(content),
+        _verify_policy_receipt(receipt, transaction)
+        transaction.restore_snapshots(
+            (_core_policy_snapshot(snapshot),),
+            (_core_policy_receipt(receipt),),
         )
-        _verify_staged_policy_file(staged)
-        return staged
-    except BaseException as error:
-        if file_descriptor >= 0:
-            os.close(file_descriptor)
-        cleanup_error = _unlink_if_identity(staged_path, identity)
-        if cleanup_error is not None:
-            error.add_note(
-                "Failed to remove incomplete architecture-policy report stage "
-                f"{staged_path}: {cleanup_error}"
-            )
-        raise
+        return report_path
 
 
-def _read_staged_policy_file(
-    staged: _StagedPolicyFile,
-    *,
-    path: str | None = None,
-    verify_mode: bool = True,
-) -> bytes:
-    selected_path = staged.path if path is None else path
-    expected_mode = (
-        staged.mode
-        if os.path.abspath(selected_path) == os.path.abspath(staged.path)
-        else staged.target_mode
+def _architecture_snapshot(snapshot: ArtifactSnapshot) -> ArchitecturePolicySnapshot:
+    return ArchitecturePolicySnapshot(
+        content=snapshot.content,
+        mode=snapshot.mode,
+        fingerprint=snapshot.fingerprint,
+        sha256=snapshot.sha256,
     )
-    open_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
-    file_descriptor = os.open(selected_path, open_flags)
-    try:
-        opened_before = os.fstat(file_descriptor)
-        fingerprint_before = _file_fingerprint(opened_before)
-        if (
-            not stat.S_ISREG(opened_before.st_mode)
-            or (opened_before.st_dev, opened_before.st_ino) != staged.identity
-            or (
-                verify_mode
-                and not _policy_modes_match(
-                    stat.S_IMODE(opened_before.st_mode),
-                    expected_mode,
-                )
-            )
-        ):
-            raise OSError(f"Staged architecture-policy report changed: {selected_path}")
-        with os.fdopen(file_descriptor, "rb") as staged_file:
-            file_descriptor = -1
-            content = staged_file.read()
-            opened_after = os.fstat(staged_file.fileno())
-        path_after = os.lstat(selected_path)
-        if (
-            not stat.S_ISREG(opened_after.st_mode)
-            or (opened_after.st_dev, opened_after.st_ino) != staged.identity
-            or (
-                verify_mode
-                and not _policy_modes_match(
-                    stat.S_IMODE(opened_after.st_mode),
-                    expected_mode,
-                )
-            )
-            or (
-                verify_mode
-                and not _policy_modes_match(
-                    stat.S_IMODE(path_after.st_mode),
-                    expected_mode,
-                )
-            )
-            or not _policy_fingerprints_match(
-                _file_fingerprint(opened_after),
-                fingerprint_before,
-            )
-            or not _policy_fingerprints_match(
-                _file_fingerprint(path_after),
-                fingerprint_before,
-            )
-            or content != staged.content
-            or _sha256_bytes(content) != staged.sha256
-        ):
-            raise OSError(
-                f"Staged architecture-policy report content changed: {selected_path}"
-            )
-    finally:
-        if file_descriptor >= 0:
-            os.close(file_descriptor)
-    _verify_regular_path_identity(selected_path, staged.identity)
-    return content
 
 
-def _verify_staged_policy_file(
-    staged: _StagedPolicyFile,
-    *,
-    path: str | None = None,
-) -> None:
-    _read_staged_policy_file(staged, path=path)
+def _core_policy_snapshot(snapshot: ArchitecturePolicySnapshot) -> ArtifactSnapshot:
+    return ArtifactSnapshot(
+        name=_ARCHITECTURE_POLICY_FILENAME,
+        content=snapshot.content,
+        mode=snapshot.mode,
+        fingerprint=snapshot.fingerprint,
+        sha256=snapshot.sha256,
+    )
 
 
-def _replace_staged_policy_file(
-    staged: _StagedPolicyFile,
-    target_path: str,
-) -> bool:
-    _verify_staged_policy_file(staged)
-    target_state = _make_policy_target_replaceable(target_path)
-    try:
-        # Keep temporary files writable until the last possible moment. On
-        # Windows a read-only destination blocks replacement, while applying
-        # the desired attribute to the source before the rename makes the
-        # final mode part of the same visible transition.
-        _set_policy_path_mode(staged.path, staged.identity, staged.target_mode)
-        os.replace(staged.path, target_path)
-    except BaseException as error:
-        if not _policy_path_matches_stage(target_path, staged):
-            try:
-                _set_policy_path_mode(staged.path, staged.identity, staged.mode)
-            except Exception as mode_error:
-                error.add_note(
-                    "Failed to restore the replaceable architecture-policy "
-                    f"stage mode: {mode_error}"
-                )
-            _restore_replace_target_mode(target_path, target_state, error)
-        raise
-    _verify_staged_policy_file(staged, path=target_path)
-    return True
-
-
-def _policy_path_matches_stage(path: str, staged: _StagedPolicyFile) -> bool:
-    try:
-        _read_staged_policy_file(staged, path=path, verify_mode=False)
-    except OSError:
-        return False
-    return True
-
-
-def _receipt_as_staged_file(
+def _core_policy_receipt(
     receipt: ArchitecturePolicyPublicationReceipt,
-    *,
-    path: str,
-    storage_mode: int,
-) -> _StagedPolicyFile:
-    return _StagedPolicyFile(
-        path=path,
-        identity=(receipt.fingerprint[0], receipt.fingerprint[1]),
+) -> ArtifactReceipt:
+    return ArtifactReceipt(
+        path=receipt.path,
         content=receipt.content,
-        mode=storage_mode,
-        target_mode=receipt.mode,
+        mode=receipt.mode,
+        fingerprint=receipt.fingerprint,
         sha256=receipt.sha256,
     )
 
 
-def _replace_published_receipt_with_backup(
+def _verify_policy_receipt(
     receipt: ArchitecturePolicyPublicationReceipt,
-    staged_copy: _StagedPolicyFile,
-    displaced_receipt: _StagedPolicyFile,
+    transaction: ByteArtifactTransaction,
 ) -> None:
-    """Park the published inode at the prepared backup path before restore."""
-    _verify_policy_receipt(receipt)
-    _verify_staged_policy_file(staged_copy)
-    target_state = _make_policy_target_replaceable(receipt.path)
     try:
-        os.replace(receipt.path, staged_copy.path)
-    except BaseException as error:
-        if not _policy_path_matches_stage(
-            displaced_receipt.path,
-            displaced_receipt,
-        ):
-            _restore_replace_target_mode(receipt.path, target_state, error)
-        raise
-    _verify_staged_policy_file(displaced_receipt)
-
-
-def _unlink_finalized_policy_file(
-    staged: _StagedPolicyFile,
-    path: str,
-) -> None:
-    """Remove a finalized file without leaving a failed target writable."""
-    _verify_staged_policy_file(staged, path=path)
-    target_state = _make_policy_target_replaceable(path)
-    try:
-        os.unlink(path)
-    except BaseException as error:
-        if not os.path.lexists(path):
-            return
-        _restore_replace_target_mode(path, target_state, error)
-        raise
-    if os.path.lexists(path):
-        error = OSError(f"Architecture-policy report remained after unlink: {path}")
-        _restore_replace_target_mode(path, target_state, error)
-        raise error
-
-
-def _verify_policy_receipt(receipt: ArchitecturePolicyPublicationReceipt) -> None:
-    state = _policy_target_state(receipt.path)
-    if (
-        state.fingerprint is None
-        or _stable_fingerprint(state.fingerprint) != receipt.fingerprint
-        or state.mode is None
-        or not _policy_modes_match(state.mode, receipt.mode)
-        or _sha256_bytes(receipt.content) != receipt.sha256
-    ):
+        transaction.verify_receipt(_core_policy_receipt(receipt))
+    except OSError as error:
         raise OSError(
             "Architecture-policy report no longer matches its publication receipt: "
             f"{receipt.path}"
-        )
-    content = _read_policy_target_bytes(receipt.path, state)
-    if content != receipt.content or _sha256_bytes(content) != receipt.sha256:
-        raise OSError(
-            "Architecture-policy report no longer matches its publication receipt: "
-            f"{receipt.path}"
-        )
+        ) from error
+
+
+def _architecture_receipt(
+    receipt: ArtifactReceipt,
+    *,
+    path: str | None = None,
+) -> ArchitecturePolicyPublicationReceipt:
+    return ArchitecturePolicyPublicationReceipt(
+        path=receipt.path if path is None else path,
+        content=receipt.content,
+        mode=receipt.mode,
+        fingerprint=receipt.fingerprint,
+        sha256=receipt.sha256,
+    )
 
 
 def _validate_policy_snapshot(snapshot: ArchitecturePolicySnapshot) -> None:
@@ -1249,7 +285,7 @@ def _validate_policy_snapshot(snapshot: ArchitecturePolicySnapshot) -> None:
         assert snapshot.fingerprint is not None
         if (
             len(snapshot.content) != snapshot.fingerprint[2]
-            or _sha256_bytes(snapshot.content) != snapshot.sha256
+            or artifact_sha256(snapshot.content) != snapshot.sha256
         ):
             raise ValueError(
                 "Architecture-policy snapshot content does not match its fingerprint."
@@ -1261,182 +297,6 @@ def _validate_policy_snapshot(snapshot: ArchitecturePolicySnapshot) -> None:
         or snapshot.sha256 is not None
     ):
         raise ValueError("An absent architecture-policy snapshot cannot contain file data.")
-
-
-def _verify_restored_snapshot(
-    report_path: str,
-    snapshot: ArchitecturePolicySnapshot,
-    restored_stage: _StagedPolicyFile | None,
-) -> None:
-    if not snapshot.present:
-        if os.path.lexists(report_path):
-            raise OSError(
-                f"Architecture-policy report should have been absent: {report_path}"
-            )
-        return
-    if restored_stage is None:
-        raise ValueError("A present snapshot requires a staged restore artifact.")
-    _verify_staged_policy_file(restored_stage, path=report_path)
-
-
-def _verify_restore_rollback_target(
-    report_path: str,
-    snapshot: ArchitecturePolicySnapshot,
-    restored_stage: _StagedPolicyFile | None,
-) -> None:
-    if not os.path.lexists(report_path):
-        return
-    _verify_restored_snapshot(report_path, snapshot, restored_stage)
-
-
-def _cleanup_policy_temporary_files(
-    temporary_files: dict[str, _StagedPolicyFile],
-    *,
-    godot_project_path: str,
-    root_identity: PathIdentity,
-    artifact_directory: str,
-    directory_identity: PathIdentity,
-) -> list[Exception]:
-    errors: list[Exception] = []
-    removed = False
-    for temporary_path, staged in tuple(temporary_files.items()):
-        try:
-            _verify_policy_directory(
-                godot_project_path,
-                root_identity,
-                artifact_directory,
-                directory_identity,
-            )
-            if not os.path.lexists(temporary_path):
-                temporary_files.pop(temporary_path, None)
-                continue
-            _verify_staged_policy_file(staged)
-            os.unlink(temporary_path)
-            temporary_files.pop(temporary_path, None)
-            removed = True
-        except Exception as error:
-            errors.append(error)
-    if removed:
-        try:
-            _fsync_policy_directory(
-                godot_project_path,
-                root_identity,
-                artifact_directory,
-                directory_identity,
-            )
-        except Exception as error:
-            errors.append(error)
-    return errors
-
-
-def _unlink_staged_policy_file(staged: _StagedPolicyFile) -> Exception | None:
-    try:
-        _verify_staged_policy_file(staged)
-        os.unlink(staged.path)
-    except Exception as error:
-        return error
-    return None
-
-
-def _unlink_if_identity(path: str, expected_identity: PathIdentity) -> Exception | None:
-    try:
-        _verify_regular_path_identity(path, expected_identity)
-        os.unlink(path)
-    except Exception as error:
-        return error
-    return None
-
-
-def _verify_regular_path_identity(path: str, expected_identity: PathIdentity) -> None:
-    try:
-        path_stat = os.lstat(path)
-    except OSError as error:
-        raise OSError(f"Staged architecture-policy report changed: {path}") from error
-    if (
-        _path_is_redirected(path, path_stat)
-        or not stat.S_ISREG(path_stat.st_mode)
-        or (path_stat.st_dev, path_stat.st_ino) != expected_identity
-    ):
-        raise OSError(f"Staged architecture-policy report changed: {path}")
-
-
-def _fsync_verified_directory(
-    path: str,
-    expected_identity: PathIdentity,
-    *,
-    description: str,
-) -> None:
-    _verify_directory_path(path, expected_identity, description=description)
-    if os.name == "nt":
-        return
-    open_flags = (
-        os.O_RDONLY
-        | getattr(os, "O_DIRECTORY", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
-    )
-    directory_descriptor = os.open(path, open_flags)
-    try:
-        opened_stat = os.fstat(directory_descriptor)
-        if (
-            not stat.S_ISDIR(opened_stat.st_mode)
-            or (opened_stat.st_dev, opened_stat.st_ino) != expected_identity
-        ):
-            raise OSError(f"{description.capitalize()} changed: {path}")
-        os.fsync(directory_descriptor)
-    finally:
-        os.close(directory_descriptor)
-    _verify_directory_path(path, expected_identity, description=description)
-
-
-def _fsync_policy_directory(
-    godot_project_path: str,
-    root_identity: PathIdentity,
-    artifact_directory: str,
-    directory_identity: PathIdentity,
-) -> None:
-    _verify_policy_directory(
-        godot_project_path,
-        root_identity,
-        artifact_directory,
-        directory_identity,
-    )
-    _fsync_verified_directory(
-        artifact_directory,
-        directory_identity,
-        description="architecture-policy report directory",
-    )
-    _verify_policy_directory(
-        godot_project_path,
-        root_identity,
-        artifact_directory,
-        directory_identity,
-    )
-
-
-def _file_fingerprint(path_stat: os.stat_result) -> FileFingerprint:
-    return (
-        path_stat.st_dev,
-        path_stat.st_ino,
-        path_stat.st_size,
-        path_stat.st_mtime_ns,
-        path_stat.st_ctime_ns,
-    )
-
-
-def _receipt_fingerprint(path_stat: os.stat_result) -> ReceiptFingerprint:
-    return _stable_fingerprint(_file_fingerprint(path_stat))
-
-
-def _stable_fingerprint(fingerprint: FileFingerprint) -> ReceiptFingerprint:
-    # Moving the same inode aside and back updates ctime on POSIX filesystems.
-    # Receipts therefore treat ctime as a concurrency hint rather than identity;
-    # verification still requires the exact device, inode, size, mtime, mode,
-    # bytes, and SHA-256 digest published by this receipt.
-    return fingerprint[:4]
-
-
-def _sha256_bytes(content: bytes) -> str:
-    return "sha256:" + hashlib.sha256(content).hexdigest()
 
 
 def build_architecture_policy_report(

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.27"
+VERSION = "0.7.28"
 
 
 def get_version():

--- a/tests/test_anchored_artifacts.py
+++ b/tests/test_anchored_artifacts.py
@@ -25,6 +25,15 @@ class TestAnchoredArtifacts(unittest.TestCase):
     def tearDown(self) -> None:
         shutil.rmtree(self.temp_dir)
 
+    def assertArtifactModeEqual(self, actual: int, expected: int) -> None:
+        if os.name == "nt":
+            self.assertEqual(
+                bool(actual & stat.S_IWUSR),
+                bool(expected & stat.S_IWUSR),
+            )
+            return
+        self.assertEqual(actual, expected)
+
     def test_capture_binding_does_not_create_missing_directory(self) -> None:
         self.artifact_directory.rmdir()
 
@@ -165,6 +174,9 @@ class TestAnchoredArtifacts(unittest.TestCase):
         self.assertEqual(list(parked.iterdir()), [])
 
     def test_backend_is_selected_before_staging_and_never_downgrades(self) -> None:
+        expected_strategy = (
+            "windows_handle" if os.name == "nt" else "verified_path"
+        )
         with patch(
             "src.conversion.anchored_artifacts._descriptor_relative_supported",
             return_value=False,
@@ -175,14 +187,14 @@ class TestAnchoredArtifacts(unittest.TestCase):
                 create=False,
                 description="test artifact directory",
             ) as transaction:
-                self.assertEqual(transaction.strategy, "verified_path")
+                self.assertEqual(transaction.strategy, expected_strategy)
                 staged = transaction.stage_bytes(
                     "report.json",
                     b"fallback\n",
                     mode=None,
                     suffix=".tmp",
                 )
-                self.assertEqual(transaction.strategy, "verified_path")
+                self.assertEqual(transaction.strategy, expected_strategy)
                 self.assertTrue(Path(staged.path).is_file())
                 self.assertIsNone(transaction.unlink_staged(staged))
 
@@ -282,8 +294,8 @@ class TestAnchoredArtifacts(unittest.TestCase):
 
         self.assertEqual(first.read_bytes(), b"first old\n")
         self.assertEqual(second.read_bytes(), b"second old\n")
-        self.assertEqual(stat.S_IMODE(first.stat().st_mode), 0o640)
-        self.assertEqual(stat.S_IMODE(second.stat().st_mode), 0o600)
+        self.assertArtifactModeEqual(stat.S_IMODE(first.stat().st_mode), 0o640)
+        self.assertArtifactModeEqual(stat.S_IMODE(second.stat().st_mode), 0o600)
         self.assertEqual(
             sorted(path.name for path in self.artifact_directory.iterdir()),
             ["first.json", "second.json"],
@@ -434,7 +446,10 @@ class TestAnchoredArtifacts(unittest.TestCase):
         ]
         self.assertEqual(len(retained), 1)
         self.assertEqual(retained[0].read_bytes(), b"second old\n")
-        self.assertEqual(stat.S_IMODE(retained[0].stat().st_mode), 0o600)
+        self.assertArtifactModeEqual(
+            stat.S_IMODE(retained[0].stat().st_mode),
+            0o600,
+        )
         notes = getattr(raised.exception, "__notes__", ())
         self.assertTrue(
             any("injected second rollback failure" in note for note in notes)
@@ -489,7 +504,10 @@ class TestAnchoredArtifacts(unittest.TestCase):
             transaction.restore_snapshots((snapshot,), (receipt,))
 
         self.assertEqual(target.read_bytes(), b"old\n")
-        self.assertEqual(stat.S_IMODE(target.stat().st_mode), 0o640)
+        self.assertArtifactModeEqual(
+            stat.S_IMODE(target.stat().st_mode),
+            0o640,
+        )
 
     def test_restore_rejects_changed_receipt_before_staging_or_mutation(self) -> None:
         target = self.artifact_directory / "report.json"

--- a/tests/test_anchored_artifacts.py
+++ b/tests/test_anchored_artifacts.py
@@ -1,0 +1,1094 @@
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Callable, cast
+from unittest.mock import patch
+
+from src.conversion import anchored_artifacts as anchored_artifacts_module
+from src.conversion.anchored_artifacts import ArtifactSpec, ByteArtifactTransaction
+
+
+class TestAnchoredArtifacts(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.root = self.temp_dir / "project"
+        self.artifact_directory = self.root / "gm2godot"
+        self.root.mkdir()
+        self.artifact_directory.mkdir()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.temp_dir)
+
+    def test_capture_binding_does_not_create_missing_directory(self) -> None:
+        self.artifact_directory.rmdir()
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            self.assertFalse(transaction.available)
+            transaction.verify_directory()
+
+        self.assertFalse(self.artifact_directory.exists())
+
+    def test_posix_binding_keeps_replacement_directory_untouched(self) -> None:
+        target = self.artifact_directory / "report.json"
+        target.write_bytes(b"old\n")
+        parked = self.root / "gm2godot.parked"
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            if transaction.strategy != "posix_dir_fd":
+                self.skipTest("descriptor-relative POSIX operations are unavailable")
+            staged = transaction.stage_bytes(
+                "report.json",
+                b"new\n",
+                mode=0o640,
+                suffix=".tmp",
+            )
+            os.rename(self.artifact_directory, parked)
+            self.artifact_directory.mkdir()
+            replacement_target = self.artifact_directory / "report.json"
+            replacement_target.write_bytes(b"attacker\n")
+            replacement_target.chmod(0o444)
+            sentinel = self.artifact_directory / "sentinel.txt"
+            sentinel.write_bytes(b"outside\n")
+            replacement_before = self._directory_snapshot(self.artifact_directory)
+
+            transaction.replace_staged(staged, "report.json")
+            with self.assertRaisesRegex(OSError, "changed"):
+                transaction.verify_directory()
+
+        self.assertEqual((parked / "report.json").read_bytes(), b"new\n")
+        self.assertEqual(
+            self._directory_snapshot(self.artifact_directory),
+            replacement_before,
+        )
+
+    def test_posix_cleanup_uses_binding_not_replacement_temp_name(self) -> None:
+        parked = self.root / "gm2godot.parked"
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            if transaction.strategy != "posix_dir_fd":
+                self.skipTest("descriptor-relative POSIX operations are unavailable")
+            staged = transaction.stage_bytes(
+                "report.json",
+                b"stage\n",
+                mode=0o600,
+                suffix=".backup",
+            )
+            os.rename(self.artifact_directory, parked)
+            self.artifact_directory.mkdir()
+            collision = self.artifact_directory / staged.name
+            collision.write_bytes(b"replacement collision\n")
+            collision.chmod(0o444)
+            sentinel = self.artifact_directory / "sentinel.txt"
+            sentinel.write_bytes(b"outside\n")
+            replacement_before = self._directory_snapshot(self.artifact_directory)
+
+            cleanup_errors = transaction.cleanup({staged.name: staged})
+
+        self.assertTrue(cleanup_errors)
+        self.assertFalse((parked / staged.name).exists())
+        self.assertEqual(
+            self._directory_snapshot(self.artifact_directory),
+            replacement_before,
+        )
+
+    @unittest.skipUnless(os.name == "posix", "POSIX relocation semantics required")
+    def test_child_is_bound_before_parent_durability_barrier(self) -> None:
+        parked = self.root / "gm2godot.parked"
+        swapped = False
+
+        def replace_child_during_root_sync(
+            phase: str,
+            directory_path: str,
+            _name: str | None,
+        ) -> None:
+            nonlocal swapped
+            if (
+                phase != "before_sync"
+                or os.path.abspath(directory_path) != os.path.abspath(self.root)
+                or swapped
+            ):
+                return
+            os.rename(self.artifact_directory, parked)
+            self.artifact_directory.mkdir()
+            (self.artifact_directory / "sentinel.txt").write_bytes(b"outside\n")
+            swapped = True
+
+        with (
+            patch(
+                "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                side_effect=replace_child_during_root_sync,
+            ),
+            self.assertRaisesRegex(OSError, "changed"),
+        ):
+            ByteArtifactTransaction.open(
+                str(self.root),
+                "gm2godot",
+                create=True,
+                description="test artifact directory",
+            )
+
+        self.assertTrue(swapped)
+        self.assertEqual(
+            self._directory_snapshot(self.artifact_directory),
+            {
+                "sentinel.txt": (
+                    (self.artifact_directory / "sentinel.txt").stat().st_dev,
+                    (self.artifact_directory / "sentinel.txt").stat().st_ino,
+                    stat.S_IMODE(
+                        (self.artifact_directory / "sentinel.txt").stat().st_mode
+                    ),
+                    b"outside\n",
+                )
+            },
+        )
+        self.assertEqual(list(parked.iterdir()), [])
+
+    def test_backend_is_selected_before_staging_and_never_downgrades(self) -> None:
+        with patch(
+            "src.conversion.anchored_artifacts._descriptor_relative_supported",
+            return_value=False,
+        ):
+            with ByteArtifactTransaction.open(
+                str(self.root),
+                "gm2godot",
+                create=False,
+                description="test artifact directory",
+            ) as transaction:
+                self.assertEqual(transaction.strategy, "verified_path")
+                staged = transaction.stage_bytes(
+                    "report.json",
+                    b"fallback\n",
+                    mode=None,
+                    suffix=".tmp",
+                )
+                self.assertEqual(transaction.strategy, "verified_path")
+                self.assertTrue(Path(staged.path).is_file())
+                self.assertIsNone(transaction.unlink_staged(staged))
+
+    def test_leaf_validation_rejects_escape_and_windows_ads_names(self) -> None:
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            invalid_names = ("", ".", "..", "../escape", "a/b", "a\\b", "x\x00y")
+            for name in invalid_names:
+                with self.subTest(name=name), self.assertRaises(ValueError):
+                    transaction.target_state(name)
+
+            with patch.object(anchored_artifacts_module.os, "name", "nt"):
+                for name in (
+                    "report.json:stream",
+                    "report.json.",
+                    "report.json ",
+                    "NUL",
+                    "con.txt",
+                    "COM1.log",
+                    "name\x1f.json",
+                ):
+                    with self.subTest(windows_name=name), self.assertRaises(ValueError):
+                        transaction.target_state(name)
+                with self.assertRaisesRegex(ValueError, "must be unique"):
+                    transaction.capture_snapshots(("Report.json", "report.json"))
+
+    def test_modeled_windows_rejects_readonly_hardlink_before_chmod(self) -> None:
+        target = self.artifact_directory / "report.json"
+        alias = self.root / "report-alias.json"
+        target.write_bytes(b"old\n")
+        os.link(target, alias)
+        target.chmod(0o444)
+
+        try:
+            with ByteArtifactTransaction.open(
+                str(self.root),
+                "gm2godot",
+                create=False,
+                description="test artifact directory",
+            ) as transaction:
+                with (
+                    patch(
+                        "src.conversion.anchored_artifacts._is_windows_platform",
+                        return_value=True,
+                    ),
+                    self.assertRaisesRegex(
+                        OSError,
+                        "read-only multiply-linked artifact",
+                    ),
+                ):
+                    transaction.publish_specs(
+                        (ArtifactSpec("report.json", b"new\n"),)
+                    )
+
+            self.assertEqual(target.read_bytes(), b"old\n")
+            self.assertEqual(alias.read_bytes(), b"old\n")
+            self.assertFalse(stat.S_IMODE(target.stat().st_mode) & stat.S_IWUSR)
+            self.assertFalse(stat.S_IMODE(alias.stat().st_mode) & stat.S_IWUSR)
+            self.assertEqual(
+                sorted(path.name for path in self.artifact_directory.iterdir()),
+                ["report.json"],
+            )
+        finally:
+            target.chmod(0o600)
+
+    def test_ordered_present_absent_publish_and_restore_share_one_core(self) -> None:
+        first = self.artifact_directory / "first.json"
+        second = self.artifact_directory / "second.json"
+        first.write_bytes(b"first old\n")
+        first.chmod(0o640)
+        second.write_bytes(b"second old\n")
+        second.chmod(0o600)
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            snapshots = transaction.capture_snapshots(("first.json", "second.json"))
+            receipts = transaction.publish_specs(
+                (
+                    ArtifactSpec("first.json", b"first new\n"),
+                    ArtifactSpec("second.json", None),
+                )
+            )
+            self.assertEqual(first.read_bytes(), b"first new\n")
+            self.assertFalse(second.exists())
+            self.assertIsNotNone(receipts[0])
+            self.assertIsNone(receipts[1])
+
+            transaction.restore_snapshots(snapshots, receipts)
+
+        self.assertEqual(first.read_bytes(), b"first old\n")
+        self.assertEqual(second.read_bytes(), b"second old\n")
+        self.assertEqual(stat.S_IMODE(first.stat().st_mode), 0o640)
+        self.assertEqual(stat.S_IMODE(second.stat().st_mode), 0o600)
+        self.assertEqual(
+            sorted(path.name for path in self.artifact_directory.iterdir()),
+            ["first.json", "second.json"],
+        )
+
+    def test_ordered_publish_rolls_back_all_prior_mutations(self) -> None:
+        first = self.artifact_directory / "first.json"
+        second = self.artifact_directory / "second.json"
+        first.write_bytes(b"first old\n")
+        second.write_bytes(b"second old\n")
+
+        def fail_after_second_commit(
+            phase: str,
+            _directory_path: str,
+            _name: str | None,
+        ) -> None:
+            if phase == "before_commit_second.json_durability":
+                raise OSError("injected ordered publication failure")
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=fail_after_second_commit,
+                ),
+                self.assertRaisesRegex(OSError, "ordered publication failure"),
+            ):
+                transaction.publish_specs(
+                    (
+                        ArtifactSpec("first.json", b"first new\n"),
+                        ArtifactSpec("second.json", None),
+                    )
+                )
+
+        self.assertEqual(first.read_bytes(), b"first old\n")
+        self.assertEqual(second.read_bytes(), b"second old\n")
+        self.assertEqual(
+            sorted(path.name for path in self.artifact_directory.iterdir()),
+            ["first.json", "second.json"],
+        )
+
+    def test_ordered_publish_rechecks_later_target_after_prior_durability(self) -> None:
+        first = self.artifact_directory / "first.json"
+        second = self.artifact_directory / "second.json"
+        first.write_bytes(b"first old\n")
+        second.write_bytes(b"second old\n")
+        changed_later_target = False
+
+        def change_second_after_first_durability(
+            phase: str,
+            _directory_path: str,
+            name: str | None,
+        ) -> None:
+            nonlocal changed_later_target
+            if phase != "after_durability" or name != "first.json":
+                return
+            second.write_bytes(b"second external\n")
+            changed_later_target = True
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=change_second_after_first_durability,
+                ),
+                self.assertRaisesRegex(OSError, "Artifact changed"),
+            ):
+                transaction.publish_specs(
+                    (
+                        ArtifactSpec("first.json", b"first new\n"),
+                        ArtifactSpec("second.json", b"second new\n"),
+                    )
+                )
+
+        self.assertTrue(changed_later_target)
+        self.assertEqual(first.read_bytes(), b"first old\n")
+        self.assertEqual(second.read_bytes(), b"second external\n")
+        self.assertEqual(
+            sorted(path.name for path in self.artifact_directory.iterdir()),
+            ["first.json", "second.json"],
+        )
+
+    def test_publish_rollback_continues_after_one_target_fails(self) -> None:
+        first = self.artifact_directory / "first.json"
+        second = self.artifact_directory / "second.json"
+        first.write_bytes(b"first old\n")
+        second.write_bytes(b"second old\n")
+        first.chmod(0o640)
+        second.chmod(0o600)
+        rolling_back = False
+        rollback_attempts: list[str] = []
+
+        def fail_second_rollback_only(
+            phase: str,
+            _directory_path: str,
+            name: str | None,
+        ) -> None:
+            nonlocal rolling_back
+            if phase == "before_commit_second.json_durability":
+                rolling_back = True
+                raise OSError("injected ordered publication failure")
+            if not rolling_back or phase != "before_commit" or name is None:
+                return
+            rollback_attempts.append(name)
+            if name == "second.json":
+                raise OSError("injected second rollback failure")
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=fail_second_rollback_only,
+                ),
+                self.assertRaisesRegex(
+                    OSError,
+                    "ordered publication failure",
+                ) as raised,
+            ):
+                transaction.publish_specs(
+                    (
+                        ArtifactSpec("first.json", b"first new\n"),
+                        ArtifactSpec("second.json", b"second new\n"),
+                    )
+                )
+
+        self.assertEqual(rollback_attempts, ["second.json", "first.json"])
+        self.assertEqual(first.read_bytes(), b"first old\n")
+        self.assertEqual(second.read_bytes(), b"second new\n")
+        retained = [
+            path
+            for path in self.artifact_directory.iterdir()
+            if path.name not in {"first.json", "second.json"}
+        ]
+        self.assertEqual(len(retained), 1)
+        self.assertEqual(retained[0].read_bytes(), b"second old\n")
+        self.assertEqual(stat.S_IMODE(retained[0].stat().st_mode), 0o600)
+        notes = getattr(raised.exception, "__notes__", ())
+        self.assertTrue(
+            any("injected second rollback failure" in note for note in notes)
+        )
+        self.assertTrue(
+            any("verified recovery artifact preserved" in note for note in notes)
+        )
+
+    def test_restore_rolls_back_completed_receipt_displacement(self) -> None:
+        target = self.artifact_directory / "report.json"
+        target.write_bytes(b"old\n")
+        target.chmod(0o640)
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            snapshot = transaction.capture_snapshot("report.json")
+            receipt = transaction.publish_specs(
+                (ArtifactSpec("report.json", b"new\n"),)
+            )[0]
+            assert receipt is not None
+            failures = 0
+
+            def fail_after_receipt_displacement(
+                phase: str,
+                _directory_path: str,
+                _name: str | None,
+            ) -> None:
+                nonlocal failures
+                if phase == "after_replace" and failures == 0:
+                    failures += 1
+                    raise OSError("injected completed displacement failure")
+
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=fail_after_receipt_displacement,
+                ),
+                self.assertRaisesRegex(OSError, "completed displacement failure"),
+            ):
+                transaction.restore_snapshots((snapshot,), (receipt,))
+
+            self.assertEqual(target.read_bytes(), receipt.content)
+            target_stat = target.stat()
+            self.assertEqual(
+                (target_stat.st_dev, target_stat.st_ino),
+                receipt.fingerprint[:2],
+            )
+            transaction.restore_snapshots((snapshot,), (receipt,))
+
+        self.assertEqual(target.read_bytes(), b"old\n")
+        self.assertEqual(stat.S_IMODE(target.stat().st_mode), 0o640)
+
+    def test_restore_rejects_changed_receipt_before_staging_or_mutation(self) -> None:
+        target = self.artifact_directory / "report.json"
+        target.write_bytes(b"old\n")
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            snapshot = transaction.capture_snapshot("report.json")
+            receipt = transaction.publish_specs(
+                (ArtifactSpec("report.json", b"new\n"),)
+            )[0]
+            assert receipt is not None
+            target.write_bytes(b"changed after publication\n")
+            directory_before = self._directory_snapshot(self.artifact_directory)
+
+            with self.assertRaisesRegex(OSError, "no longer matches its receipt"):
+                transaction.restore_snapshots((snapshot,), (receipt,))
+
+        self.assertEqual(
+            self._directory_snapshot(self.artifact_directory),
+            directory_before,
+        )
+
+    def test_restore_rechecks_receipt_after_staging_before_mutation(self) -> None:
+        target = self.artifact_directory / "report.json"
+        target.write_bytes(b"old\n")
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            snapshot = transaction.capture_snapshot("report.json")
+            receipt = transaction.publish_specs(
+                (ArtifactSpec("report.json", b"new\n"),)
+            )[0]
+            assert receipt is not None
+            changed_during_staging = False
+
+            def replace_after_first_restore_stage(
+                phase: str,
+                _directory_path: str,
+                _name: str | None,
+            ) -> None:
+                nonlocal changed_during_staging
+                if phase != "after_stage" or changed_during_staging:
+                    return
+                target.write_bytes(b"changed during restore staging\n")
+                changed_during_staging = True
+
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=replace_after_first_restore_stage,
+                ),
+                self.assertRaisesRegex(OSError, "no longer matches its receipt"),
+            ):
+                transaction.restore_snapshots((snapshot,), (receipt,))
+
+        self.assertTrue(changed_during_staging)
+        self.assertEqual(target.read_bytes(), b"changed during restore staging\n")
+        self.assertEqual(
+            sorted(path.name for path in self.artifact_directory.iterdir()),
+            ["report.json"],
+        )
+
+    def test_restore_does_not_displace_target_changed_at_replace_boundary(
+        self,
+    ) -> None:
+        target = self.artifact_directory / "report.json"
+        target.write_bytes(b"old\n")
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            snapshot = transaction.capture_snapshot("report.json")
+            receipt = transaction.publish_specs(
+                (ArtifactSpec("report.json", b"new\n"),)
+            )[0]
+            assert receipt is not None
+            replaced = False
+
+            def replace_at_native_boundary(
+                phase: str,
+                _directory_path: str,
+                _name: str | None,
+            ) -> None:
+                nonlocal replaced
+                if phase != "before_replace" or replaced:
+                    return
+                replacement = self.artifact_directory / "external.tmp"
+                replacement.write_bytes(b"external replacement\n")
+                os.replace(replacement, target)
+                replaced = True
+
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=replace_at_native_boundary,
+                ),
+                self.assertRaisesRegex(OSError, "transaction file changed"),
+            ):
+                transaction.restore_snapshots((snapshot,), (receipt,))
+
+        self.assertTrue(replaced)
+        self.assertEqual(target.read_bytes(), b"external replacement\n")
+        self.assertEqual(
+            sorted(path.name for path in self.artifact_directory.iterdir()),
+            ["report.json"],
+        )
+
+    def test_ordered_restore_rechecks_later_receipt_after_prior_durability(
+        self,
+    ) -> None:
+        first = self.artifact_directory / "first.json"
+        second = self.artifact_directory / "second.json"
+        first.write_bytes(b"first old\n")
+        second.write_bytes(b"second old\n")
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            snapshots = transaction.capture_snapshots(("first.json", "second.json"))
+            receipts = transaction.publish_specs(
+                (
+                    ArtifactSpec("first.json", b"first new\n"),
+                    ArtifactSpec("second.json", b"second new\n"),
+                )
+            )
+            first_receipt, second_receipt = receipts
+            assert first_receipt is not None
+            assert second_receipt is not None
+            changed_later_receipt = False
+
+            def change_second_after_first_durability(
+                phase: str,
+                _directory_path: str,
+                name: str | None,
+            ) -> None:
+                nonlocal changed_later_receipt
+                if phase != "after_durability" or name != "first.json":
+                    return
+                second.write_bytes(b"second external\n")
+                changed_later_receipt = True
+
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=change_second_after_first_durability,
+                ),
+                self.assertRaisesRegex(OSError, "no longer matches its receipt"),
+            ):
+                transaction.restore_snapshots(snapshots, receipts)
+
+        self.assertTrue(changed_later_receipt)
+        self.assertEqual(first.read_bytes(), first_receipt.content)
+        self.assertEqual(second.read_bytes(), b"second external\n")
+        self.assertEqual(
+            sorted(path.name for path in self.artifact_directory.iterdir()),
+            ["first.json", "second.json"],
+        )
+
+    def test_restore_rollback_continues_and_retains_exact_receipt(self) -> None:
+        first = self.artifact_directory / "first.json"
+        second = self.artifact_directory / "second.json"
+        first.write_bytes(b"first old\n")
+        second.write_bytes(b"second old\n")
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            snapshots = transaction.capture_snapshots(("first.json", "second.json"))
+            receipts = transaction.publish_specs(
+                (
+                    ArtifactSpec("first.json", b"first new\n"),
+                    ArtifactSpec("second.json", b"second new\n"),
+                )
+            )
+            first_receipt, second_receipt = receipts
+            assert first_receipt is not None
+            assert second_receipt is not None
+            rolling_back = False
+            rollback_attempts: list[str] = []
+
+            def fail_second_rollback_only(
+                phase: str,
+                _directory_path: str,
+                name: str | None,
+            ) -> None:
+                nonlocal rolling_back
+                if phase == "before_restore_second.json_durability":
+                    rolling_back = True
+                    raise OSError("injected ordered restore failure")
+                if not rolling_back or phase != "before_commit" or name is None:
+                    return
+                rollback_attempts.append(name)
+                if name == "second.json":
+                    raise OSError("injected receipt rollback failure")
+
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=fail_second_rollback_only,
+                ),
+                self.assertRaisesRegex(
+                    OSError,
+                    "ordered restore failure",
+                ) as raised,
+            ):
+                transaction.restore_snapshots(snapshots, receipts)
+
+            transaction.verify_receipt(first_receipt)
+
+        self.assertEqual(rollback_attempts, ["second.json", "first.json"])
+        self.assertEqual(first.read_bytes(), first_receipt.content)
+        self.assertEqual(second.read_bytes(), b"second old\n")
+        retained = [
+            path
+            for path in self.artifact_directory.iterdir()
+            if path.name not in {"first.json", "second.json"}
+        ]
+        self.assertEqual(len(retained), 1)
+        retained_stat = retained[0].stat()
+        self.assertEqual(
+            (retained_stat.st_dev, retained_stat.st_ino),
+            second_receipt.fingerprint[:2],
+        )
+        self.assertEqual(retained[0].read_bytes(), second_receipt.content)
+        notes = getattr(raised.exception, "__notes__", ())
+        self.assertTrue(
+            any("injected receipt rollback failure" in note for note in notes)
+        )
+        self.assertTrue(
+            any("verified recovery artifact preserved" in note for note in notes)
+        )
+
+    @unittest.skipUnless(os.name == "nt", "native Windows handle semantics required")
+    def test_windows_binding_blocks_directory_and_root_relocation(self) -> None:
+        parked_directory = self.root / "gm2godot.parked"
+        parked_root = self.temp_dir / "project.parked"
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ):
+            with self.assertRaises(OSError):
+                os.rename(self.artifact_directory, parked_directory)
+            with self.assertRaises(OSError):
+                os.rename(self.root, parked_root)
+
+        os.rename(self.artifact_directory, parked_directory)
+        os.rename(parked_directory, self.artifact_directory)
+        os.rename(self.root, parked_root)
+        os.rename(parked_root, self.root)
+
+    @unittest.skipUnless(os.name == "nt", "native Windows handle semantics required")
+    def test_windows_child_prebind_swap_to_junction_is_rejected(self) -> None:
+        outside = self.temp_dir / "outside-prebind"
+        outside.mkdir()
+        sentinel = outside / "sentinel.txt"
+        sentinel.write_bytes(b"outside\n")
+        parked = self.root / "gm2godot.parked"
+        real_open = cast(
+            Callable[[str, tuple[int, int]], tuple[Any, int]],
+            getattr(anchored_artifacts_module, "_open_windows_directory_handle"),
+        )
+        swapped = False
+
+        def swap_before_child_handle(
+            path: str,
+            expected_identity: tuple[int, int],
+        ) -> tuple[Any, int]:
+            nonlocal swapped
+            if (
+                os.path.normcase(os.path.abspath(path))
+                == os.path.normcase(os.path.abspath(self.artifact_directory))
+                and not swapped
+            ):
+                os.rename(self.artifact_directory, parked)
+                completed = subprocess.run(
+                    [
+                        "cmd.exe",
+                        "/d",
+                        "/c",
+                        "mklink",
+                        "/J",
+                        str(self.artifact_directory),
+                        str(outside),
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(completed.returncode, 0, completed.stderr)
+                swapped = True
+            return real_open(path, expected_identity)
+
+        try:
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._open_windows_directory_handle",
+                    side_effect=swap_before_child_handle,
+                ),
+                self.assertRaisesRegex(OSError, "changed"),
+            ):
+                ByteArtifactTransaction.open(
+                    str(self.root),
+                    "gm2godot",
+                    create=False,
+                    description="test artifact directory",
+                )
+            self.assertTrue(swapped)
+            self.assertEqual(sentinel.read_bytes(), b"outside\n")
+            self.assertEqual(list(parked.iterdir()), [])
+        finally:
+            if self.artifact_directory.is_junction():
+                os.rmdir(self.artifact_directory)
+            if parked.exists():
+                os.rename(parked, self.artifact_directory)
+
+    @unittest.skipUnless(os.name == "nt", "native Windows junction semantics required")
+    def test_windows_binding_rejects_real_junction_without_touching_target(self) -> None:
+        outside = self.temp_dir / "outside"
+        outside.mkdir()
+        sentinel = outside / "sentinel.txt"
+        sentinel.write_bytes(b"outside\n")
+        self.artifact_directory.rmdir()
+        completed = subprocess.run(
+            [
+                "cmd.exe",
+                "/d",
+                "/c",
+                "mklink",
+                "/J",
+                str(self.artifact_directory),
+                str(outside),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        try:
+            junction_stat = os.lstat(self.artifact_directory)
+            attributes_seen: list[int] = []
+            real_attributes = cast(
+                Callable[[Any, int, str], int],
+                getattr(anchored_artifacts_module, "_windows_directory_attributes"),
+            )
+
+            def record_attributes(kernel32: Any, handle: int, path: str) -> int:
+                attributes = real_attributes(kernel32, handle, path)
+                attributes_seen.append(attributes)
+                return attributes
+
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._windows_directory_attributes",
+                    side_effect=record_attributes,
+                ),
+                self.assertRaisesRegex(OSError, "changed"),
+            ):
+                open_windows_directory = cast(
+                    Callable[[str, tuple[int, int]], tuple[Any, int]],
+                    getattr(
+                        anchored_artifacts_module,
+                        "_open_windows_directory_handle",
+                    ),
+                )
+                open_windows_directory(
+                    str(self.artifact_directory),
+                    (junction_stat.st_dev, junction_stat.st_ino),
+                )
+            self.assertTrue(attributes_seen)
+            directory_attribute = cast(
+                int,
+                getattr(
+                    anchored_artifacts_module,
+                    "_WINDOWS_FILE_ATTRIBUTE_DIRECTORY",
+                ),
+            )
+            reparse_attribute = cast(
+                int,
+                getattr(
+                    anchored_artifacts_module,
+                    "_WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT",
+                ),
+            )
+            self.assertTrue(
+                attributes_seen[-1] & directory_attribute
+            )
+            self.assertTrue(
+                attributes_seen[-1] & reparse_attribute
+            )
+            with self.assertRaisesRegex(OSError, "redirected"):
+                ByteArtifactTransaction.open(
+                    str(self.root),
+                    "gm2godot",
+                    create=False,
+                    description="test artifact directory",
+                )
+            self.assertEqual(sentinel.read_bytes(), b"outside\n")
+        finally:
+            os.rmdir(self.artifact_directory)
+            self.artifact_directory.mkdir()
+
+    @unittest.skipUnless(os.name == "nt", "native Windows move semantics required")
+    def test_windows_moves_use_extended_write_through_paths(self) -> None:
+        target_name = "report-Δ-日本語.json"
+        target = self.artifact_directory / target_name
+        target.write_bytes(b"old\n")
+        calls: list[tuple[str, str, int]] = []
+
+        class RecordingWindowsApi:
+            def __init__(self, wrapped: Any) -> None:
+                self.wrapped = wrapped
+
+            def MoveFileExW(
+                self,
+                source: str,
+                destination: str,
+                flags: int,
+            ) -> int:
+                calls.append((source, destination, flags))
+                move = cast(
+                    Callable[[str, str, int], int],
+                    getattr(self.wrapped, "MoveFileExW"),
+                )
+                return move(source, destination, flags)
+
+            def __getattr__(self, name: str) -> Any:
+                return getattr(self.wrapped, name)
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            self.assertEqual(transaction.strategy, "windows_handle")
+            transaction.directory.windows_api = RecordingWindowsApi(
+                transaction.directory.windows_api
+            )
+            receipt = transaction.publish_specs(
+                (ArtifactSpec(target_name, b"new\n"),)
+            )[0]
+            assert receipt is not None
+            absent_receipt = transaction.publish_specs(
+                (ArtifactSpec(target_name, None),)
+            )[0]
+            self.assertIsNone(absent_receipt)
+
+        self.assertFalse(target.exists())
+        self.assertEqual(len(calls), 2)
+        expected_flags = (
+            cast(
+                int,
+                getattr(
+                    anchored_artifacts_module,
+                    "_WINDOWS_MOVEFILE_REPLACE_EXISTING",
+                ),
+            )
+            | cast(
+                int,
+                getattr(
+                    anchored_artifacts_module,
+                    "_WINDOWS_MOVEFILE_WRITE_THROUGH",
+                ),
+            )
+        )
+        for source, destination, flags in calls:
+            self.assertTrue(source.startswith("\\\\?\\"))
+            self.assertTrue(destination.startswith("\\\\?\\"))
+            self.assertEqual(flags, expected_flags)
+        self.assertTrue(calls[1][1].endswith(".tombstone"))
+
+    @unittest.skipUnless(os.name == "nt", "native Windows hardlinks required")
+    def test_windows_readonly_hardlink_is_rejected_without_alias_mutation(self) -> None:
+        target = self.artifact_directory / "report.json"
+        alias = self.root / "report-alias.json"
+        target.write_bytes(b"old\n")
+        os.link(target, alias)
+        target.chmod(0o444)
+        try:
+            with ByteArtifactTransaction.open(
+                str(self.root),
+                "gm2godot",
+                create=False,
+                description="test artifact directory",
+            ) as transaction:
+                with self.assertRaisesRegex(
+                    OSError,
+                    "read-only multiply-linked artifact",
+                ):
+                    transaction.publish_specs(
+                        (ArtifactSpec("report.json", b"new\n"),)
+                    )
+            target_stat = target.stat()
+            alias_stat = alias.stat()
+            self.assertEqual(
+                (target_stat.st_dev, target_stat.st_ino),
+                (alias_stat.st_dev, alias_stat.st_ino),
+            )
+            self.assertGreaterEqual(target_stat.st_nlink, 2)
+            self.assertEqual(target.read_bytes(), b"old\n")
+            self.assertEqual(alias.read_bytes(), b"old\n")
+            self.assertFalse(stat.S_IMODE(target_stat.st_mode) & stat.S_IWUSR)
+            self.assertFalse(stat.S_IMODE(alias_stat.st_mode) & stat.S_IWUSR)
+        finally:
+            target.chmod(0o600)
+
+    @unittest.skipUnless(os.name == "nt", "native Windows attributes required")
+    def test_windows_single_link_readonly_publish_and_restore(self) -> None:
+        target = self.artifact_directory / "report.json"
+        target.write_bytes(b"old\n")
+        target.chmod(0o444)
+        try:
+            with ByteArtifactTransaction.open(
+                str(self.root),
+                "gm2godot",
+                create=False,
+                description="test artifact directory",
+            ) as transaction:
+                snapshot = transaction.capture_snapshot("report.json")
+                receipt = transaction.publish_specs(
+                    (ArtifactSpec("report.json", b"new\n"),)
+                )[0]
+                assert receipt is not None
+                self.assertEqual(target.read_bytes(), b"new\n")
+                self.assertFalse(
+                    stat.S_IMODE(target.stat().st_mode) & stat.S_IWUSR
+                )
+                transaction.restore_snapshots((snapshot,), (receipt,))
+
+            self.assertEqual(target.read_bytes(), b"old\n")
+            self.assertFalse(stat.S_IMODE(target.stat().st_mode) & stat.S_IWUSR)
+            self.assertEqual(
+                sorted(path.name for path in self.artifact_directory.iterdir()),
+                ["report.json"],
+            )
+        finally:
+            if target.exists():
+                target.chmod(0o600)
+
+    @unittest.skipUnless(os.name == "nt", "native Windows long paths required")
+    def test_windows_long_unicode_publish_and_restore(self) -> None:
+        long_root = self.temp_dir / ("a" * 120) / ("b" * 120) / "project-日本語"
+        long_root.mkdir(parents=True)
+        child_name = "gm2godot-Δοκιμή"
+        target_name = "architecture-policy-日本語.json"
+        target = long_root / child_name / target_name
+        self.assertGreater(len(str(target)), 260)
+
+        with ByteArtifactTransaction.open(
+            str(long_root),
+            child_name,
+            create=True,
+            description="long Unicode artifact directory",
+        ) as transaction:
+            snapshot = transaction.capture_snapshot(target_name)
+            receipt = transaction.publish_specs(
+                (ArtifactSpec(target_name, "受け渡しΔ\n".encode()),)
+            )[0]
+            assert receipt is not None
+            transaction.verify_receipt(receipt)
+            transaction.restore_snapshots((snapshot,), (receipt,))
+
+        self.assertFalse(target.exists())
+        self.assertEqual(list((long_root / child_name).iterdir()), [])
+
+    @staticmethod
+    def _directory_snapshot(path: Path) -> dict[str, tuple[int, int, int, bytes]]:
+        snapshot: dict[str, tuple[int, int, int, bytes]] = {}
+        for child in path.iterdir():
+            child_stat = child.lstat()
+            snapshot[child.name] = (
+                child_stat.st_dev,
+                child_stat.st_ino,
+                stat.S_IMODE(child_stat.st_mode),
+                child.read_bytes(),
+            )
+        return snapshot
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_architecture_policy.py
+++ b/tests/test_architecture_policy.py
@@ -11,7 +11,9 @@ from pathlib import Path
 from typing import Callable, cast
 from unittest.mock import patch
 
+from src.conversion import anchored_artifacts as anchored_artifacts_module
 from src.conversion import architecture_policy as architecture_policy_module
+from src.conversion.anchored_artifacts import ByteArtifactTransaction
 from src.conversion.architecture_policy import (
     ARCHITECTURE_POLICY_RELATIVE_PATH,
     build_architecture_policy_report,
@@ -30,6 +32,31 @@ def _write_json(path: Path, value: object) -> None:
 def _write_text(path: Path, value: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(value, encoding="utf-8")
+
+
+def _lstat_at(path: str | bytes, *, dir_fd: int | None) -> os.stat_result:
+    return os.stat(path, dir_fd=dir_fd, follow_symlinks=False)
+
+
+def _lexists_at(path: str | bytes, *, dir_fd: int | None) -> bool:
+    try:
+        _lstat_at(path, dir_fd=dir_fd)
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def _directory_snapshot(path: Path) -> dict[str, tuple[int, int, int, bytes]]:
+    snapshot: dict[str, tuple[int, int, int, bytes]] = {}
+    for child in path.iterdir():
+        child_stat = child.lstat()
+        snapshot[child.name] = (
+            child_stat.st_dev,
+            child_stat.st_ino,
+            stat.S_IMODE(child_stat.st_mode),
+            child.read_bytes(),
+        )
+    return snapshot
 
 
 def _remove_readonly_test_path(
@@ -187,23 +214,21 @@ class TestArchitecturePolicy(unittest.TestCase):
     ) -> None:
         report_path = self.godot_dir / ARCHITECTURE_POLICY_RELATIVE_PATH
         report_path.parent.mkdir(parents=True)
-        stage_policy = cast(
-            Callable[..., object],
-            getattr(architecture_policy_module, "_stage_policy_bytes"),
+        transaction = ByteArtifactTransaction.open(
+            str(self.godot_dir),
+            "gm2godot",
+            create=False,
+            description="architecture-policy report directory",
         )
-        verify_staged = cast(
-            Callable[[object], None],
-            getattr(architecture_policy_module, "_verify_staged_policy_file"),
-        )
-        staged = stage_policy(
-            str(report_path),
+        staged = transaction.stage_bytes(
+            report_path.name,
             b'{"staged": "ctime drift"}\n',
             mode=None,
             suffix=".tmp",
         )
         real_fingerprint = cast(
             Callable[[os.stat_result], tuple[int, int, int, int, int]],
-            getattr(architecture_policy_module, "_file_fingerprint"),
+            getattr(anchored_artifacts_module, "_file_fingerprint"),
         )
         fingerprint_calls = 0
 
@@ -221,32 +246,33 @@ class TestArchitecturePolicy(unittest.TestCase):
         try:
             with (
                 patch(
-                    "src.conversion.architecture_policy._is_windows_platform",
+                    "src.conversion.anchored_artifacts._is_windows_platform",
                     return_value=True,
                 ),
                 patch(
-                    "src.conversion.architecture_policy._file_fingerprint",
+                    "src.conversion.anchored_artifacts._file_fingerprint",
                     side_effect=ctime_drifting_fingerprint,
                 ),
             ):
-                verify_staged(staged)
+                transaction.verify_staged(staged)
 
             self.assertEqual(fingerprint_calls, 3)
             fingerprint_calls = 0
             with (
                 patch(
-                    "src.conversion.architecture_policy._is_windows_platform",
+                    "src.conversion.anchored_artifacts._is_windows_platform",
                     return_value=False,
                 ),
                 patch(
-                    "src.conversion.architecture_policy._file_fingerprint",
+                    "src.conversion.anchored_artifacts._file_fingerprint",
                     side_effect=ctime_drifting_fingerprint,
                 ),
                 self.assertRaisesRegex(OSError, "content changed"),
             ):
-                verify_staged(staged)
+                transaction.verify_staged(staged)
         finally:
-            Path(cast(str, getattr(staged, "path"))).unlink(missing_ok=True)
+            transaction.unlink_staged(staged)
+            transaction.__exit__(None, None, None)
 
         fingerprints_match = cast(
             Callable[
@@ -256,7 +282,7 @@ class TestArchitecturePolicy(unittest.TestCase):
                 ],
                 bool,
             ],
-            getattr(architecture_policy_module, "_policy_fingerprints_match"),
+            getattr(anchored_artifacts_module, "fingerprints_match"),
         )
         original = (1, 2, 3, 4, 5)
         ctime_only_drift = (1, 2, 3, 4, 50)
@@ -264,7 +290,7 @@ class TestArchitecturePolicy(unittest.TestCase):
         identity_drift = (10, 20, 3, 4, 5)
         size_drift = (1, 2, 30, 4, 5)
         with patch(
-            "src.conversion.architecture_policy._is_windows_platform",
+            "src.conversion.anchored_artifacts._is_windows_platform",
             return_value=True,
         ):
             self.assertTrue(fingerprints_match(original, ctime_only_drift))
@@ -272,7 +298,7 @@ class TestArchitecturePolicy(unittest.TestCase):
             self.assertFalse(fingerprints_match(original, identity_drift))
             self.assertFalse(fingerprints_match(original, size_drift))
         with patch(
-            "src.conversion.architecture_policy._is_windows_platform",
+            "src.conversion.anchored_artifacts._is_windows_platform",
             return_value=False,
         ):
             self.assertFalse(fingerprints_match(original, ctime_only_drift))
@@ -281,17 +307,9 @@ class TestArchitecturePolicy(unittest.TestCase):
         report_path = self.godot_dir / ARCHITECTURE_POLICY_RELATIVE_PATH
         report_path.parent.mkdir(parents=True)
         report_path.write_bytes(b'{"stable": true}\n')
-        target_state = cast(
-            Callable[[str], object],
-            getattr(architecture_policy_module, "_policy_target_state"),
-        )(str(report_path))
-        verify_target_state = cast(
-            Callable[[str, object], None],
-            getattr(architecture_policy_module, "_verify_policy_target_state"),
-        )
         real_fingerprint = cast(
             Callable[[os.stat_result], tuple[int, int, int, int, int]],
-            getattr(architecture_policy_module, "_file_fingerprint"),
+            getattr(anchored_artifacts_module, "_file_fingerprint"),
         )
 
         def path_ctime_drift(
@@ -300,25 +318,35 @@ class TestArchitecturePolicy(unittest.TestCase):
             fingerprint = real_fingerprint(path_stat)
             return (*fingerprint[:4], fingerprint[4] + 1)
 
-        with (
-            patch(
-                "src.conversion.architecture_policy._is_windows_platform",
-                return_value=True,
-            ),
-            patch(
-                "src.conversion.architecture_policy._file_fingerprint",
-                side_effect=path_ctime_drift,
-            ),
-            self.assertRaisesRegex(OSError, "report changed"),
-        ):
-            verify_target_state(str(report_path), target_state)
+        with ByteArtifactTransaction.open(
+            str(self.godot_dir),
+            "gm2godot",
+            create=False,
+            description="architecture-policy report directory",
+        ) as transaction:
+            target_state = transaction.target_state("architecture_policy.json")
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._is_windows_platform",
+                    return_value=True,
+                ),
+                patch(
+                    "src.conversion.anchored_artifacts._file_fingerprint",
+                    side_effect=path_ctime_drift,
+                ),
+                self.assertRaisesRegex(OSError, "Artifact changed"),
+            ):
+                transaction.verify_target_state(
+                    "architecture_policy.json",
+                    target_state,
+                )
 
     def test_windows_receipt_guard_rejects_identity_size_content_and_mode_changes(
         self,
     ) -> None:
         self._write_minimal_project()
         verify_receipt = cast(
-            Callable[[object], None],
+            Callable[..., None],
             getattr(architecture_policy_module, "_verify_policy_receipt"),
         )
 
@@ -355,17 +383,23 @@ class TestArchitecturePolicy(unittest.TestCase):
                 else:
                     report_path.chmod(receipt.mode ^ stat.S_IWUSR)
 
-                with (
-                    patch(
-                        "src.conversion.architecture_policy._is_windows_platform",
-                        return_value=True,
-                    ),
-                    self.assertRaisesRegex(
-                        OSError,
-                        "no longer matches its publication receipt",
-                    ),
-                ):
-                    verify_receipt(receipt)
+                with ByteArtifactTransaction.open(
+                    str(godot_dir),
+                    "gm2godot",
+                    create=False,
+                    description="architecture-policy report directory",
+                ) as transaction:
+                    with (
+                        patch(
+                            "src.conversion.anchored_artifacts._is_windows_platform",
+                            return_value=True,
+                        ),
+                        self.assertRaisesRegex(
+                            OSError,
+                            "no longer matches its publication receipt",
+                        ),
+                    ):
+                        verify_receipt(receipt, transaction)
 
     def test_mocked_windows_readonly_report_publishes_restores_and_cleans(
         self,
@@ -377,38 +411,55 @@ class TestArchitecturePolicy(unittest.TestCase):
         report_path.write_bytes(previous_content)
         report_path.chmod(0o444)
         snapshot = capture_architecture_policy_snapshot(str(self.godot_dir))
-        real_replace = os.replace
+        real_rename = os.rename
         real_unlink = os.unlink
 
-        def windows_replace(source: str, destination: str) -> None:
-            if os.path.lexists(destination):
-                destination_mode = stat.S_IMODE(os.lstat(destination).st_mode)
+        def windows_replace(
+            source: str,
+            destination: str,
+            *,
+            src_dir_fd: int | None = None,
+            dst_dir_fd: int | None = None,
+        ) -> None:
+            if _lexists_at(destination, dir_fd=dst_dir_fd):
+                destination_mode = stat.S_IMODE(
+                    _lstat_at(destination, dir_fd=dst_dir_fd).st_mode
+                )
                 if not destination_mode & stat.S_IWUSR:
                     raise PermissionError(
                         "mock Windows refuses to replace a read-only destination"
                     )
-            real_replace(source, destination)
+            real_rename(
+                source,
+                destination,
+                src_dir_fd=src_dir_fd,
+                dst_dir_fd=dst_dir_fd,
+            )
 
-        def windows_unlink(path: str) -> None:
-            if os.path.lexists(path):
-                path_mode = stat.S_IMODE(os.lstat(path).st_mode)
+        def windows_unlink(
+            path: str | bytes,
+            *,
+            dir_fd: int | None = None,
+        ) -> None:
+            if _lexists_at(path, dir_fd=dir_fd):
+                path_mode = stat.S_IMODE(_lstat_at(path, dir_fd=dir_fd).st_mode)
                 if not path_mode & stat.S_IWUSR:
                     raise PermissionError(
                         "mock Windows refuses to unlink a read-only file"
                     )
-            real_unlink(path)
+            real_unlink(path, dir_fd=dir_fd)
 
         with (
             patch(
-                "src.conversion.architecture_policy._is_windows_platform",
+                "src.conversion.anchored_artifacts._is_windows_platform",
                 return_value=True,
             ),
             patch(
-                "src.conversion.architecture_policy.os.replace",
+                "src.conversion.anchored_artifacts.os.rename",
                 side_effect=windows_replace,
             ),
             patch(
-                "src.conversion.architecture_policy.os.unlink",
+                "src.conversion.anchored_artifacts.os.unlink",
                 side_effect=windows_unlink,
             ),
         ):
@@ -442,39 +493,49 @@ class TestArchitecturePolicy(unittest.TestCase):
         report_path.parent.mkdir(parents=True)
         report_path.write_bytes(previous_content)
         report_path.chmod(0o444)
-        real_replace = os.replace
         real_unlink = os.unlink
 
-        def fail_report_replace(source: str, destination: str) -> None:
-            if os.path.abspath(destination) == os.path.abspath(report_path):
-                destination_mode = stat.S_IMODE(os.lstat(destination).st_mode)
+        def fail_report_replace(
+            phase: str,
+            directory_path: str,
+            name: str | None,
+        ) -> None:
+            if phase == "before_replace" and name == report_path.name:
+                assert name is not None
+                destination = os.path.join(directory_path, name)
+                destination_mode = stat.S_IMODE(
+                    os.lstat(destination).st_mode
+                )
                 if not destination_mode & stat.S_IWUSR:
                     raise PermissionError(
                         "mock Windows refuses to replace a read-only destination"
                     )
                 raise OSError("injected Windows replacement failure")
-            real_replace(source, destination)
 
-        def windows_unlink(path: str) -> None:
-            if os.path.lexists(path):
-                path_mode = stat.S_IMODE(os.lstat(path).st_mode)
+        def windows_unlink(
+            path: str | bytes,
+            *,
+            dir_fd: int | None = None,
+        ) -> None:
+            if _lexists_at(path, dir_fd=dir_fd):
+                path_mode = stat.S_IMODE(_lstat_at(path, dir_fd=dir_fd).st_mode)
                 if not path_mode & stat.S_IWUSR:
                     raise PermissionError(
                         "mock Windows refuses to unlink a read-only file"
                     )
-            real_unlink(path)
+            real_unlink(path, dir_fd=dir_fd)
 
         with (
             patch(
-                "src.conversion.architecture_policy._is_windows_platform",
+                "src.conversion.anchored_artifacts._is_windows_platform",
                 return_value=True,
             ),
             patch(
-                "src.conversion.architecture_policy.os.replace",
+                "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
                 side_effect=fail_report_replace,
             ),
             patch(
-                "src.conversion.architecture_policy.os.unlink",
+                "src.conversion.anchored_artifacts.os.unlink",
                 side_effect=windows_unlink,
             ),
             self.assertRaisesRegex(OSError, "Windows replacement failure"),
@@ -500,64 +561,72 @@ class TestArchitecturePolicy(unittest.TestCase):
         report_path.parent.mkdir(parents=True)
         report_path.write_bytes(previous_content)
         report_path.chmod(0o444)
-        real_replace = os.replace
+        real_rename = os.rename
         real_unlink = os.unlink
-        real_fsync_directory = cast(
-            Callable[[str, tuple[int, int], str, tuple[int, int]], None],
-            getattr(architecture_policy_module, "_fsync_policy_directory"),
-        )
         fsync_calls = 0
 
-        def windows_replace(source: str, destination: str) -> None:
-            if os.path.lexists(destination):
-                destination_mode = stat.S_IMODE(os.lstat(destination).st_mode)
+        def windows_replace(
+            source: str,
+            destination: str,
+            *,
+            src_dir_fd: int | None = None,
+            dst_dir_fd: int | None = None,
+        ) -> None:
+            if _lexists_at(destination, dir_fd=dst_dir_fd):
+                destination_mode = stat.S_IMODE(
+                    _lstat_at(destination, dir_fd=dst_dir_fd).st_mode
+                )
                 if not destination_mode & stat.S_IWUSR:
                     raise PermissionError(
                         "mock Windows refuses to replace a read-only destination"
                     )
-            real_replace(source, destination)
+            real_rename(
+                source,
+                destination,
+                src_dir_fd=src_dir_fd,
+                dst_dir_fd=dst_dir_fd,
+            )
 
-        def windows_unlink(path: str) -> None:
-            if os.path.lexists(path):
-                path_mode = stat.S_IMODE(os.lstat(path).st_mode)
+        def windows_unlink(
+            path: str | bytes,
+            *,
+            dir_fd: int | None = None,
+        ) -> None:
+            if _lexists_at(path, dir_fd=dir_fd):
+                path_mode = stat.S_IMODE(_lstat_at(path, dir_fd=dir_fd).st_mode)
                 if not path_mode & stat.S_IWUSR:
                     raise PermissionError(
                         "mock Windows refuses to unlink a read-only file"
                     )
-            real_unlink(path)
+            real_unlink(path, dir_fd=dir_fd)
 
         def fail_first_directory_fsync(
-            godot_project_path: str,
-            root_identity: tuple[int, int],
-            artifact_directory: str,
-            directory_identity: tuple[int, int],
+            phase: str,
+            _directory_path: str,
+            _name: str | None,
         ) -> None:
             nonlocal fsync_calls
+            if phase != "before_durability":
+                return
             fsync_calls += 1
             if fsync_calls == 1:
                 raise OSError("injected Windows directory fsync failure")
-            real_fsync_directory(
-                godot_project_path,
-                root_identity,
-                artifact_directory,
-                directory_identity,
-            )
 
         with (
             patch(
-                "src.conversion.architecture_policy._is_windows_platform",
+                "src.conversion.anchored_artifacts._is_windows_platform",
                 return_value=True,
             ),
             patch(
-                "src.conversion.architecture_policy.os.replace",
+                "src.conversion.anchored_artifacts.os.rename",
                 side_effect=windows_replace,
             ),
             patch(
-                "src.conversion.architecture_policy.os.unlink",
+                "src.conversion.anchored_artifacts.os.unlink",
                 side_effect=windows_unlink,
             ),
             patch(
-                "src.conversion.architecture_policy._fsync_policy_directory",
+                "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
                 side_effect=fail_first_directory_fsync,
             ),
             self.assertRaisesRegex(OSError, "Windows directory fsync failure"),
@@ -579,26 +648,22 @@ class TestArchitecturePolicy(unittest.TestCase):
     ) -> None:
         self._write_minimal_project()
         report_directory = self.godot_dir / "gm2godot"
-        real_fsync = cast(
-            Callable[..., None],
-            getattr(architecture_policy_module, "_fsync_verified_directory"),
-        )
+        real_sync = anchored_artifacts_module.VerifiedDirectory.sync
         root_fsync_failures = 0
 
         def fail_first_root_fsync(
-            path: str,
-            identity: tuple[int, int],
-            *,
-            description: str,
+            binding: anchored_artifacts_module.VerifiedDirectory,
         ) -> None:
             nonlocal root_fsync_failures
-            if os.path.abspath(path) == os.path.abspath(self.godot_dir):
+            if os.path.abspath(binding.path) == os.path.abspath(self.godot_dir):
                 root_fsync_failures += 1
                 raise OSError("injected root fsync failure")
-            real_fsync(path, identity, description=description)
+            real_sync(binding)
 
-        with patch(
-            "src.conversion.architecture_policy._fsync_verified_directory",
+        with patch.object(
+            anchored_artifacts_module.VerifiedDirectory,
+            "sync",
+            autospec=True,
             side_effect=fail_first_root_fsync,
         ):
             with self.assertRaisesRegex(OSError, "root fsync failure"):
@@ -614,18 +679,17 @@ class TestArchitecturePolicy(unittest.TestCase):
         retry_root_fsyncs = 0
 
         def record_retry_root_fsync(
-            path: str,
-            identity: tuple[int, int],
-            *,
-            description: str,
+            binding: anchored_artifacts_module.VerifiedDirectory,
         ) -> None:
             nonlocal retry_root_fsyncs
-            if os.path.abspath(path) == os.path.abspath(self.godot_dir):
+            if os.path.abspath(binding.path) == os.path.abspath(self.godot_dir):
                 retry_root_fsyncs += 1
-            real_fsync(path, identity, description=description)
+            real_sync(binding)
 
-        with patch(
-            "src.conversion.architecture_policy._fsync_verified_directory",
+        with patch.object(
+            anchored_artifacts_module.VerifiedDirectory,
+            "sync",
+            autospec=True,
             side_effect=record_retry_root_fsync,
         ):
             receipt = publish_architecture_policy_report(
@@ -705,13 +769,17 @@ class TestArchitecturePolicy(unittest.TestCase):
         report_path = Path(receipt.path)
         real_unlink = os.unlink
 
-        def unlink_report_then_raise(path: str | bytes) -> None:
-            real_unlink(path)
-            if os.path.abspath(path) == os.path.abspath(receipt.path):
+        def unlink_report_then_raise(
+            path: str | bytes,
+            *,
+            dir_fd: int | None = None,
+        ) -> None:
+            real_unlink(path, dir_fd=dir_fd)
+            if os.path.basename(os.fsdecode(path)) == Path(receipt.path).name:
                 raise OSError("injected post-unlink failure")
 
         with patch(
-            "src.conversion.architecture_policy.os.unlink",
+            "src.conversion.anchored_artifacts.os.unlink",
             side_effect=unlink_report_then_raise,
         ):
             restored_path = restore_architecture_policy_snapshot(
@@ -737,41 +805,36 @@ class TestArchitecturePolicy(unittest.TestCase):
         )
         report_path = Path(receipt.path)
         real_unlink = os.unlink
-        real_fsync_directory = cast(
-            Callable[[str, tuple[int, int], str, tuple[int, int]], None],
-            getattr(architecture_policy_module, "_fsync_policy_directory"),
-        )
         fsync_calls = 0
 
-        def unlink_report_then_raise(path: str | bytes) -> None:
-            real_unlink(path)
-            if os.path.abspath(path) == os.path.abspath(receipt.path):
+        def unlink_report_then_raise(
+            path: str | bytes,
+            *,
+            dir_fd: int | None = None,
+        ) -> None:
+            real_unlink(path, dir_fd=dir_fd)
+            if os.path.basename(os.fsdecode(path)) == Path(receipt.path).name:
                 raise OSError("injected post-unlink failure")
 
         def fail_first_directory_fsync(
-            godot_project_path: str,
-            root_identity: tuple[int, int],
-            artifact_directory: str,
-            directory_identity: tuple[int, int],
+            phase: str,
+            _directory_path: str,
+            _name: str | None,
         ) -> None:
             nonlocal fsync_calls
+            if phase != "before_durability":
+                return
             fsync_calls += 1
             if fsync_calls == 1:
                 raise OSError("injected restore fsync failure")
-            real_fsync_directory(
-                godot_project_path,
-                root_identity,
-                artifact_directory,
-                directory_identity,
-            )
 
         with (
             patch(
-                "src.conversion.architecture_policy.os.unlink",
+                "src.conversion.anchored_artifacts.os.unlink",
                 side_effect=unlink_report_then_raise,
             ),
             patch(
-                "src.conversion.architecture_policy._fsync_policy_directory",
+                "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
                 side_effect=fail_first_directory_fsync,
             ),
             self.assertRaisesRegex(OSError, "injected restore fsync failure"),
@@ -871,32 +934,23 @@ class TestArchitecturePolicy(unittest.TestCase):
         report_path.write_bytes(previous_content)
         report_path.chmod(0o640)
         previous_mode = stat.S_IMODE(report_path.stat().st_mode)
-        real_fsync_directory = cast(
-            Callable[[str, tuple[int, int], str, tuple[int, int]], None],
-            getattr(architecture_policy_module, "_fsync_policy_directory"),
-        )
         fsync_calls = 0
 
         def fail_first_directory_fsync(
-            godot_project_path: str,
-            root_identity: tuple[int, int],
-            artifact_directory: str,
-            directory_identity: tuple[int, int],
+            phase: str,
+            _directory_path: str,
+            _name: str | None,
         ) -> None:
             nonlocal fsync_calls
+            if phase != "before_durability":
+                return
             fsync_calls += 1
             if fsync_calls == 1:
                 raise OSError("injected directory fsync failure")
-            real_fsync_directory(
-                godot_project_path,
-                root_identity,
-                artifact_directory,
-                directory_identity,
-            )
 
         with (
             patch(
-                "src.conversion.architecture_policy._fsync_policy_directory",
+                "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
                 side_effect=fail_first_directory_fsync,
             ),
             self.assertRaisesRegex(OSError, "injected directory fsync failure"),
@@ -954,14 +1008,18 @@ class TestArchitecturePolicy(unittest.TestCase):
         report_path.write_bytes(b'{"previous": true}\n')
         real_unlink = os.unlink
 
-        def interrupt_backup_cleanup(path: str | bytes) -> None:
+        def interrupt_backup_cleanup(
+            path: str | bytes,
+            *,
+            dir_fd: int | None = None,
+        ) -> None:
             if os.fsdecode(path).endswith(".backup"):
                 raise KeyboardInterrupt("injected cleanup interrupt")
-            real_unlink(path)
+            real_unlink(path, dir_fd=dir_fd)
 
         with (
             patch(
-                "src.conversion.architecture_policy.os.unlink",
+                "src.conversion.anchored_artifacts.os.unlink",
                 side_effect=interrupt_backup_cleanup,
             ),
             self.assertRaisesRegex(KeyboardInterrupt, "cleanup interrupt"),
@@ -985,32 +1043,23 @@ class TestArchitecturePolicy(unittest.TestCase):
             target_platform="linux",
             enabled_converters=["rooms"],
         )
-        real_fsync_directory = cast(
-            Callable[[str, tuple[int, int], str, tuple[int, int]], None],
-            getattr(architecture_policy_module, "_fsync_policy_directory"),
-        )
         fsync_calls = 0
 
         def fail_first_directory_fsync(
-            godot_project_path: str,
-            root_identity: tuple[int, int],
-            artifact_directory: str,
-            directory_identity: tuple[int, int],
+            phase: str,
+            _directory_path: str,
+            _name: str | None,
         ) -> None:
             nonlocal fsync_calls
+            if phase != "before_durability":
+                return
             fsync_calls += 1
             if fsync_calls == 1:
                 raise OSError("injected restore fsync failure")
-            real_fsync_directory(
-                godot_project_path,
-                root_identity,
-                artifact_directory,
-                directory_identity,
-            )
 
         with (
             patch(
-                "src.conversion.architecture_policy._fsync_policy_directory",
+                "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
                 side_effect=fail_first_directory_fsync,
             ),
             self.assertRaisesRegex(OSError, "injected restore fsync failure"),
@@ -1041,32 +1090,23 @@ class TestArchitecturePolicy(unittest.TestCase):
             enabled_converters=["rooms"],
         )
         original_fingerprint = receipt.fingerprint
-        real_fsync_directory = cast(
-            Callable[[str, tuple[int, int], str, tuple[int, int]], None],
-            getattr(architecture_policy_module, "_fsync_policy_directory"),
-        )
         fsync_calls = 0
 
         def fail_first_directory_fsync(
-            godot_project_path: str,
-            root_identity: tuple[int, int],
-            artifact_directory: str,
-            directory_identity: tuple[int, int],
+            phase: str,
+            _directory_path: str,
+            _name: str | None,
         ) -> None:
             nonlocal fsync_calls
+            if phase != "before_durability":
+                return
             fsync_calls += 1
             if fsync_calls == 1:
                 raise OSError("injected post-mutation restore failure")
-            real_fsync_directory(
-                godot_project_path,
-                root_identity,
-                artifact_directory,
-                directory_identity,
-            )
 
         with (
             patch(
-                "src.conversion.architecture_policy._fsync_policy_directory",
+                "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
                 side_effect=fail_first_directory_fsync,
             ),
             self.assertRaisesRegex(OSError, "post-mutation restore failure"),
@@ -1221,6 +1261,186 @@ class TestArchitecturePolicy(unittest.TestCase):
                 target_platform="linux",
                 enabled_converters=["rooms"],
             )
+
+    @unittest.skipUnless(os.name == "posix", "POSIX directory relocation is required")
+    def test_publish_never_mutates_physical_replacement_at_any_main_phase(
+        self,
+    ) -> None:
+        self._write_minimal_project()
+        phases = (
+            "before_stage",
+            "before_backup",
+            "before_commit",
+            "before_durability",
+            "before_cleanup",
+        )
+        for phase in phases:
+            with self.subTest(phase=phase):
+                godot_dir = self.temp_dir / f"phase-{phase}"
+                report_directory = godot_dir / "gm2godot"
+                report_path = report_directory / "architecture_policy.json"
+                parked = godot_dir / "gm2godot.parked"
+                godot_dir.mkdir()
+                report_directory.mkdir()
+                report_path.write_bytes(b'{"previous": true}\n')
+                replacement_before: dict[str, tuple[int, int, int, bytes]] = {}
+                swapped = False
+
+                def replace_directory(
+                    current_phase: str,
+                    directory_path: str,
+                    _name: str | None,
+                ) -> None:
+                    nonlocal replacement_before, swapped
+                    if (
+                        swapped
+                        or current_phase != phase
+                        or os.path.abspath(directory_path)
+                        != os.path.abspath(report_directory)
+                    ):
+                        return
+                    swapped = True
+                    os.rename(report_directory, parked)
+                    report_directory.mkdir()
+                    (report_directory / "architecture_policy.json").write_bytes(
+                        b'{"replacement": true}\n'
+                    )
+                    (report_directory / ".architecture_policy.json.collision.backup").write_bytes(
+                        b"collision\n"
+                    )
+                    (report_directory / "sentinel.txt").write_bytes(b"outside\n")
+                    replacement_before = _directory_snapshot(report_directory)
+
+                with (
+                    patch(
+                        "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                        side_effect=replace_directory,
+                    ),
+                    self.assertRaisesRegex(OSError, "changed"),
+                ):
+                    publish_architecture_policy_report(
+                        str(self.gm_dir),
+                        str(godot_dir),
+                        target_platform="linux",
+                        enabled_converters=["rooms"],
+                    )
+
+                self.assertTrue(swapped)
+                self.assertEqual(
+                    _directory_snapshot(report_directory),
+                    replacement_before,
+                )
+
+    @unittest.skipUnless(os.name == "posix", "POSIX directory relocation is required")
+    def test_publish_rollback_stays_bound_after_physical_replacement(self) -> None:
+        self._write_minimal_project()
+        report_directory = self.godot_dir / "gm2godot"
+        report_path = report_directory / "architecture_policy.json"
+        parked = self.godot_dir / "gm2godot.parked"
+        report_directory.mkdir()
+        report_path.write_bytes(b'{"previous": true}\n')
+        replacement_before: dict[str, tuple[int, int, int, bytes]] = {}
+        swapped = False
+
+        def fail_then_replace(
+            phase: str,
+            directory_path: str,
+            _name: str | None,
+        ) -> None:
+            nonlocal replacement_before, swapped
+            if phase == "after_commit":
+                raise OSError("injected post-commit failure")
+            if phase != "before_rollback" or swapped:
+                return
+            swapped = True
+            os.rename(report_directory, parked)
+            report_directory.mkdir()
+            (report_directory / "architecture_policy.json").write_bytes(
+                b'{"replacement": true}\n'
+            )
+            (report_directory / "sentinel.txt").write_bytes(b"outside\n")
+            replacement_before = _directory_snapshot(report_directory)
+
+        with (
+            patch(
+                "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                side_effect=fail_then_replace,
+            ),
+            self.assertRaisesRegex(OSError, "post-commit failure") as raised,
+        ):
+            publish_architecture_policy_report(
+                str(self.gm_dir),
+                str(self.godot_dir),
+                target_platform="linux",
+                enabled_converters=["rooms"],
+            )
+
+        self.assertTrue(swapped)
+        self.assertEqual(
+            _directory_snapshot(report_directory),
+            replacement_before,
+        )
+        rollback_notes = [
+            note
+            for note in getattr(raised.exception, "__notes__", ())
+            if "verified recovery artifact preserved" in note
+        ]
+        self.assertEqual(len(rollback_notes), 1)
+        self.assertIn(str(parked), rollback_notes[0])
+
+    @unittest.skipUnless(os.name == "posix", "POSIX directory relocation is required")
+    def test_restore_stays_bound_after_physical_replacement(self) -> None:
+        self._write_minimal_project()
+        report_directory = self.godot_dir / "gm2godot"
+        report_path = report_directory / "architecture_policy.json"
+        parked = self.godot_dir / "gm2godot.parked"
+        report_directory.mkdir()
+        report_path.write_bytes(b'{"previous": true}\n')
+        snapshot = capture_architecture_policy_snapshot(str(self.godot_dir))
+        receipt = publish_architecture_policy_report(
+            str(self.gm_dir),
+            str(self.godot_dir),
+            target_platform="linux",
+            enabled_converters=["rooms"],
+        )
+        replacement_before: dict[str, tuple[int, int, int, bytes]] = {}
+        swapped = False
+
+        def replace_before_snapshot_commit(
+            phase: str,
+            directory_path: str,
+            _name: str | None,
+        ) -> None:
+            nonlocal replacement_before, swapped
+            if phase != "before_commit" or swapped:
+                return
+            swapped = True
+            os.rename(report_directory, parked)
+            report_directory.mkdir()
+            (report_directory / "architecture_policy.json").write_bytes(
+                b'{"replacement": true}\n'
+            )
+            (report_directory / "sentinel.txt").write_bytes(b"outside\n")
+            replacement_before = _directory_snapshot(report_directory)
+
+        with (
+            patch(
+                "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                side_effect=replace_before_snapshot_commit,
+            ),
+            self.assertRaisesRegex(OSError, "changed"),
+        ):
+            restore_architecture_policy_snapshot(
+                str(self.godot_dir),
+                snapshot,
+                receipt,
+            )
+
+        self.assertTrue(swapped)
+        self.assertEqual(
+            _directory_snapshot(report_directory),
+            replacement_before,
+        )
 
     def test_feature_scan_ignores_gml_file_symlink_outside_project(self) -> None:
         self._write_minimal_project()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_27(self) -> None:
-        self.assertEqual(get_version(), "0.7.27")
+    def test_release_version_is_0_7_28(self) -> None:
+        self.assertEqual(get_version(), "0.7.28")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- bind architecture-policy publication and restoration to a reusable byte-artifact transaction
- anchor POSIX operations to directory descriptors, pin reparse-checked Windows handles, and document the verified-path fallback
- preserve exact snapshots, receipts, rollback recovery, and release-version surfaces for 0.7.28

Closes #774

## Test plan
- [x] `./venv/bin/pyright --warnings`
- [x] `./venv/bin/python -m ruff check .`
- [x] `./venv/bin/python -m unittest` (2257 tests, 67 skipped)
- [x] exact Godot 4.7.1 headless smoke suites