### PR TITLE
Anchor diagnostic report pair transactions

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.28, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.29, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.29 - 2026-07-19
+
+- Anchored diagnostic JSON/Markdown capture, publication, restoration, invalidation, rollback, recovery retention and cleanup to the shared verified-directory byte-artifact transaction.
+- Bound snapshots and receipts to both the report root and `gm2godot/` identities, with component-by-component creation and parent durability barriers for missing external report roots.
+- Preserved stable paths, Markdown-first ordered commit, exact modes, read-only handling and ordinary-failure rollback; added physical replacement coverage across pair phases and documented that hard-crash pair atomicity remains future work.
+
 ## 0.7.28 - 2026-07-19
 
 - Anchored architecture-policy publication and restoration to one retained destination-directory binding, using descriptor-relative POSIX operations, no-delete-share Win32 handles, write-through Windows moves, and an explicit verified-path fallback.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.28`.
+Current source version: `0.7.29`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.28 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.29 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.28 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.29 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.28 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.29 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -24,6 +24,8 @@ Paths below are relative to the generated Godot project unless a report director
 | `gm2godot/extension_compatibility_report.json` and `group_compatibility_report.json` | Project extension/native-binding findings and texture/audio group compatibility details. | When the corresponding converters inspect those resources. |
 
 The JSON diagnostic entries can include `source_path`, line and column, resource and event/API context, a manifest entry, tracking issue, and workaround. Start with the first `error`, then unsupported warnings, then other warnings.
+
+The JSON/Markdown pair uses one verified report-directory binding for capture, staging, ordered replacement, rollback, invalidation and cleanup. POSIX hosts use descriptor-relative no-follow operations; Windows retains reparse-checked, no-delete-share handles and write-through moves. When an explicit external report root is missing, GM2Godot creates and durability-syncs each parent entry before descending. Ordinary failures restore the complete prior pair, but a hard crash between the two file commits is not yet pair-atomic, so keep the reports with the latest attempt evidence rather than treating either filename alone as a generation marker.
 
 ## Terminal outcomes
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.28 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.29 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -205,15 +205,19 @@ Important trust rules:
 
 The exact schemas and transaction rules are defined by [`conversion_manifest.py`](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/conversion_manifest.py), [`conversion_outcome.py`](https://github.com/Infiland/GM2Godot/blob/main/src/conversion/conversion_outcome.py), and their [manifest tests](https://github.com/Infiland/GM2Godot/blob/main/tests/test_conversion_manifest.py).
 
-### Architecture-policy publication confinement
+### Anchored report publication confinement
 
-`architecture_policy.json` is staged, backed up, published, rolled back, recovered and cleaned through one destination-directory binding retained for the complete operation. On POSIX hosts with the required APIs, every child lookup and namespace mutation is relative to a no-follow directory descriptor and durability barriers call `fsync()` on that retained descriptor. Replacing the visible `gm2godot/` path therefore makes publication fail, but cannot redirect cleanup or rollback into the replacement directory.
+`architecture_policy.json` and the `conversion_diagnostics.json` / `.md` pair are staged, backed up, published, rolled back, recovered and cleaned through one destination-directory binding retained for each complete operation. Diagnostic snapshots and publication receipts bind both the report root and its exact `gm2godot/` child. An explicit external report root that does not exist is created one component at a time through its verified parent; each new directory entry crosses the parent durability barrier before creation descends further.
 
-On Windows, GM2Godot opens both the destination project and the exact captured `gm2godot/` directory with reparse-point inspection and without delete sharing before it creates a stage. Child paths remain safe to resolve while those handles prevent either directory from being relocated; replacement requests use write-through completion. Publishing absence first moves the exact target behind a private write-through tombstone, then removes that tombstone on a best-effort basis. Windows has no documented general equivalent to POSIX directory `fsync`, so directory barriers revalidate the retained handle. This is a confinement and strongest-available write-through guarantee, not a claim of identical power-loss durability; a crash can leave hidden tombstone debris, but cannot restore its old public name.
+On POSIX hosts with the required APIs, every child lookup and namespace mutation is relative to a no-follow directory descriptor and durability barriers call `fsync()` on that retained descriptor. Replacing the visible `gm2godot/` path therefore makes publication fail, but cannot redirect capture, restore, invalidation, cleanup or rollback into the replacement directory.
+
+On Windows, GM2Godot opens both the report root and the exact captured `gm2godot/` directory with reparse-point inspection and without delete sharing before it creates a stage. Child paths remain safe to resolve while those handles prevent either directory from being relocated; replacement requests use write-through completion. Publishing absence first moves the exact target behind a private write-through tombstone, then removes that tombstone on a best-effort basis. Windows has no documented general equivalent to POSIX directory `fsync`, so directory barriers revalidate the retained handle. This is a confinement and strongest-available write-through guarantee, not a claim of identical power-loss durability; a crash can leave hidden tombstone debris, but cannot restore its old public name.
 
 If a non-Windows host lacks descriptor-relative open, stat, mkdir, rename or unlink, `O_NOFOLLOW`, `O_DIRECTORY`, or descriptor chmod, the transaction selects a `verified_path` fallback before staging. That fallback verifies the root and destination identities before and after each full-path operation. It rejects links and changed directories but narrows rather than eliminates the final non-cooperating path-resolution race. The backend is fixed for the transaction and never downgrades after a stage exists.
 
 The retained directory binding does not lock individual artifact names against a non-cooperating writer. Exact inode, mode, byte and digest checks run after staging, before every ordered mutation, and again at the native replace/unlink boundary. A process that races the final system call can still win the remaining leaf-entry interval on platforms without a suitable handle-relative primitive. Close editors, games and other writers while conversion or recovery is running; unexpected exact-state changes fail the transaction and preserve verified recovery material instead of authorizing an overwrite.
+
+The two diagnostic files retain stable public paths and ordinary-exception rollback, but they are still separate ordered replacements. A hard process or machine crash between their durability barriers can therefore expose one old file and one new file. Treat the pair as belonging to one successful invocation only when their outcome and surrounding attempt evidence agree; a future generation protocol is required for old-or-new crash atomicity across the pair.
 
 ## Extension mappings and platform bridges
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.28 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.29 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.28;
+- GM2Godot 0.7.29;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.28 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.29 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -46,7 +46,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.28`.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.29`.
 
 ## Run from source
 
@@ -133,6 +133,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.28`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.29`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.28 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.29 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.28 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.29 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/src/conversion/anchored_artifacts.py
+++ b/src/conversion/anchored_artifacts.py
@@ -384,6 +384,112 @@ class VerifiedDirectory(AbstractContextManager["VerifiedDirectory"]):
             raise
         return binding
 
+    @classmethod
+    def open_or_create(
+        cls,
+        path: str,
+        *,
+        description: str,
+    ) -> "VerifiedDirectory":
+        """Create a missing directory chain through verified parent bindings.
+
+        Every component is opened without following its final entry, and every
+        parent crosses its durability barrier before the implementation
+        descends into the child. Repeating the barrier for an existing final
+        component makes a retry complete a prior creation whose parent sync
+        failed after the directory became visible.
+        """
+        absolute_path = os.path.abspath(path)
+        components: list[str] = []
+        existing_parent = absolute_path
+        while True:
+            parent_path, component = os.path.split(existing_parent)
+            if not component:
+                return cls.open(absolute_path, description=description)
+            components.append(_safe_leaf(component))
+            try:
+                parent_stat = os.lstat(parent_path)
+            except FileNotFoundError:
+                existing_parent = parent_path
+                continue
+            if _path_is_redirected(parent_path, parent_stat) or not stat.S_ISDIR(
+                parent_stat.st_mode
+            ):
+                raise OSError(
+                    f"Refusing redirected or non-directory {description} parent: "
+                    f"{parent_path}"
+                )
+            existing_parent = parent_path
+            break
+
+        binding = cls.open(
+            existing_parent,
+            description=f"{description} parent",
+        )
+        try:
+            ordered_components = tuple(reversed(components))
+            for index, component in enumerate(ordered_components):
+                child_path = binding.child_path(component)
+                try:
+                    child_stat = binding.stat(component)
+                except FileNotFoundError:
+                    try:
+                        binding.mkdir(component)
+                    except FileExistsError:
+                        pass
+                    child_stat = binding.stat(component)
+                if _path_is_redirected(child_path, child_stat) or not stat.S_ISDIR(
+                    child_stat.st_mode
+                ):
+                    raise OSError(
+                        f"Refusing redirected or non-directory {description}: "
+                        f"{child_path}"
+                    )
+                child_identity = (child_stat.st_dev, child_stat.st_ino)
+                child_description = (
+                    description
+                    if index == len(ordered_components) - 1
+                    else f"{description} parent"
+                )
+                child = binding.open_child(
+                    component,
+                    expected_identity=child_identity,
+                    description=child_description,
+                )
+                try:
+                    binding.sync()
+                    child.verify_path()
+                    binding.verify_path()
+                except BaseException as error:
+                    try:
+                        child.close()
+                    except BaseException as close_error:
+                        error.add_note(
+                            f"Could not close rejected {child_description} binding: "
+                            f"{close_error}"
+                        )
+                    raise
+                try:
+                    binding.close()
+                except BaseException as error:
+                    try:
+                        child.close()
+                    except BaseException as close_error:
+                        error.add_note(
+                            f"Could not close {child_description} binding: {close_error}"
+                        )
+                    raise
+                binding = child
+            return binding
+        except BaseException as error:
+            try:
+                binding.close()
+            except BaseException as close_error:
+                error.add_note(
+                    f"Could not close {description} creation binding: {close_error}"
+                )
+            raise
+
     def __exit__(
         self,
         _exc_type: object,
@@ -807,12 +913,21 @@ class AnchoredArtifactDirectory(
         relative_directory: str,
         *,
         create: bool,
+        create_root: bool = False,
         description: str,
     ) -> "AnchoredArtifactDirectory":
         child_name = _safe_leaf(relative_directory)
-        root = VerifiedDirectory.open(
-            root_path,
-            description=f"{description} root",
+        root_description = f"{description} root"
+        root = (
+            VerifiedDirectory.open_or_create(
+                root_path,
+                description=root_description,
+            )
+            if create_root
+            else VerifiedDirectory.open(
+                root_path,
+                description=root_description,
+            )
         )
         child_path = root.child_path(child_name)
         directory: VerifiedDirectory | None = None
@@ -1050,6 +1165,7 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
         relative_directory: str,
         *,
         create: bool,
+        create_root: bool = False,
         description: str,
     ) -> "ByteArtifactTransaction":
         return cls(
@@ -1057,6 +1173,7 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
                 root_path,
                 relative_directory,
                 create=create,
+                create_root=create_root,
                 description=description,
             )
         )

--- a/src/conversion/diagnostics.py
+++ b/src/conversion/diagnostics.py
@@ -4,23 +4,25 @@ import hashlib
 import json
 import os
 import re
-import stat
-import tempfile
 import threading
 from dataclasses import dataclass
-from typing import Callable, Literal, TypeAlias, cast
+from typing import Callable, Literal, TypeAlias
 
+from src.conversion.anchored_artifacts import (
+    ArtifactReceipt,
+    ArtifactSnapshot,
+    ArtifactSpec,
+    ByteArtifactTransaction,
+    artifact_sha256,
+    modes_match,
+    stable_artifact_fingerprint,
+)
 from src.conversion.conversion_outcome import ConversionOutcome
 from src.conversion.type_defs import StrPath
 
 DiagnosticSeverity: TypeAlias = Literal["info", "warning", "error"]
 FileFingerprint: TypeAlias = tuple[int, int, int, int, int]
 PathIdentity: TypeAlias = tuple[int, int]
-
-# Windows models ``chmod`` as a read-only file attribute rather than the full
-# POSIX permission mask.  Keep this as a module-level capability flag so the
-# Windows replacement rules can be exercised narrowly on other platforms.
-_WINDOWS_READONLY_FILE_ATTRIBUTES = os.name == "nt"
 
 DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH = os.path.join(
     "gm2godot", "conversion_diagnostics.json"
@@ -29,17 +31,10 @@ DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH = os.path.join(
     "gm2godot", "conversion_diagnostics.md"
 )
 
-
-@dataclass(frozen=True)
-class _ReportTargetState:
-    fingerprint: FileFingerprint | None
-    mode: int | None
-
-    @property
-    def identity(self) -> PathIdentity | None:
-        if self.fingerprint is None:
-            return None
-        return self.fingerprint[:2]
+_REPORT_DIRECTORY_NAME = "gm2godot"
+_JSON_REPORT_NAME = "conversion_diagnostics.json"
+_MARKDOWN_REPORT_NAME = "conversion_diagnostics.md"
+_REPORT_DIRECTORY_DESCRIPTION = "diagnostic report directory"
 
 
 @dataclass(frozen=True)
@@ -75,6 +70,7 @@ class ConversionDiagnosticReportSnapshot:
 
     json_path: str
     markdown_path: str
+    root_identity: PathIdentity
     directory_identity: PathIdentity
     json_report: DiagnosticReportFileSnapshot
     markdown_report: DiagnosticReportFileSnapshot
@@ -86,23 +82,10 @@ class ConversionDiagnosticReportPublicationReceipt:
 
     json_path: str
     markdown_path: str
+    root_identity: PathIdentity
     directory_identity: PathIdentity
     json_report: DiagnosticReportFingerprint
     markdown_report: DiagnosticReportFingerprint
-
-
-@dataclass(frozen=True)
-class _TemporaryReport:
-    path: str
-    fingerprint: DiagnosticReportFingerprint
-    destination_mode: int
-
-
-@dataclass(frozen=True)
-class _PublishedReport:
-    path: str
-    fingerprint: DiagnosticReportFingerprint | None
-    backup: _TemporaryReport | None
 
 
 @dataclass(frozen=True)
@@ -196,7 +179,10 @@ class DiagnosticCollector:
         return diagnostic
 
     def add_from_log_message(
-        self, message: str, *, code: str = "GM2GD-WARNING"
+        self,
+        message: str,
+        *,
+        code: str = "GM2GD-WARNING",
     ) -> ConversionDiagnostic | None:
         stripped = message.strip()
         severity = _severity_from_log_message(stripped)
@@ -238,7 +224,8 @@ class DiagnosticCollector:
         )
 
     def wrap_log_callback(
-        self, log_callback: Callable[[str], None]
+        self,
+        log_callback: Callable[[str], None],
     ) -> Callable[[str], None]:
         def _wrapped(message: str) -> None:
             self.add_from_log_message(message)
@@ -325,46 +312,16 @@ class DiagnosticCollector:
         godot_project_path: StrPath,
     ) -> ConversionDiagnosticReportPublicationReceipt:
         """Publish both reports and return proof of their exact committed state."""
-        json_path, markdown_path = _normalized_diagnostic_report_paths(
-            godot_project_path
-        )
-        report_directory = os.path.dirname(json_path)
-        directory_identity = _prepare_report_directory(report_directory)
-        _verify_report_directory(report_directory, directory_identity)
-        json_state = _report_target_state(json_path)
-        markdown_state = _report_target_state(markdown_path)
-        previous_json = _capture_report_file(json_path, json_state)
-        previous_markdown = _capture_report_file(markdown_path, markdown_state)
-        _verify_report_file_snapshot(json_path, previous_json)
-        _verify_report_file_snapshot(markdown_path, previous_markdown)
-        json_report, markdown_report = _publish_report_pair(
-            json_path=json_path,
+        return _publish_report_pair(
+            godot_project_path,
             json_content=self.to_json().encode("utf-8"),
-            json_mode=json_state.mode,
-            markdown_path=markdown_path,
             markdown_content=self.to_markdown().encode("utf-8"),
-            markdown_mode=markdown_state.mode,
-            expected_json_state=json_state,
-            expected_markdown_state=markdown_state,
-            report_directory=report_directory,
-            directory_identity=directory_identity,
-            exact_json_fingerprint=previous_json.fingerprint,
-            exact_markdown_fingerprint=previous_markdown.fingerprint,
-        )
-        if json_report is None or markdown_report is None:
-            raise AssertionError("Published diagnostic reports must both be present.")
-        return ConversionDiagnosticReportPublicationReceipt(
-            json_path=json_path,
-            markdown_path=markdown_path,
-            directory_identity=directory_identity,
-            json_report=json_report,
-            markdown_report=markdown_report,
         )
 
     def write_reports(self, godot_project_path: StrPath) -> tuple[str, str]:
         """Publish both reports while preserving the legacy path tuple API."""
-        self.publish_reports(godot_project_path)
-        return _diagnostic_report_paths(godot_project_path)
+        receipt = self.publish_reports(godot_project_path)
+        return receipt.json_path, receipt.markdown_path
 
     def _sorted_diagnostics(self) -> tuple[ConversionDiagnostic, ...]:
         return tuple(
@@ -386,29 +343,30 @@ class DiagnosticCollector:
 def capture_conversion_diagnostic_reports(
     godot_project_path: StrPath,
 ) -> ConversionDiagnosticReportSnapshot:
-    """Capture exact report bytes and metadata without following redirects."""
-    json_path, markdown_path = _normalized_diagnostic_report_paths(
-        godot_project_path
-    )
-    report_directory = os.path.dirname(json_path)
-    directory_identity = _prepare_report_directory(report_directory)
-    _verify_report_directory(report_directory, directory_identity)
-    json_report = _capture_report_file(json_path, _report_target_state(json_path))
-    _verify_report_directory(report_directory, directory_identity)
-    markdown_report = _capture_report_file(
-        markdown_path,
-        _report_target_state(markdown_path),
-    )
-    _verify_report_directory(report_directory, directory_identity)
-    _verify_report_file_snapshot(json_path, json_report)
-    _verify_report_file_snapshot(markdown_path, markdown_report)
-    return ConversionDiagnosticReportSnapshot(
-        json_path=json_path,
-        markdown_path=markdown_path,
-        directory_identity=directory_identity,
-        json_report=json_report,
-        markdown_report=markdown_report,
-    )
+    """Capture exact report bytes and metadata through retained bindings."""
+    root = _normalized_report_root(godot_project_path)
+    json_path, markdown_path = _diagnostic_report_paths(root)
+    with ByteArtifactTransaction.open(
+        root,
+        _REPORT_DIRECTORY_NAME,
+        create=True,
+        create_root=True,
+        description=_REPORT_DIRECTORY_DESCRIPTION,
+    ) as transaction:
+        json_snapshot, markdown_snapshot = transaction.capture_snapshots(
+            (_JSON_REPORT_NAME, _MARKDOWN_REPORT_NAME)
+        )
+        directory_identity = transaction.directory_identity
+        if directory_identity is None:
+            raise AssertionError("Diagnostic report directory must be present.")
+        return ConversionDiagnosticReportSnapshot(
+            json_path=json_path,
+            markdown_path=markdown_path,
+            root_identity=transaction.root_identity,
+            directory_identity=directory_identity,
+            json_report=_diagnostic_snapshot(json_snapshot),
+            markdown_report=_diagnostic_snapshot(markdown_snapshot),
+        )
 
 
 def restore_conversion_diagnostic_reports(
@@ -416,368 +374,244 @@ def restore_conversion_diagnostic_reports(
     snapshot: ConversionDiagnosticReportSnapshot,
     receipt: ConversionDiagnosticReportPublicationReceipt,
 ) -> None:
-    """Restore a same-directory snapshot over the exact pair in ``receipt``.
-
-    The snapshot may be an older trusted baseline retained across multiple
-    managed rewrites; the receipt must always describe the latest rewrite.
-    """
-    json_path, markdown_path = _normalized_diagnostic_report_paths(
-        godot_project_path
-    )
-    if (
-        snapshot.json_path != json_path
-        or snapshot.markdown_path != markdown_path
-        or receipt.json_path != json_path
-        or receipt.markdown_path != markdown_path
-    ):
-        raise ValueError("Diagnostic report snapshot and receipt paths do not match.")
-    if (
-        snapshot.directory_identity != receipt.directory_identity
-    ):
-        raise ValueError(
-            "Diagnostic report snapshot and receipt directories do not match."
-        )
+    """Restore a report-pair snapshot over the exact receipt-backed pair."""
+    root = _normalized_report_root(godot_project_path)
+    _validate_report_pair_paths(root, snapshot, receipt)
     _validate_report_file_snapshot(snapshot.json_report)
     _validate_report_file_snapshot(snapshot.markdown_report)
     _validate_report_fingerprint(receipt.json_report)
     _validate_report_fingerprint(receipt.markdown_report)
+    if (
+        snapshot.root_identity != receipt.root_identity
+        or snapshot.directory_identity != receipt.directory_identity
+    ):
+        raise ValueError(
+            "Diagnostic report snapshot and receipt directories do not match."
+        )
 
-    report_directory = os.path.dirname(json_path)
-    _verify_report_directory(report_directory, receipt.directory_identity)
-    # Moving the exact displaced inode out and back during a failed restore
-    # changes ctime on POSIX.  Rebase only that volatile metadata after proving
-    # that identity, size, mode, and content still match the caller's receipt.
-    json_state = _current_state_matching_receipt(
-        json_path,
-        receipt.json_report,
-    )
-    markdown_state = _current_state_matching_receipt(
-        markdown_path,
-        receipt.markdown_report,
-    )
-    restored_json, restored_markdown = _publish_report_pair(
-        json_path=json_path,
-        json_content=snapshot.json_report.content,
-        json_mode=snapshot.json_report.mode,
-        markdown_path=markdown_path,
-        markdown_content=snapshot.markdown_report.content,
-        markdown_mode=snapshot.markdown_report.mode,
-        expected_json_state=json_state,
-        expected_markdown_state=markdown_state,
-        report_directory=report_directory,
-        directory_identity=receipt.directory_identity,
-        preserve_displaced_targets=True,
-    )
-    _verify_restored_report(json_path, snapshot.json_report, restored_json)
-    _verify_restored_report(
-        markdown_path,
-        snapshot.markdown_report,
-        restored_markdown,
-    )
+    with ByteArtifactTransaction.open(
+        root,
+        _REPORT_DIRECTORY_NAME,
+        create=False,
+        description=_REPORT_DIRECTORY_DESCRIPTION,
+    ) as transaction:
+        if not transaction.available:
+            raise OSError(
+                "Diagnostic report directory disappeared before restore."
+            )
+        if (
+            transaction.root_identity != receipt.root_identity
+            or transaction.directory_identity != receipt.directory_identity
+        ):
+            raise OSError(
+                "Diagnostic report root or directory changed before restore."
+            )
+        markdown_receipt = _core_receipt(
+            transaction,
+            _MARKDOWN_REPORT_NAME,
+            receipt.markdown_report,
+        )
+        json_receipt = _core_receipt(
+            transaction,
+            _JSON_REPORT_NAME,
+            receipt.json_report,
+        )
+        transaction.restore_snapshots(
+            (
+                _core_snapshot(
+                    _MARKDOWN_REPORT_NAME,
+                    snapshot.markdown_report,
+                ),
+                _core_snapshot(
+                    _JSON_REPORT_NAME,
+                    snapshot.json_report,
+                ),
+            ),
+            (markdown_receipt, json_receipt),
+        )
 
 
 def invalidate_conversion_diagnostic_reports(godot_project_path: StrPath) -> None:
-    """Best-effort removal of a diagnostic report pair known to be stale."""
-    root_path: str = os.fspath(godot_project_path)
-    root = os.path.abspath(root_path)
+    """Best-effort removal of each stale report through one retained binding."""
+    root = _normalized_report_root(godot_project_path)
     try:
-        root_stat = os.lstat(root)
-    except OSError:
-        return
-    if _path_is_redirected(root, root_stat) or not stat.S_ISDIR(
-        root_stat.st_mode
-    ):
-        return
-    root_identity = (root_stat.st_dev, root_stat.st_ino)
-    report_paths = _diagnostic_report_paths(root)
-    report_directory = os.path.dirname(report_paths[0])
-    try:
-        directory_stat = os.lstat(report_directory)
-    except OSError:
-        return
-    if _path_is_redirected(report_directory, directory_stat) or not stat.S_ISDIR(
-        directory_stat.st_mode
-    ):
-        return
-    directory_identity = (directory_stat.st_dev, directory_stat.st_ino)
-    for report_path in report_paths:
-        try:
-            _verify_project_root(root, root_identity)
-            _verify_report_directory(report_directory, directory_identity)
-        except OSError:
-            return
-        _unlink_best_effort(report_path)
-
-
-def _diagnostic_report_paths(godot_project_path: StrPath) -> tuple[str, str]:
-    root = os.fspath(godot_project_path)
-    return (
-        os.path.join(root, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH),
-        os.path.join(root, DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH),
-    )
-
-
-def _normalized_diagnostic_report_paths(
-    godot_project_path: StrPath,
-) -> tuple[str, str]:
-    root_path: str = os.fspath(godot_project_path)
-    root = os.path.abspath(root_path)
-    _prepare_project_root(root)
-    return _diagnostic_report_paths(root)
-
-
-def _prepare_project_root(path: str) -> PathIdentity:
-    try:
-        path_stat = os.lstat(path)
-    except FileNotFoundError:
-        os.makedirs(path, exist_ok=True)
-        path_stat = os.lstat(path)
-    if _path_is_redirected(path, path_stat) or not stat.S_ISDIR(
-        path_stat.st_mode
-    ):
-        raise OSError(f"Refusing redirected Godot project root: {path}")
-    return (path_stat.st_dev, path_stat.st_ino)
-
-
-def _verify_project_root(path: str, expected_identity: PathIdentity) -> None:
-    try:
-        path_stat = os.lstat(path)
-    except OSError as error:
-        raise OSError(f"Godot project root changed: {path}") from error
-    if (
-        _path_is_redirected(path, path_stat)
-        or not stat.S_ISDIR(path_stat.st_mode)
-        or (path_stat.st_dev, path_stat.st_ino) != expected_identity
-    ):
-        raise OSError(f"Godot project root changed: {path}")
-
-
-def _prepare_report_directory(path: str) -> tuple[int, int]:
-    project_root = os.path.dirname(path)
-    root_identity = _prepare_project_root(project_root)
-    try:
-        path_stat = os.lstat(path)
-    except FileNotFoundError:
-        try:
-            os.mkdir(path)
-        except FileExistsError:
-            pass
-        path_stat = os.lstat(path)
-    if _path_is_redirected(path, path_stat) or not stat.S_ISDIR(path_stat.st_mode):
-        raise OSError(f"Refusing redirected diagnostic report directory: {path}")
-    directory_identity = (path_stat.st_dev, path_stat.st_ino)
-    _verify_project_root(project_root, root_identity)
-    _verify_report_directory(path, directory_identity)
-    # Always cross this durability barrier.  A prior attempt may have created
-    # the child directory and then failed its root fsync, so merely observing
-    # an existing child cannot prove that its directory entry is durable.
-    _fsync_project_root(project_root, root_identity)
-    _verify_report_directory(path, directory_identity)
-    return directory_identity
-
-
-def _verify_report_directory(
-    path: str,
-    expected_identity: tuple[int, int],
-) -> None:
-    project_root = os.path.dirname(path)
-    try:
-        root_stat = os.lstat(project_root)
-    except OSError as error:
-        raise OSError(f"Diagnostic report directory changed: {path}") from error
-    if _path_is_redirected(project_root, root_stat) or not stat.S_ISDIR(
-        root_stat.st_mode
-    ):
-        raise OSError(f"Diagnostic report directory changed: {path}")
-    try:
-        path_stat = os.lstat(path)
-    except OSError as error:
-        raise OSError(f"Diagnostic report directory changed: {path}") from error
-    if (
-        _path_is_redirected(path, path_stat)
-        or not stat.S_ISDIR(path_stat.st_mode)
-        or (path_stat.st_dev, path_stat.st_ino) != expected_identity
-    ):
-        raise OSError(f"Diagnostic report directory changed: {path}")
-
-
-def _path_is_redirected(path: str, path_stat: os.stat_result) -> bool:
-    """Return whether a path is a symbolic link or Windows junction."""
-    if stat.S_ISLNK(path_stat.st_mode):
-        return True
-    junction_candidate: object = getattr(os.path, "isjunction", None)
-    if not callable(junction_candidate):
-        return False
-    junction_checker = cast(Callable[[str], bool], junction_candidate)
-    return junction_checker(path)
-
-
-def _report_target_state(path: str) -> _ReportTargetState:
-    try:
-        path_stat = os.lstat(path)
-    except FileNotFoundError:
-        return _ReportTargetState(fingerprint=None, mode=None)
-    if _path_is_redirected(path, path_stat) or not stat.S_ISREG(
-        path_stat.st_mode
-    ):
-        raise OSError(f"Refusing non-regular diagnostic report: {path}")
-    return _ReportTargetState(
-        fingerprint=_file_fingerprint(path_stat),
-        mode=stat.S_IMODE(path_stat.st_mode),
-    )
-
-
-def _verify_report_target_state(
-    path: str,
-    expected: _ReportTargetState,
-) -> None:
-    try:
-        path_stat = os.lstat(path)
-    except FileNotFoundError:
-        if expected.identity is None:
-            return
-        raise OSError(f"Diagnostic report disappeared during publication: {path}")
-    if (
-        expected.fingerprint is None
-        or _path_is_redirected(path, path_stat)
-        or not stat.S_ISREG(path_stat.st_mode)
-        or _file_fingerprint(path_stat) != expected.fingerprint
-        or expected.mode is None
-        or not _report_modes_match(
-            stat.S_IMODE(path_stat.st_mode),
-            expected.mode,
+        transaction = ByteArtifactTransaction.open(
+            root,
+            _REPORT_DIRECTORY_NAME,
+            create=False,
+            description=_REPORT_DIRECTORY_DESCRIPTION,
         )
-    ):
-        raise OSError(f"Diagnostic report changed during publication: {path}")
+    except OSError:
+        return
+    with transaction:
+        if not transaction.available:
+            return
+        for name in (_JSON_REPORT_NAME, _MARKDOWN_REPORT_NAME):
+            try:
+                transaction.publish_specs((ArtifactSpec(name, None),))
+            except OSError:
+                continue
 
 
-def _regular_path_identity(path: str) -> PathIdentity:
-    path_stat = os.lstat(path)
-    if _path_is_redirected(path, path_stat) or not stat.S_ISREG(
-        path_stat.st_mode
-    ):
-        raise OSError(f"Refusing non-regular staged diagnostic report: {path}")
-    return (path_stat.st_dev, path_stat.st_ino)
-
-
-def _verify_regular_path_identity(
-    path: str,
-    expected_identity: PathIdentity,
-) -> None:
-    try:
-        identity = _regular_path_identity(path)
-    except OSError as error:
-        raise OSError(f"Staged diagnostic report changed: {path}") from error
-    if identity != expected_identity:
-        raise OSError(f"Staged diagnostic report changed: {path}")
-
-
-def _file_fingerprint(path_stat: os.stat_result) -> FileFingerprint:
-    return (
-        path_stat.st_dev,
-        path_stat.st_ino,
-        path_stat.st_size,
-        path_stat.st_mtime_ns,
-        path_stat.st_ctime_ns,
-    )
-
-
-def _file_fingerprints_match(
-    actual: FileFingerprint,
-    expected: FileFingerprint,
-) -> bool:
-    """Compare stable file metadata, allowing Windows timestamp divergence.
-
-    Native Windows can report different ``ctime_ns`` values for the same file
-    through a path ``lstat`` and a held descriptor ``fstat``. Device, inode,
-    exact size, and ``mtime_ns`` remain mandatory there. Callers use this only
-    for descriptor parity; path-to-path transaction guards remain exact.
-    POSIX retains exact metadata checks.
-    """
-    if _WINDOWS_READONLY_FILE_ATTRIBUTES:
-        return actual[:4] == expected[:4]
-    return actual == expected
-
-
-def _sha256_bytes(content: bytes) -> str:
-    return hashlib.sha256(content).hexdigest()
-
-
-def _target_state_from_fingerprint(
-    fingerprint: DiagnosticReportFingerprint,
-) -> _ReportTargetState:
-    return _ReportTargetState(
-        fingerprint=fingerprint.stat,
-        mode=fingerprint.mode,
-    )
-
-
-def _read_report_bytes(path: str, expected: _ReportTargetState) -> bytes:
-    if expected.fingerprint is None:
-        raise ValueError("Cannot read an absent diagnostic report.")
-    open_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
-    file_descriptor = os.open(path, open_flags)
-    try:
-        opened_before = os.fstat(file_descriptor)
-        path_before = os.lstat(path)
-        if (
-            not stat.S_ISREG(opened_before.st_mode)
-            or not stat.S_ISREG(path_before.st_mode)
-            or not _file_fingerprints_match(
-                _file_fingerprint(opened_before),
-                expected.fingerprint,
+def _publish_report_pair(
+    godot_project_path: StrPath,
+    *,
+    json_content: bytes,
+    markdown_content: bytes,
+) -> ConversionDiagnosticReportPublicationReceipt:
+    root = _normalized_report_root(godot_project_path)
+    json_path, markdown_path = _diagnostic_report_paths(root)
+    with ByteArtifactTransaction.open(
+        root,
+        _REPORT_DIRECTORY_NAME,
+        create=True,
+        create_root=True,
+        description=_REPORT_DIRECTORY_DESCRIPTION,
+    ) as transaction:
+        markdown_receipt, json_receipt = transaction.publish_specs(
+            (
+                ArtifactSpec(_MARKDOWN_REPORT_NAME, markdown_content),
+                ArtifactSpec(_JSON_REPORT_NAME, json_content),
             )
-            or _file_fingerprint(path_before) != expected.fingerprint
-            or expected.mode is None
-            or not _report_modes_match(
-                stat.S_IMODE(opened_before.st_mode),
-                expected.mode,
-            )
-            or not _report_modes_match(
-                stat.S_IMODE(path_before.st_mode),
-                expected.mode,
-            )
-        ):
-            raise OSError(f"Diagnostic report changed while reading it: {path}")
-        with os.fdopen(file_descriptor, "rb") as report_file:
-            file_descriptor = -1
-            content = report_file.read()
-            opened_after = os.fstat(report_file.fileno())
-        if (
-            not _file_fingerprints_match(
-                _file_fingerprint(opened_after),
-                expected.fingerprint,
-            )
-            or not _report_modes_match(
-                stat.S_IMODE(opened_after.st_mode),
-                expected.mode,
-            )
-        ):
-            raise OSError(f"Diagnostic report changed while reading it: {path}")
-    finally:
-        if file_descriptor >= 0:
-            os.close(file_descriptor)
-    _verify_report_target_state(path, expected)
-    return content
+        )
+        if markdown_receipt is None or json_receipt is None:
+            raise AssertionError("Published diagnostic reports must both be present.")
+        directory_identity = transaction.directory_identity
+        if directory_identity is None:
+            raise AssertionError("Diagnostic report directory must be present.")
+        return ConversionDiagnosticReportPublicationReceipt(
+            json_path=json_path,
+            markdown_path=markdown_path,
+            root_identity=transaction.root_identity,
+            directory_identity=directory_identity,
+            json_report=_diagnostic_receipt(
+                transaction,
+                _JSON_REPORT_NAME,
+                json_receipt,
+            ),
+            markdown_report=_diagnostic_receipt(
+                transaction,
+                _MARKDOWN_REPORT_NAME,
+                markdown_receipt,
+            ),
+        )
 
 
-def _capture_report_file(
-    path: str,
-    state: _ReportTargetState,
+def _diagnostic_snapshot(
+    snapshot: ArtifactSnapshot,
 ) -> DiagnosticReportFileSnapshot:
-    if state.fingerprint is None:
+    if not snapshot.present:
         return DiagnosticReportFileSnapshot(content=None, fingerprint=None)
-    if state.mode is None:
-        raise AssertionError("A present diagnostic report must have a mode.")
-    content = _read_report_bytes(path, state)
+    if (
+        snapshot.content is None
+        or snapshot.fingerprint is None
+        or snapshot.mode is None
+        or snapshot.sha256 is None
+    ):
+        raise AssertionError("A present diagnostic report snapshot is incomplete.")
     return DiagnosticReportFileSnapshot(
-        content=content,
+        content=snapshot.content,
         fingerprint=DiagnosticReportFingerprint(
-            stat=state.fingerprint,
-            mode=state.mode,
-            sha256=_sha256_bytes(content),
+            stat=snapshot.fingerprint,
+            mode=snapshot.mode,
+            sha256=_unprefixed_sha256(snapshot.sha256),
         ),
     )
+
+
+def _diagnostic_receipt(
+    transaction: ByteArtifactTransaction,
+    name: str,
+    receipt: ArtifactReceipt,
+) -> DiagnosticReportFingerprint:
+    transaction.verify_receipt(receipt)
+    state = transaction.target_state(name)
+    if state.fingerprint is None or state.mode is None:
+        raise OSError(f"Published diagnostic report disappeared: {receipt.path}")
+    return DiagnosticReportFingerprint(
+        stat=state.fingerprint,
+        mode=state.mode,
+        sha256=_unprefixed_sha256(receipt.sha256),
+    )
+
+
+def _core_snapshot(
+    name: str,
+    snapshot: DiagnosticReportFileSnapshot,
+) -> ArtifactSnapshot:
+    if snapshot.fingerprint is None:
+        return ArtifactSnapshot(
+            name=name,
+            content=None,
+            mode=None,
+            fingerprint=None,
+            sha256=None,
+        )
+    if snapshot.content is None:
+        raise ValueError("A present diagnostic report snapshot has no content.")
+    return ArtifactSnapshot(
+        name=name,
+        content=snapshot.content,
+        mode=snapshot.fingerprint.mode,
+        fingerprint=snapshot.fingerprint.stat,
+        sha256=artifact_sha256(snapshot.content),
+    )
+
+
+def _core_receipt(
+    transaction: ByteArtifactTransaction,
+    name: str,
+    fingerprint: DiagnosticReportFingerprint,
+) -> ArtifactReceipt:
+    _validate_report_fingerprint(fingerprint)
+    state = transaction.target_state(name)
+    if (
+        state.fingerprint is None
+        or state.mode is None
+        or state.fingerprint[:3] != fingerprint.stat[:3]
+        or not modes_match(state.mode, fingerprint.mode)
+    ):
+        raise OSError(
+            "Diagnostic report changed since publication: "
+            f"{transaction.directory.child_path(name)}"
+        )
+    content = transaction.read_target_bytes(name, state)
+    if _raw_sha256(content) != fingerprint.sha256:
+        raise OSError(
+            "Diagnostic report content changed since publication: "
+            f"{transaction.directory.child_path(name)}"
+        )
+    return ArtifactReceipt(
+        path=transaction.directory.child_path(name),
+        content=content,
+        mode=state.mode,
+        fingerprint=stable_artifact_fingerprint(state.fingerprint),
+        sha256=artifact_sha256(content),
+    )
+
+
+def _validate_report_pair_paths(
+    root: str,
+    snapshot: ConversionDiagnosticReportSnapshot,
+    receipt: ConversionDiagnosticReportPublicationReceipt,
+) -> None:
+    expected_json, expected_markdown = _diagnostic_report_paths(root)
+    expected_paths = (
+        os.path.normcase(expected_json),
+        os.path.normcase(expected_markdown),
+    )
+    for paths in (
+        (snapshot.json_path, snapshot.markdown_path),
+        (receipt.json_path, receipt.markdown_path),
+    ):
+        normalized = tuple(
+            os.path.normcase(os.path.abspath(path))
+            for path in paths
+        )
+        if normalized != expected_paths:
+            raise ValueError(
+                "Diagnostic report snapshot and receipt paths do not match."
+            )
 
 
 def _validate_report_fingerprint(
@@ -788,7 +622,10 @@ def _validate_report_fingerprint(
         or fingerprint.stat[2] < 0
         or not 0 <= fingerprint.mode <= 0o7777
         or len(fingerprint.sha256) != 64
-        or any(character not in "0123456789abcdef" for character in fingerprint.sha256)
+        or any(
+            character not in "0123456789abcdef"
+            for character in fingerprint.sha256
+        )
     ):
         raise ValueError("Invalid diagnostic report fingerprint.")
 
@@ -805,1232 +642,40 @@ def _validate_report_file_snapshot(
     _validate_report_fingerprint(snapshot.fingerprint)
     if (
         snapshot.fingerprint.stat[2] != len(snapshot.content)
-        or snapshot.fingerprint.sha256 != _sha256_bytes(snapshot.content)
+        or snapshot.fingerprint.sha256 != _raw_sha256(snapshot.content)
     ):
-        raise ValueError("Diagnostic report snapshot content does not match its fingerprint.")
-
-
-def _verify_report_fingerprint(
-    path: str,
-    expected: DiagnosticReportFingerprint,
-) -> None:
-    _validate_report_fingerprint(expected)
-    content = _read_report_bytes(path, _target_state_from_fingerprint(expected))
-    if _sha256_bytes(content) != expected.sha256:
-        raise OSError(f"Diagnostic report content changed: {path}")
-
-
-def _current_state_matching_receipt(
-    path: str,
-    expected: DiagnosticReportFingerprint,
-) -> _ReportTargetState:
-    """Return current metadata after stable receipt fields still match.
-
-    ``mtime`` and ``ctime`` are concurrency hints rather than semantic receipt
-    identity: moving the same inode aside and back during rollback can change
-    them.  Identity, exact size, mode, and SHA-256 must never drift.
-    """
-    _validate_report_fingerprint(expected)
-    current = _report_target_state(path)
-    if (
-        current.fingerprint is None
-        or current.identity != expected.identity
-        or current.fingerprint[2] != expected.stat[2]
-        or current.mode is None
-        or not _report_modes_match(current.mode, expected.mode)
-    ):
-        raise OSError(f"Diagnostic report changed since publication: {path}")
-    content = _read_report_bytes(path, current)
-    if _sha256_bytes(content) != expected.sha256:
-        raise OSError(f"Diagnostic report content changed: {path}")
-    return current
-
-
-def _verify_report_file_snapshot(
-    path: str,
-    snapshot: DiagnosticReportFileSnapshot,
-) -> None:
-    _validate_report_file_snapshot(snapshot)
-    if snapshot.fingerprint is None:
-        _verify_report_target_state(
-            path,
-            _ReportTargetState(fingerprint=None, mode=None),
+        raise ValueError(
+            "Diagnostic report snapshot content does not match its fingerprint."
         )
-        return
-    current = _read_report_bytes(
-        path,
-        _target_state_from_fingerprint(snapshot.fingerprint),
-    )
-    if (
-        _sha256_bytes(current) != snapshot.fingerprint.sha256
-        or current != snapshot.content
-    ):
-        raise OSError(f"Diagnostic report content changed: {path}")
 
 
-def _stage_existing_report(
-    path: str,
-    expected: _ReportTargetState,
-) -> _TemporaryReport | None:
-    if expected.identity is None:
-        return None
-    content = _read_report_bytes(path, expected)
-    return _stage_report_bytes(
-        path,
-        content,
-        mode=expected.mode,
-        suffix=".backup",
+def _diagnostic_report_paths(godot_project_path: StrPath) -> tuple[str, str]:
+    root = os.fspath(godot_project_path)
+    return (
+        os.path.join(root, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH),
+        os.path.join(root, DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH),
     )
 
 
-def _stage_report_bytes(
-    path: str,
-    content: bytes,
-    *,
-    mode: int | None,
-    suffix: str,
-) -> _TemporaryReport:
-    report_directory = os.path.dirname(path) or os.curdir
-    file_descriptor, staged_path = tempfile.mkstemp(
-        dir=report_directory,
-        prefix=f".{os.path.basename(path)}.",
-        suffix=suffix,
-    )
-    initial_stat = os.fstat(file_descriptor)
-    staged_identity = (initial_stat.st_dev, initial_stat.st_ino)
-    destination_mode = (
-        stat.S_IMODE(initial_stat.st_mode) if mode is None else mode
-    )
-    expected_mode = (
-        stat.S_IMODE(initial_stat.st_mode)
-        if _WINDOWS_READONLY_FILE_ATTRIBUTES
-        else destination_mode
-    )
-    try:
-        # mkstemp's restrictive mode is retained for a new report, so the
-        # process umask is never bypassed.  An existing regular report keeps
-        # its prior mode through the held descriptor when the platform
-        # supports fchmod, avoiding a path-swap window before publication.
-        # Apply that mode after writing because POSIX clears set-ID bits when
-        # file content changes.
-        staged_file = os.fdopen(file_descriptor, "wb")
-        file_descriptor = -1
-        with staged_file:
-            staged_file.write(content)
-            staged_file.flush()
-            if mode is not None and not _WINDOWS_READONLY_FILE_ATTRIBUTES:
-                _set_staged_report_mode(
-                    staged_file.fileno(),
-                    staged_path,
-                    staged_identity,
-                    mode,
-                )
-            os.fsync(staged_file.fileno())
-        staged_state = _report_target_state(staged_path)
-        if (
-            staged_state.identity != staged_identity
-            or staged_state.fingerprint is None
-            or staged_state.mode is None
-            or not _report_modes_match(staged_state.mode, expected_mode)
-        ):
-            raise OSError(f"Staged diagnostic report changed: {staged_path}")
-        temporary_report = _TemporaryReport(
-            path=staged_path,
-            fingerprint=DiagnosticReportFingerprint(
-                stat=staged_state.fingerprint,
-                mode=staged_state.mode,
-                sha256=_sha256_bytes(content),
-            ),
-            destination_mode=destination_mode,
-        )
-        _verify_temporary_report(temporary_report)
-        return temporary_report
-    except BaseException as error:
-        if file_descriptor >= 0:
-            os.close(file_descriptor)
-        cleanup_error = _unlink_temporary_report(staged_path, staged_identity)
-        if cleanup_error is not None:
-            error.add_note(
-                "Failed to remove incomplete diagnostic report stage "
-                f"{staged_path}: {cleanup_error}"
-            )
-        raise
+def _normalized_report_root(godot_project_path: StrPath) -> str:
+    root: str = os.fspath(godot_project_path)
+    return os.path.abspath(root)
 
 
-def _set_staged_report_mode(
-    file_descriptor: int,
-    staged_path: str,
-    staged_identity: PathIdentity,
-    mode: int,
-) -> None:
-    fchmod_candidate: object = getattr(os, "fchmod", None)
-    if callable(fchmod_candidate):
-        fchmod = cast(Callable[[int, int], None], fchmod_candidate)
-        try:
-            fchmod(file_descriptor, mode)
-        except NotImplementedError:
-            pass
-        else:
-            opened_stat = os.fstat(file_descriptor)
-            if (
-                not stat.S_ISREG(opened_stat.st_mode)
-                or (opened_stat.st_dev, opened_stat.st_ino) != staged_identity
-                or stat.S_IMODE(opened_stat.st_mode) != mode
-            ):
-                raise OSError(
-                    f"Staged diagnostic report changed: {staged_path}"
-                )
-            _verify_regular_path_identity(staged_path, staged_identity)
-            return
-
-    # Windows does not expose fchmod on all supported Python builds.  Guard
-    # its path-based fallback on both sides so an observed swap is rejected.
-    _verify_regular_path_identity(staged_path, staged_identity)
-    os.chmod(staged_path, mode)
-    _verify_regular_path_identity(staged_path, staged_identity)
+def _raw_sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
 
 
-def _report_modes_match(actual: int, expected: int) -> bool:
-    if _WINDOWS_READONLY_FILE_ATTRIBUTES:
-        return bool(actual & stat.S_IWRITE) == bool(expected & stat.S_IWRITE)
-    return actual == expected
-
-
-def _set_report_mode_guarded(
-    path: str,
-    expected_identity: PathIdentity,
-    mode: int,
-) -> _ReportTargetState:
-    """Set one final report's mode without accepting a path replacement."""
-    _verify_regular_path_identity(path, expected_identity)
-    os.chmod(path, mode)
-    _verify_regular_path_identity(path, expected_identity)
-    state = _report_target_state(path)
-    if (
-        state.fingerprint is None
-        or state.identity != expected_identity
-        or state.mode is None
-        or not _report_modes_match(state.mode, mode)
-    ):
-        raise OSError(f"Diagnostic report mode changed unexpectedly: {path}")
-    return state
-
-
-def _make_report_replaceable(
-    path: str,
-    expected: _ReportTargetState,
-) -> tuple[_ReportTargetState, bool]:
-    """Temporarily clear a Windows destination's read-only attribute."""
-    if (
-        not _WINDOWS_READONLY_FILE_ATTRIBUTES
-        or expected.fingerprint is None
-        or expected.mode is None
-        or expected.mode & stat.S_IWRITE
-    ):
-        return expected, False
-    expected_identity = expected.identity
-    if expected_identity is None:
-        raise AssertionError("A present diagnostic report must have an identity.")
-    _verify_report_target_state(path, expected)
-    writable = _set_report_mode_guarded(
-        path,
-        expected_identity,
-        expected.mode | stat.S_IWRITE,
-    )
-    if (
-        writable.fingerprint is None
-        or writable.fingerprint[2] != expected.fingerprint[2]
-    ):
-        raise OSError(f"Diagnostic report changed while making it writable: {path}")
-    return writable, True
-
-
-def _restore_report_mode_after_failed_replacement(
-    path: str,
-    prepared: _ReportTargetState,
-    original: _ReportTargetState,
-    changed: bool,
-) -> None:
-    if not changed:
-        return
-    if (
-        prepared.identity is None
-        or original.identity != prepared.identity
-        or original.mode is None
-    ):
-        raise AssertionError("A replaceable report must retain its original mode.")
-    _set_report_mode_guarded(path, prepared.identity, original.mode)
-
-
-def _verify_relocated_temporary_report(
-    report: _TemporaryReport,
-    path: str,
-    *,
-    destination_mode: int | None = None,
-) -> DiagnosticReportFingerprint:
-    state = _report_target_state(path)
-    if (
-        state.fingerprint is None
-        or state.mode is None
-        or state.identity != report.fingerprint.identity
-        or (
-            destination_mode is not None
-            and not _report_modes_match(state.mode, destination_mode)
-        )
-    ):
-        raise OSError(f"Staged diagnostic report changed: {path}")
-    content = _read_report_bytes(path, state)
-    if _sha256_bytes(content) != report.fingerprint.sha256:
-        raise OSError(f"Staged diagnostic report content changed: {path}")
-    return DiagnosticReportFingerprint(
-        stat=state.fingerprint,
-        mode=state.mode,
-        sha256=report.fingerprint.sha256,
-    )
-
-
-def _apply_temporary_report_destination_mode(
-    report: _TemporaryReport,
-    path: str,
-) -> DiagnosticReportFingerprint:
-    current = _verify_relocated_temporary_report(report, path)
-    if not _report_modes_match(current.mode, report.destination_mode):
-        _set_report_mode_guarded(
-            path,
-            report.fingerprint.identity,
-            report.destination_mode,
-        )
-    return _verify_relocated_temporary_report(
-        report,
-        path,
-        destination_mode=report.destination_mode,
-    )
-
-
-def _verify_temporary_report(
-    report: _TemporaryReport,
-    *,
-    path: str | None = None,
-) -> DiagnosticReportFingerprint:
-    selected_path = report.path if path is None else path
-    state = _report_target_state(selected_path)
-    if (
-        state.identity != report.fingerprint.identity
-        or state.mode is None
-        or not _report_modes_match(state.mode, report.fingerprint.mode)
-    ):
-        raise OSError(f"Staged diagnostic report changed: {selected_path}")
-    content = _read_report_bytes(selected_path, state)
-    if _sha256_bytes(content) != report.fingerprint.sha256:
-        raise OSError(
-            f"Staged diagnostic report content changed: {selected_path}"
-        )
-    if state.fingerprint is None:
-        raise AssertionError("A verified temporary report must be present.")
-    current = DiagnosticReportFingerprint(
-        stat=state.fingerprint,
-        mode=state.mode,
-        sha256=report.fingerprint.sha256,
-    )
-    if path is None and (
-        current.stat != report.fingerprint.stat
-        or not _report_modes_match(current.mode, report.fingerprint.mode)
-        or current.sha256 != report.fingerprint.sha256
-    ):
-        raise OSError(f"Staged diagnostic report changed: {selected_path}")
-    return current
-
-
-def _verify_expected_report(
-    path: str,
-    state: _ReportTargetState,
-    exact: DiagnosticReportFingerprint | None,
-) -> None:
-    if exact is not None:
-        exact_state = _target_state_from_fingerprint(exact)
-        if (
-            state.fingerprint != exact_state.fingerprint
-            or state.mode is None
-            or exact_state.mode is None
-            or not _report_modes_match(state.mode, exact_state.mode)
-        ):
-            raise ValueError("Exact diagnostic report receipt does not match state.")
-        if _WINDOWS_READONLY_FILE_ATTRIBUTES:
-            _current_state_matching_receipt(path, exact)
-        else:
-            _verify_report_fingerprint(path, exact)
-    else:
-        _verify_report_target_state(path, state)
-
-
-def _publish_staged_report(
-    staged_report: _TemporaryReport,
-    report_path: str,
-    backup: _TemporaryReport | None,
-    temporary_reports: dict[str, _TemporaryReport],
-    published_reports: list[_PublishedReport],
-    *,
-    replace_existing_publication: bool = False,
-) -> None:
-    _verify_temporary_report(staged_report)
-    original_target = _report_target_state(report_path)
-    prepared_target, target_mode_changed = _make_report_replaceable(
-        report_path,
-        original_target,
-    )
-    replacement_completed = False
-    replacement_error: BaseException | None = None
-    try:
-        os.replace(staged_report.path, report_path)
-        replacement_completed = True
-    except BaseException as error:
-        replacement_error = error
-        try:
-            replacement_completed = (
-                _regular_path_identity(report_path)
-                == staged_report.fingerprint.identity
-            )
-        except OSError:
-            replacement_completed = False
-        if not replacement_completed:
-            try:
-                _restore_report_mode_after_failed_replacement(
-                    report_path,
-                    prepared_target,
-                    original_target,
-                    target_mode_changed,
-                )
-            except BaseException as restore_error:
-                error.add_note(
-                    "Failed to restore the diagnostic report read-only "
-                    f"attribute after replacement failure: {restore_error}"
-                )
-            raise
-    temporary_reports.pop(staged_report.path, None)
-    provisional_fingerprint = _verify_relocated_temporary_report(
-        staged_report,
-        report_path,
-    )
-    published_report = _PublishedReport(
-        path=report_path,
-        fingerprint=provisional_fingerprint,
-        backup=backup,
-    )
-    if replace_existing_publication:
-        if not published_reports or published_reports[-1].path != report_path:
-            raise AssertionError(
-                "A displaced diagnostic report must be recorded before publication."
-            )
-        published_reports[-1] = published_report
-    else:
-        published_reports.append(published_report)
-    try:
-        published_fingerprint = _apply_temporary_report_destination_mode(
-            staged_report,
-            report_path,
-        )
-    except BaseException as integrity_error:
-        try:
-            current_fingerprint = _verify_relocated_temporary_report(
-                staged_report,
-                report_path,
-            )
-            published_reports[-1] = _PublishedReport(
-                path=report_path,
-                fingerprint=current_fingerprint,
-                backup=backup,
-            )
-        except BaseException as current_error:
-            integrity_error.add_note(
-                "Published diagnostic report also failed current-state "
-                f"verification: {current_error}"
-            )
-        if replacement_error is not None:
-            replacement_error.add_note(
-                "Published diagnostic report also failed integrity verification: "
-                f"{integrity_error}"
-            )
-            raise replacement_error
-        raise
-    published_reports[-1] = _PublishedReport(
-        path=report_path,
-        fingerprint=published_fingerprint,
-        backup=backup,
-    )
-    if replacement_error is not None:
-        raise replacement_error
-
-
-def _remove_report(
-    report_path: str,
-    backup: _TemporaryReport | None,
-    published_reports: list[_PublishedReport],
-) -> None:
-    original_target = _report_target_state(report_path)
-    prepared_target, target_mode_changed = _make_report_replaceable(
-        report_path,
-        original_target,
-    )
-    removal_completed = False
-    removal_error: BaseException | None = None
-    try:
-        os.unlink(report_path)
-        removal_completed = True
-    except BaseException as error:
-        removal_error = error
-        removal_completed = not os.path.lexists(report_path)
-        if not removal_completed:
-            try:
-                _restore_report_mode_after_failed_replacement(
-                    report_path,
-                    prepared_target,
-                    original_target,
-                    target_mode_changed,
-                )
-            except BaseException as restore_error:
-                error.add_note(
-                    "Failed to restore the diagnostic report read-only "
-                    f"attribute after removal failure: {restore_error}"
-                )
-            raise
-    published_reports.append(
-        _PublishedReport(
-            path=report_path,
-            fingerprint=None,
-            backup=backup,
-        )
-    )
-    _verify_report_target_state(
-        report_path,
-        _ReportTargetState(fingerprint=None, mode=None),
-    )
-    if removal_error is not None:
-        raise removal_error
-
-
-def _displace_report_for_restore(
-    report_path: str,
-    expected: _ReportTargetState,
-    backup: _TemporaryReport | None,
-    temporary_reports: dict[str, _TemporaryReport],
-) -> tuple[_TemporaryReport, BaseException | None]:
-    """Move the exact published inode aside so rollback can move it back."""
-    if expected.fingerprint is None or expected.mode is None or backup is None:
-        raise AssertionError("A receipt-backed diagnostic report must be present.")
-    expected_identity = expected.identity
-    if expected_identity is None:
-        raise AssertionError("A receipt-backed report must have an identity.")
-    _verify_report_target_state(report_path, expected)
-    _verify_temporary_report(backup)
-    prepared_target, target_mode_changed = _make_report_replaceable(
-        report_path,
-        expected,
-    )
-    displacement_error: BaseException | None = None
-    displacement_completed = False
-    try:
-        os.replace(report_path, backup.path)
-        displacement_completed = True
-    except BaseException as error:
-        displacement_error = error
-        try:
-            displacement_completed = (
-                _regular_path_identity(backup.path) == expected.identity
-                and not os.path.lexists(report_path)
-            )
-        except OSError:
-            displacement_completed = False
-        if not displacement_completed:
-            try:
-                _restore_report_mode_after_failed_replacement(
-                    report_path,
-                    prepared_target,
-                    expected,
-                    target_mode_changed,
-                )
-            except BaseException as restore_error:
-                error.add_note(
-                    "Failed to restore the diagnostic report read-only "
-                    f"attribute after displacement failure: {restore_error}"
-                )
-            raise
-
-    displaced: _TemporaryReport | None = None
-    try:
-        displaced_state = _report_target_state(backup.path)
-        if (
-            displaced_state.fingerprint is None
-            or displaced_state.identity != expected.identity
-            or displaced_state.fingerprint[2] != expected.fingerprint[2]
-        ):
-            raise OSError(
-                f"Displaced diagnostic report changed: {report_path}"
-            )
-        if displaced_state.mode is None:
-            raise AssertionError("A displaced diagnostic report must have a mode.")
-        displaced = _TemporaryReport(
-            path=backup.path,
-            fingerprint=DiagnosticReportFingerprint(
-                stat=displaced_state.fingerprint,
-                mode=displaced_state.mode,
-                sha256=backup.fingerprint.sha256,
-            ),
-            destination_mode=expected.mode,
-        )
-        temporary_reports[backup.path] = displaced
-        _verify_temporary_report(displaced)
-        _verify_report_target_state(
-            report_path,
-            _ReportTargetState(fingerprint=None, mode=None),
-        )
-    except BaseException as integrity_error:
-        try:
-            os.replace(backup.path, report_path)
-            temporary_reports.pop(backup.path, None)
-            if displaced is None:
-                _set_report_mode_guarded(
-                    report_path,
-                    expected_identity,
-                    expected.mode,
-                )
-            else:
-                _apply_temporary_report_destination_mode(displaced, report_path)
-        except Exception as rollback_error:
-            integrity_error.add_note(
-                "Failed to return displaced diagnostic report after integrity "
-                f"failure: {rollback_error}"
-            )
-        raise
-    return displaced, displacement_error
-
-
-def _verify_published_report(report: _PublishedReport) -> None:
-    if report.fingerprint is None:
-        _verify_report_target_state(
-            report.path,
-            _ReportTargetState(fingerprint=None, mode=None),
-        )
-    else:
-        _verify_report_fingerprint(report.path, report.fingerprint)
-
-
-def _validate_desired_report(content: bytes | None, mode: int | None) -> None:
-    if content is None:
-        if mode is not None:
-            raise ValueError("An absent diagnostic report cannot have a mode.")
-        return
-    if mode is not None and not 0 <= mode <= 0o7777:
-        raise ValueError("Invalid diagnostic report mode.")
-
-
-def _publish_report_pair(
-    *,
-    json_path: str,
-    json_content: bytes | None,
-    json_mode: int | None,
-    markdown_path: str,
-    markdown_content: bytes | None,
-    markdown_mode: int | None,
-    expected_json_state: _ReportTargetState,
-    expected_markdown_state: _ReportTargetState,
-    report_directory: str,
-    directory_identity: PathIdentity,
-    exact_json_fingerprint: DiagnosticReportFingerprint | None = None,
-    exact_markdown_fingerprint: DiagnosticReportFingerprint | None = None,
-    preserve_displaced_targets: bool = False,
-) -> tuple[
-    DiagnosticReportFingerprint | None,
-    DiagnosticReportFingerprint | None,
-]:
-    _validate_desired_report(json_content, json_mode)
-    _validate_desired_report(markdown_content, markdown_mode)
-    _verify_report_directory(report_directory, directory_identity)
-    _verify_expected_report(
-        json_path,
-        expected_json_state,
-        exact_json_fingerprint,
-    )
-    _verify_expected_report(
-        markdown_path,
-        expected_markdown_state,
-        exact_markdown_fingerprint,
-    )
-
-    specs = (
-        (
-            json_path,
-            json_content,
-            json_mode,
-            expected_json_state,
-            exact_json_fingerprint,
-        ),
-        (
-            markdown_path,
-            markdown_content,
-            markdown_mode,
-            expected_markdown_state,
-            exact_markdown_fingerprint,
-        ),
-    )
-    temporary_reports: dict[str, _TemporaryReport] = {}
-    staged: dict[str, _TemporaryReport | None] = {}
-    backups: dict[str, _TemporaryReport | None] = {}
-    published: list[_PublishedReport] = []
-    active_error: BaseException | None = None
-    try:
-        for report_path, content, mode, state, exact in specs:
-            _verify_report_directory(report_directory, directory_identity)
-            _verify_expected_report(report_path, state, exact)
-            staged_report = (
-                None
-                if content is None
-                else _stage_report_bytes(
-                    report_path,
-                    content,
-                    mode=mode,
-                    suffix=".tmp",
-                )
-            )
-            staged[report_path] = staged_report
-            if staged_report is not None:
-                temporary_reports[staged_report.path] = staged_report
-
-        for report_path, _content, _mode, state, exact in specs:
-            _verify_report_directory(report_directory, directory_identity)
-            _verify_expected_report(report_path, state, exact)
-            backup = _stage_existing_report(report_path, state)
-            backups[report_path] = backup
-            if backup is not None:
-                temporary_reports[backup.path] = backup
-            if (
-                exact is not None
-                and backup is not None
-                and backup.fingerprint.sha256 != exact.sha256
-            ):
-                raise OSError(
-                    "Diagnostic report changed while creating its backup: "
-                    f"{report_path}"
-                )
-
-        try:
-            for report_path, content, _mode, state, exact in reversed(specs):
-                _verify_report_directory(report_directory, directory_identity)
-                _verify_expected_report(report_path, state, exact)
-                staged_report = staged[report_path]
-                backup = backups[report_path]
-                if preserve_displaced_targets:
-                    displaced, displacement_error = _displace_report_for_restore(
-                        report_path,
-                        state,
-                        backup,
-                        temporary_reports,
-                    )
-                    backups[report_path] = displaced
-                    backup = displaced
-                    published.append(
-                        _PublishedReport(
-                            path=report_path,
-                            fingerprint=None,
-                            backup=backup,
-                        )
-                    )
-                    if displacement_error is not None:
-                        raise displacement_error
-                    if content is not None:
-                        if staged_report is None:
-                            raise AssertionError("A present report must have a stage.")
-                        _publish_staged_report(
-                            staged_report,
-                            report_path,
-                            backup,
-                            temporary_reports,
-                            published,
-                            replace_existing_publication=True,
-                        )
-                elif content is None:
-                    if state.fingerprint is not None:
-                        _remove_report(report_path, backup, published)
-                else:
-                    if staged_report is None:
-                        raise AssertionError("A present report must have a stage.")
-                    _publish_staged_report(
-                        staged_report,
-                        report_path,
-                        backup,
-                        temporary_reports,
-                        published,
-                    )
-                _fsync_report_directory(report_directory, directory_identity)
-                if published and published[-1].path == report_path:
-                    _verify_published_report(published[-1])
-            _verify_report_directory(report_directory, directory_identity)
-            for published_report in published:
-                _verify_published_report(published_report)
-        except BaseException as publish_error:
-            rollback_errors = _rollback_reports(
-                published,
-                temporary_reports,
-                json_path=json_path,
-                json_state=expected_json_state,
-                json_exact=exact_json_fingerprint,
-                markdown_path=markdown_path,
-                markdown_state=expected_markdown_state,
-                markdown_exact=exact_markdown_fingerprint,
-                report_directory=report_directory,
-                directory_identity=directory_identity,
-            )
-            if rollback_errors:
-                publish_error.add_note(
-                    "Diagnostics rollback also failed: "
-                    + "; ".join(str(error) for error in rollback_errors)
-                )
-            raise
-    except BaseException as error:
-        active_error = error
-        raise
-    finally:
-        cleanup_errors = _cleanup_temporary_reports(
-            temporary_reports,
-            report_directory=report_directory,
-            directory_identity=directory_identity,
-        )
-        if cleanup_errors and active_error is not None:
-            active_error.add_note(
-                "Diagnostics cleanup also failed: "
-                + "; ".join(str(error) for error in cleanup_errors)
-            )
-
-    json_report = _verify_desired_report(json_path, json_content, json_mode)
-    markdown_report = _verify_desired_report(
-        markdown_path,
-        markdown_content,
-        markdown_mode,
-    )
-    _verify_report_directory(report_directory, directory_identity)
-    _verify_optional_report_fingerprint(json_path, json_report)
-    _verify_optional_report_fingerprint(markdown_path, markdown_report)
-    return json_report, markdown_report
-
-
-def _verify_optional_report_fingerprint(
-    path: str,
-    fingerprint: DiagnosticReportFingerprint | None,
-) -> None:
-    if fingerprint is None:
-        _verify_report_target_state(
-            path,
-            _ReportTargetState(fingerprint=None, mode=None),
-        )
-    else:
-        _verify_report_fingerprint(path, fingerprint)
-
-
-def _verify_desired_report(
-    path: str,
-    content: bytes | None,
-    mode: int | None,
-) -> DiagnosticReportFingerprint | None:
-    if content is None:
-        _verify_report_target_state(
-            path,
-            _ReportTargetState(fingerprint=None, mode=None),
-        )
-        return None
-    state = _report_target_state(path)
-    if mode is not None and (
-        state.mode is None or not _report_modes_match(state.mode, mode)
-    ):
-        raise OSError(f"Restored diagnostic report mode changed: {path}")
-    captured = _capture_report_file(path, state)
-    if captured.content != content or captured.fingerprint is None:
-        raise OSError(f"Published diagnostic report content changed: {path}")
-    return captured.fingerprint
-
-
-def _verify_restored_report(
-    path: str,
-    snapshot: DiagnosticReportFileSnapshot,
-    restored: DiagnosticReportFingerprint | None,
-) -> None:
-    _validate_report_file_snapshot(snapshot)
-    if snapshot.content is None:
-        if restored is not None:
-            raise OSError(f"Absent diagnostic report was recreated: {path}")
-        _verify_report_target_state(
-            path,
-            _ReportTargetState(fingerprint=None, mode=None),
-        )
-        return
-    if (
-        restored is None
-        or snapshot.mode is None
-        or not _report_modes_match(restored.mode, snapshot.mode)
-    ):
-        raise OSError(f"Restored diagnostic report mode changed: {path}")
-    _verify_report_fingerprint(path, restored)
-    current = _read_report_bytes(path, _target_state_from_fingerprint(restored))
-    if current != snapshot.content:
-        raise OSError(f"Restored diagnostic report content changed: {path}")
-
-
-def _rollback_reports(
-    published: list[_PublishedReport],
-    temporary_reports: dict[str, _TemporaryReport],
-    *,
-    json_path: str,
-    json_state: _ReportTargetState,
-    json_exact: DiagnosticReportFingerprint | None,
-    markdown_path: str,
-    markdown_state: _ReportTargetState,
-    markdown_exact: DiagnosticReportFingerprint | None,
-    report_directory: str,
-    directory_identity: PathIdentity,
-) -> list[Exception]:
-    errors: list[Exception] = []
-    restored: list[tuple[_PublishedReport, _TemporaryReport | None]] = []
-    for report in reversed(published):
-        recovery: _TemporaryReport | None = None
-        try:
-            _verify_report_directory(report_directory, directory_identity)
-            _verify_published_report(report)
-            if report.backup is None:
-                if report.fingerprint is not None:
-                    published_state = _target_state_from_fingerprint(
-                        report.fingerprint
-                    )
-                    prepared_state, mode_changed = _make_report_replaceable(
-                        report.path,
-                        published_state,
-                    )
-                    try:
-                        os.unlink(report.path)
-                    except Exception as unlink_error:
-                        if os.path.lexists(report.path):
-                            try:
-                                _restore_report_mode_after_failed_replacement(
-                                    report.path,
-                                    prepared_state,
-                                    published_state,
-                                    mode_changed,
-                                )
-                            except Exception as restore_error:
-                                unlink_error.add_note(
-                                    "Failed to restore the diagnostic report "
-                                    "read-only attribute after rollback removal "
-                                    f"failure: {restore_error}"
-                                )
-                            raise
-            else:
-                backup_content = _read_temporary_report(report.backup)
-                recovery = _stage_report_bytes(
-                    report.path,
-                    backup_content,
-                    mode=report.backup.destination_mode,
-                    suffix=".recovery.backup",
-                )
-                temporary_reports[recovery.path] = recovery
-                if report.fingerprint is None:
-                    published_state = _ReportTargetState(
-                        fingerprint=None,
-                        mode=None,
-                    )
-                else:
-                    published_state = _target_state_from_fingerprint(
-                        report.fingerprint
-                    )
-                prepared_state, mode_changed = _make_report_replaceable(
-                    report.path,
-                    published_state,
-                )
-                replacement_completed = False
-                try:
-                    os.replace(report.backup.path, report.path)
-                    replacement_completed = True
-                except Exception as replace_error:
-                    try:
-                        replacement_completed = (
-                            _regular_path_identity(report.path)
-                            == report.backup.fingerprint.identity
-                        )
-                    except OSError:
-                        replacement_completed = False
-                    if not replacement_completed:
-                        try:
-                            _restore_report_mode_after_failed_replacement(
-                                report.path,
-                                prepared_state,
-                                published_state,
-                                mode_changed,
-                            )
-                        except Exception as restore_error:
-                            replace_error.add_note(
-                                "Failed to restore the diagnostic report "
-                                "read-only attribute after rollback replacement "
-                                f"failure: {restore_error}"
-                            )
-                        raise
-                temporary_reports.pop(report.backup.path, None)
-                restored_fingerprint = (
-                    _apply_temporary_report_destination_mode(
-                        report.backup,
-                        report.path,
-                    )
-                )
-                report = _PublishedReport(
-                    path=report.path,
-                    fingerprint=report.fingerprint,
-                    backup=_TemporaryReport(
-                        path=report.backup.path,
-                        fingerprint=restored_fingerprint,
-                        destination_mode=report.backup.destination_mode,
-                    ),
-                )
-            _fsync_report_directory(report_directory, directory_identity)
-            if report.backup is None:
-                _verify_report_target_state(
-                    report.path,
-                    _ReportTargetState(fingerprint=None, mode=None),
-                )
-            else:
-                _verify_relocated_temporary_report(
-                    report.backup,
-                    report.path,
-                    destination_mode=report.backup.destination_mode,
-                )
-            restored.append((report, recovery))
-        except Exception as error:
-            recovery_path = _preserve_recovery_report(
-                recovery,
-                report.backup,
-                temporary_reports,
-            )
-            if recovery_path is not None:
-                wrapped_error = OSError(
-                    f"{error}; previous diagnostic report preserved at: "
-                    f"{recovery_path}"
-                )
-                wrapped_error.__cause__ = error
-                errors.append(wrapped_error)
-            else:
-                errors.append(error)
-
-    for report, recovery in restored:
-        try:
-            if report.backup is None:
-                _verify_report_target_state(
-                    report.path,
-                    _ReportTargetState(fingerprint=None, mode=None),
-                )
-            else:
-                _verify_relocated_temporary_report(
-                    report.backup,
-                    report.path,
-                    destination_mode=report.backup.destination_mode,
-                )
-        except Exception as error:
-            recovery_path = _preserve_recovery_report(
-                recovery,
-                None,
-                temporary_reports,
-            )
-            if recovery_path is not None:
-                wrapped_error = OSError(
-                    f"{error}; previous diagnostic report preserved at: "
-                    f"{recovery_path}"
-                )
-                wrapped_error.__cause__ = error
-                errors.append(wrapped_error)
-            else:
-                errors.append(error)
-
-    if not errors:
-        restored_by_path = {
-            report.path: (report, recovery)
-            for report, recovery in restored
-        }
-        for path, state, exact in (
-            (json_path, json_state, json_exact),
-            (markdown_path, markdown_state, markdown_exact),
-        ):
-            restored_report = restored_by_path.get(path)
-            try:
-                if restored_report is None:
-                    _verify_expected_report(path, state, exact)
-                elif restored_report[0].backup is None:
-                    _verify_report_target_state(
-                        path,
-                        _ReportTargetState(fingerprint=None, mode=None),
-                    )
-                else:
-                    _verify_relocated_temporary_report(
-                        restored_report[0].backup,
-                        path,
-                        destination_mode=(
-                            restored_report[0].backup.destination_mode
-                        ),
-                    )
-            except Exception as error:
-                recovery_path = (
-                    None
-                    if restored_report is None
-                    else _preserve_recovery_report(
-                        restored_report[1],
-                        None,
-                        temporary_reports,
-                    )
-                )
-                if recovery_path is None:
-                    errors.append(error)
-                else:
-                    wrapped_error = OSError(
-                        f"{error}; previous diagnostic report preserved at: "
-                        f"{recovery_path}"
-                    )
-                    wrapped_error.__cause__ = error
-                    errors.append(wrapped_error)
-    return errors
-
-
-def _read_temporary_report(report: _TemporaryReport) -> bytes:
-    state = _report_target_state(report.path)
-    if (
-        state.identity != report.fingerprint.identity
-        or state.mode is None
-        or not _report_modes_match(state.mode, report.fingerprint.mode)
-    ):
-        raise OSError(f"Staged diagnostic report changed: {report.path}")
-    content = _read_report_bytes(report.path, state)
-    if _sha256_bytes(content) != report.fingerprint.sha256:
-        raise OSError(f"Staged diagnostic report content changed: {report.path}")
-    return content
-
-
-def _preserve_recovery_report(
-    recovery: _TemporaryReport | None,
-    backup: _TemporaryReport | None,
-    temporary_reports: dict[str, _TemporaryReport],
-) -> str | None:
-    for candidate in (recovery, backup):
-        if candidate is None:
-            continue
-        try:
-            _verify_temporary_report(candidate)
-        except OSError:
-            continue
-        temporary_reports.pop(candidate.path, None)
-        return candidate.path
-    return None
-
-
-def _cleanup_temporary_reports(
-    temporary_reports: dict[str, _TemporaryReport],
-    *,
-    report_directory: str,
-    directory_identity: PathIdentity,
-) -> list[Exception]:
-    errors: list[Exception] = []
-    removed = False
-    for path, report in tuple(temporary_reports.items()):
-        try:
-            _verify_report_directory(report_directory, directory_identity)
-            if not os.path.lexists(path):
-                temporary_reports.pop(path, None)
-                continue
-            _verify_temporary_report(report)
-            try:
-                os.unlink(path)
-            except Exception:
-                if os.path.lexists(path):
-                    raise
-            temporary_reports.pop(path, None)
-            removed = True
-        except Exception as error:
-            errors.append(error)
-    if removed:
-        try:
-            _fsync_report_directory(report_directory, directory_identity)
-        except Exception as error:
-            errors.append(error)
-    return errors
-
-
-def _unlink_temporary_report(
-    path: str,
-    expected_identity: PathIdentity,
-) -> Exception | None:
-    try:
-        if not os.path.lexists(path):
-            return None
-        if _regular_path_identity(path) != expected_identity:
-            raise OSError(f"Staged diagnostic report changed: {path}")
-        os.unlink(path)
-    except Exception as error:
-        return error
-    return None
-
-
-def _fsync_report_directory(
-    path: str,
-    expected_identity: PathIdentity,
-) -> None:
-    _fsync_directory(
-        path,
-        expected_identity,
-        verify=_verify_report_directory,
-        changed_message=f"Diagnostic report directory changed: {path}",
-    )
-
-
-def _fsync_project_root(
-    path: str,
-    expected_identity: PathIdentity,
-) -> None:
-    _fsync_directory(
-        path,
-        expected_identity,
-        verify=_verify_project_root,
-        changed_message=f"Godot project root changed: {path}",
-    )
-
-
-def _fsync_directory(
-    path: str,
-    expected_identity: PathIdentity,
-    *,
-    verify: Callable[[str, PathIdentity], None],
-    changed_message: str,
-) -> None:
-    verify(path, expected_identity)
-    if os.name == "nt":
-        return
-    open_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(
-        os,
-        "O_NOFOLLOW",
-        0,
-    )
-    directory_descriptor = os.open(path, open_flags)
-    try:
-        opened_stat = os.fstat(directory_descriptor)
-        if (
-            not stat.S_ISDIR(opened_stat.st_mode)
-            or (opened_stat.st_dev, opened_stat.st_ino) != expected_identity
-        ):
-            raise OSError(changed_message)
-        os.fsync(directory_descriptor)
-    finally:
-        os.close(directory_descriptor)
-    verify(path, expected_identity)
-
-
-def _unlink_best_effort(path: str) -> None:
-    try:
-        os.unlink(path)
-    except OSError:
-        pass
+def _unprefixed_sha256(value: str) -> str:
+    prefix = "sha256:"
+    if not value.startswith(prefix) or len(value) != len(prefix) + 64:
+        raise ValueError("Invalid artifact SHA-256 digest.")
+    return value[len(prefix):]
 
 
 def write_conversion_diagnostic_reports(
-    godot_project_path: StrPath, diagnostics: DiagnosticCollector
+    godot_project_path: StrPath,
+    diagnostics: DiagnosticCollector,
 ) -> tuple[str, str]:
     return diagnostics.write_reports(godot_project_path)
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.28"
+VERSION = "0.7.29"
 
 
 def get_version():

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -5,68 +5,104 @@ import json
 import os
 import shutil
 import stat
-import sys
 import tempfile
 import unittest
 from dataclasses import replace
-from typing import Callable, cast
+from pathlib import Path
 from unittest.mock import patch
 
-PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if PROJECT_ROOT not in sys.path:
-    sys.path.insert(0, PROJECT_ROOT)
-
+from src.conversion import anchored_artifacts as anchored_artifacts_module
+from src.conversion.anchored_artifacts import VerifiedDirectory
+from src.conversion.conversion_outcome import ConversionCounts, ConversionOutcome
 from src.conversion.diagnostics import (
     DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH,
     DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
     DiagnosticCollector,
-    DiagnosticReportFingerprint,
     capture_conversion_diagnostic_reports,
     invalidate_conversion_diagnostic_reports,
     publish_conversion_diagnostic_reports,
     restore_conversion_diagnostic_reports,
 )
-from src.conversion import diagnostics as diagnostics_module
-from src.conversion.conversion_outcome import ConversionCounts, ConversionOutcome
 from tests.conversion_outcome_helpers import completed_conversion_step_ledger
 
 
+def _directory_snapshot(path: Path) -> dict[str, tuple[int, int, int, bytes]]:
+    snapshot: dict[str, tuple[int, int, int, bytes]] = {}
+    for child in path.iterdir():
+        child_stat = child.lstat()
+        snapshot[child.name] = (
+            child_stat.st_dev,
+            child_stat.st_ino,
+            stat.S_IMODE(child_stat.st_mode),
+            child.read_bytes(),
+        )
+    return snapshot
+
+
+def _write_report_pair(root: Path, json_content: bytes, markdown_content: bytes) -> None:
+    json_path = root / DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH
+    markdown_path = root / DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_bytes(json_content)
+    markdown_path.write_bytes(markdown_content)
+
+
+def _replacement_report_directory(path: Path) -> dict[str, tuple[int, int, int, bytes]]:
+    path.mkdir()
+    (path / "conversion_diagnostics.json").write_bytes(b"replacement json\n")
+    (path / "conversion_diagnostics.md").write_bytes(b"replacement markdown\n")
+    (path / "sentinel.txt").write_bytes(b"unrelated sentinel\n")
+    return _directory_snapshot(path)
+
+
 class TestDiagnosticCollector(unittest.TestCase):
-    def test_warning_log_wrapper_preserves_log_and_records_diagnostic(self):
+    def assertModeEqual(self, actual: int, expected: int) -> None:
+        if os.name == "nt":
+            self.assertEqual(
+                bool(actual & stat.S_IWUSR),
+                bool(expected & stat.S_IWUSR),
+            )
+            return
+        self.assertEqual(actual, expected)
+
+    def test_warning_log_wrapper_preserves_log_and_records_diagnostic(self) -> None:
         logs: list[str] = []
         diagnostics = DiagnosticCollector()
-        wrapped_log = diagnostics.wrap_log_callback(lambda message: logs.append(message))
+        wrapped_log = diagnostics.wrap_log_callback(logs.append)
 
         wrapped_log("Warning: Unsupported room layer emitted as placeholder.")
         wrapped_log("Converted sprite spr_player.")
 
-        self.assertEqual(logs, [
-            "Warning: Unsupported room layer emitted as placeholder.",
-            "Converted sprite spr_player.",
-        ])
+        self.assertEqual(
+            logs,
+            [
+                "Warning: Unsupported room layer emitted as placeholder.",
+                "Converted sprite spr_player.",
+            ],
+        )
         recorded = diagnostics.diagnostics()
         self.assertEqual(len(recorded), 1)
         self.assertEqual(recorded[0].severity, "warning")
         self.assertEqual(recorded[0].code, "GM2GD-WARNING")
 
-    def test_info_log_wrapper_records_informational_diagnostic(self):
+    def test_info_log_wrapper_records_informational_diagnostic(self) -> None:
         diagnostics = DiagnosticCollector()
-        wrapped_log = diagnostics.wrap_log_callback(lambda message: None)
+        wrapped_log = diagnostics.wrap_log_callback(lambda _message: None)
 
-        wrapped_log("Info: Missing optional GameMaker metadata file; fallback metadata preserved.")
+        wrapped_log(
+            "Info: Missing optional GameMaker metadata file; fallback metadata preserved."
+        )
 
         recorded = diagnostics.diagnostics()
         self.assertEqual(len(recorded), 1)
         self.assertEqual(recorded[0].severity, "info")
-        self.assertEqual(recorded[0].code, "GM2GD-WARNING")
 
-    def test_transpile_failure_extracts_api_and_issue_metadata(self):
+    def test_transpile_failure_extracts_api_and_issue_metadata(self) -> None:
         diagnostics = DiagnosticCollector()
 
         diagnostic = diagnostics.add_transpile_failure(
-            "Warning: Could not transpile GameMaker event code for obj/Create_0.gml: "
-            "GML API 'show_message_async' from Asynchronous Functions is unsupported; "
-            "tracked by #507. Dialog callbacks are not wired.",
+            "Warning: Could not transpile GameMaker event code: "
+            "GML API 'show_message_async' is unsupported; tracked by #507.",
             source_path="/tmp/project/objects/obj/Create_0.gml",
             resource="obj",
             resource_type="object",
@@ -76,46 +112,28 @@ class TestDiagnosticCollector(unittest.TestCase):
         self.assertEqual(diagnostic.api, "show_message_async")
         self.assertEqual(diagnostic.manifest_entry, "show_message_async")
         self.assertEqual(diagnostic.issue_number, 507)
-        self.assertEqual(diagnostic.source_path, "/tmp/project/objects/obj/Create_0.gml")
-        self.assertEqual(diagnostic.resource_type, "object")
-        self.assertEqual(diagnostic.event, "_ready")
+        self.assertEqual(
+            diagnostic.source_path,
+            "/tmp/project/objects/obj/Create_0.gml",
+        )
 
-    def test_exact_structured_duplicates_are_deduped(self):
+    def test_exact_structured_duplicates_are_deduped(self) -> None:
         diagnostics = DiagnosticCollector()
-
-        diagnostics.add(
-            "warning",
-            "GM2GD-SOURCE-PATH-REJECTED",
-            "Warning: Rejected GameMaker source path '../outside.wav'.",
-            source_path="sounds/snd_test/snd_test.yy",
-            resource="snd_test",
-            resource_type="sound",
-            manifest_entry="soundFile",
-        )
-        diagnostics.add(
-            "warning",
-            "GM2GD-SOURCE-PATH-REJECTED",
-            "Warning: Rejected GameMaker source path '../outside.wav'.",
-            source_path="sounds/snd_test/snd_test.yy",
-            resource="snd_test",
-            resource_type="sound",
-            manifest_entry="soundFile",
-        )
-        diagnostics.add(
-            "warning",
-            "GM2GD-SOURCE-PATH-REJECTED",
-            "Warning: Rejected GameMaker source path '../outside.wav'.",
-            source_path="sounds/snd_test/snd_test.yy",
-            resource="snd_other",
-            resource_type="sound",
-            manifest_entry="soundFile",
-        )
+        for resource in ("snd_test", "snd_test", "snd_other"):
+            diagnostics.add(
+                "warning",
+                "GM2GD-SOURCE-PATH-REJECTED",
+                "Warning: Rejected GameMaker source path '../outside.wav'.",
+                source_path="sounds/snd_test/snd_test.yy",
+                resource=resource,
+                resource_type="sound",
+                manifest_entry="soundFile",
+            )
 
         self.assertEqual(len(diagnostics.diagnostics()), 2)
 
-    def test_reports_are_written_as_deterministic_json_and_markdown(self):
-        tmp_dir = tempfile.mkdtemp()
-        try:
+    def test_reports_are_deterministic_json_and_markdown(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             diagnostics = DiagnosticCollector()
             diagnostics.add(
                 "warning",
@@ -131,859 +149,24 @@ class TestDiagnosticCollector(unittest.TestCase):
 
             self.assertEqual(
                 json_path,
-                os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH),
-            )
-            self.assertEqual(
-                markdown_path,
-                os.path.join(tmp_dir, DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH),
-            )
-            with open(json_path, "r", encoding="utf-8") as json_file:
-                data = json.load(json_file)
-            with open(markdown_path, "r", encoding="utf-8") as markdown_file:
-                markdown = markdown_file.read()
-
-            self.assertEqual(data["summary"]["warning"], 1)
-            self.assertEqual(data["diagnostics"][0]["code"], "GM2GD-RESOURCE-UNSUPPORTED")
-            self.assertIn("GM2Godot Conversion Diagnostics", markdown)
-            self.assertIn("GM2GD-RESOURCE-UNSUPPORTED", markdown)
-        finally:
-            shutil.rmtree(tmp_dir)
-
-    def test_snapshot_captures_absent_report_pair(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            snapshot = capture_conversion_diagnostic_reports(tmp_dir)
-
-            self.assertEqual(snapshot.json_path, os.path.join(
-                os.path.abspath(tmp_dir),
-                DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH,
-            ))
-            self.assertEqual(snapshot.json_report.content, None)
-            self.assertEqual(snapshot.json_report.fingerprint, None)
-            self.assertEqual(snapshot.markdown_report.content, None)
-            self.assertEqual(snapshot.markdown_report.fingerprint, None)
-            report_directory_stat = os.stat(os.path.join(tmp_dir, "gm2godot"))
-            self.assertEqual(
-                snapshot.directory_identity,
-                (report_directory_stat.st_dev, report_directory_stat.st_ino),
-            )
-
-    def test_snapshot_captures_exact_bytes_modes_and_fingerprints(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            markdown_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-            )
-            os.makedirs(os.path.dirname(json_path))
-            json_content = b"old json\x00\xff\n"
-            markdown_content = b"old markdown\r\n"
-            for path, content, mode in (
-                (json_path, json_content, 0o640),
-                (markdown_path, markdown_content, 0o600),
-            ):
-                with open(path, "wb") as report_file:
-                    report_file.write(content)
-                os.chmod(path, mode)
-
-            snapshot = capture_conversion_diagnostic_reports(tmp_dir)
-
-            for path, expected_content, expected_mode, captured in (
-                (json_path, json_content, 0o640, snapshot.json_report),
-                (
-                    markdown_path,
-                    markdown_content,
-                    0o600,
-                    snapshot.markdown_report,
-                ),
-            ):
-                self.assertEqual(captured.content, expected_content)
-                self.assertIsNotNone(captured.fingerprint)
-                assert captured.fingerprint is not None
-                path_stat = os.stat(path, follow_symlinks=False)
-                self.assertEqual(
-                    captured.fingerprint.identity,
-                    (path_stat.st_dev, path_stat.st_ino),
-                )
-                self.assertEqual(
-                    captured.fingerprint.sha256,
-                    hashlib.sha256(expected_content).hexdigest(),
-                )
-                if os.name != "nt":
-                    self.assertEqual(captured.mode, expected_mode)
-
-    def test_windows_descriptor_io_accepts_ctime_only_fingerprint_drift(
-        self,
-    ) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            report_path = os.path.join(tmp_dir, "diagnostic.json")
-            report_content = b'{"stable": true}\n'
-            with open(report_path, "wb") as report_file:
-                report_file.write(report_content)
-            target_state = cast(
-                Callable[[str], object],
-                getattr(diagnostics_module, "_report_target_state"),
-            )(report_path)
-            read_report = cast(
-                Callable[[str, object], bytes],
-                getattr(diagnostics_module, "_read_report_bytes"),
-            )
-            real_fingerprint = cast(
-                Callable[[os.stat_result], tuple[int, int, int, int, int]],
-                getattr(diagnostics_module, "_file_fingerprint"),
-            )
-            fingerprint_reads = 0
-
-            def drift_timestamps(
-                path_stat: os.stat_result,
-            ) -> tuple[int, int, int, int, int]:
-                nonlocal fingerprint_reads
-                fingerprint_reads += 1
-                fingerprint = real_fingerprint(path_stat)
-                if fingerprint_reads in (1, 3):
-                    return (*fingerprint[:4], fingerprint[4] + fingerprint_reads)
-                return fingerprint
-
-            with (
-                patch.object(
-                    diagnostics_module,
-                    "_WINDOWS_READONLY_FILE_ATTRIBUTES",
-                    True,
-                ),
-                patch(
-                    "src.conversion.diagnostics._file_fingerprint",
-                    side_effect=drift_timestamps,
-                ),
-            ):
-                self.assertEqual(
-                    read_report(report_path, target_state),
-                    report_content,
-                )
-
-            self.assertEqual(fingerprint_reads, 4)
-
-    def test_windows_target_state_keeps_exact_path_ctime_guard(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            report_path = os.path.join(tmp_dir, "diagnostic.json")
-            with open(report_path, "wb") as report_file:
-                report_file.write(b'{"stable": true}\n')
-            target_state = cast(
-                Callable[[str], object],
-                getattr(diagnostics_module, "_report_target_state"),
-            )(report_path)
-            verify_target_state = cast(
-                Callable[[str, object], None],
-                getattr(diagnostics_module, "_verify_report_target_state"),
-            )
-            real_fingerprint = cast(
-                Callable[[os.stat_result], tuple[int, int, int, int, int]],
-                getattr(diagnostics_module, "_file_fingerprint"),
-            )
-
-            def path_ctime_drift(
-                path_stat: os.stat_result,
-            ) -> tuple[int, int, int, int, int]:
-                fingerprint = real_fingerprint(path_stat)
-                return (*fingerprint[:4], fingerprint[4] + 1)
-
-            with (
-                patch.object(
-                    diagnostics_module,
-                    "_WINDOWS_READONLY_FILE_ATTRIBUTES",
-                    True,
-                ),
-                patch(
-                    "src.conversion.diagnostics._file_fingerprint",
-                    side_effect=path_ctime_drift,
-                ),
-                self.assertRaisesRegex(OSError, "changed during publication"),
-            ):
-                verify_target_state(report_path, target_state)
-
-    def test_fingerprint_comparator_relaxes_only_windows_ctime(self) -> None:
-        fingerprints_match = cast(
-            Callable[
-                [
-                    tuple[int, int, int, int, int],
-                    tuple[int, int, int, int, int],
-                ],
-                bool,
-            ],
-            getattr(diagnostics_module, "_file_fingerprints_match"),
-        )
-        expected = (11, 22, 33, 44, 55)
-        ctime_drift = (11, 22, 33, 44, 555)
-        mtime_drift = (11, 22, 33, 444, 55)
-
-        with patch.object(
-            diagnostics_module,
-            "_WINDOWS_READONLY_FILE_ATTRIBUTES",
-            True,
-        ):
-            self.assertTrue(fingerprints_match(ctime_drift, expected))
-            self.assertFalse(fingerprints_match(mtime_drift, expected))
-            self.assertFalse(
-                fingerprints_match((111, 22, 33, 44, 555), expected)
-            )
-            self.assertFalse(
-                fingerprints_match((11, 222, 33, 44, 555), expected)
-            )
-            self.assertFalse(
-                fingerprints_match((11, 22, 333, 44, 555), expected)
-            )
-
-        with patch.object(
-            diagnostics_module,
-            "_WINDOWS_READONLY_FILE_ATTRIBUTES",
-            False,
-        ):
-            self.assertFalse(fingerprints_match(ctime_drift, expected))
-
-    def test_windows_rejects_identity_size_mtime_content_and_mode_drift(
-        self,
-    ) -> None:
-        verify_fingerprint = cast(
-            Callable[[str, DiagnosticReportFingerprint], None],
-            getattr(diagnostics_module, "_verify_report_fingerprint"),
-        )
-        for drift in ("identity", "size", "mtime", "content", "mode"):
-            with self.subTest(drift=drift), tempfile.TemporaryDirectory() as tmp_dir:
-                with patch.object(
-                    diagnostics_module,
-                    "_WINDOWS_READONLY_FILE_ATTRIBUTES",
-                    True,
-                ):
-                    receipt = DiagnosticCollector().publish_reports(tmp_dir)
-                    report_path = receipt.json_path
-                    fingerprint = receipt.json_report
-                    with open(report_path, "rb") as report_file:
-                        content = report_file.read()
-                    report_mode = stat.S_IMODE(os.stat(report_path).st_mode)
-
-                    if drift == "identity":
-                        replacement_path = f"{report_path}.replacement"
-                        with open(replacement_path, "wb") as replacement_file:
-                            replacement_file.write(content)
-                        os.chmod(replacement_path, report_mode)
-                        os.replace(replacement_path, report_path)
-                    elif drift == "size":
-                        with open(report_path, "ab") as report_file:
-                            report_file.write(b"x")
-                    elif drift == "mtime":
-                        report_stat = os.stat(report_path)
-                        os.utime(
-                            report_path,
-                            ns=(
-                                report_stat.st_atime_ns,
-                                report_stat.st_mtime_ns + 1_000_000_000,
-                            ),
-                        )
-                    elif drift == "content":
-                        with open(report_path, "r+b") as report_file:
-                            report_file.write(
-                                bytes((content[0] ^ 1,))
-                            )
-                        current_stat = os.stat(report_path)
-                        fingerprint = replace(
-                            fingerprint,
-                            stat=(
-                                current_stat.st_dev,
-                                current_stat.st_ino,
-                                current_stat.st_size,
-                                current_stat.st_mtime_ns,
-                                current_stat.st_ctime_ns,
-                            ),
-                        )
-                    else:
-                        os.chmod(report_path, report_mode ^ stat.S_IWRITE)
-
-                    with self.assertRaises(OSError):
-                        verify_fingerprint(report_path, fingerprint)
-
-    def test_snapshot_refuses_redirected_or_nonregular_report(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            external_path = os.path.join(tmp_dir, "external.json")
-            os.makedirs(os.path.dirname(json_path))
-            with open(external_path, "wb") as external_file:
-                external_file.write(b"external sentinel\n")
-            try:
-                os.symlink(external_path, json_path)
-            except (NotImplementedError, OSError) as error:
-                self.skipTest(f"Symbolic links are unavailable: {error}")
-
-            with self.assertRaisesRegex(OSError, "non-regular diagnostic report"):
-                capture_conversion_diagnostic_reports(tmp_dir)
-
-            with open(external_path, "rb") as external_file:
-                self.assertEqual(external_file.read(), b"external sentinel\n")
-
-    def test_reports_and_invalidation_refuse_symlinked_project_root(
-        self,
-    ) -> None:
-        with tempfile.TemporaryDirectory() as container:
-            external_root = os.path.join(container, "external_project")
-            report_directory = os.path.join(external_root, "gm2godot")
-            os.makedirs(report_directory)
-            external_reports = (
                 os.path.join(
-                    external_root,
+                    os.path.abspath(tmp_dir),
                     DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH,
                 ),
-                os.path.join(
-                    external_root,
-                    DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-                ),
             )
-            for report_path in external_reports:
-                with open(report_path, "wb") as report_file:
-                    report_file.write(b"external sentinel\n")
-            redirected_root = os.path.join(container, "redirected_project")
-            try:
-                os.symlink(external_root, redirected_root)
-            except (NotImplementedError, OSError) as error:
-                self.skipTest(f"Symbolic links are unavailable: {error}")
-
-            with self.assertRaisesRegex(
-                OSError,
-                "redirected Godot project root",
-            ):
-                DiagnosticCollector().publish_reports(redirected_root)
-            with self.assertRaisesRegex(
-                OSError,
-                "redirected Godot project root",
-            ):
-                capture_conversion_diagnostic_reports(redirected_root)
-            invalidate_conversion_diagnostic_reports(redirected_root)
-
-            for report_path in external_reports:
-                with open(report_path, "rb") as report_file:
-                    self.assertEqual(
-                        report_file.read(),
-                        b"external sentinel\n",
-                    )
-
-    def test_reports_and_invalidation_refuse_mocked_junction_project_root(
-        self,
-    ) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            report_directory = os.path.join(tmp_dir, "gm2godot")
-            os.makedirs(report_directory)
-            report_paths = (
-                os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH),
-                os.path.join(
-                    tmp_dir,
-                    DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-                ),
-            )
-            for report_path in report_paths:
-                with open(report_path, "wb") as report_file:
-                    report_file.write(b"junction sentinel\n")
-            normalized_root = os.path.normcase(os.path.abspath(tmp_dir))
-
-            def root_is_junction(path: str) -> bool:
-                return os.path.normcase(os.path.abspath(path)) == normalized_root
-
-            with patch.object(
-                os.path,
-                "isjunction",
-                side_effect=root_is_junction,
-                create=True,
-            ):
-                with self.assertRaisesRegex(
-                    OSError,
-                    "redirected Godot project root",
-                ):
-                    DiagnosticCollector().publish_reports(tmp_dir)
-                invalidate_conversion_diagnostic_reports(tmp_dir)
-
-            for report_path in report_paths:
-                with open(report_path, "rb") as report_file:
-                    self.assertEqual(
-                        report_file.read(),
-                        b"junction sentinel\n",
-                    )
-
-    def test_new_report_directory_is_durably_linked_from_project_root(
-        self,
-    ) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            report_directory = os.path.join(tmp_dir, "gm2godot")
-            fsync_project_root_impl = cast(
-                Callable[[str, tuple[int, int]], None],
-                getattr(diagnostics_module, "_fsync_project_root"),
-            )
-
-            with patch(
-                "src.conversion.diagnostics._fsync_project_root",
-                wraps=fsync_project_root_impl,
-            ) as fsync_project_root:
-                DiagnosticCollector().publish_reports(tmp_dir)
-
-            fsync_project_root.assert_called_once()
-            fsync_root, fsync_identity = fsync_project_root.call_args.args
-            self.assertEqual(fsync_root, os.path.abspath(tmp_dir))
-            root_stat = os.stat(tmp_dir, follow_symlinks=False)
+            data = json.loads(Path(json_path).read_text(encoding="utf-8"))
+            markdown = Path(markdown_path).read_text(encoding="utf-8")
+            self.assertEqual(data["summary"]["warning"], 1)
             self.assertEqual(
-                fsync_identity,
-                (root_stat.st_dev, root_stat.st_ino),
+                data["diagnostics"][0]["code"],
+                "GM2GD-RESOURCE-UNSUPPORTED",
             )
-            self.assertTrue(os.path.isdir(report_directory))
-
-    def test_existing_report_directory_retries_project_root_fsync(
-        self,
-    ) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            report_directory = os.path.join(tmp_dir, "gm2godot")
-            real_fsync_project_root = cast(
-                Callable[[str, tuple[int, int]], None],
-                getattr(diagnostics_module, "_fsync_project_root"),
-            )
-
-            with patch(
-                "src.conversion.diagnostics._fsync_project_root",
-                side_effect=OSError("project root fsync failed"),
-            ):
-                with self.assertRaisesRegex(
-                    OSError,
-                    "project root fsync failed",
-                ):
-                    DiagnosticCollector().publish_reports(tmp_dir)
-
-            self.assertTrue(os.path.isdir(report_directory))
-            with patch(
-                "src.conversion.diagnostics._fsync_project_root",
-                wraps=real_fsync_project_root,
-            ) as retry_fsync:
-                DiagnosticCollector().publish_reports(tmp_dir)
-
-            retry_fsync.assert_called_once()
-
-    def test_publish_receipt_proves_current_pair_and_helper_matches_api(
-        self,
-    ) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            diagnostics = DiagnosticCollector()
-            diagnostics.add("warning", "GM2GD-TEST", "receipt sentinel")
-
-            receipt = publish_conversion_diagnostic_reports(tmp_dir, diagnostics)
-
-            for path, fingerprint in (
-                (receipt.json_path, receipt.json_report),
-                (receipt.markdown_path, receipt.markdown_report),
-            ):
-                path_stat = os.stat(path, follow_symlinks=False)
-                with open(path, "rb") as report_file:
-                    content = report_file.read()
-                self.assertEqual(
-                    fingerprint.identity,
-                    (path_stat.st_dev, path_stat.st_ino),
-                )
-                self.assertEqual(
-                    fingerprint.sha256,
-                    hashlib.sha256(content).hexdigest(),
-                )
-                self.assertEqual(
-                    fingerprint.mode,
-                    stat.S_IMODE(path_stat.st_mode),
-                )
-    def test_restore_reinstates_exact_present_report_pair(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            markdown_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-            )
-            os.makedirs(os.path.dirname(json_path))
-            previous = {
-                json_path: (b"trusted json\x00\n", 0o640),
-                markdown_path: (b"trusted markdown\r\n", 0o600),
-            }
-            for path, (content, mode) in previous.items():
-                with open(path, "wb") as report_file:
-                    report_file.write(content)
-                os.chmod(path, mode)
-            snapshot = capture_conversion_diagnostic_reports(tmp_dir)
-            receipt = DiagnosticCollector().publish_reports(tmp_dir)
-
-            restore_conversion_diagnostic_reports(tmp_dir, snapshot, receipt)
-
-            for path, (content, mode) in previous.items():
-                with open(path, "rb") as report_file:
-                    self.assertEqual(report_file.read(), content)
-                if os.name != "nt":
-                    self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), mode)
-            self.assertEqual(
-                set(os.listdir(os.path.dirname(json_path))),
-                {os.path.basename(json_path), os.path.basename(markdown_path)},
-            )
-
-    def test_restore_reinstates_absent_report_pair(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            snapshot = capture_conversion_diagnostic_reports(tmp_dir)
-            receipt = DiagnosticCollector().publish_reports(tmp_dir)
-
-            restore_conversion_diagnostic_reports(tmp_dir, snapshot, receipt)
-
-            self.assertFalse(os.path.lexists(receipt.json_path))
-            self.assertFalse(os.path.lexists(receipt.markdown_path))
-            self.assertEqual(os.listdir(os.path.dirname(receipt.json_path)), [])
-
-    def test_restore_reinstates_mixed_present_and_absent_pair(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            os.makedirs(os.path.dirname(json_path))
-            with open(json_path, "wb") as report_file:
-                report_file.write(b"trusted json only\n")
-            os.chmod(json_path, 0o640)
-            snapshot = capture_conversion_diagnostic_reports(tmp_dir)
-            receipt = DiagnosticCollector().publish_reports(tmp_dir)
-
-            restore_conversion_diagnostic_reports(tmp_dir, snapshot, receipt)
-
-            with open(json_path, "rb") as report_file:
-                self.assertEqual(report_file.read(), b"trusted json only\n")
-            self.assertFalse(os.path.lexists(receipt.markdown_path))
-            if os.name != "nt":
-                self.assertEqual(stat.S_IMODE(os.stat(json_path).st_mode), 0o640)
-
-    def test_old_baseline_can_restore_over_latest_matching_receipt(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            markdown_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-            )
-            os.makedirs(os.path.dirname(json_path))
-            with open(json_path, "wb") as report_file:
-                report_file.write(b"trusted json\n")
-            with open(markdown_path, "wb") as report_file:
-                report_file.write(b"trusted markdown\n")
-            baseline = capture_conversion_diagnostic_reports(tmp_dir)
-            first = DiagnosticCollector()
-            first.add("warning", "GM2GD-FIRST", "first rewrite")
-            first.publish_reports(tmp_dir)
-            second = DiagnosticCollector()
-            second.add("error", "GM2GD-SECOND", "second rewrite")
-            latest_receipt = second.publish_reports(tmp_dir)
-
-            restore_conversion_diagnostic_reports(
-                tmp_dir,
-                baseline,
-                latest_receipt,
-            )
-
-            with open(json_path, "rb") as report_file:
-                self.assertEqual(report_file.read(), b"trusted json\n")
-            with open(markdown_path, "rb") as report_file:
-                self.assertEqual(report_file.read(), b"trusted markdown\n")
-
-    def test_restore_refuses_pair_changed_after_receipt(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            baseline = capture_conversion_diagnostic_reports(tmp_dir)
-            receipt = DiagnosticCollector().publish_reports(tmp_dir)
-            with open(receipt.json_path, "ab") as report_file:
-                report_file.write(b"third-party mutation\n")
-            with open(receipt.markdown_path, "rb") as report_file:
-                markdown_before = report_file.read()
-
-            with self.assertRaisesRegex(OSError, "changed"):
-                restore_conversion_diagnostic_reports(
-                    tmp_dir,
-                    baseline,
-                    receipt,
-                )
-
-            with open(receipt.json_path, "rb") as report_file:
-                self.assertTrue(report_file.read().endswith(b"third-party mutation\n"))
-            with open(receipt.markdown_path, "rb") as report_file:
-                self.assertEqual(report_file.read(), markdown_before)
-
-    def test_restore_refuses_replaced_identity_even_with_exact_same_bytes(
-        self,
-    ) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            baseline = capture_conversion_diagnostic_reports(tmp_dir)
-            receipt = DiagnosticCollector().publish_reports(tmp_dir)
-            with open(receipt.json_path, "rb") as report_file:
-                published_json = report_file.read()
-            published_mode = stat.S_IMODE(os.stat(receipt.json_path).st_mode)
-            replacement_path = os.path.join(
-                os.path.dirname(receipt.json_path),
-                "replacement.json",
-            )
-            with open(replacement_path, "wb") as report_file:
-                report_file.write(published_json)
-            os.chmod(replacement_path, published_mode)
-            os.replace(replacement_path, receipt.json_path)
-
-            with self.assertRaisesRegex(OSError, "changed"):
-                restore_conversion_diagnostic_reports(
-                    tmp_dir,
-                    baseline,
-                    receipt,
-                )
-
-            with open(receipt.json_path, "rb") as report_file:
-                self.assertEqual(report_file.read(), published_json)
-            self.assertTrue(os.path.isfile(receipt.markdown_path))
-
-    def test_restore_refuses_mode_changed_after_receipt(self) -> None:
-        if os.name == "nt":
-            self.skipTest("Exact POSIX mode checks are unavailable")
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            baseline = capture_conversion_diagnostic_reports(tmp_dir)
-            receipt = DiagnosticCollector().publish_reports(tmp_dir)
-            original_mode = stat.S_IMODE(os.stat(receipt.json_path).st_mode)
-            changed_mode = original_mode ^ stat.S_IXUSR
-            os.chmod(receipt.json_path, changed_mode)
-
-            with self.assertRaisesRegex(OSError, "changed since publication"):
-                restore_conversion_diagnostic_reports(
-                    tmp_dir,
-                    baseline,
-                    receipt,
-                )
-
-            self.assertEqual(
-                stat.S_IMODE(os.stat(receipt.json_path).st_mode),
-                changed_mode,
-            )
-            self.assertTrue(os.path.isfile(receipt.markdown_path))
-
-    def test_windows_restore_publication_boundary_rejects_same_size_tamper(
-        self,
-    ) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            baseline = capture_conversion_diagnostic_reports(tmp_dir)
-            receipt = DiagnosticCollector().publish_reports(tmp_dir)
-            with open(receipt.json_path, "rb") as report_file:
-                published_json = report_file.read()
-            with open(receipt.markdown_path, "rb") as report_file:
-                published_markdown = report_file.read()
-            tampered_json = bytes((published_json[0] ^ 1,)) + published_json[1:]
-            real_stage_existing = cast(
-                Callable[[str, object], object],
-                getattr(diagnostics_module, "_stage_existing_report"),
-            )
-            json_tampered = False
-
-            def tamper_after_json_backup(
-                path: str,
-                expected: object,
-            ) -> object:
-                nonlocal json_tampered
-                backup = real_stage_existing(path, expected)
-                if path == receipt.json_path and not json_tampered:
-                    json_tampered = True
-                    report_stat = os.stat(path)
-                    with open(path, "r+b") as report_file:
-                        report_file.write(tampered_json)
-                        report_file.flush()
-                        os.fsync(report_file.fileno())
-                    os.utime(
-                        path,
-                        ns=(
-                            report_stat.st_atime_ns,
-                            report_stat.st_mtime_ns + 1_000_000_000,
-                        ),
-                    )
-                return backup
-
-            with (
-                patch.object(
-                    diagnostics_module,
-                    "_WINDOWS_READONLY_FILE_ATTRIBUTES",
-                    True,
-                ),
-                patch(
-                    "src.conversion.diagnostics._stage_existing_report",
-                    side_effect=tamper_after_json_backup,
-                ),
-            ):
-                with self.assertRaisesRegex(OSError, "changed"):
-                    restore_conversion_diagnostic_reports(
-                        tmp_dir,
-                        baseline,
-                        receipt,
-                    )
-
-            self.assertTrue(json_tampered)
-            with open(receipt.json_path, "rb") as report_file:
-                self.assertEqual(report_file.read(), tampered_json)
-            with open(receipt.markdown_path, "rb") as report_file:
-                self.assertEqual(report_file.read(), published_markdown)
-            self.assertNotEqual(tampered_json, published_json)
-
-    def test_restore_refuses_snapshot_content_that_does_not_match_fingerprint(
-        self,
-    ) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            markdown_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-            )
-            os.makedirs(os.path.dirname(json_path))
-            for path, content in (
-                (json_path, b"trusted json\n"),
-                (markdown_path, b"trusted markdown\n"),
-            ):
-                with open(path, "wb") as report_file:
-                    report_file.write(content)
-            baseline = capture_conversion_diagnostic_reports(tmp_dir)
-            receipt = DiagnosticCollector().publish_reports(tmp_dir)
-            with open(receipt.json_path, "rb") as report_file:
-                published_json = report_file.read()
-            tampered_json = replace(
-                baseline.json_report,
-                content=b"tampered baseline\n",
-            )
-            tampered_baseline = replace(
-                baseline,
-                json_report=tampered_json,
-            )
-
-            with self.assertRaisesRegex(ValueError, "does not match"):
-                restore_conversion_diagnostic_reports(
-                    tmp_dir,
-                    tampered_baseline,
-                    receipt,
-                )
-
-            with open(receipt.json_path, "rb") as report_file:
-                self.assertEqual(report_file.read(), published_json)
-            self.assertTrue(os.path.isfile(receipt.markdown_path))
-
-    def test_restore_failure_rolls_back_to_published_receipt_pair(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            markdown_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-            )
-            os.makedirs(os.path.dirname(json_path))
-            with open(json_path, "wb") as report_file:
-                report_file.write(b"trusted json\n")
-            with open(markdown_path, "wb") as report_file:
-                report_file.write(b"trusted markdown\n")
-            baseline = capture_conversion_diagnostic_reports(tmp_dir)
-            diagnostics = DiagnosticCollector()
-            diagnostics.add("error", "GM2GD-NEW", "new receipt")
-            receipt = diagnostics.publish_reports(tmp_dir)
-            with open(json_path, "rb") as report_file:
-                published_json = report_file.read()
-            with open(markdown_path, "rb") as report_file:
-                published_markdown = report_file.read()
-            real_replace = os.replace
-
-            def fail_json_restore(source: str, destination: str) -> None:
-                if destination == json_path and source.endswith(".tmp"):
-                    raise OSError("json restore failed")
-                real_replace(source, destination)
-
-            with patch(
-                "src.conversion.diagnostics.os.replace",
-                side_effect=fail_json_restore,
-            ):
-                with self.assertRaisesRegex(OSError, "json restore failed"):
-                    restore_conversion_diagnostic_reports(
-                        tmp_dir,
-                        baseline,
-                        receipt,
-                    )
-
-            with open(json_path, "rb") as report_file:
-                self.assertEqual(report_file.read(), published_json)
-            with open(markdown_path, "rb") as report_file:
-                self.assertEqual(report_file.read(), published_markdown)
-            for report_path, fingerprint in (
-                (json_path, receipt.json_report),
-                (markdown_path, receipt.markdown_report),
-            ):
-                report_stat = os.stat(report_path, follow_symlinks=False)
-                self.assertEqual(
-                    (report_stat.st_dev, report_stat.st_ino),
-                    fingerprint.identity,
-                )
-                self.assertEqual(
-                    stat.S_IMODE(report_stat.st_mode),
-                    fingerprint.mode,
-                )
-            self.assertEqual(
-                set(os.listdir(os.path.dirname(json_path))),
-                {os.path.basename(json_path), os.path.basename(markdown_path)},
-            )
-
-            # The same receipt remains valid after rollback even though moving
-            # its inodes out and back may have changed timestamp metadata.
-            restore_conversion_diagnostic_reports(
-                tmp_dir,
-                baseline,
-                receipt,
-            )
-            with open(json_path, "rb") as report_file:
-                self.assertEqual(report_file.read(), b"trusted json\n")
-            with open(markdown_path, "rb") as report_file:
-                self.assertEqual(report_file.read(), b"trusted markdown\n")
-
-    def test_absent_restore_failure_rolls_back_deleted_report(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            baseline = capture_conversion_diagnostic_reports(tmp_dir)
-            diagnostics = DiagnosticCollector()
-            diagnostics.add("error", "GM2GD-NEW", "new receipt")
-            receipt = diagnostics.publish_reports(tmp_dir)
-            with open(receipt.json_path, "rb") as report_file:
-                published_json = report_file.read()
-            with open(receipt.markdown_path, "rb") as report_file:
-                published_markdown = report_file.read()
-            real_replace = os.replace
-
-            def fail_json_removal(source: str, destination: str) -> None:
-                if source == receipt.json_path and destination.endswith(".backup"):
-                    raise OSError("json removal failed")
-                real_replace(source, destination)
-
-            with patch(
-                "src.conversion.diagnostics.os.replace",
-                side_effect=fail_json_removal,
-            ):
-                with self.assertRaisesRegex(OSError, "json removal failed"):
-                    restore_conversion_diagnostic_reports(
-                        tmp_dir,
-                        baseline,
-                        receipt,
-                    )
-
-            with open(receipt.json_path, "rb") as report_file:
-                self.assertEqual(report_file.read(), published_json)
-            with open(receipt.markdown_path, "rb") as report_file:
-                self.assertEqual(report_file.read(), published_markdown)
-            for report_path, fingerprint in (
-                (receipt.json_path, receipt.json_report),
-                (receipt.markdown_path, receipt.markdown_report),
-            ):
-                report_stat = os.stat(report_path, follow_symlinks=False)
-                self.assertEqual(
-                    (report_stat.st_dev, report_stat.st_ino),
-                    fingerprint.identity,
-                )
-            self.assertEqual(
-                set(os.listdir(os.path.dirname(receipt.json_path))),
-                {
-                    os.path.basename(receipt.json_path),
-                    os.path.basename(receipt.markdown_path),
-                },
-            )
-
-            restore_conversion_diagnostic_reports(tmp_dir, baseline, receipt)
-            self.assertFalse(os.path.lexists(receipt.json_path))
-            self.assertFalse(os.path.lexists(receipt.markdown_path))
+            self.assertIn("GM2Godot Conversion Diagnostics", markdown)
+            self.assertIn("GM2GD-RESOURCE-UNSUPPORTED", markdown)
 
     def test_report_schema_is_unchanged_without_conversion_outcome(self) -> None:
-        diagnostics = DiagnosticCollector()
-
         self.assertEqual(
-            set(diagnostics.to_json_dict()),
+            set(DiagnosticCollector().to_json_dict()),
             {"summary", "diagnostics"},
         )
 
@@ -1001,786 +184,1015 @@ class TestDiagnosticCollector(unittest.TestCase):
         )
         diagnostics.set_outcome(outcome)
 
-        report = diagnostics.to_json_dict()
+        self.assertEqual(diagnostics.to_json_dict()["outcome"], outcome.to_dict())
+        self.assertIn(
+            "Conversion outcome: `partial`",
+            diagnostics.to_markdown(),
+        )
 
-        self.assertEqual(report["outcome"], outcome.to_dict())
-        self.assertIn("Conversion outcome: `partial`", diagnostics.to_markdown())
-
-    def test_markdown_staging_failure_leaves_no_new_report_pair(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            diagnostics = DiagnosticCollector()
-            diagnostics.set_outcome(ConversionOutcome(state="success"))
-            report_directory = os.path.join(tmp_dir, "gm2godot")
-            real_mkstemp = tempfile.mkstemp
-            stage_calls = 0
-
-            def fail_second_stage(
-                suffix: str | None = None,
-                prefix: str | None = None,
-                dir: str | os.PathLike[str] | None = None,
-                text: bool = False,
-            ) -> tuple[int, str]:
-                nonlocal stage_calls
-                stage_calls += 1
-                if stage_calls == 2:
-                    raise OSError("markdown staging failed")
-                return real_mkstemp(
-                    suffix=suffix,
-                    prefix=prefix,
-                    dir=dir,
-                    text=text,
-                )
-
-            with patch(
-                "src.conversion.diagnostics.tempfile.mkstemp",
-                side_effect=fail_second_stage,
-            ):
-                with self.assertRaisesRegex(OSError, "markdown staging failed"):
-                    diagnostics.write_reports(tmp_dir)
-
-            self.assertFalse(
-                os.path.exists(
-                    os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-                )
-            )
-            self.assertFalse(
-                os.path.exists(
-                    os.path.join(tmp_dir, DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH)
-                )
-            )
-            self.assertEqual(os.listdir(report_directory), [])
-
-    def test_second_replace_failure_restores_previous_report_pair(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            markdown_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-            )
-            os.makedirs(os.path.dirname(json_path), exist_ok=True)
-            with open(json_path, "w", encoding="utf-8") as json_file:
-                json_file.write("previous json\n")
-            with open(markdown_path, "w", encoding="utf-8") as markdown_file:
-                markdown_file.write("previous markdown\n")
-            os.chmod(json_path, 0o640)
-            os.chmod(markdown_path, 0o600)
-
-            diagnostics = DiagnosticCollector()
-            diagnostics.set_outcome(ConversionOutcome(state="success"))
-            real_replace = os.replace
-            destinations: list[str] = []
-            json_replace_attempts = 0
-
-            def fail_first_json_replace(source: str, destination: str) -> None:
-                nonlocal json_replace_attempts
-                destinations.append(destination)
-                if destination == json_path:
-                    json_replace_attempts += 1
-                    if json_replace_attempts == 1:
-                        raise OSError("json publish failed")
-                real_replace(source, destination)
-
-            with patch(
-                "src.conversion.diagnostics.os.replace",
-                side_effect=fail_first_json_replace,
-            ):
-                with self.assertRaisesRegex(OSError, "json publish failed"):
-                    diagnostics.write_reports(tmp_dir)
-
-            self.assertEqual(destinations[:2], [markdown_path, json_path])
-            with open(json_path, "r", encoding="utf-8") as json_file:
-                self.assertEqual(json_file.read(), "previous json\n")
-            with open(markdown_path, "r", encoding="utf-8") as markdown_file:
-                self.assertEqual(markdown_file.read(), "previous markdown\n")
-            if os.name != "nt":
-                self.assertEqual(stat.S_IMODE(os.stat(json_path).st_mode), 0o640)
-                self.assertEqual(
-                    stat.S_IMODE(os.stat(markdown_path).st_mode),
-                    0o600,
-                )
-            self.assertEqual(
-                set(os.listdir(os.path.dirname(json_path))),
-                {os.path.basename(json_path), os.path.basename(markdown_path)},
-            )
-
-    def test_windows_readonly_attributes_survive_publish_and_restore(
+    def test_snapshot_captures_absent_pair_and_both_directory_identities(
         self,
     ) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            markdown_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
+            snapshot = capture_conversion_diagnostic_reports(tmp_dir)
+
+            root_stat = os.stat(tmp_dir, follow_symlinks=False)
+            report_directory = Path(tmp_dir) / "gm2godot"
+            directory_stat = report_directory.stat()
+            self.assertEqual(
+                snapshot.root_identity,
+                (root_stat.st_dev, root_stat.st_ino),
             )
-            os.makedirs(os.path.dirname(json_path))
-            for report_path, content, mode in (
-                (json_path, b"readonly json\n", 0o444),
-                (markdown_path, b"writable markdown\n", 0o600),
+            self.assertEqual(
+                snapshot.directory_identity,
+                (directory_stat.st_dev, directory_stat.st_ino),
+            )
+            self.assertIsNone(snapshot.json_report.content)
+            self.assertIsNone(snapshot.json_report.fingerprint)
+            self.assertIsNone(snapshot.markdown_report.content)
+            self.assertIsNone(snapshot.markdown_report.fingerprint)
+
+    def test_snapshot_captures_exact_bytes_modes_and_fingerprints(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            json_path = root / DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH
+            markdown_path = root / DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH
+            _write_report_pair(root, b"old json\x00\xff\n", b"old markdown\r\n")
+            json_path.chmod(0o640)
+            markdown_path.chmod(0o600)
+
+            snapshot = capture_conversion_diagnostic_reports(root)
+
+            for path, content, mode, captured in (
+                (json_path, b"old json\x00\xff\n", 0o640, snapshot.json_report),
+                (
+                    markdown_path,
+                    b"old markdown\r\n",
+                    0o600,
+                    snapshot.markdown_report,
+                ),
             ):
-                with open(report_path, "wb") as report_file:
-                    report_file.write(content)
-                os.chmod(report_path, mode)
+                self.assertEqual(captured.content, content)
+                self.assertIsNotNone(captured.fingerprint)
+                assert captured.fingerprint is not None
+                path_stat = path.stat()
+                self.assertEqual(
+                    captured.fingerprint.identity,
+                    (path_stat.st_dev, path_stat.st_ino),
+                )
+                self.assertEqual(
+                    captured.fingerprint.sha256,
+                    hashlib.sha256(content).hexdigest(),
+                )
+                self.assertModeEqual(captured.mode or 0, mode)
 
-            real_replace = os.replace
-            real_unlink = os.unlink
+    def test_publish_receipt_proves_pair_and_helper_matches_api(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            diagnostics = DiagnosticCollector()
+            diagnostics.add("warning", "GM2GD-TEST", "receipt sentinel")
 
-            def windows_replace(source: str, destination: str) -> None:
-                for candidate in (source, destination):
-                    if os.path.lexists(candidate) and not (
-                        stat.S_IMODE(os.lstat(candidate).st_mode) & stat.S_IWRITE
-                    ):
-                        raise PermissionError(
-                            f"Windows refuses to replace read-only file: {candidate}"
-                        )
-                real_replace(source, destination)
+            receipt = publish_conversion_diagnostic_reports(tmp_dir, diagnostics)
 
-            def windows_unlink(path: str) -> None:
-                if os.path.lexists(path) and not (
-                    stat.S_IMODE(os.lstat(path).st_mode) & stat.S_IWRITE
-                ):
-                    raise PermissionError(
-                        f"Windows refuses to unlink read-only file: {path}"
+            root_stat = os.stat(tmp_dir, follow_symlinks=False)
+            directory_stat = os.stat(
+                os.path.join(tmp_dir, "gm2godot"),
+                follow_symlinks=False,
+            )
+            self.assertEqual(
+                receipt.root_identity,
+                (root_stat.st_dev, root_stat.st_ino),
+            )
+            self.assertEqual(
+                receipt.directory_identity,
+                (directory_stat.st_dev, directory_stat.st_ino),
+            )
+            for path, fingerprint in (
+                (receipt.json_path, receipt.json_report),
+                (receipt.markdown_path, receipt.markdown_report),
+            ):
+                content = Path(path).read_bytes()
+                path_stat = os.stat(path, follow_symlinks=False)
+                self.assertEqual(
+                    fingerprint.identity,
+                    (path_stat.st_dev, path_stat.st_ino),
+                )
+                self.assertEqual(
+                    fingerprint.sha256,
+                    hashlib.sha256(content).hexdigest(),
+                )
+
+    def test_restore_reinstates_exact_present_pair(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            json_path = root / DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH
+            markdown_path = root / DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH
+            _write_report_pair(root, b"trusted json\x00\n", b"trusted markdown\r\n")
+            json_path.chmod(0o640)
+            markdown_path.chmod(0o600)
+            snapshot = capture_conversion_diagnostic_reports(root)
+            receipt = DiagnosticCollector().publish_reports(root)
+
+            restore_conversion_diagnostic_reports(root, snapshot, receipt)
+
+            self.assertEqual(json_path.read_bytes(), b"trusted json\x00\n")
+            self.assertEqual(markdown_path.read_bytes(), b"trusted markdown\r\n")
+            self.assertModeEqual(stat.S_IMODE(json_path.stat().st_mode), 0o640)
+            self.assertModeEqual(
+                stat.S_IMODE(markdown_path.stat().st_mode),
+                0o600,
+            )
+            self.assertEqual(
+                sorted(path.name for path in json_path.parent.iterdir()),
+                ["conversion_diagnostics.json", "conversion_diagnostics.md"],
+            )
+
+    def test_restore_reinstates_absent_and_mixed_pairs(self) -> None:
+        with tempfile.TemporaryDirectory() as absent_dir:
+            snapshot = capture_conversion_diagnostic_reports(absent_dir)
+            receipt = DiagnosticCollector().publish_reports(absent_dir)
+            restore_conversion_diagnostic_reports(absent_dir, snapshot, receipt)
+            self.assertFalse(Path(receipt.json_path).exists())
+            self.assertFalse(Path(receipt.markdown_path).exists())
+
+        with tempfile.TemporaryDirectory() as mixed_dir:
+            root = Path(mixed_dir)
+            json_path = root / DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH
+            json_path.parent.mkdir()
+            json_path.write_bytes(b"trusted json only\n")
+            json_path.chmod(0o640)
+            snapshot = capture_conversion_diagnostic_reports(root)
+            receipt = DiagnosticCollector().publish_reports(root)
+            restore_conversion_diagnostic_reports(root, snapshot, receipt)
+            self.assertEqual(json_path.read_bytes(), b"trusted json only\n")
+            self.assertFalse(Path(receipt.markdown_path).exists())
+            self.assertModeEqual(stat.S_IMODE(json_path.stat().st_mode), 0o640)
+
+    def test_old_baseline_can_restore_over_latest_matching_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _write_report_pair(root, b"trusted json\n", b"trusted markdown\n")
+            baseline = capture_conversion_diagnostic_reports(root)
+            first = DiagnosticCollector()
+            first.add("warning", "GM2GD-FIRST", "first rewrite")
+            first.publish_reports(root)
+            second = DiagnosticCollector()
+            second.add("error", "GM2GD-SECOND", "second rewrite")
+            latest_receipt = second.publish_reports(root)
+
+            restore_conversion_diagnostic_reports(root, baseline, latest_receipt)
+
+            self.assertEqual(
+                (root / DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH).read_bytes(),
+                b"trusted json\n",
+            )
+            self.assertEqual(
+                (root / DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH).read_bytes(),
+                b"trusted markdown\n",
+            )
+
+    def test_restore_refuses_changed_or_replaced_receipt_targets(self) -> None:
+        for case in ("content", "identity", "mode"):
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as tmp_dir:
+                root = Path(tmp_dir)
+                baseline = capture_conversion_diagnostic_reports(root)
+                receipt = DiagnosticCollector().publish_reports(root)
+                json_path = Path(receipt.json_path)
+                original = json_path.read_bytes()
+                if case == "content":
+                    json_path.write_bytes(bytes((original[0] ^ 1,)) + original[1:])
+                elif case == "identity":
+                    replacement_path = json_path.with_suffix(".replacement")
+                    replacement_path.write_bytes(original)
+                    replacement_path.chmod(receipt.json_report.mode)
+                    os.replace(replacement_path, json_path)
+                else:
+                    if os.name == "nt":
+                        self.skipTest("Exact POSIX mode drift is unavailable")
+                    json_path.chmod(receipt.json_report.mode ^ stat.S_IXUSR)
+
+                with self.assertRaisesRegex(OSError, "changed"):
+                    restore_conversion_diagnostic_reports(root, baseline, receipt)
+
+                self.assertTrue(json_path.exists())
+                self.assertTrue(Path(receipt.markdown_path).exists())
+
+    def test_restore_validates_root_and_report_directory_bindings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            baseline = capture_conversion_diagnostic_reports(root)
+            receipt = DiagnosticCollector().publish_reports(root)
+
+            for field in ("root_identity", "directory_identity"):
+                with self.subTest(field=field):
+                    identity = getattr(receipt, field)
+                    forged = replace(
+                        receipt,
+                        **{field: (identity[0], identity[1] + 1)},
                     )
-                real_unlink(path)
+                    with self.assertRaisesRegex(ValueError, "directories do not match"):
+                        restore_conversion_diagnostic_reports(
+                            root,
+                            baseline,
+                            forged,
+                        )
+
+    def test_restore_refuses_forged_snapshot_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _write_report_pair(root, b"trusted json\n", b"trusted markdown\n")
+            baseline = capture_conversion_diagnostic_reports(root)
+            receipt = DiagnosticCollector().publish_reports(root)
+            forged = replace(
+                baseline,
+                json_report=replace(
+                    baseline.json_report,
+                    content=b"tampered baseline\n",
+                ),
+            )
+
+            with self.assertRaisesRegex(ValueError, "does not match"):
+                restore_conversion_diagnostic_reports(root, forged, receipt)
+
+            self.assertEqual(
+                Path(receipt.json_path).read_bytes(),
+                json.dumps(
+                    DiagnosticCollector().to_json_dict(),
+                    indent=2,
+                    sort_keys=True,
+                ).encode("utf-8")
+                + b"\n",
+            )
+
+    def test_restore_failure_rolls_back_to_original_receipt_pair(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _write_report_pair(root, b"trusted json\n", b"trusted markdown\n")
+            baseline = capture_conversion_diagnostic_reports(root)
+            diagnostics = DiagnosticCollector()
+            diagnostics.add("error", "GM2GD-NEW", "new receipt")
+            receipt = diagnostics.publish_reports(root)
+            published = (
+                Path(receipt.json_path).read_bytes(),
+                Path(receipt.markdown_path).read_bytes(),
+            )
+            failures = 0
+
+            def fail_after_first_restore_commit(
+                phase: str,
+                _directory_path: str,
+                name: str | None,
+            ) -> None:
+                nonlocal failures
+                if (
+                    phase == "after_commit"
+                    and name == "conversion_diagnostics.md"
+                    and failures == 0
+                ):
+                    failures += 1
+                    raise OSError("injected restore failure")
 
             with (
-                patch.object(
-                    diagnostics_module,
-                    "_WINDOWS_READONLY_FILE_ATTRIBUTES",
-                    True,
-                ),
                 patch(
-                    "src.conversion.diagnostics.os.replace",
-                    side_effect=windows_replace,
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=fail_after_first_restore_commit,
                 ),
-                patch(
-                    "src.conversion.diagnostics.os.unlink",
-                    side_effect=windows_unlink,
-                ),
+                self.assertRaisesRegex(OSError, "injected restore failure"),
             ):
-                snapshot = capture_conversion_diagnostic_reports(tmp_dir)
-                receipt = DiagnosticCollector().publish_reports(tmp_dir)
+                restore_conversion_diagnostic_reports(root, baseline, receipt)
 
-                self.assertFalse(
-                    stat.S_IMODE(os.stat(json_path).st_mode) & stat.S_IWRITE
-                )
-                self.assertTrue(
-                    stat.S_IMODE(os.stat(markdown_path).st_mode) & stat.S_IWRITE
-                )
+            self.assertEqual(Path(receipt.json_path).read_bytes(), published[0])
+            self.assertEqual(Path(receipt.markdown_path).read_bytes(), published[1])
+            restore_conversion_diagnostic_reports(root, baseline, receipt)
 
-                restore_conversion_diagnostic_reports(
-                    tmp_dir,
-                    snapshot,
-                    receipt,
-                )
+    def test_external_report_root_chain_is_synced_before_descent(self) -> None:
+        with tempfile.TemporaryDirectory() as container:
+            container_path = Path(container)
+            report_root = container_path / "one" / "two" / "reports"
+            sync_paths: list[str] = []
+            real_sync = VerifiedDirectory.sync
 
-            with open(json_path, "rb") as report_file:
-                self.assertEqual(report_file.read(), b"readonly json\n")
-            with open(markdown_path, "rb") as report_file:
-                self.assertEqual(report_file.read(), b"writable markdown\n")
-            self.assertFalse(
-                stat.S_IMODE(os.stat(json_path).st_mode) & stat.S_IWRITE
+            def record_sync(binding: VerifiedDirectory) -> None:
+                sync_paths.append(os.path.abspath(binding.path))
+                real_sync(binding)
+
+            with patch.object(
+                VerifiedDirectory,
+                "sync",
+                autospec=True,
+                side_effect=record_sync,
+            ):
+                DiagnosticCollector().publish_reports(report_root)
+
+            self.assertEqual(
+                sync_paths[:4],
+                [
+                    os.path.abspath(container),
+                    os.path.abspath(container_path / "one"),
+                    os.path.abspath(container_path / "one" / "two"),
+                    os.path.abspath(report_root),
+                ],
             )
             self.assertTrue(
-                stat.S_IMODE(os.stat(markdown_path).st_mode) & stat.S_IWRITE
-            )
-            self.assertEqual(
-                set(os.listdir(os.path.dirname(json_path))),
-                {os.path.basename(json_path), os.path.basename(markdown_path)},
+                (report_root / DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH).is_file()
             )
 
-    def test_windows_readonly_attributes_survive_publish_rollback(
-        self,
-    ) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            markdown_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-            )
-            os.makedirs(os.path.dirname(json_path))
-            for report_path, content in (
-                (json_path, b"previous json\n"),
-                (markdown_path, b"previous markdown\n"),
-            ):
-                with open(report_path, "wb") as report_file:
-                    report_file.write(content)
-                os.chmod(report_path, 0o444)
+    def test_external_root_creation_retry_repeats_failed_parent_sync(self) -> None:
+        with tempfile.TemporaryDirectory() as container:
+            report_parent = Path(container) / "one" / "two"
+            report_root = report_parent / "reports"
+            real_sync = VerifiedDirectory.sync
+            failed = False
 
-            real_replace = os.replace
-            real_unlink = os.unlink
-            json_publish_failed = False
-
-            def fail_json_publish(source: str, destination: str) -> None:
-                nonlocal json_publish_failed
-                for candidate in (source, destination):
-                    if os.path.lexists(candidate) and not (
-                        stat.S_IMODE(os.lstat(candidate).st_mode) & stat.S_IWRITE
-                    ):
-                        raise PermissionError(
-                            f"Windows refuses to replace read-only file: {candidate}"
-                        )
+            def fail_report_root_parent_sync(binding: VerifiedDirectory) -> None:
+                nonlocal failed
                 if (
-                    destination == json_path
-                    and source.endswith(".tmp")
-                    and not json_publish_failed
+                    not failed
+                    and os.path.abspath(binding.path)
+                    == os.path.abspath(report_parent)
                 ):
-                    json_publish_failed = True
-                    raise OSError("json publish failed")
-                real_replace(source, destination)
-
-            def windows_unlink(path: str) -> None:
-                if os.path.lexists(path) and not (
-                    stat.S_IMODE(os.lstat(path).st_mode) & stat.S_IWRITE
-                ):
-                    raise PermissionError(
-                        f"Windows refuses to unlink read-only file: {path}"
-                    )
-                real_unlink(path)
+                    failed = True
+                    raise OSError("injected external parent sync failure")
+                real_sync(binding)
 
             with (
                 patch.object(
-                    diagnostics_module,
-                    "_WINDOWS_READONLY_FILE_ATTRIBUTES",
-                    True,
+                    VerifiedDirectory,
+                    "sync",
+                    autospec=True,
+                    side_effect=fail_report_root_parent_sync,
                 ),
-                patch(
-                    "src.conversion.diagnostics.os.replace",
-                    side_effect=fail_json_publish,
-                ),
-                patch(
-                    "src.conversion.diagnostics.os.unlink",
-                    side_effect=windows_unlink,
-                ),
+                self.assertRaisesRegex(OSError, "external parent sync failure"),
             ):
-                with self.assertRaisesRegex(OSError, "json publish failed"):
-                    DiagnosticCollector().publish_reports(tmp_dir)
+                DiagnosticCollector().publish_reports(report_root)
 
-            for report_path, expected_content in (
-                (json_path, b"previous json\n"),
-                (markdown_path, b"previous markdown\n"),
+            self.assertTrue(report_root.is_dir())
+            self.assertFalse((report_root / "gm2godot").exists())
+            retry_sync_paths: list[str] = []
+
+            def record_retry(binding: VerifiedDirectory) -> None:
+                retry_sync_paths.append(os.path.abspath(binding.path))
+                real_sync(binding)
+
+            with patch.object(
+                VerifiedDirectory,
+                "sync",
+                autospec=True,
+                side_effect=record_retry,
             ):
-                with open(report_path, "rb") as report_file:
-                    self.assertEqual(report_file.read(), expected_content)
-                self.assertFalse(
-                    stat.S_IMODE(os.stat(report_path).st_mode) & stat.S_IWRITE
-                )
+                DiagnosticCollector().publish_reports(report_root)
+
+            self.assertGreaterEqual(len(retry_sync_paths), 2)
             self.assertEqual(
-                set(os.listdir(os.path.dirname(json_path))),
-                {os.path.basename(json_path), os.path.basename(markdown_path)},
+                retry_sync_paths[:2],
+                [
+                    os.path.abspath(report_parent),
+                    os.path.abspath(report_root),
+                ],
             )
 
-    def test_cleanup_fsync_failure_after_commit_still_returns_receipt(
-        self,
-    ) -> None:
+    def test_staging_failure_leaves_no_new_pair(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            markdown_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-            )
-            report_directory = os.path.dirname(json_path)
-            os.makedirs(report_directory)
-            for report_path, content in (
-                (json_path, b"old json\n"),
-                (markdown_path, b"old markdown\n"),
-            ):
-                with open(report_path, "wb") as report_file:
-                    report_file.write(content)
-            diagnostics = DiagnosticCollector()
-            diagnostics.add("warning", "GM2GD-NEW", "new reports")
-            real_fsync = cast(
-                Callable[[str, tuple[int, int]], None],
-                getattr(diagnostics_module, "_fsync_report_directory"),
-            )
-            cleanup_fsync_failures = 0
+            root = Path(tmp_dir)
 
-            def fail_cleanup_fsync(
-                path: str,
-                identity: tuple[int, int],
+            def fail_json_stage(
+                phase: str,
+                _directory_path: str,
+                name: str | None,
             ) -> None:
-                nonlocal cleanup_fsync_failures
-                remaining_backups = tuple(
-                    name
-                    for name in os.listdir(path)
-                    if name.endswith(".backup")
-                )
-                if not remaining_backups:
-                    cleanup_fsync_failures += 1
-                    raise OSError("cleanup fsync failed")
-                real_fsync(path, identity)
+                if phase == "before_stage" and name == "conversion_diagnostics.json":
+                    raise OSError("injected JSON staging failure")
 
-            with patch(
-                "src.conversion.diagnostics._fsync_report_directory",
-                side_effect=fail_cleanup_fsync,
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=fail_json_stage,
+                ),
+                self.assertRaisesRegex(OSError, "JSON staging failure"),
             ):
-                receipt = diagnostics.publish_reports(tmp_dir)
+                DiagnosticCollector().publish_reports(root)
 
-            self.assertEqual(cleanup_fsync_failures, 1)
-            for report_path, fingerprint in (
-                (json_path, receipt.json_report),
-                (markdown_path, receipt.markdown_report),
-            ):
-                with open(report_path, "rb") as report_file:
-                    content = report_file.read()
-                self.assertEqual(
-                    hashlib.sha256(content).hexdigest(),
-                    fingerprint.sha256,
-                )
-                self.assertNotIn(b"old ", content)
-            self.assertEqual(
-                set(os.listdir(report_directory)),
-                {os.path.basename(json_path), os.path.basename(markdown_path)},
-            )
+            self.assertEqual(list((root / "gm2godot").iterdir()), [])
 
-    def test_cleanup_accepts_unlink_that_removes_backup_then_raises(
+    def test_pair_commits_markdown_then_json_and_rolls_back_second_failure(
         self,
     ) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            markdown_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-            )
-            report_directory = os.path.dirname(json_path)
-            os.makedirs(report_directory)
-            for report_path, content in (
-                (json_path, b"old json\n"),
-                (markdown_path, b"old markdown\n"),
-            ):
-                with open(report_path, "wb") as report_file:
-                    report_file.write(content)
-            diagnostics = DiagnosticCollector()
-            diagnostics.add("warning", "GM2GD-NEW", "new reports")
-            real_unlink = os.unlink
-            removed_then_raised = 0
+            root = Path(tmp_dir)
+            _write_report_pair(root, b"old json\n", b"old markdown\n")
+            commits: list[str] = []
 
-            def remove_backup_then_raise(path: str) -> None:
-                nonlocal removed_then_raised
-                real_unlink(path)
-                if path.endswith(".backup"):
-                    removed_then_raised += 1
-                    raise OSError("unlink reported failure after removal")
+            def fail_json_commit(
+                phase: str,
+                _directory_path: str,
+                name: str | None,
+            ) -> None:
+                if phase != "before_commit" or name is None:
+                    return
+                commits.append(name)
+                if name == "conversion_diagnostics.json":
+                    raise OSError("injected JSON commit failure")
+
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=fail_json_commit,
+                ),
+                self.assertRaisesRegex(OSError, "JSON commit failure"),
+            ):
+                DiagnosticCollector().publish_reports(root)
+
+            self.assertEqual(
+                commits,
+                [
+                    "conversion_diagnostics.md",
+                    "conversion_diagnostics.json",
+                    "conversion_diagnostics.md",
+                ],
+            )
+            self.assertEqual(
+                (root / DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH).read_bytes(),
+                b"old json\n",
+            )
+            self.assertEqual(
+                (root / DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH).read_bytes(),
+                b"old markdown\n",
+            )
+
+    def test_cleanup_durability_failure_after_commit_keeps_valid_receipt(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _write_report_pair(root, b"old json\n", b"old markdown\n")
+            failures = 0
+
+            def fail_cleanup_sync(
+                phase: str,
+                _directory_path: str,
+                _name: str | None,
+            ) -> None:
+                nonlocal failures
+                if phase == "before_cleanup_durability":
+                    failures += 1
+                    raise OSError("injected cleanup durability failure")
 
             with patch(
-                "src.conversion.diagnostics.os.unlink",
-                side_effect=remove_backup_then_raise,
+                "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                side_effect=fail_cleanup_sync,
             ):
-                receipt = diagnostics.publish_reports(tmp_dir)
+                receipt = DiagnosticCollector().publish_reports(root)
 
-            self.assertEqual(removed_then_raised, 2)
-            self.assertEqual(receipt.json_path, json_path)
-            self.assertEqual(receipt.markdown_path, markdown_path)
+            self.assertEqual(failures, 1)
             self.assertEqual(
-                set(os.listdir(report_directory)),
-                {os.path.basename(json_path), os.path.basename(markdown_path)},
+                hashlib.sha256(Path(receipt.json_path).read_bytes()).hexdigest(),
+                receipt.json_report.sha256,
+            )
+            self.assertEqual(
+                sorted(path.name for path in (root / "gm2godot").iterdir()),
+                ["conversion_diagnostics.json", "conversion_diagnostics.md"],
             )
 
     def test_cleanup_propagates_keyboard_interrupt(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            markdown_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-            )
-            report_directory = os.path.dirname(json_path)
-            os.makedirs(report_directory)
-            for report_path in (json_path, markdown_path):
-                with open(report_path, "wb") as report_file:
-                    report_file.write(b"old report\n")
+            root = Path(tmp_dir)
+            _write_report_pair(root, b"old json\n", b"old markdown\n")
             real_unlink = os.unlink
 
-            def interrupt_backup_cleanup(path: str) -> None:
-                if path.endswith(".backup"):
-                    raise KeyboardInterrupt("diagnostic cleanup interrupted")
-                real_unlink(path)
+            def interrupt_backup_cleanup(
+                path: str | bytes,
+                *,
+                dir_fd: int | None = None,
+            ) -> None:
+                if os.fsdecode(path).endswith(".backup"):
+                    raise KeyboardInterrupt("injected cleanup interrupt")
+                real_unlink(path, dir_fd=dir_fd)
 
-            with patch(
-                "src.conversion.diagnostics.os.unlink",
-                side_effect=interrupt_backup_cleanup,
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts.os.unlink",
+                    side_effect=interrupt_backup_cleanup,
+                ),
+                self.assertRaisesRegex(KeyboardInterrupt, "cleanup interrupt"),
             ):
-                with self.assertRaisesRegex(
-                    KeyboardInterrupt,
-                    "diagnostic cleanup interrupted",
-                ):
-                    DiagnosticCollector().publish_reports(tmp_dir)
+                DiagnosticCollector().publish_reports(root)
 
-    def test_post_replace_exception_still_restores_previous_pair(self) -> None:
+    def test_rollback_failure_preserves_verified_previous_report(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            markdown_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-            )
-            os.makedirs(os.path.dirname(json_path))
-            with open(json_path, "w", encoding="utf-8") as report_file:
-                report_file.write("previous json\n")
-            with open(markdown_path, "w", encoding="utf-8") as report_file:
-                report_file.write("previous markdown\n")
-            real_replace = os.replace
-            injected = False
-
-            def replace_then_fail(source: str, destination: str) -> None:
-                nonlocal injected
-                real_replace(source, destination)
-                if not injected and source.endswith(".tmp"):
-                    injected = True
-                    raise OSError("post-replace failure")
-
-            with patch(
-                "src.conversion.diagnostics.os.replace",
-                side_effect=replace_then_fail,
-            ):
-                with self.assertRaisesRegex(OSError, "post-replace failure"):
-                    DiagnosticCollector().write_reports(tmp_dir)
-
-            with open(json_path, "r", encoding="utf-8") as report_file:
-                self.assertEqual(report_file.read(), "previous json\n")
-            with open(markdown_path, "r", encoding="utf-8") as report_file:
-                self.assertEqual(report_file.read(), "previous markdown\n")
-            self.assertEqual(
-                set(os.listdir(os.path.dirname(json_path))),
-                {os.path.basename(json_path), os.path.basename(markdown_path)},
-            )
-
-    def test_rollback_failure_preserves_previous_report_backup(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            markdown_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-            )
-            report_directory = os.path.dirname(json_path)
-            os.makedirs(report_directory)
-            with open(json_path, "w", encoding="utf-8") as report_file:
-                report_file.write("previous json\n")
-            with open(markdown_path, "w", encoding="utf-8") as report_file:
-                report_file.write("previous markdown\n")
-
-            diagnostics = DiagnosticCollector()
-            diagnostics.set_outcome(ConversionOutcome(state="success"))
-            real_replace = os.replace
+            root = Path(tmp_dir)
+            _write_report_pair(root, b"old json\n", b"old markdown\n")
+            rolling_back = False
 
             def fail_publish_and_rollback(
-                source: str,
-                destination: str,
+                phase: str,
+                _directory_path: str,
+                name: str | None,
             ) -> None:
-                if destination == json_path and source.endswith(".tmp"):
-                    raise OSError("json publish failed")
-                if destination == markdown_path and source.endswith(".backup"):
-                    raise OSError("markdown rollback failed")
-                real_replace(source, destination)
-
-            with patch(
-                "src.conversion.diagnostics.os.replace",
-                side_effect=fail_publish_and_rollback,
-            ):
-                with self.assertRaisesRegex(OSError, "json publish failed"):
-                    diagnostics.write_reports(tmp_dir)
-
-            recovery_paths = [
-                os.path.join(report_directory, name)
-                for name in os.listdir(report_directory)
-                if name.endswith(".backup")
-            ]
-            self.assertEqual(len(recovery_paths), 1)
-            with open(recovery_paths[0], "r", encoding="utf-8") as backup_file:
-                self.assertEqual(backup_file.read(), "previous markdown\n")
-            with open(json_path, "r", encoding="utf-8") as report_file:
-                self.assertEqual(report_file.read(), "previous json\n")
-            with open(markdown_path, "r", encoding="utf-8") as report_file:
-                self.assertNotEqual(report_file.read(), "previous markdown\n")
-            self.assertFalse(
-                any(name.endswith(".tmp") for name in os.listdir(report_directory))
-            )
-
-    def test_reports_refuse_final_symlink_without_reading_referent(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            report_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH,
-            )
-            external_path = os.path.join(tmp_dir, "external.json")
-            os.makedirs(os.path.dirname(report_path))
-            with open(external_path, "w", encoding="utf-8") as external_file:
-                external_file.write("external sentinel\n")
-            try:
-                os.symlink(external_path, report_path)
-            except (NotImplementedError, OSError) as error:
-                self.skipTest(f"Symbolic links are unavailable: {error}")
-
-            with self.assertRaisesRegex(OSError, "non-regular diagnostic report"):
-                DiagnosticCollector().write_reports(tmp_dir)
-
-            self.assertTrue(os.path.islink(report_path))
-            with open(external_path, "r", encoding="utf-8") as external_file:
-                self.assertEqual(external_file.read(), "external sentinel\n")
-
-    def test_reports_refuse_symlinked_report_directory(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            external_directory = os.path.join(tmp_dir, "external")
-            os.makedirs(external_directory)
-            report_directory = os.path.join(tmp_dir, "gm2godot")
-            try:
-                os.symlink(external_directory, report_directory)
-            except (NotImplementedError, OSError) as error:
-                self.skipTest(f"Symbolic links are unavailable: {error}")
-
-            with self.assertRaisesRegex(
-                OSError,
-                "redirected diagnostic report directory",
-            ):
-                DiagnosticCollector().write_reports(tmp_dir)
-
-            self.assertEqual(os.listdir(external_directory), [])
-
-    def test_report_verification_and_invalidation_refuse_mocked_junction(
-        self,
-    ) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH,
-            )
-            markdown_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-            )
-            report_directory = os.path.dirname(json_path)
-            os.makedirs(report_directory)
-            for report_path in (json_path, markdown_path):
-                with open(report_path, "w", encoding="utf-8") as report_file:
-                    report_file.write("stale sentinel\n")
-
-            normalized_report_directory = os.path.normcase(
-                os.path.abspath(report_directory)
-            )
-            report_directory_checks = 0
-
-            def junction_after_initial_check(path: str) -> bool:
-                nonlocal report_directory_checks
+                nonlocal rolling_back
                 if (
-                    os.path.normcase(os.path.abspath(path))
-                    != normalized_report_directory
+                    phase == "before_commit"
+                    and name == "conversion_diagnostics.json"
+                    and not rolling_back
                 ):
-                    return False
-                report_directory_checks += 1
-                return report_directory_checks > 1
+                    rolling_back = True
+                    raise OSError("injected JSON publication failure")
+                if (
+                    rolling_back
+                    and phase == "before_commit"
+                    and name == "conversion_diagnostics.md"
+                ):
+                    raise OSError("injected Markdown rollback failure")
 
-            with patch.object(
-                os.path,
-                "isjunction",
-                side_effect=junction_after_initial_check,
-                create=True,
-            ):
-                with self.assertRaisesRegex(
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=fail_publish_and_rollback,
+                ),
+                self.assertRaisesRegex(
                     OSError,
-                    "Diagnostic report directory changed",
-                ):
-                    DiagnosticCollector().write_reports(tmp_dir)
-                invalidate_conversion_diagnostic_reports(tmp_dir)
+                    "JSON publication failure",
+                ) as raised,
+            ):
+                DiagnosticCollector().publish_reports(root)
 
-            for report_path in (json_path, markdown_path):
-                with open(report_path, "r", encoding="utf-8") as report_file:
-                    self.assertEqual(report_file.read(), "stale sentinel\n")
+            notes = getattr(raised.exception, "__notes__", ())
+            self.assertTrue(
+                any("verified recovery artifact preserved" in note for note in notes)
+            )
+            retained = [
+                path
+                for path in (root / "gm2godot").iterdir()
+                if path.name not in {
+                    "conversion_diagnostics.json",
+                    "conversion_diagnostics.md",
+                }
+            ]
+            self.assertEqual(len(retained), 1)
+            self.assertEqual(retained[0].read_bytes(), b"old markdown\n")
+
+    def test_reports_refuse_redirects_and_nonregular_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as container:
+            container_path = Path(container)
+            outside = container_path / "outside"
+            outside.mkdir()
+            root_link = container_path / "root-link"
+            try:
+                root_link.symlink_to(outside, target_is_directory=True)
+            except (NotImplementedError, OSError) as error:
+                self.skipTest(f"Symbolic links are unavailable: {error}")
+            with self.assertRaisesRegex(OSError, "redirected"):
+                DiagnosticCollector().publish_reports(root_link)
+            self.assertEqual(list(outside.iterdir()), [])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            outside = root / "outside"
+            outside.mkdir()
+            report_directory = root / "gm2godot"
+            report_directory.symlink_to(outside, target_is_directory=True)
+            with self.assertRaisesRegex(OSError, "redirected"):
+                DiagnosticCollector().publish_reports(root)
+            self.assertEqual(list(outside.iterdir()), [])
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            report_path = root / DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH
+            report_path.parent.mkdir()
+            outside_report = root / "outside.json"
+            outside_report.write_bytes(b"outside\n")
+            report_path.symlink_to(outside_report)
+            with self.assertRaisesRegex(OSError, "non-regular"):
+                DiagnosticCollector().publish_reports(root)
+            self.assertEqual(outside_report.read_bytes(), b"outside\n")
+
+            report_path.unlink()
+            if hasattr(os, "mkfifo"):
+                os.mkfifo(report_path)
+                with self.assertRaisesRegex(OSError, "non-regular"):
+                    DiagnosticCollector().publish_reports(root)
 
     def test_reports_replace_hardlinks_without_mutating_referents(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            markdown_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-            )
-            os.makedirs(os.path.dirname(json_path))
-            external_json = os.path.join(tmp_dir, "external.json")
-            external_markdown = os.path.join(tmp_dir, "external.md")
-            for path, content in (
-                (external_json, "external json\n"),
-                (external_markdown, "external markdown\n"),
-            ):
-                with open(path, "w", encoding="utf-8") as external_file:
-                    external_file.write(content)
+            root = Path(tmp_dir)
+            report_directory = root / "gm2godot"
+            report_directory.mkdir()
+            external_json = root / "external.json"
+            external_markdown = root / "external.md"
+            external_json.write_bytes(b"external json\n")
+            external_markdown.write_bytes(b"external markdown\n")
             try:
-                os.link(external_json, json_path)
-                os.link(external_markdown, markdown_path)
+                os.link(
+                    external_json,
+                    root / DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH,
+                )
+                os.link(
+                    external_markdown,
+                    root / DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
+                )
             except (NotImplementedError, OSError) as error:
                 self.skipTest(f"Hard links are unavailable: {error}")
 
-            DiagnosticCollector().write_reports(tmp_dir)
+            DiagnosticCollector().publish_reports(root)
 
-            with open(external_json, "r", encoding="utf-8") as external_file:
-                self.assertEqual(external_file.read(), "external json\n")
-            with open(external_markdown, "r", encoding="utf-8") as external_file:
-                self.assertEqual(external_file.read(), "external markdown\n")
-            self.assertNotEqual(os.stat(json_path).st_ino, os.stat(external_json).st_ino)
+            self.assertEqual(external_json.read_bytes(), b"external json\n")
+            self.assertEqual(external_markdown.read_bytes(), b"external markdown\n")
             self.assertNotEqual(
-                os.stat(markdown_path).st_ino,
-                os.stat(external_markdown).st_ino,
+                (root / DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH).stat().st_ino,
+                external_json.stat().st_ino,
             )
 
-    def test_reports_refuse_nonregular_final_target(self) -> None:
-        if not hasattr(os, "mkfifo"):
-            self.skipTest("FIFO creation is unavailable")
+    def test_new_private_modes_and_existing_exact_modes_are_preserved(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            report_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH,
-            )
-            os.makedirs(os.path.dirname(report_path))
-            os.mkfifo(report_path)
-
-            with self.assertRaisesRegex(OSError, "non-regular diagnostic report"):
-                DiagnosticCollector().write_reports(tmp_dir)
-
-    def test_report_writer_does_not_require_os_fchmod(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
             with patch.object(
-                os,
+                anchored_artifacts_module.os,
                 "fchmod",
                 side_effect=AssertionError("os.fchmod must not be called"),
                 create=True,
             ):
-                json_path, markdown_path = DiagnosticCollector().write_reports(
-                    tmp_dir
-                )
-
-            self.assertTrue(os.path.isfile(json_path))
-            self.assertTrue(os.path.isfile(markdown_path))
-            if os.name != "nt":
-                self.assertEqual(stat.S_IMODE(os.stat(json_path).st_mode), 0o600)
-                self.assertEqual(
-                    stat.S_IMODE(os.stat(markdown_path).st_mode),
-                    0o600,
-                )
-
-    def test_existing_report_modes_are_set_through_held_descriptors(
-        self,
-    ) -> None:
-        if os.name == "nt":
-            self.skipTest("Windows preserves only the read-only file attribute")
-        fchmod_candidate = getattr(os, "fchmod", None)
-        if not callable(fchmod_candidate):
-            self.skipTest("os.fchmod is unavailable")
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            markdown_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-            )
-            os.makedirs(os.path.dirname(json_path))
-            for report_path, mode in (
-                (json_path, 0o640),
-                (markdown_path, 0o600),
-            ):
-                with open(report_path, "wb") as report_file:
-                    report_file.write(b"old report\n")
-                os.chmod(report_path, mode)
-            real_fchmod = fchmod_candidate
-            fchmod_calls: list[tuple[tuple[int, int], int]] = []
-
-            def record_fchmod(file_descriptor: int, mode: int) -> None:
-                opened_stat = os.fstat(file_descriptor)
-                fchmod_calls.append(
-                    ((opened_stat.st_dev, opened_stat.st_ino), mode)
-                )
-                real_fchmod(file_descriptor, mode)
-
-            with patch.object(os, "fchmod", side_effect=record_fchmod):
-                DiagnosticCollector().publish_reports(tmp_dir)
-
-            self.assertEqual(len(fchmod_calls), 4)
-            self.assertEqual(
-                sorted(mode for _identity, mode in fchmod_calls),
-                [0o600, 0o600, 0o640, 0o640],
-            )
-            self.assertEqual(
-                len({identity for identity, _mode in fchmod_calls}),
-                4,
+                receipt = DiagnosticCollector().publish_reports(root)
+            self.assertTrue(Path(receipt.json_path).is_file())
+            self.assertModeEqual(
+                stat.S_IMODE(Path(receipt.json_path).stat().st_mode),
+                0o600,
             )
 
-    def test_existing_set_id_modes_are_preserved_after_staging_writes(
-        self,
-    ) -> None:
         if os.name == "nt" or not callable(getattr(os, "fchmod", None)):
-            self.skipTest("POSIX descriptor mode preservation is unavailable")
+            return
         with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            markdown_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-            )
-            os.makedirs(os.path.dirname(json_path))
-            expected_modes = {
-                json_path: 0o4750,
-                markdown_path: 0o2750,
-            }
-            for report_path, mode in expected_modes.items():
-                with open(report_path, "wb") as report_file:
-                    report_file.write(b"old report\n")
-                os.chmod(report_path, mode)
-                if stat.S_IMODE(os.stat(report_path).st_mode) != mode:
-                    self.skipTest("The test filesystem does not retain set-ID modes")
+            root = Path(tmp_dir)
+            _write_report_pair(root, b"old json\n", b"old markdown\n")
+            json_path = root / DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH
+            markdown_path = root / DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH
+            json_path.chmod(0o4750)
+            markdown_path.chmod(0o2750)
+            if (
+                stat.S_IMODE(json_path.stat().st_mode) != 0o4750
+                or stat.S_IMODE(markdown_path.stat().st_mode) != 0o2750
+            ):
+                self.skipTest("Filesystem does not preserve set-ID modes")
 
-            DiagnosticCollector().publish_reports(tmp_dir)
+            DiagnosticCollector().publish_reports(root)
 
-            for report_path, mode in expected_modes.items():
-                self.assertEqual(
-                    stat.S_IMODE(os.stat(report_path).st_mode),
-                    mode,
-                )
+            self.assertEqual(stat.S_IMODE(json_path.stat().st_mode), 0o4750)
+            self.assertEqual(stat.S_IMODE(markdown_path.stat().st_mode), 0o2750)
 
-    def test_invalidate_reports_is_best_effort_for_both_paths(self) -> None:
+    def test_modeled_windows_readonly_pair_survives_publish_restore_and_rollback(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
-            json_path = os.path.join(tmp_dir, DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH)
-            markdown_path = os.path.join(
-                tmp_dir,
-                DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH,
-            )
-            os.makedirs(os.path.dirname(json_path), exist_ok=True)
-            for report_path in (json_path, markdown_path):
-                with open(report_path, "w", encoding="utf-8") as report_file:
-                    report_file.write("stale\n")
-            real_unlink = os.unlink
-
-            def fail_json_unlink(path: str) -> None:
-                if path == json_path:
-                    raise PermissionError("json is locked")
-                real_unlink(path)
+            root = Path(tmp_dir)
+            json_path = root / DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH
+            markdown_path = root / DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH
+            _write_report_pair(root, b"readonly json\n", b"readonly markdown\n")
+            json_path.chmod(0o444)
+            markdown_path.chmod(0o444)
 
             with patch(
-                "src.conversion.diagnostics.os.unlink",
+                "src.conversion.anchored_artifacts._is_windows_platform",
+                return_value=True,
+            ):
+                snapshot = capture_conversion_diagnostic_reports(root)
+                receipt = DiagnosticCollector().publish_reports(root)
+                self.assertFalse(
+                    stat.S_IMODE(json_path.stat().st_mode) & stat.S_IWUSR
+                )
+                self.assertFalse(
+                    stat.S_IMODE(markdown_path.stat().st_mode) & stat.S_IWUSR
+                )
+                restore_conversion_diagnostic_reports(root, snapshot, receipt)
+
+            self.assertEqual(json_path.read_bytes(), b"readonly json\n")
+            self.assertEqual(markdown_path.read_bytes(), b"readonly markdown\n")
+            self.assertFalse(stat.S_IMODE(json_path.stat().st_mode) & stat.S_IWUSR)
+            self.assertFalse(
+                stat.S_IMODE(markdown_path.stat().st_mode) & stat.S_IWUSR
+            )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            json_path = root / DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH
+            markdown_path = root / DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH
+            _write_report_pair(root, b"readonly json\n", b"readonly markdown\n")
+            json_path.chmod(0o444)
+            markdown_path.chmod(0o444)
+
+            def fail_json_commit(
+                phase: str,
+                _directory_path: str,
+                name: str | None,
+            ) -> None:
+                if phase == "before_commit" and name == "conversion_diagnostics.json":
+                    raise OSError("injected readonly pair failure")
+
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._is_windows_platform",
+                    return_value=True,
+                ),
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=fail_json_commit,
+                ),
+                self.assertRaisesRegex(OSError, "readonly pair failure"),
+            ):
+                DiagnosticCollector().publish_reports(root)
+
+            self.assertEqual(json_path.read_bytes(), b"readonly json\n")
+            self.assertEqual(markdown_path.read_bytes(), b"readonly markdown\n")
+            self.assertFalse(stat.S_IMODE(json_path.stat().st_mode) & stat.S_IWUSR)
+            self.assertFalse(
+                stat.S_IMODE(markdown_path.stat().st_mode) & stat.S_IWUSR
+            )
+
+    def test_invalidation_is_best_effort_for_both_bound_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _write_report_pair(root, b"stale json\n", b"stale markdown\n")
+            real_unlink = VerifiedDirectory.unlink
+
+            def fail_json_unlink(
+                binding: VerifiedDirectory,
+                name: str,
+                *,
+                expected_identity: tuple[int, int],
+            ) -> BaseException | None:
+                if name == "conversion_diagnostics.json":
+                    raise PermissionError("json is locked")
+                return real_unlink(
+                    binding,
+                    name,
+                    expected_identity=expected_identity,
+                )
+
+            with patch.object(
+                VerifiedDirectory,
+                "unlink",
+                autospec=True,
                 side_effect=fail_json_unlink,
             ):
-                invalidate_conversion_diagnostic_reports(tmp_dir)
+                invalidate_conversion_diagnostic_reports(root)
 
-            self.assertTrue(os.path.exists(json_path))
-            self.assertFalse(os.path.exists(markdown_path))
-
-            invalidate_conversion_diagnostic_reports(tmp_dir)
-            self.assertFalse(os.path.exists(json_path))
-
-    def test_invalidate_reports_refuses_symlinked_report_directory(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            external_directory = os.path.join(tmp_dir, "external")
-            os.makedirs(external_directory)
-            external_report = os.path.join(
-                external_directory,
-                os.path.basename(DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH),
+            self.assertTrue(
+                (root / DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH).exists()
             )
-            with open(external_report, "w", encoding="utf-8") as report_file:
-                report_file.write("external sentinel\n")
+            self.assertFalse(
+                (root / DIAGNOSTIC_REPORT_MARKDOWN_RELATIVE_PATH).exists()
+            )
+            invalidate_conversion_diagnostic_reports(root)
+            self.assertFalse(
+                (root / DIAGNOSTIC_REPORT_JSON_RELATIVE_PATH).exists()
+            )
+
+    @unittest.skipUnless(os.name == "posix", "POSIX relocation semantics required")
+    def test_publish_never_mutates_physical_replacement_at_each_pair_phase(
+        self,
+    ) -> None:
+        cases = (
+            ("before_stage", "conversion_diagnostics.md"),
+            ("before_backup", "conversion_diagnostics.md"),
+            ("before_backup", "conversion_diagnostics.json"),
+            ("before_commit", "conversion_diagnostics.md"),
+            ("before_commit", "conversion_diagnostics.json"),
+            ("before_durability", "conversion_diagnostics.md"),
+            ("before_durability", "conversion_diagnostics.json"),
+            ("before_sync", None),
+            ("before_cleanup", None),
+        )
+        for index, (selected_phase, selected_name) in enumerate(cases):
+            with self.subTest(phase=selected_phase, name=selected_name):
+                temp_dir = Path(tempfile.mkdtemp())
+                self.addCleanup(shutil.rmtree, temp_dir, True)
+                root = temp_dir / f"project-{index}"
+                root.mkdir()
+                _write_report_pair(root, b"old json\n", b"old markdown\n")
+                report_directory = root / "gm2godot"
+                parked = root / "gm2godot.parked"
+                swapped = False
+                replacement_before: dict[str, tuple[int, int, int, bytes]] = {}
+
+                def replace_directory(
+                    phase: str,
+                    directory_path: str,
+                    name: str | None,
+                ) -> None:
+                    nonlocal swapped, replacement_before
+                    if (
+                        swapped
+                        or phase != selected_phase
+                        or name != selected_name
+                        or os.path.abspath(directory_path)
+                        != os.path.abspath(report_directory)
+                    ):
+                        return
+                    swapped = True
+                    os.rename(report_directory, parked)
+                    replacement_before = _replacement_report_directory(
+                        report_directory
+                    )
+
+                with (
+                    patch(
+                        "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                        side_effect=replace_directory,
+                    ),
+                    self.assertRaises(OSError),
+                ):
+                    DiagnosticCollector().publish_reports(root)
+
+                self.assertTrue(swapped)
+                self.assertEqual(
+                    _directory_snapshot(report_directory),
+                    replacement_before,
+                )
+
+    @unittest.skipUnless(os.name == "posix", "POSIX relocation semantics required")
+    def test_restore_displacement_stays_bound_after_physical_replacement(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _write_report_pair(root, b"old json\n", b"old markdown\n")
+            snapshot = capture_conversion_diagnostic_reports(root)
+            receipt = DiagnosticCollector().publish_reports(root)
+            report_directory = root / "gm2godot"
+            parked = root / "gm2godot.parked"
+            replacement_before: dict[str, tuple[int, int, int, bytes]] = {}
+            swapped = False
+
+            def replace_before_displacement(
+                phase: str,
+                directory_path: str,
+                _name: str | None,
+            ) -> None:
+                nonlocal swapped, replacement_before
+                if (
+                    swapped
+                    or phase != "before_replace"
+                    or os.path.abspath(directory_path)
+                    != os.path.abspath(report_directory)
+                ):
+                    return
+                swapped = True
+                os.rename(report_directory, parked)
+                replacement_before = _replacement_report_directory(
+                    report_directory
+                )
+
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=replace_before_displacement,
+                ),
+                self.assertRaises(OSError),
+            ):
+                restore_conversion_diagnostic_reports(root, snapshot, receipt)
+
+            self.assertTrue(swapped)
+            self.assertEqual(
+                _directory_snapshot(report_directory),
+                replacement_before,
+            )
+
+    @unittest.skipUnless(os.name == "posix", "POSIX relocation semantics required")
+    def test_rollback_and_invalidation_stay_bound_after_replacement(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _write_report_pair(root, b"old json\n", b"old markdown\n")
+            report_directory = root / "gm2godot"
+            parked = root / "gm2godot.parked"
+            replacement_before: dict[str, tuple[int, int, int, bytes]] = {}
+            swapped = False
+
+            def fail_then_replace_for_rollback(
+                phase: str,
+                directory_path: str,
+                name: str | None,
+            ) -> None:
+                nonlocal swapped, replacement_before
+                if phase == "after_commit" and name == "conversion_diagnostics.md":
+                    raise OSError("injected post-commit failure")
+                if (
+                    swapped
+                    or phase != "before_rollback"
+                    or os.path.abspath(directory_path)
+                    != os.path.abspath(report_directory)
+                ):
+                    return
+                swapped = True
+                os.rename(report_directory, parked)
+                replacement_before = _replacement_report_directory(
+                    report_directory
+                )
+
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=fail_then_replace_for_rollback,
+                ),
+                self.assertRaisesRegex(OSError, "post-commit failure"),
+            ):
+                DiagnosticCollector().publish_reports(root)
+
+            self.assertTrue(swapped)
+            self.assertEqual(
+                _directory_snapshot(report_directory),
+                replacement_before,
+            )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _write_report_pair(root, b"stale json\n", b"stale markdown\n")
+            report_directory = root / "gm2godot"
+            parked = root / "gm2godot.parked"
+            replacement_before = {}
+            swapped = False
+
+            def replace_before_invalidation_unlink(
+                phase: str,
+                directory_path: str,
+                _name: str | None,
+            ) -> None:
+                nonlocal swapped, replacement_before
+                if (
+                    swapped
+                    or phase != "before_unlink"
+                    or os.path.abspath(directory_path)
+                    != os.path.abspath(report_directory)
+                ):
+                    return
+                swapped = True
+                os.rename(report_directory, parked)
+                replacement_before = _replacement_report_directory(
+                    report_directory
+                )
+
+            with patch(
+                "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                side_effect=replace_before_invalidation_unlink,
+            ):
+                invalidate_conversion_diagnostic_reports(root)
+
+            self.assertTrue(swapped)
+            self.assertEqual(
+                _directory_snapshot(report_directory),
+                replacement_before,
+            )
+
+    @unittest.skipUnless(os.name == "nt", "Native Windows handles required")
+    def test_windows_bindings_block_root_and_report_relocation_during_publish(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as container:
+            root = Path(container) / "external" / "reports"
+            report_directory = root / "gm2godot"
+            parked_root = root.with_name("reports.parked")
+            parked_reports = root / "gm2godot.parked"
+            relocation_checked = False
+
+            def try_relocation(
+                phase: str,
+                _directory_path: str,
+                _name: str | None,
+            ) -> None:
+                nonlocal relocation_checked
+                if phase != "before_stage" or relocation_checked:
+                    return
+                relocation_checked = True
+                with self.assertRaises(OSError):
+                    os.rename(report_directory, parked_reports)
+                with self.assertRaises(OSError):
+                    os.rename(root, parked_root)
+
+            with patch(
+                "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                side_effect=try_relocation,
+            ):
+                receipt = DiagnosticCollector().publish_reports(root)
+
+            self.assertTrue(relocation_checked)
+            self.assertTrue(Path(receipt.json_path).is_file())
+
+    def test_invalidation_refuses_redirected_report_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            outside = root / "outside"
+            outside.mkdir()
+            external_report = outside / "conversion_diagnostics.json"
+            external_report.write_bytes(b"external sentinel\n")
             try:
-                os.symlink(
-                    external_directory,
-                    os.path.join(tmp_dir, "gm2godot"),
+                (root / "gm2godot").symlink_to(
+                    outside,
+                    target_is_directory=True,
                 )
             except (NotImplementedError, OSError) as error:
                 self.skipTest(f"Symbolic links are unavailable: {error}")
 
-            invalidate_conversion_diagnostic_reports(tmp_dir)
+            invalidate_conversion_diagnostic_reports(root)
 
-            with open(external_report, "r", encoding="utf-8") as report_file:
-                self.assertEqual(report_file.read(), "external sentinel\n")
+            self.assertEqual(
+                external_report.read_bytes(),
+                b"external sentinel\n",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -908,27 +908,21 @@ class TestDiagnosticCollector(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
             _write_report_pair(root, b"stale json\n", b"stale markdown\n")
-            real_unlink = VerifiedDirectory.unlink
 
-            def fail_json_unlink(
-                binding: VerifiedDirectory,
-                name: str,
-                *,
-                expected_identity: tuple[int, int],
-            ) -> BaseException | None:
-                if name == "conversion_diagnostics.json":
+            def fail_json_invalidation(
+                phase: str,
+                _directory_path: str,
+                name: str | None,
+            ) -> None:
+                if (
+                    phase == "before_backup"
+                    and name == "conversion_diagnostics.json"
+                ):
                     raise PermissionError("json is locked")
-                return real_unlink(
-                    binding,
-                    name,
-                    expected_identity=expected_identity,
-                )
 
-            with patch.object(
-                VerifiedDirectory,
-                "unlink",
-                autospec=True,
-                side_effect=fail_json_unlink,
+            with patch(
+                "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                side_effect=fail_json_invalidation,
             ):
                 invalidate_conversion_diagnostic_reports(root)
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_28(self) -> None:
-        self.assertEqual(get_version(), "0.7.28")
+    def test_release_version_is_0_7_29(self) -> None:
+        self.assertEqual(get_version(), "0.7.29")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- route diagnostic JSON/Markdown capture, publication, restoration, invalidation, rollback, recovery, and cleanup through the shared verified-directory transaction
- bind pair snapshots and receipts to both report-root identities, and durably create missing external report-root components through verified parents
- preserve stable paths, Markdown-first ordering, exact modes, Windows read-only behavior, and ordinary-failure rollback while documenting the remaining hard-crash pair boundary
- bump the project version from 0.7.28 to 0.7.29

## Test plan
- [x] `./venv/bin/pyright --warnings`
- [x] `./venv/bin/python -m ruff check .`
- [x] focused diagnostic, artifact, converter, CLI, version, and documentation tests (183 tests, 8 platform skips)
- [x] `GODOT_BIN=/Applications/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest` (2,242 tests, 64 intentional/platform skips)
- [x] exact Godot binary reports `4.7.1.stable.official.a13da4feb`
- [x] `git diff --check`

## Documentation sources
Context7 was unavailable after the required discovery retry. The implementation was checked against the official [Python descriptor-relative filesystem documentation](https://docs.python.org/3/library/os.html#paths-relative-to-directory-descriptors), [Microsoft CreateFileW directory/reparse flags](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew), [Microsoft FlushFileBuffers contract](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-flushfilebuffers), [Godot 4.7 command-line reference](https://docs.godotengine.org/en/4.7/tutorials/editor/command_line_tutorial.html), and [GameMaker LTS output-window behavior](https://manual.gamemaker.io/lts/en/Introduction/The_Output_Window.htm).

Closes #775