### PR TITLE
Anchor conversion manifest and attempt-ledger publication

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.29, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.30, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.30 - 2026-07-19
+
+- Anchored conversion-attempt and canonical-manifest staging, backup reads, attempt-first replacement, rollback, recovery retention, stale cleanup, durability barriers, and final receipts to one shared verified-directory byte-artifact transaction.
+- Preserved stable artifact paths, exact modes, Windows read-only behavior, asset-registry revalidation, the `updated` / `preserved` / `absent` trust contract, and canonical SHA verification while rejecting physical directory replacement at every publication boundary.
+- Added adversarial POSIX replacement and hard-link sentinel coverage across staging, backup, both commits, every sync, rollback, recovery and cleanup, plus native Windows relocation coverage and exact Godot 4.7.1 validation.
+
 ## 0.7.29 - 2026-07-19
 
 - Anchored diagnostic JSON/Markdown capture, publication, restoration, invalidation, rollback, recovery retention and cleanup to the shared verified-directory byte-artifact transaction.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.29`.
+Current source version: `0.7.30`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.29 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.30 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.29 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.30 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.29 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.30 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -77,7 +77,7 @@ Read `canonical_manifest` in the attempt ledger:
 | `preserved` | `false` | `unverified` | A regular canonical file already existed and was left untouched. Its recorded digest identifies those bytes, but preservation does not prove that its schema or contents describe the current destination or latest attempt. |
 | `absent` | `false` | `unavailable` | No canonical manifest exists; `sha256` is `null`. |
 
-The digest string is `sha256:` followed by the lowercase hash of the raw `conversion_manifest.json` bytes. The attempt and canonical files are each atomically replaced, but they are not one multi-file atomic unit: publication is attempt-first and canonical-last. A missing canonical file or digest mismatch can therefore identify an interrupted pair publication. Do not trust the canonical manifest until the digest matches.
+The digest string is `sha256:` followed by the lowercase hash of the raw `conversion_manifest.json` bytes. Staging, backup reads, attempt-first replacement, canonical-last replacement, rollback, recovery and cleanup stay on one verified `gm2godot/` directory binding through final receipt validation; POSIX uses descriptor-relative no-follow operations and Windows retains a reparse-checked handle that denies directory deletion. The two files are still not one multi-file crash-atomic unit. A missing canonical file or digest mismatch can therefore identify an interrupted pair publication. Do not trust the canonical manifest until the digest matches.
 
 Even when the digest matches, inspect both records:
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.29 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.30 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -198,7 +198,7 @@ Important trust rules:
 
 - Unsafe destinations rejected during preflight are not modified and do not receive an attempt ledger.
 - A partial canonical manifest is written only when every requested converter step completed; its partiality comes from skipped or failed resources.
-- `conversion_attempt.json` is committed before `conversion_manifest.json`. Each file replacement is atomic, but the pair is not one multi-file atomic transaction.
+- `conversion_attempt.json` is committed before `conversion_manifest.json` through one verified `gm2godot/` directory binding. Each file replacement is atomic, but the pair is not one multi-file crash-atomic transaction.
 - Consumers must compare `conversion_attempt.json` → `canonical_manifest.sha256` with the actual canonical manifest. A mismatch means publication was interrupted.
 - `canonical_manifest.status = preserved` is transaction-relative. It does not prove that an older manifest describes the destination after a failed or cancelled attempt.
 - `generated_files` describes files changed from the conversion’s initial output snapshot; it intentionally does not claim ownership of every unchanged pre-existing file.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.29 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.30 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.29;
+- GM2Godot 0.7.30;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.29 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.30 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -46,7 +46,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.29`.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.30`.
 
 ## Run from source
 
@@ -133,6 +133,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.29`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.30`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.29 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.30 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.29 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.30 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/src/conversion/anchored_artifacts.py
+++ b/src/conversion/anchored_artifacts.py
@@ -693,6 +693,14 @@ class VerifiedDirectory(AbstractContextManager["VerifiedDirectory"]):
             return False
         return True
 
+    def list_names(self) -> tuple[str, ...]:
+        if self.strategy == "posix_dir_fd":
+            return tuple(sorted(os.listdir(self.descriptor)))
+        self.verify_path()
+        names = tuple(sorted(os.listdir(self.path)))
+        self.verify_path()
+        return names
+
     def open_file(self, name: str, flags: int, mode: int = 0o600) -> int:
         leaf = _safe_leaf(name)
         flags |= getattr(os, "O_NOFOLLOW", 0)
@@ -1821,12 +1829,37 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
             sha256=_sha256_bytes(content),
         )
 
+    def capture_staged(self, name: str) -> StagedArtifact | None:
+        """Capture an existing private artifact for identity-bound cleanup."""
+        leaf = _safe_leaf(name)
+        state = self.target_state(leaf)
+        if state.fingerprint is None:
+            return None
+        if state.mode is None:
+            raise AssertionError("A present artifact target must have a mode.")
+        content = self.read_target_bytes(leaf, state)
+        staged = StagedArtifact(
+            directory_path=self.path,
+            name=leaf,
+            identity=(state.fingerprint[0], state.fingerprint[1]),
+            content=content,
+            mode=state.mode,
+            target_mode=state.mode,
+            sha256=_sha256_bytes(content),
+        )
+        self.verify_staged(staged)
+        return staged
+
     def capture_snapshots(
         self,
         names: tuple[str, ...],
     ) -> tuple[ArtifactSnapshot, ...]:
         self._validate_unique_names(names)
         return tuple(self.capture_snapshot(name) for name in names)
+
+    def verify_snapshot(self, snapshot: ArtifactSnapshot) -> None:
+        self._validate_snapshot(snapshot)
+        self._verify_snapshot_current(snapshot)
 
     def _verify_snapshot_current(self, snapshot: ArtifactSnapshot) -> None:
         state = self._snapshot_state(snapshot)
@@ -1845,9 +1878,18 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
     def publish_specs(
         self,
         specs: tuple[ArtifactSpec, ...],
+        *,
+        guards: tuple[ArtifactSnapshot, ...] = (),
+        before_commit: Callable[[str], None] | None = None,
+        after_commit: Callable[[str], None] | None = None,
     ) -> tuple[ArtifactReceipt | None, ...]:
-        """Publish an ordered present/absent set with reverse rollback."""
-        self._validate_unique_names(tuple(spec.name for spec in specs))
+        """Publish an ordered present/absent set with guards and reverse rollback."""
+        self._validate_unique_names(
+            tuple(spec.name for spec in specs)
+            + tuple(guard.name for guard in guards)
+        )
+        for guard in guards:
+            self._validate_snapshot(guard)
         normalized_specs = tuple(
             ArtifactSpec(
                 name=_safe_leaf(spec.name),
@@ -1864,8 +1906,16 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
         temporary_files: dict[str, StagedArtifact] = {}
         active_error: BaseException | None = None
         mutations: list[_PublishedMutation] = []
+
+        def verify_guards() -> None:
+            self.verify_directory()
+            for guard in guards:
+                self._verify_snapshot_current(guard)
+
         try:
+            verify_guards()
             for spec, snapshot in zip(normalized_specs, snapshots, strict=True):
+                verify_guards()
                 desired = None
                 if spec.content is not None:
                     desired = self.stage_bytes(
@@ -1877,6 +1927,7 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
                     temporary_files[desired.name] = desired
                 desired_stages[spec.name] = desired
             for spec, snapshot in zip(normalized_specs, snapshots, strict=True):
+                verify_guards()
                 backup = self.stage_existing(
                     spec.name,
                     self._snapshot_state(snapshot),
@@ -1894,8 +1945,9 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
                         f"{self.directory.child_path(snapshot.name)}"
                     )
                 self._verify_snapshot_current(snapshot)
+                verify_guards()
 
-            self.verify_directory()
+            verify_guards()
             for snapshot in snapshots:
                 self._verify_snapshot_current(snapshot)
 
@@ -1906,8 +1958,13 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
                 # give another writer time to change a later target. Never
                 # overwrite that external state from the stale preflight.
                 self._verify_snapshot_current(snapshot)
+                verify_guards()
                 mutation_started = False
                 completion_error: BaseException | None = None
+                if before_commit is not None:
+                    before_commit(spec.name)
+                    self._verify_snapshot_current(snapshot)
+                    verify_guards()
                 if desired is not None:
                     completion_error = self.replace_staged(desired, spec.name)
                     mutation_started = True
@@ -1932,6 +1989,10 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
                     self.phase("before_durability", spec.name)
                     self.sync(f"commit_{spec.name}_durability")
                     self.phase("after_durability", spec.name)
+                    verify_guards()
+                    if after_commit is not None:
+                        after_commit(spec.name)
+                        verify_guards()
 
             receipts = tuple(
                 None
@@ -1957,7 +2018,7 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
                     + "; ".join(str(error) for error in cleanup_errors)
                 )
 
-        self.verify_directory()
+        verify_guards()
         for spec, receipt in zip(normalized_specs, receipts, strict=True):
             if receipt is None:
                 if self.directory.lexists(spec.name):
@@ -2158,6 +2219,7 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
                         backup.content,
                         mode=backup.target_mode,
                         suffix=".recovery.backup",
+                        phase_name="recovery_stage",
                     )
                     temporary_files[recovery.name] = recovery
                     completion_error = self.replace_staged(backup, name)

--- a/src/conversion/conversion_manifest.py
+++ b/src/conversion/conversion_manifest.py
@@ -5,11 +5,17 @@ import json
 import os
 import posixpath
 import stat
-import tempfile
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import TypeAlias, cast
+from typing import TypeAlias
 
+from src.conversion.anchored_artifacts import (
+    ArtifactSnapshot,
+    ArtifactSpec,
+    ByteArtifactTransaction,
+    StagedArtifact,
+    artifact_sha256,
+)
 from src.conversion.architecture_policy import build_architecture_policy_report
 from src.conversion.asset_registry import (
     AssetRegistryConverter,
@@ -37,12 +43,13 @@ CONVERSION_MANIFEST_RELATIVE_PATH = os.path.join("gm2godot", "conversion_manifes
 CONVERSION_ATTEMPT_RELATIVE_PATH = os.path.join("gm2godot", "conversion_attempt.json")
 _MANIFEST_FILENAME = os.path.basename(CONVERSION_MANIFEST_RELATIVE_PATH)
 _ATTEMPT_FILENAME = os.path.basename(CONVERSION_ATTEMPT_RELATIVE_PATH)
+_ARTIFACT_DIRECTORY = os.path.dirname(CONVERSION_MANIFEST_RELATIVE_PATH)
+_ARTIFACT_DIRECTORY_DESCRIPTION = "conversion artifact directory"
 _IMAGE_EXTENSIONS = frozenset({".bmp", ".gif", ".ico", ".jpeg", ".jpg", ".png", ".svg", ".webp"})
 _AUDIO_EXTENSIONS = frozenset({".aac", ".flac", ".m4a", ".mp3", ".ogg", ".opus", ".wav"})
 _FONT_EXTENSIONS = frozenset({".otf", ".ttf", ".woff", ".woff2"})
 
 FileFingerprint: TypeAlias = tuple[int, int, int, int, int]
-PathIdentity: TypeAlias = tuple[int, int]
 
 
 @dataclass(frozen=True)
@@ -64,41 +71,6 @@ class GeneratedFileEntry:
             "kind": self.kind,
             "sha256": self.sha256,
         }
-
-
-@dataclass(frozen=True)
-class _ArtifactTargetState:
-    fingerprint: FileFingerprint | None
-    mode: int | None
-
-    @property
-    def identity(self) -> PathIdentity | None:
-        if self.fingerprint is None:
-            return None
-        return self.fingerprint[:2]
-
-
-@dataclass(frozen=True)
-class _TemporaryArtifact:
-    path: str
-    identity: PathIdentity
-    sha256: str
-    # ``mode`` is the mode the artifact must have after publication.  On
-    # Windows, a read-only destination cannot be replaced and a read-only
-    # temporary file cannot be cleaned up.  ``staged_mode`` therefore records
-    # the cleanup-safe mode retained while the file still has its temporary
-    # name; it may differ from ``mode`` until the final replacement.
-    mode: int
-    staged_mode: int
-
-
-@dataclass(frozen=True)
-class _PublishedArtifact:
-    path: str
-    identity: PathIdentity
-    sha256: str
-    mode: int
-    backup: _TemporaryArtifact | None
 
 
 def write_conversion_artifacts(
@@ -138,25 +110,14 @@ def write_conversion_artifacts(
 
     manifest_path = os.path.join(godot_project_path, CONVERSION_MANIFEST_RELATIVE_PATH)
     attempt_path = os.path.join(godot_project_path, CONVERSION_ATTEMPT_RELATIVE_PATH)
-    (
-        artifact_directory,
-        initial_root_identity,
-        initial_directory_identity,
-    ) = _inspect_artifact_directory(godot_project_path)
-    manifest_state = (
-        _artifact_target_state(manifest_path)
-        if initial_directory_identity is not None
-        else _ArtifactTargetState(fingerprint=None, mode=None)
-    )
-    attempt_state = (
-        _artifact_target_state(attempt_path)
-        if initial_directory_identity is not None
-        else _ArtifactTargetState(fingerprint=None, mode=None)
-    )
 
     manifest_content: bytes | None = None
     manifest_asset_converter: AssetRegistryConverter | None = None
     manifest_asset_publication: AssetRegistryPublication | None = None
+    manifest_status: str
+    current_output_status: str
+    manifest_digest: str | None = None
+    attempt_content: bytes | None = None
     if manifest_outcome is not None:
         manifest_asset_converter = _asset_registry_converter(
             gm_project_path,
@@ -178,228 +139,121 @@ def write_conversion_artifacts(
         manifest_content = _serialize_json(manifest_payload)
         manifest_status = "updated"
         current_output_status = "verified"
-        manifest_digest: str | None = _sha256_bytes(manifest_content)
-    elif manifest_state.identity is not None:
-        manifest_content_before = _read_artifact_bytes(manifest_path, manifest_state)
-        manifest_status = "preserved"
-        current_output_status = "unverified"
-        manifest_digest = _sha256_bytes(manifest_content_before)
-    else:
-        manifest_status = "absent"
-        current_output_status = "unavailable"
-        manifest_digest = None
-
-    attempt_payload: JsonDict = {
-        "format_version": 1,
-        "attempt": _conversion_record(attempt_outcome),
-        "canonical_manifest": {
-            "path": CONVERSION_MANIFEST_RELATIVE_PATH.replace(os.sep, "/"),
-            "status": manifest_status,
-            "updated": manifest_outcome is not None,
-            "current_output": current_output_status,
-            "sha256": manifest_digest,
-        },
-    }
-    attempt_content = _serialize_json(attempt_payload)
-
-    prepared_directory, root_identity, directory_identity = (
-        _prepare_artifact_directory(godot_project_path)
-    )
-    if (
-        prepared_directory != artifact_directory
-        or root_identity != initial_root_identity
-        or (
-            initial_directory_identity is not None
-            and directory_identity != initial_directory_identity
+        manifest_digest = artifact_sha256(manifest_content)
+        attempt_content = _serialize_json(
+            _conversion_attempt_payload(
+                attempt_outcome,
+                manifest_status=manifest_status,
+                manifest_updated=True,
+                current_output_status=current_output_status,
+                manifest_digest=manifest_digest,
+            )
         )
-    ):
-        raise OSError("Conversion artifact directory changed before publication.")
-    _verify_artifact_directory(
+
+    with ByteArtifactTransaction.open(
         godot_project_path,
-        root_identity,
-        artifact_directory,
-        directory_identity,
-    )
-    _verify_artifact_target_state(manifest_path, manifest_state)
-    _verify_artifact_target_state(attempt_path, attempt_state)
-    stale_temporary_paths = _capture_owned_stale_artifacts(
-        godot_project_path,
-        root_identity,
-        artifact_directory,
-        directory_identity,
-    )
-
-    publish_specs: list[tuple[str, bytes, _ArtifactTargetState]] = [
-        (attempt_path, attempt_content, attempt_state),
-    ]
-    if manifest_content is not None and manifest_outcome is not None:
-        publish_specs.append((manifest_path, manifest_content, manifest_state))
-
-    temporary_paths: dict[str, _TemporaryArtifact] = {}
-    published: list[_PublishedArtifact] = []
-    active_error: BaseException | None = None
-
-    def verify_preserved_manifest() -> None:
+        _ARTIFACT_DIRECTORY,
+        create=True,
+        description=_ARTIFACT_DIRECTORY_DESCRIPTION,
+    ) as transaction:
+        manifest_guard: ArtifactSnapshot | None = None
         if manifest_outcome is None:
-            _verify_artifact_target_state(manifest_path, manifest_state)
-
-    try:
-        staged: dict[str, _TemporaryArtifact] = {}
-        backups: dict[str, _TemporaryArtifact | None] = {}
-        for target_path, content, target_state in publish_specs:
-            _verify_artifact_directory(
-                godot_project_path,
-                root_identity,
-                artifact_directory,
-                directory_identity,
-            )
-            verify_preserved_manifest()
-            _verify_artifact_target_state(target_path, target_state)
-            staged_artifact = _stage_artifact_bytes(
-                target_path,
-                content,
-                mode=target_state.mode,
-                suffix=".tmp",
-            )
-            temporary_paths[staged_artifact.path] = staged_artifact
-            staged[target_path] = staged_artifact
-
-        for target_path, _content, target_state in publish_specs:
-            _verify_artifact_directory(
-                godot_project_path,
-                root_identity,
-                artifact_directory,
-                directory_identity,
-            )
-            verify_preserved_manifest()
-            backup = _stage_existing_artifact(target_path, target_state)
-            backups[target_path] = backup
-            if backup is not None:
-                temporary_paths[backup.path] = backup
-
-        try:
-            for target_path, _content, target_state in publish_specs:
-                _verify_artifact_directory(
-                    godot_project_path,
-                    root_identity,
-                    artifact_directory,
-                    directory_identity,
-                )
-                verify_preserved_manifest()
-                _verify_artifact_target_state(target_path, target_state)
-                if (
-                    target_path == manifest_path
-                    and manifest_asset_converter is not None
-                    and manifest_asset_publication is not None
-                ):
-                    manifest_asset_converter.revalidate_publication(
-                        manifest_asset_publication,
-                        validate_content=False,
+            manifest_guard = transaction.capture_snapshot(_MANIFEST_FILENAME)
+            if manifest_guard.present:
+                if manifest_guard.content is None:
+                    raise AssertionError(
+                        "A present conversion manifest snapshot must have content."
                     )
-                staged_artifact = staged[target_path]
-                backup = backups[target_path]
-                _publish_staged_artifact(
-                    staged_artifact,
-                    target_path,
-                    target_state,
-                    backup,
-                    temporary_paths,
-                    published,
+                manifest_status = "preserved"
+                current_output_status = "unverified"
+                manifest_digest = artifact_sha256(manifest_guard.content)
+            else:
+                manifest_status = "absent"
+                current_output_status = "unavailable"
+                manifest_digest = None
+            attempt_content = _serialize_json(
+                _conversion_attempt_payload(
+                    attempt_outcome,
+                    manifest_status=manifest_status,
+                    manifest_updated=False,
+                    current_output_status=current_output_status,
+                    manifest_digest=manifest_digest,
                 )
-                _fsync_artifact_directory(
-                    godot_project_path,
-                    root_identity,
-                    artifact_directory,
-                    directory_identity,
-                )
-                _verify_temporary_artifact(
-                    staged_artifact,
-                    path=target_path,
-                )
-                verify_preserved_manifest()
-                if (
-                    target_path == manifest_path
-                    and manifest_asset_converter is not None
-                    and manifest_asset_publication is not None
-                ):
-                    manifest_asset_converter.revalidate_publication(
-                        manifest_asset_publication,
-                        validate_content=True,
-                    )
-            _verify_artifact_directory(
-                godot_project_path,
-                root_identity,
-                artifact_directory,
-                directory_identity,
             )
-            for published_artifact in published:
-                _verify_published_artifact(published_artifact)
-            verify_preserved_manifest()
-        except BaseException as publish_error:
-            rollback_errors = _rollback_artifacts(
-                published,
-                temporary_paths,
-                godot_project_path=godot_project_path,
-                root_identity=root_identity,
-                artifact_directory=artifact_directory,
-                directory_identity=directory_identity,
+
+        if attempt_content is None:
+            raise AssertionError("Conversion attempt content must be serialized.")
+        stale_artifacts = _capture_owned_stale_transaction_artifacts(transaction)
+        specs = [ArtifactSpec(_ATTEMPT_FILENAME, attempt_content)]
+        if manifest_content is not None:
+            specs.append(ArtifactSpec(_MANIFEST_FILENAME, manifest_content))
+
+        def revalidate_before_commit(name: str) -> None:
+            if name != _MANIFEST_FILENAME:
+                return
+            if (
+                manifest_asset_converter is None
+                or manifest_asset_publication is None
+            ):
+                raise AssertionError(
+                    "Canonical publication requires prepared asset receipts."
+                )
+            manifest_asset_converter.revalidate_publication(
+                manifest_asset_publication,
+                validate_content=False,
             )
-            if rollback_errors:
-                publish_error.add_note(
-                    "Conversion artifact rollback also failed: "
-                    + "; ".join(str(error) for error in rollback_errors)
+
+        def revalidate_after_commit(name: str) -> None:
+            if name != _MANIFEST_FILENAME:
+                return
+            if (
+                manifest_asset_converter is None
+                or manifest_asset_publication is None
+            ):
+                raise AssertionError(
+                    "Canonical publication requires prepared asset receipts."
                 )
-            raise
-    except BaseException as error:
-        active_error = error
-        raise
-    finally:
-        if active_error is None:
-            # Recovery copies from an earlier failed cleanup remain useful until
-            # a later artifact pair commits.  Only then may this transaction
-            # retire the rigorously recognized, identity-captured leftovers.
-            for stale_path, stale_artifact in stale_temporary_paths.items():
-                stale_target = _owned_temporary_artifact_target(
-                    os.path.basename(stale_path)
-                )
-                if (
-                    stale_target == _MANIFEST_FILENAME
-                    and manifest_outcome is None
-                ):
-                    # An attempt-only commit does not supersede a canonical
-                    # recovery copy left by an earlier failed rollback.
-                    continue
-                temporary_paths.setdefault(stale_path, stale_artifact)
-        cleanup_errors = _cleanup_temporary_artifacts(
-            temporary_paths,
-            godot_project_path=godot_project_path,
-            root_identity=root_identity,
-            artifact_directory=artifact_directory,
-            directory_identity=directory_identity,
+            manifest_asset_converter.revalidate_publication(
+                manifest_asset_publication,
+                validate_content=True,
+            )
+
+        receipts = transaction.publish_specs(
+            tuple(specs),
+            guards=() if manifest_guard is None else (manifest_guard,),
+            before_commit=revalidate_before_commit,
+            after_commit=revalidate_after_commit,
         )
-        if cleanup_errors:
-            message = "Conversion artifact cleanup failed: " + "; ".join(
-                str(error) for error in cleanup_errors
-            )
-            if active_error is not None:
-                active_error.add_note(message)
-            # Both final replacements and their directory fsyncs have already
-            # completed.  Cleanup cannot make that durable commit a failed
-            # conversion attempt. Recoverable leftovers are excluded from
-            # generated-files accounting and retried after a later commit.
+        attempt_receipt = receipts[0]
+        if attempt_receipt is None:
+            raise AssertionError("Conversion attempt publication produced no receipt.")
+        manifest_receipt = receipts[1] if len(receipts) == 2 else None
+        if manifest_content is not None and manifest_receipt is None:
+            raise AssertionError("Conversion manifest publication produced no receipt.")
 
-    # Cleanup performs the transaction's final directory fsync. Revalidate the
-    # committed pair afterward so a concurrent change during that sync can
-    # never be reported as a successful publication.
-    _verify_artifact_directory(
-        godot_project_path,
-        root_identity,
-        artifact_directory,
-        directory_identity,
-    )
-    for published_artifact in published:
-        _verify_published_artifact(published_artifact)
-    verify_preserved_manifest()
+        # A completed attempt supersedes owned attempt leftovers. A canonical
+        # recovery copy remains useful until a later canonical update commits.
+        stale_to_cleanup = {
+            name: staged
+            for name, staged in stale_artifacts.items()
+            if _owned_temporary_artifact_target(name) != _MANIFEST_FILENAME
+            or manifest_outcome is not None
+        }
+        transaction.cleanup(stale_to_cleanup)
+
+        # Cleanup may be best-effort after a durable commit, but directory and
+        # receipt drift must never be reported as successful publication.
+        transaction.verify_directory()
+        transaction.verify_receipt(attempt_receipt)
+        if manifest_guard is not None:
+            transaction.verify_snapshot(manifest_guard)
+        if manifest_receipt is not None:
+            transaction.verify_receipt(manifest_receipt)
+            if manifest_receipt.sha256 != manifest_digest:
+                raise OSError(
+                    "Published conversion manifest digest does not match the "
+                    "attempt ledger."
+                )
 
     return (
         manifest_path if manifest_outcome is not None else None,
@@ -579,280 +433,47 @@ def _validate_attempt_matches_canonical(
             )
 
 
-def _serialize_json(payload: JsonDict) -> bytes:
-    return (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
-
-
-def _sha256_bytes(content: bytes) -> str:
-    return "sha256:" + hashlib.sha256(content).hexdigest()
-
-
-def _inspect_artifact_directory(
-    godot_project_path: str,
-) -> tuple[str, PathIdentity, PathIdentity | None]:
-    try:
-        root_stat = os.lstat(godot_project_path)
-    except OSError as error:
-        raise OSError(
-            f"Conversion artifact root is unavailable: {godot_project_path}"
-        ) from error
-    if _path_is_redirected(godot_project_path, root_stat) or not stat.S_ISDIR(
-        root_stat.st_mode
-    ):
-        raise OSError(
-            f"Refusing redirected or non-directory conversion artifact root: "
-            f"{godot_project_path}"
-        )
-    root_identity = (root_stat.st_dev, root_stat.st_ino)
-    artifact_directory = os.path.join(
-        godot_project_path,
-        os.path.dirname(CONVERSION_MANIFEST_RELATIVE_PATH),
-    )
-    try:
-        directory_stat = os.lstat(artifact_directory)
-    except FileNotFoundError:
-        return artifact_directory, root_identity, None
-    if _path_is_redirected(artifact_directory, directory_stat) or not stat.S_ISDIR(
-        directory_stat.st_mode
-    ):
-        raise OSError(
-            "Refusing redirected or non-directory conversion artifact directory: "
-            f"{artifact_directory}"
-        )
-    directory_identity = (directory_stat.st_dev, directory_stat.st_ino)
-    _verify_artifact_directory(
-        godot_project_path,
-        root_identity,
-        artifact_directory,
-        directory_identity,
-    )
-    return artifact_directory, root_identity, directory_identity
-
-
-def _prepare_artifact_directory(
-    godot_project_path: str,
-) -> tuple[str, PathIdentity, PathIdentity]:
-    artifact_directory, root_identity, directory_identity = (
-        _inspect_artifact_directory(godot_project_path)
-    )
-    if directory_identity is None:
-        _verify_directory_path(
-            godot_project_path,
-            root_identity,
-            description="conversion artifact root",
-        )
-        try:
-            os.mkdir(artifact_directory)
-        except FileExistsError:
-            pass
-        directory_stat = os.lstat(artifact_directory)
-        if _path_is_redirected(
-            artifact_directory,
-            directory_stat,
-        ) or not stat.S_ISDIR(directory_stat.st_mode):
-            raise OSError(
-                "Refusing redirected or non-directory conversion artifact "
-                f"directory: {artifact_directory}"
-            )
-        directory_identity = (directory_stat.st_dev, directory_stat.st_ino)
-    # Always sync the parent before using the child.  A previous publication
-    # may have created the directory and then failed while syncing this root;
-    # on that retry the child already exists but its directory entry still
-    # needs to become durable.
-    _fsync_verified_directory(
-        godot_project_path,
-        root_identity,
-        description="conversion artifact root",
-    )
-    _verify_artifact_directory(
-        godot_project_path,
-        root_identity,
-        artifact_directory,
-        directory_identity,
-    )
-    return artifact_directory, root_identity, directory_identity
-
-
-def _verify_artifact_directory(
-    godot_project_path: str,
-    root_identity: PathIdentity,
-    artifact_directory: str,
-    directory_identity: PathIdentity,
-) -> None:
-    _verify_directory_path(
-        godot_project_path,
-        root_identity,
-        description="conversion artifact root",
-    )
-    _verify_directory_path(
-        artifact_directory,
-        directory_identity,
-        description="conversion artifact directory",
-    )
-
-
-def _verify_directory_path(
-    path: str,
-    expected_identity: PathIdentity,
+def _conversion_attempt_payload(
+    attempt_outcome: ConversionOutcome,
     *,
-    description: str,
-) -> None:
-    try:
-        path_stat = os.lstat(path)
-    except OSError as error:
-        raise OSError(f"{description.capitalize()} changed: {path}") from error
-    if (
-        _path_is_redirected(path, path_stat)
-        or not stat.S_ISDIR(path_stat.st_mode)
-        or (path_stat.st_dev, path_stat.st_ino) != expected_identity
-    ):
-        raise OSError(f"{description.capitalize()} changed: {path}")
+    manifest_status: str,
+    manifest_updated: bool,
+    current_output_status: str,
+    manifest_digest: str | None,
+) -> JsonDict:
+    return {
+        "format_version": 1,
+        "attempt": _conversion_record(attempt_outcome),
+        "canonical_manifest": {
+            "path": CONVERSION_MANIFEST_RELATIVE_PATH.replace(os.sep, "/"),
+            "status": manifest_status,
+            "updated": manifest_updated,
+            "current_output": current_output_status,
+            "sha256": manifest_digest,
+        },
+    }
 
 
-def _path_is_redirected(path: str, path_stat: os.stat_result) -> bool:
-    if stat.S_ISLNK(path_stat.st_mode):
-        return True
-    junction_candidate: object = getattr(os.path, "isjunction", None)
-    if not callable(junction_candidate):
-        return False
-    junction_checker = cast(Callable[[str], bool], junction_candidate)
-    return junction_checker(path)
-
-
-def _artifact_target_state(path: str) -> _ArtifactTargetState:
-    try:
-        path_stat = os.lstat(path)
-    except FileNotFoundError:
-        return _ArtifactTargetState(fingerprint=None, mode=None)
-    if _path_is_redirected(path, path_stat) or not stat.S_ISREG(path_stat.st_mode):
-        raise OSError(f"Refusing redirected or non-regular conversion artifact: {path}")
-    return _ArtifactTargetState(
-        fingerprint=_file_fingerprint(path_stat),
-        mode=stat.S_IMODE(path_stat.st_mode),
-    )
-
-
-def _verify_artifact_target_state(
-    path: str,
-    expected: _ArtifactTargetState,
-) -> None:
-    try:
-        path_stat = os.lstat(path)
-    except FileNotFoundError:
-        if expected.fingerprint is None:
-            return
-        raise OSError(f"Conversion artifact disappeared during publication: {path}")
-    if (
-        expected.fingerprint is None
-        or _path_is_redirected(path, path_stat)
-        or not stat.S_ISREG(path_stat.st_mode)
-        or _file_fingerprint(path_stat) != expected.fingerprint
-        or stat.S_IMODE(path_stat.st_mode) != expected.mode
-    ):
-        raise OSError(f"Conversion artifact changed during publication: {path}")
-
-
-def _read_artifact_bytes(path: str, expected: _ArtifactTargetState) -> bytes:
-    if expected.fingerprint is None:
-        raise ValueError("Cannot read an absent conversion artifact.")
-    open_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
-    file_descriptor = os.open(path, open_flags)
-    try:
-        open_stat_before = os.fstat(file_descriptor)
-        path_stat = os.lstat(path)
-        if (
-            not stat.S_ISREG(open_stat_before.st_mode)
-            or not _file_fingerprints_match(
-                _file_fingerprint(open_stat_before),
-                expected.fingerprint,
-            )
-            or _file_fingerprint(path_stat) != expected.fingerprint
-        ):
-            raise OSError(
-                f"Conversion artifact changed while reading it: {path}"
-            )
-        with os.fdopen(file_descriptor, "rb") as artifact_file:
-            file_descriptor = -1
-            content = artifact_file.read()
-            open_stat_after = os.fstat(artifact_file.fileno())
-        if not _file_fingerprints_match(
-            _file_fingerprint(open_stat_after),
-            expected.fingerprint,
-        ):
-            raise OSError(f"Conversion artifact changed while reading it: {path}")
-    finally:
-        if file_descriptor >= 0:
-            os.close(file_descriptor)
-    _verify_artifact_target_state(path, expected)
-    return content
-
-
-def _stage_existing_artifact(
-    path: str,
-    expected: _ArtifactTargetState,
-) -> _TemporaryArtifact | None:
-    if expected.fingerprint is None:
-        return None
-    content = _read_artifact_bytes(path, expected)
-    _verify_artifact_target_state(path, expected)
-    return _stage_artifact_bytes(
-        path,
-        content,
-        mode=expected.mode,
-        suffix=".backup",
-    )
-
-
-def _capture_owned_stale_artifacts(
-    godot_project_path: str,
-    root_identity: PathIdentity,
-    artifact_directory: str,
-    directory_identity: PathIdentity,
-) -> dict[str, _TemporaryArtifact]:
-    """Capture safe-to-retire leftovers from earlier artifact transactions."""
-    _verify_artifact_directory(
-        godot_project_path,
-        root_identity,
-        artifact_directory,
-        directory_identity,
-    )
-    captured: dict[str, _TemporaryArtifact] = {}
-    with os.scandir(artifact_directory) as entries:
-        filenames = sorted(entry.name for entry in entries)
-    for filename in filenames:
-        if not _is_owned_temporary_artifact_filename(filename):
+def _capture_owned_stale_transaction_artifacts(
+    transaction: ByteArtifactTransaction,
+) -> dict[str, StagedArtifact]:
+    """Capture only identity-bound transaction leftovers for later cleanup."""
+    transaction.phase("before_stale_recovery", None)
+    captured: dict[str, StagedArtifact] = {}
+    for name in transaction.directory.list_names():
+        if _owned_temporary_artifact_target(name) is None:
             continue
-        path = os.path.join(artifact_directory, filename)
         try:
-            target_state = _artifact_target_state(path)
-            if (
-                target_state.identity is None
-                or target_state.mode is None
-            ):
-                continue
-            content = _read_artifact_bytes(path, target_state)
+            staged = transaction.capture_staged(name)
         except OSError:
-            # Redirected, non-regular, inaccessible, or concurrently changed
-            # lookalikes are never candidates for automatic deletion.
+            # Redirected, multiply-linked, inaccessible, or concurrently
+            # changed lookalikes are never candidates for automatic deletion.
             continue
-        captured[path] = _TemporaryArtifact(
-            path=path,
-            identity=target_state.identity,
-            sha256=_sha256_bytes(content),
-            mode=target_state.mode,
-            staged_mode=target_state.mode,
-        )
-    _verify_artifact_directory(
-        godot_project_path,
-        root_identity,
-        artifact_directory,
-        directory_identity,
-    )
+        if staged is not None:
+            captured[name] = staged
+    transaction.verify_directory()
+    transaction.phase("after_stale_recovery", None)
     return captured
-
-
-def _is_owned_temporary_artifact_filename(filename: str) -> bool:
-    return _owned_temporary_artifact_target(filename) is not None
 
 
 def _owned_temporary_artifact_target(filename: str) -> str | None:
@@ -872,654 +493,8 @@ def _owned_temporary_artifact_target(filename: str) -> str | None:
     return None
 
 
-def _stage_artifact_bytes(
-    path: str,
-    content: bytes,
-    *,
-    mode: int | None,
-    suffix: str,
-) -> _TemporaryArtifact:
-    artifact_directory = os.path.dirname(path) or os.curdir
-    file_descriptor, staged_path = tempfile.mkstemp(
-        dir=artifact_directory,
-        prefix=f".{os.path.basename(path)}.",
-        suffix=suffix,
-    )
-    initial_stat = os.fstat(file_descriptor)
-    staged_identity = (initial_stat.st_dev, initial_stat.st_ino)
-    target_mode = (
-        stat.S_IMODE(initial_stat.st_mode)
-        if mode is None
-        else mode
-    )
-    try:
-        with os.fdopen(file_descriptor, "wb") as staged_file:
-            file_descriptor = -1
-            staged_file.write(content)
-            staged_file.flush()
-            if mode is not None and not (
-                _uses_windows_file_attribute_modes()
-                and _mode_is_read_only(mode)
-            ):
-                fchmod_candidate: object = getattr(os, "fchmod", None)
-                if callable(fchmod_candidate):
-                    fchmod = cast(Callable[[int, int], None], fchmod_candidate)
-                    try:
-                        fchmod(staged_file.fileno(), mode)
-                    except NotImplementedError:
-                        fchmod_candidate = None
-                if not callable(fchmod_candidate):
-                    _verify_regular_path_identity(staged_path, staged_identity)
-                    os.chmod(staged_path, mode)
-                    _verify_regular_path_identity(staged_path, staged_identity)
-            os.fsync(staged_file.fileno())
-        staged_stat = os.lstat(staged_path)
-        staged_mode = stat.S_IMODE(staged_stat.st_mode)
-        if (
-            not _uses_windows_file_attribute_modes()
-            and staged_mode != target_mode
-        ) or (
-            _uses_windows_file_attribute_modes()
-            and _mode_is_read_only(staged_mode)
-        ):
-            raise OSError(
-                f"Staged conversion artifact mode changed: {staged_path}"
-            )
-        staged_artifact = _TemporaryArtifact(
-            path=staged_path,
-            identity=staged_identity,
-            sha256=_sha256_bytes(content),
-            mode=target_mode,
-            staged_mode=staged_mode,
-        )
-        _verify_temporary_artifact(staged_artifact)
-        return staged_artifact
-    except BaseException as error:
-        if file_descriptor >= 0:
-            os.close(file_descriptor)
-        cleanup_error = _unlink_if_identity(staged_path, staged_identity)
-        if cleanup_error is not None:
-            error.add_note(
-                "Failed to remove incomplete conversion artifact stage "
-                f"{staged_path}: {cleanup_error}"
-            )
-        raise
-
-
-def _verify_regular_path_identity(path: str, expected: PathIdentity) -> None:
-    try:
-        path_stat = os.lstat(path)
-    except OSError as error:
-        raise OSError(f"Staged conversion artifact changed: {path}") from error
-    if (
-        _path_is_redirected(path, path_stat)
-        or not stat.S_ISREG(path_stat.st_mode)
-        or (path_stat.st_dev, path_stat.st_ino) != expected
-    ):
-        raise OSError(f"Staged conversion artifact changed: {path}")
-
-
-def _regular_path_identity(path: str) -> PathIdentity:
-    path_stat = os.lstat(path)
-    if _path_is_redirected(path, path_stat) or not stat.S_ISREG(path_stat.st_mode):
-        raise OSError(f"Refusing redirected or non-regular conversion artifact: {path}")
-    return (path_stat.st_dev, path_stat.st_ino)
-
-
-def _read_verified_temporary_artifact(
-    artifact: _TemporaryArtifact,
-    *,
-    path: str | None = None,
-) -> bytes:
-    selected_path = artifact.path if path is None else path
-    expected_mode = artifact.staged_mode if path is None else artifact.mode
-    open_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
-    file_descriptor = os.open(selected_path, open_flags)
-    try:
-        opened_before = os.fstat(file_descriptor)
-        fingerprint_before = _file_fingerprint(opened_before)
-        if (
-            not stat.S_ISREG(opened_before.st_mode)
-            or (opened_before.st_dev, opened_before.st_ino) != artifact.identity
-            or stat.S_IMODE(opened_before.st_mode) != expected_mode
-        ):
-            raise OSError(
-                f"Staged conversion artifact changed: {selected_path}"
-            )
-        with os.fdopen(file_descriptor, "rb") as artifact_file:
-            file_descriptor = -1
-            content = artifact_file.read()
-            opened_after = os.fstat(artifact_file.fileno())
-        path_after = os.lstat(selected_path)
-        if (
-            not stat.S_ISREG(opened_after.st_mode)
-            or (opened_after.st_dev, opened_after.st_ino) != artifact.identity
-            or stat.S_IMODE(opened_after.st_mode) != expected_mode
-            or stat.S_IMODE(path_after.st_mode) != expected_mode
-            or not _file_fingerprints_match(
-                _file_fingerprint(opened_after),
-                fingerprint_before,
-            )
-            or not _file_fingerprints_match(
-                _file_fingerprint(path_after),
-                fingerprint_before,
-            )
-            or _sha256_bytes(content) != artifact.sha256
-        ):
-            raise OSError(
-                f"Staged conversion artifact content changed: {selected_path}"
-            )
-    finally:
-        if file_descriptor >= 0:
-            os.close(file_descriptor)
-    _verify_regular_path_identity(selected_path, artifact.identity)
-    return content
-
-
-def _verify_temporary_artifact(
-    artifact: _TemporaryArtifact,
-    *,
-    path: str | None = None,
-) -> None:
-    _read_verified_temporary_artifact(artifact, path=path)
-
-
-def _uses_windows_file_attribute_modes() -> bool:
-    """Return whether chmod only models the Windows read-only attribute."""
-    return os.name == "nt"
-
-
-def _mode_is_read_only(mode: int) -> bool:
-    return not bool(mode & stat.S_IWRITE)
-
-
-def _set_artifact_mode_exact(
-    path: str,
-    expected_identity: PathIdentity,
-    mode: int,
-) -> None:
-    _verify_regular_path_identity(path, expected_identity)
-    os.chmod(path, mode)
-    _verify_regular_path_identity(path, expected_identity)
-    current_mode = stat.S_IMODE(os.lstat(path).st_mode)
-    if current_mode != mode:
-        raise OSError(f"Conversion artifact mode changed: {path}")
-
-
-def _restore_artifact_mode_if_identity_matches(
-    path: str,
-    expected_identity: PathIdentity,
-    mode: int,
-) -> Exception | None:
-    try:
-        path_stat = os.lstat(path)
-    except FileNotFoundError:
-        return None
-    except Exception as error:
-        return error
-    if (
-        _path_is_redirected(path, path_stat)
-        or not stat.S_ISREG(path_stat.st_mode)
-        or (path_stat.st_dev, path_stat.st_ino) != expected_identity
-    ):
-        return OSError(f"Conversion artifact changed before mode restore: {path}")
-    if stat.S_IMODE(path_stat.st_mode) == mode:
-        return None
-    try:
-        _set_artifact_mode_exact(path, expected_identity, mode)
-    except Exception as error:
-        return error
-    return None
-
-
-def _make_windows_destination_writable(
-    path: str,
-    expected_identity: PathIdentity | None,
-    expected_mode: int | None,
-) -> bool:
-    """Temporarily clear a destination's Windows read-only attribute."""
-    if (
-        not _uses_windows_file_attribute_modes()
-        or expected_identity is None
-        or expected_mode is None
-        or not _mode_is_read_only(expected_mode)
-    ):
-        return False
-    _verify_regular_path_identity(path, expected_identity)
-    writable_mode = expected_mode | stat.S_IWRITE
-    try:
-        os.chmod(path, writable_mode)
-        _verify_regular_path_identity(path, expected_identity)
-        current_mode = stat.S_IMODE(os.lstat(path).st_mode)
-        if _mode_is_read_only(current_mode):
-            raise OSError(f"Conversion artifact remained read-only: {path}")
-    except BaseException as error:
-        restore_error = _restore_artifact_mode_if_identity_matches(
-            path,
-            expected_identity,
-            expected_mode,
-        )
-        if restore_error is not None:
-            error.add_note(
-                "Failed to restore read-only conversion artifact after mode "
-                f"preparation failure: {restore_error}"
-            )
-        raise
-    return True
-
-
-def _activate_windows_artifact_mode(artifact: _TemporaryArtifact) -> bool:
-    """Apply a staged artifact's final Windows mode immediately before rename."""
-    if (
-        not _uses_windows_file_attribute_modes()
-        or artifact.staged_mode == artifact.mode
-    ):
-        return False
-    try:
-        _set_artifact_mode_exact(
-            artifact.path,
-            artifact.identity,
-            artifact.mode,
-        )
-    except BaseException as error:
-        restore_error = _restore_artifact_mode_if_identity_matches(
-            artifact.path,
-            artifact.identity,
-            artifact.staged_mode,
-        )
-        if restore_error is not None:
-            error.add_note(
-                "Failed to restore writable conversion artifact stage after "
-                f"mode activation failure: {restore_error}"
-            )
-        raise
-    return True
-
-
-def _replace_temporary_artifact(
-    artifact: _TemporaryArtifact,
-    target_path: str,
-    *,
-    expected_target_identity: PathIdentity | None,
-    expected_target_mode: int | None,
-) -> BaseException | None:
-    """Replace a target while preserving Windows read-only semantics.
-
-    A non-``None`` return means ``os.replace`` reported an error after the
-    staged inode nevertheless reached the target.  The caller can verify the
-    committed inode before deciding whether that error remains primary.
-    """
-    destination_mode_changed = False
-    staged_mode_changed = False
-    try:
-        destination_mode_changed = _make_windows_destination_writable(
-            target_path,
-            expected_target_identity,
-            expected_target_mode,
-        )
-        staged_mode_changed = _activate_windows_artifact_mode(artifact)
-        os.replace(artifact.path, target_path)
-    except BaseException as error:
-        try:
-            replacement_completed = (
-                _regular_path_identity(target_path) == artifact.identity
-            )
-        except OSError:
-            replacement_completed = False
-        if replacement_completed:
-            return error
-
-        restore_errors: list[Exception] = []
-        if staged_mode_changed:
-            restore_error = _restore_artifact_mode_if_identity_matches(
-                artifact.path,
-                artifact.identity,
-                artifact.staged_mode,
-            )
-            if restore_error is not None:
-                restore_errors.append(restore_error)
-        if destination_mode_changed:
-            assert expected_target_identity is not None
-            assert expected_target_mode is not None
-            restore_error = _restore_artifact_mode_if_identity_matches(
-                target_path,
-                expected_target_identity,
-                expected_target_mode,
-            )
-            if restore_error is not None:
-                restore_errors.append(restore_error)
-        if restore_errors:
-            error.add_note(
-                "Conversion artifact mode restoration also failed: "
-                + "; ".join(str(restore_error) for restore_error in restore_errors)
-            )
-        raise
-    return None
-
-
-def _publish_staged_artifact(
-    staged_artifact: _TemporaryArtifact,
-    target_path: str,
-    expected_target_state: _ArtifactTargetState,
-    backup: _TemporaryArtifact | None,
-    temporary_paths: dict[str, _TemporaryArtifact],
-    published: list[_PublishedArtifact],
-) -> None:
-    _verify_temporary_artifact(staged_artifact)
-    replacement_error = _replace_temporary_artifact(
-        staged_artifact,
-        target_path,
-        expected_target_identity=expected_target_state.identity,
-        expected_target_mode=expected_target_state.mode,
-    )
-    temporary_paths.pop(staged_artifact.path, None)
-    published.append(
-        _PublishedArtifact(
-            path=target_path,
-            identity=staged_artifact.identity,
-            sha256=staged_artifact.sha256,
-            mode=staged_artifact.mode,
-            backup=backup,
-        )
-    )
-    try:
-        _verify_temporary_artifact(staged_artifact, path=target_path)
-    except BaseException as integrity_error:
-        if replacement_error is not None:
-            replacement_error.add_note(
-                "Published conversion artifact also failed integrity "
-                f"verification: {integrity_error}"
-            )
-            raise replacement_error
-        raise
-    if replacement_error is not None:
-        raise replacement_error
-
-
-def _verify_published_artifact(artifact: _PublishedArtifact) -> None:
-    _verify_temporary_artifact(
-        _TemporaryArtifact(
-            path=artifact.path,
-            identity=artifact.identity,
-            sha256=artifact.sha256,
-            mode=artifact.mode,
-            staged_mode=artifact.mode,
-        )
-    )
-
-
-def _remove_published_artifact(artifact: _PublishedArtifact) -> None:
-    destination_mode_changed = _make_windows_destination_writable(
-        artifact.path,
-        artifact.identity,
-        artifact.mode,
-    )
-    try:
-        os.unlink(artifact.path)
-    except BaseException as error:
-        if not os.path.lexists(artifact.path):
-            return
-        if destination_mode_changed:
-            restore_error = _restore_artifact_mode_if_identity_matches(
-                artifact.path,
-                artifact.identity,
-                artifact.mode,
-            )
-            if restore_error is not None:
-                error.add_note(
-                    "Failed to restore conversion artifact mode after removal "
-                    f"failure: {restore_error}"
-                )
-        raise
-
-
-def _rollback_artifacts(
-    published: list[_PublishedArtifact],
-    temporary_paths: dict[str, _TemporaryArtifact],
-    *,
-    godot_project_path: str,
-    root_identity: PathIdentity,
-    artifact_directory: str,
-    directory_identity: PathIdentity,
-) -> list[BaseException]:
-    errors: list[BaseException] = []
-    restored: list[
-        tuple[_PublishedArtifact, _TemporaryArtifact | None]
-    ] = []
-    for artifact in reversed(published):
-        recovery_artifact: _TemporaryArtifact | None = None
-        try:
-            _verify_artifact_directory(
-                godot_project_path,
-                root_identity,
-                artifact_directory,
-                directory_identity,
-            )
-            _verify_published_artifact(artifact)
-            if artifact.backup is None:
-                _remove_published_artifact(artifact)
-            else:
-                backup_content = _read_verified_temporary_artifact(
-                    artifact.backup,
-                )
-                recovery_artifact = _stage_artifact_bytes(
-                    artifact.path,
-                    backup_content,
-                    mode=artifact.backup.mode,
-                    suffix=".recovery.backup",
-                )
-                temporary_paths[recovery_artifact.path] = recovery_artifact
-                _replace_temporary_artifact(
-                    artifact.backup,
-                    artifact.path,
-                    expected_target_identity=artifact.identity,
-                    expected_target_mode=artifact.mode,
-                )
-                temporary_paths.pop(artifact.backup.path, None)
-                _verify_temporary_artifact(
-                    artifact.backup,
-                    path=artifact.path,
-                )
-            _fsync_artifact_directory(
-                godot_project_path,
-                root_identity,
-                artifact_directory,
-                directory_identity,
-            )
-            if artifact.backup is None:
-                if os.path.lexists(artifact.path):
-                    raise OSError(
-                        "Removed conversion artifact reappeared during rollback: "
-                        f"{artifact.path}"
-                    )
-            else:
-                _verify_temporary_artifact(
-                    artifact.backup,
-                    path=artifact.path,
-                )
-            restored.append((artifact, recovery_artifact))
-        except BaseException as error:
-            recovery_path: str | None = None
-            if recovery_artifact is not None:
-                try:
-                    _verify_temporary_artifact(recovery_artifact)
-                except OSError:
-                    pass
-                else:
-                    recovery_path = recovery_artifact.path
-            if recovery_path is None and artifact.backup is not None:
-                try:
-                    _verify_temporary_artifact(artifact.backup)
-                except OSError:
-                    pass
-                else:
-                    recovery_path = artifact.backup.path
-            if recovery_path is not None:
-                temporary_paths.pop(recovery_path, None)
-                rollback_error = OSError(
-                    f"{error}; previous conversion artifact preserved at: "
-                    f"{recovery_path}"
-                )
-                rollback_error.__cause__ = error
-                errors.append(rollback_error)
-            else:
-                errors.append(error)
-    for artifact, recovery_artifact in restored:
-        try:
-            _verify_artifact_directory(
-                godot_project_path,
-                root_identity,
-                artifact_directory,
-                directory_identity,
-            )
-            if artifact.backup is None:
-                if os.path.lexists(artifact.path):
-                    raise OSError(
-                        "Removed conversion artifact reappeared after rollback: "
-                        f"{artifact.path}"
-                    )
-            else:
-                _verify_temporary_artifact(
-                    artifact.backup,
-                    path=artifact.path,
-                )
-        except BaseException as error:
-            recovery_path: str | None = None
-            if recovery_artifact is not None:
-                try:
-                    _verify_temporary_artifact(recovery_artifact)
-                except OSError:
-                    pass
-                else:
-                    recovery_path = recovery_artifact.path
-            if recovery_path is not None:
-                temporary_paths.pop(recovery_path, None)
-                rollback_error = OSError(
-                    f"{error}; previous conversion artifact preserved at: "
-                    f"{recovery_path}"
-                )
-                rollback_error.__cause__ = error
-                errors.append(rollback_error)
-            else:
-                errors.append(error)
-    return errors
-
-
-def _cleanup_temporary_artifacts(
-    temporary_paths: dict[str, _TemporaryArtifact],
-    *,
-    godot_project_path: str,
-    root_identity: PathIdentity,
-    artifact_directory: str,
-    directory_identity: PathIdentity,
-) -> list[Exception]:
-    errors: list[Exception] = []
-    removed = False
-    for temporary_path, temporary_artifact in tuple(temporary_paths.items()):
-        try:
-            _verify_artifact_directory(
-                godot_project_path,
-                root_identity,
-                artifact_directory,
-                directory_identity,
-            )
-            if not os.path.lexists(temporary_path):
-                temporary_paths.pop(temporary_path, None)
-                continue
-            _verify_temporary_artifact(temporary_artifact)
-            try:
-                os.unlink(temporary_path)
-            except Exception:
-                if os.path.lexists(temporary_path):
-                    raise
-            temporary_paths.pop(temporary_path, None)
-            removed = True
-        except Exception as error:
-            errors.append(error)
-    if removed:
-        try:
-            _fsync_artifact_directory(
-                godot_project_path,
-                root_identity,
-                artifact_directory,
-                directory_identity,
-            )
-        except Exception as error:
-            errors.append(error)
-    return errors
-
-
-def _unlink_if_identity(
-    path: str,
-    expected_identity: PathIdentity,
-) -> Exception | None:
-    try:
-        _verify_regular_path_identity(path, expected_identity)
-        os.unlink(path)
-    except Exception as error:
-        return error
-    return None
-
-
-def _fsync_verified_directory(
-    path: str,
-    expected_identity: PathIdentity,
-    *,
-    description: str,
-) -> None:
-    _verify_directory_path(
-        path,
-        expected_identity,
-        description=description,
-    )
-    if os.name == "nt":
-        return
-    open_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(
-        os,
-        "O_NOFOLLOW",
-        0,
-    )
-    directory_descriptor = os.open(path, open_flags)
-    try:
-        opened_stat = os.fstat(directory_descriptor)
-        if (
-            not stat.S_ISDIR(opened_stat.st_mode)
-            or (opened_stat.st_dev, opened_stat.st_ino) != expected_identity
-        ):
-            raise OSError(f"{description.capitalize()} changed: {path}")
-        os.fsync(directory_descriptor)
-    finally:
-        os.close(directory_descriptor)
-    _verify_directory_path(
-        path,
-        expected_identity,
-        description=description,
-    )
-
-
-def _fsync_artifact_directory(
-    godot_project_path: str,
-    root_identity: PathIdentity,
-    artifact_directory: str,
-    directory_identity: PathIdentity,
-) -> None:
-    _verify_artifact_directory(
-        godot_project_path,
-        root_identity,
-        artifact_directory,
-        directory_identity,
-    )
-    _fsync_verified_directory(
-        artifact_directory,
-        directory_identity,
-        description="conversion artifact directory",
-    )
-    _verify_artifact_directory(
-        godot_project_path,
-        root_identity,
-        artifact_directory,
-        directory_identity,
-    )
+def _serialize_json(payload: JsonDict) -> bytes:
+    return (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
 
 
 def _asset_registry_entries(
@@ -1640,28 +615,6 @@ def _file_fingerprint(path_stat: os.stat_result) -> FileFingerprint:
         path_stat.st_mtime_ns,
         path_stat.st_ctime_ns,
     )
-
-
-def _file_fingerprints_match(
-    actual: FileFingerprint,
-    expected: FileFingerprint,
-) -> bool:
-    """Compare stable metadata without trusting Windows ctime parity.
-
-    Native Windows can expose different ``st_ctime_ns`` values for the same
-    file through path and descriptor stat calls. Identity, exact size, and
-    modification time remain mandatory there. Callers use this compatibility
-    comparison only for descriptor parity or SHA-256-backed staged content;
-    path-to-path transaction guards remain exact. POSIX comparisons remain
-    fully exact.
-    """
-    if _uses_windows_file_fingerprint_semantics():
-        return actual[:4] == expected[:4]
-    return actual == expected
-
-
-def _uses_windows_file_fingerprint_semantics() -> bool:
-    return os.name == "nt"
 
 
 def _generated_file_kind(relative_path: str) -> str:

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.29"
+VERSION = "0.7.30"
 
 
 def get_version():

--- a/tests/test_conversion_manifest.py
+++ b/tests/test_conversion_manifest.py
@@ -640,128 +640,38 @@ class TestConversionManifest(unittest.TestCase):
         self.assertNotIn("custom.gd", generated_by_path)
         self.assertNotIn("project.godot", generated_by_path)
 
-    def test_artifact_pair_is_fsynced_and_published_attempt_first_from_same_directory(
+    def test_artifact_pair_commits_attempt_first_through_one_bound_directory(
         self,
     ) -> None:
         godot_dir = self.temp_dir / "godot"
         godot_dir.mkdir()
-        real_replace = os.replace
-        real_fsync = os.fsync
+        commits: list[tuple[str, str]] = []
 
-        with (
-            patch(
-                "src.conversion.conversion_manifest.os.replace",
-                wraps=real_replace,
-            ) as replace,
-            patch(
-                "src.conversion.conversion_manifest.os.fsync",
-                wraps=real_fsync,
-            ) as fsync,
+        def record_commits(
+            phase: str,
+            directory_path: str,
+            name: str | None,
+        ) -> None:
+            if phase == "after_commit" and name is not None:
+                commits.append((directory_path, name))
+
+        with patch(
+            "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+            side_effect=record_commits,
         ):
             manifest_path, attempt_path = self._write_artifacts(godot_dir)
 
-        self.assertIsNotNone(manifest_path)
-        self.assertEqual(len(replace.call_args_list), 2)
-        destinations = [Path(call.args[1]) for call in replace.call_args_list]
+        artifact_directory = os.path.abspath(godot_dir / "gm2godot")
         self.assertEqual(
-            destinations,
+            commits,
             [
-                godot_dir / CONVERSION_ATTEMPT_RELATIVE_PATH,
-                godot_dir / CONVERSION_MANIFEST_RELATIVE_PATH,
+                (artifact_directory, "conversion_attempt.json"),
+                (artifact_directory, "conversion_manifest.json"),
             ],
         )
-        for call in replace.call_args_list:
-            staged_path, destination_path = call.args
-            self.assertEqual(Path(staged_path).parent, Path(destination_path).parent)
-        self.assertGreaterEqual(fsync.call_count, 2 if os.name == "nt" else 4)
-        self.assertEqual(self._temporary_artifact_files(godot_dir), [])
         self.assertTrue(Path(cast(str, manifest_path)).is_file())
         self.assertTrue(Path(attempt_path).is_file())
-
-    @unittest.skipIf(os.name == "nt", "Directory fsync is unavailable on Windows")
-    def test_new_artifact_directory_entry_is_fsynced_through_project_root(
-        self,
-    ) -> None:
-        godot_dir = self.temp_dir / "godot"
-        godot_dir.mkdir()
-        real_directory_fsync = cast(
-            Callable[..., None],
-            getattr(conversion_manifest_module, "_fsync_verified_directory"),
-        )
-
-        with patch(
-            "src.conversion.conversion_manifest._fsync_verified_directory",
-            wraps=real_directory_fsync,
-        ) as fsync_directory:
-            self._write_artifacts(godot_dir)
-
-        self.assertTrue(
-            any(
-                Path(call.args[0]) == godot_dir
-                and call.kwargs.get("description") == "conversion artifact root"
-                for call in fsync_directory.call_args_list
-            )
-        )
-
-    @unittest.skipIf(os.name == "nt", "Directory fsync is unavailable on Windows")
-    def test_retry_fsyncs_project_root_after_directory_creation_sync_failure(
-        self,
-    ) -> None:
-        godot_dir = self.temp_dir / "godot"
-        godot_dir.mkdir()
-        real_directory_fsync = cast(
-            Callable[..., None],
-            getattr(conversion_manifest_module, "_fsync_verified_directory"),
-        )
-        root_sync_failed = False
-
-        def fail_first_root_sync(
-            path: str,
-            expected_identity: object,
-            *,
-            description: str,
-        ) -> None:
-            nonlocal root_sync_failed
-            if description == "conversion artifact root" and not root_sync_failed:
-                root_sync_failed = True
-                raise OSError("injected artifact root fsync failure")
-            real_directory_fsync(
-                path,
-                cast(tuple[int, int], expected_identity),
-                description=description,
-            )
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest._fsync_verified_directory",
-                side_effect=fail_first_root_sync,
-            ),
-            self.assertRaisesRegex(OSError, "injected artifact root fsync failure"),
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertTrue(root_sync_failed)
-        self.assertTrue((godot_dir / "gm2godot").is_dir())
-        self.assertFalse(
-            (godot_dir / CONVERSION_ATTEMPT_RELATIVE_PATH).exists()
-        )
-        self.assertFalse(
-            (godot_dir / CONVERSION_MANIFEST_RELATIVE_PATH).exists()
-        )
-
-        with patch(
-            "src.conversion.conversion_manifest._fsync_verified_directory",
-            wraps=real_directory_fsync,
-        ) as retry_fsync:
-            self._write_artifacts(godot_dir)
-
-        self.assertTrue(
-            any(
-                Path(call.args[0]) == godot_dir
-                and call.kwargs.get("description") == "conversion artifact root"
-                for call in retry_fsync.call_args_list
-            )
-        )
+        self.assertEqual(self._temporary_artifact_files(godot_dir), [])
 
     def test_attempt_only_preserves_canonical_bytes_and_records_exact_digest(
         self,
@@ -769,31 +679,18 @@ class TestConversionManifest(unittest.TestCase):
         godot_dir, manifest_path, attempt_path, manifest_before, _ = (
             self._existing_artifacts()
         )
-        failed_outcome = self._failed_outcome()
 
         returned_manifest, returned_attempt = self._write_artifacts(
             godot_dir,
             manifest_outcome=None,
-            attempt_outcome=failed_outcome,
+            attempt_outcome=self._failed_outcome(),
         )
 
         self.assertIsNone(returned_manifest)
         self.assertEqual(Path(returned_attempt), attempt_path)
         self.assertEqual(manifest_path.read_bytes(), manifest_before)
         attempt = json.loads(attempt_path.read_text(encoding="utf-8"))
-        self.assertEqual(attempt["format_version"], 1)
         self.assertEqual(attempt["attempt"]["state"], "failed")
-        self.assertFalse(attempt["attempt"]["cancelled"])
-        self.assertEqual(
-            attempt["attempt"]["steps"],
-            {
-                "requested": ["scripts", "objects"],
-                "executed": ["scripts", "objects"],
-                "completed": ["scripts"],
-                "skipped": [],
-                "failed": ["objects"],
-            },
-        )
         self.assertEqual(
             attempt["canonical_manifest"],
             {
@@ -805,7 +702,6 @@ class TestConversionManifest(unittest.TestCase):
                 + hashlib.sha256(manifest_before).hexdigest(),
             },
         )
-        self.assertEqual(self._temporary_artifact_files(godot_dir), [])
 
     def test_attempt_only_records_absent_canonical_and_cancellation(self) -> None:
         godot_dir = self.temp_dir / "godot"
@@ -853,26 +749,18 @@ class TestConversionManifest(unittest.TestCase):
         manifest = json.loads(manifest_bytes)
         self.assertEqual(manifest["format_version"], 2)
         self.assertEqual(manifest["conversion"]["state"], "partial")
-        self.assertFalse(manifest["conversion"]["cancelled"])
         self.assertEqual(
             manifest["conversion"]["steps"]["completed"],
             ["scripts", "objects"],
         )
-        self.assertEqual(manifest["conversion"]["steps"]["skipped"], [])
         attempt = json.loads(Path(attempt_path_value).read_text(encoding="utf-8"))
         self.assertEqual(
-            attempt["canonical_manifest"],
-            {
-                "path": "gm2godot/conversion_manifest.json",
-                "status": "updated",
-                "updated": True,
-                "current_output": "verified",
-                "sha256": "sha256:"
-                + hashlib.sha256(manifest_bytes).hexdigest(),
-            },
+            attempt["canonical_manifest"]["sha256"],
+            "sha256:" + hashlib.sha256(manifest_bytes).hexdigest(),
         )
+        self.assertEqual(attempt["canonical_manifest"]["status"], "updated")
 
-    def test_generated_files_exclude_attempt_stages_and_backups_but_keep_manifest_self(
+    def test_generated_files_exclude_transaction_files_but_keep_manifest_self(
         self,
     ) -> None:
         godot_dir = self.temp_dir / "godot"
@@ -882,9 +770,8 @@ class TestConversionManifest(unittest.TestCase):
         excluded_names = (
             "conversion_attempt.json",
             ".conversion_attempt.json.stale.tmp",
-            ".conversion_attempt.json.recovery.backup",
-            ".conversion_manifest.json.stale.tmp",
-            ".conversion_manifest.json.recovery.backup",
+            ".conversion_attempt.json.abcdefgh.recovery.backup",
+            ".conversion_manifest.json.stale.backup",
         )
         for filename in excluded_names:
             (artifact_dir / filename).write_text(filename, encoding="utf-8")
@@ -907,46 +794,35 @@ class TestConversionManifest(unittest.TestCase):
             self.assertNotIn(f"gm2godot/{filename}", generated)
         self.assertIn("gm2godot/kept_report.json", generated)
         self.assertEqual(
-            generated["gm2godot/conversion_manifest.json"],
-            {
-                "path": "gm2godot/conversion_manifest.json",
-                "kind": "manifest",
-                "sha256": "self",
-            },
+            generated["gm2godot/conversion_manifest.json"]["sha256"],
+            "self",
         )
 
-    def test_serialization_failure_preserves_existing_artifact_pair(self) -> None:
-        godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
-            self._existing_artifacts()
+    def test_serialization_failure_preserves_pair_without_creating_directory(
+        self,
+    ) -> None:
+        existing_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
+            self._existing_artifacts(self.temp_dir / "existing")
         )
+        missing_dir = self.temp_dir / "missing"
+        missing_dir.mkdir()
 
-        with (
-            patch(
-                "src.conversion.conversion_manifest._serialize_json",
-                side_effect=TypeError("injected serialization failure"),
-            ),
-            self.assertRaisesRegex(TypeError, "injected serialization failure"),
-        ):
-            self._write_artifacts(godot_dir)
+        for godot_dir in (existing_dir, missing_dir):
+            with (
+                patch(
+                    "src.conversion.conversion_manifest._serialize_json",
+                    side_effect=TypeError("injected serialization failure"),
+                ),
+                self.assertRaisesRegex(
+                    TypeError,
+                    "injected serialization failure",
+                ),
+            ):
+                self._write_artifacts(godot_dir)
 
         self.assertEqual(manifest_path.read_bytes(), manifest_before)
         self.assertEqual(attempt_path.read_bytes(), attempt_before)
-        self.assertEqual(self._temporary_artifact_files(godot_dir), [])
-
-    def test_serialization_failure_does_not_create_artifact_directory(self) -> None:
-        godot_dir = self.temp_dir / "godot"
-        godot_dir.mkdir()
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest._serialize_json",
-                side_effect=TypeError("injected serialization failure"),
-            ),
-            self.assertRaisesRegex(TypeError, "injected serialization failure"),
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertFalse((godot_dir / "gm2godot").exists())
+        self.assertFalse((missing_dir / "gm2godot").exists())
 
     def test_included_output_delete_at_manifest_boundary_rolls_back_pair(
         self,
@@ -1330,579 +1206,31 @@ class TestConversionManifest(unittest.TestCase):
 
         self.assertFalse((godot_dir / "gm2godot").exists())
 
-    def test_staged_write_failure_preserves_existing_pair_and_cleans_stages(self) -> None:
-        godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
-            self._existing_artifacts()
+    def test_stage_and_canonical_commit_failures_restore_existing_pair(self) -> None:
+        cases = (
+            ("before_stage", "conversion_manifest.json", "staging failed"),
+            ("before_commit", "conversion_manifest.json", "commit failed"),
         )
-        real_fsync = os.fsync
-        call_count = 0
-
-        def fail_second_fsync(file_descriptor: int) -> None:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 2:
-                raise OSError("injected staged write failure")
-            real_fsync(file_descriptor)
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest.os.fsync",
-                side_effect=fail_second_fsync,
-            ),
-            self.assertRaisesRegex(OSError, "injected staged write failure"),
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertEqual(manifest_path.read_bytes(), manifest_before)
-        self.assertEqual(attempt_path.read_bytes(), attempt_before)
-        self.assertEqual(self._temporary_artifact_files(godot_dir), [])
-
-    def test_incomplete_stage_cleanup_failure_is_reported_and_retained(self) -> None:
-        godot_dir = self.temp_dir / "godot"
-        godot_dir.mkdir()
-        real_fsync = os.fsync
-        real_unlink = os.unlink
-
-        def fail_file_fsync(file_descriptor: int) -> None:
-            if stat.S_ISREG(os.fstat(file_descriptor).st_mode):
-                raise OSError("injected stage fsync failure")
-            real_fsync(file_descriptor)
-
-        def fail_stage_unlink(path: str | bytes) -> None:
-            if os.fsdecode(path).endswith(".tmp"):
-                raise OSError("injected stage cleanup failure")
-            real_unlink(path)
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest.os.fsync",
-                side_effect=fail_file_fsync,
-            ),
-            patch(
-                "src.conversion.conversion_manifest.os.unlink",
-                side_effect=fail_stage_unlink,
-            ),
-            self.assertRaisesRegex(OSError, "injected stage fsync failure") as context,
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertTrue(
-            any(
-                "Failed to remove incomplete conversion artifact stage" in note
-                and "injected stage cleanup failure" in note
-                for note in getattr(context.exception, "__notes__", [])
-            )
-        )
-        self.assertEqual(len(self._temporary_artifact_files(godot_dir)), 1)
-
-    def test_later_successful_publish_cleans_owned_backup_leftovers(self) -> None:
-        godot_dir, _, _, _, _ = self._existing_artifacts()
-        real_unlink = os.unlink
-
-        def fail_backup_cleanup(path: str | bytes) -> None:
-            if os.fsdecode(path).endswith(".backup"):
-                raise PermissionError("injected backup cleanup refusal")
-            real_unlink(path)
-
-        with patch(
-            "src.conversion.conversion_manifest.os.unlink",
-            side_effect=fail_backup_cleanup,
-        ):
-            self._write_artifacts(godot_dir)
-
-        leftovers = self._temporary_artifact_files(godot_dir)
-        self.assertEqual(len(leftovers), 2)
-        self.assertTrue(all(path.name.endswith(".backup") for path in leftovers))
-
-        self._write_artifacts(godot_dir)
-
-        self.assertEqual(self._temporary_artifact_files(godot_dir), [])
-
-    def test_attempt_only_publish_preserves_canonical_recovery_leftover(self) -> None:
-        godot_dir, manifest_path, _, _, _ = self._existing_artifacts()
-        recovery_path = manifest_path.parent / (
-            f".{manifest_path.name}.abcdefgh.recovery.backup"
-        )
-        recovery_content = b'{"trusted": "recovery"}\n'
-        recovery_path.write_bytes(recovery_content)
-
-        self._write_artifacts(
-            godot_dir,
-            manifest_outcome=None,
-            attempt_outcome=self._failed_outcome(),
-        )
-
-        self.assertEqual(recovery_path.read_bytes(), recovery_content)
-
-        self._write_artifacts(godot_dir)
-
-        self.assertFalse(recovery_path.exists())
-
-    def test_cleanup_control_flow_signals_propagate_after_valid_commit(self) -> None:
-        for signal_type in (KeyboardInterrupt, SystemExit):
-            with self.subTest(signal_type=signal_type.__name__):
-                godot_dir, manifest_path, attempt_path, _, _ = (
-                    self._existing_artifacts(
-                        self.temp_dir / signal_type.__name__.lower()
-                    )
+        for phase, name, message in cases:
+            with self.subTest(phase=phase):
+                godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
+                    self._existing_artifacts(self.temp_dir / phase)
                 )
-                real_unlink = os.unlink
-                interrupted = False
 
-                def interrupt_backup_cleanup(path: str | bytes) -> None:
-                    nonlocal interrupted
-                    if not interrupted and os.fsdecode(path).endswith(".backup"):
-                        interrupted = True
-                        raise signal_type("injected cleanup control-flow signal")
-                    real_unlink(path)
+                def fail_selected_phase(
+                    current_phase: str,
+                    _directory_path: str,
+                    current_name: str | None,
+                ) -> None:
+                    if current_phase == phase and current_name == name:
+                        raise OSError(message)
 
                 with (
                     patch(
-                        "src.conversion.conversion_manifest.os.unlink",
-                        side_effect=interrupt_backup_cleanup,
+                        "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                        side_effect=fail_selected_phase,
                     ),
-                    self.assertRaises(signal_type),
-                ):
-                    self._write_artifacts(godot_dir)
-
-                self.assertTrue(interrupted)
-                manifest_bytes = manifest_path.read_bytes()
-                attempt = json.loads(attempt_path.read_text(encoding="utf-8"))
-                self.assertEqual(
-                    attempt["canonical_manifest"]["sha256"],
-                    "sha256:" + hashlib.sha256(manifest_bytes).hexdigest(),
-                )
-                self.assertGreaterEqual(
-                    len(self._temporary_artifact_files(godot_dir)),
-                    1,
-                )
-
-                self._write_artifacts(godot_dir)
-
-                self.assertEqual(self._temporary_artifact_files(godot_dir), [])
-
-    def test_incomplete_stage_cleanup_does_not_swallow_keyboard_interrupt(
-        self,
-    ) -> None:
-        godot_dir = self.temp_dir / "stage-cleanup-interrupt"
-        godot_dir.mkdir()
-        real_fsync = os.fsync
-        real_unlink = os.unlink
-
-        def fail_file_fsync(file_descriptor: int) -> None:
-            if stat.S_ISREG(os.fstat(file_descriptor).st_mode):
-                raise OSError("injected stage failure")
-            real_fsync(file_descriptor)
-
-        def interrupt_stage_cleanup(path: str | bytes) -> None:
-            if os.fsdecode(path).endswith(".tmp"):
-                raise KeyboardInterrupt("injected stage cleanup interrupt")
-            real_unlink(path)
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest.os.fsync",
-                side_effect=fail_file_fsync,
-            ),
-            patch(
-                "src.conversion.conversion_manifest.os.unlink",
-                side_effect=interrupt_stage_cleanup,
-            ),
-            self.assertRaisesRegex(
-                KeyboardInterrupt,
-                "injected stage cleanup interrupt",
-            ),
-        ):
-            self._write_artifacts(godot_dir)
-
-    @unittest.skipIf(os.name == "nt", "Symlink creation is not portable on Windows")
-    def test_stale_cleanup_refuses_redirected_lookalike(self) -> None:
-        godot_dir, _, attempt_path, _, _ = self._existing_artifacts()
-        external_path = self.temp_dir / "external-stale-lookalike.json"
-        external_content = b"external sentinel\n"
-        external_path.write_bytes(external_content)
-        lookalike = attempt_path.parent / (
-            f".{attempt_path.name}.abcdefgh.backup"
-        )
-        lookalike.symlink_to(external_path)
-
-        self._write_artifacts(godot_dir)
-
-        self.assertTrue(lookalike.is_symlink())
-        self.assertEqual(external_path.read_bytes(), external_content)
-
-    def test_second_replace_failure_rolls_back_attempt_and_preserves_pair(self) -> None:
-        godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
-            self._existing_artifacts()
-        )
-        real_replace = os.replace
-
-        def fail_canonical_publish(source: str, destination: str) -> None:
-            if (
-                Path(destination) == manifest_path
-                and source.endswith(".tmp")
-            ):
-                raise OSError("injected canonical replace failure")
-            real_replace(source, destination)
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest.os.replace",
-                side_effect=fail_canonical_publish,
-            ),
-            self.assertRaisesRegex(OSError, "injected canonical replace failure"),
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertEqual(manifest_path.read_bytes(), manifest_before)
-        self.assertEqual(attempt_path.read_bytes(), attempt_before)
-        self.assertEqual(self._temporary_artifact_files(godot_dir), [])
-
-    def test_final_publication_revalidates_the_entire_artifact_pair(self) -> None:
-        godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
-            self._existing_artifacts()
-        )
-        real_replace = os.replace
-        corrupted_attempt = b"corrupted during canonical publication\n"
-
-        def publish_then_corrupt_attempt(source: str, destination: str) -> None:
-            real_replace(source, destination)
-            if Path(destination) == manifest_path and source.endswith(".tmp"):
-                attempt_path.write_bytes(corrupted_attempt)
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest.os.replace",
-                side_effect=publish_then_corrupt_attempt,
-            ),
-            self.assertRaisesRegex(OSError, "content changed") as context,
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertEqual(manifest_path.read_bytes(), manifest_before)
-        self.assertEqual(attempt_path.read_bytes(), corrupted_attempt)
-        recovery_files = list(
-            attempt_path.parent.glob(f".{attempt_path.name}.*.backup")
-        )
-        self.assertEqual(len(recovery_files), 1)
-        self.assertEqual(recovery_files[0].read_bytes(), attempt_before)
-        self.assertTrue(
-            any(
-                "rollback also failed" in note
-                and os.fspath(recovery_files[0]) in note
-                for note in getattr(context.exception, "__notes__", [])
-            )
-        )
-
-    def test_publication_revalidates_pair_after_cleanup_fsync(self) -> None:
-        godot_dir, manifest_path, attempt_path, _, _ = self._existing_artifacts()
-        real_directory_fsync = cast(
-            Callable[..., None],
-            getattr(conversion_manifest_module, "_fsync_artifact_directory"),
-        )
-        directory_fsync_calls = 0
-        corrupted_attempt = b"corrupted during cleanup fsync\n"
-
-        def corrupt_during_cleanup_fsync(
-            *args: object,
-            **kwargs: object,
-        ) -> None:
-            nonlocal directory_fsync_calls
-            directory_fsync_calls += 1
-            real_directory_fsync(*args, **kwargs)
-            if directory_fsync_calls == 3:
-                attempt_path.write_bytes(corrupted_attempt)
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest._fsync_artifact_directory",
-                side_effect=corrupt_during_cleanup_fsync,
-            ),
-            self.assertRaisesRegex(OSError, "content changed"),
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertEqual(directory_fsync_calls, 3)
-        self.assertTrue(manifest_path.is_file())
-        self.assertEqual(attempt_path.read_bytes(), corrupted_attempt)
-        self.assertEqual(self._temporary_artifact_files(godot_dir), [])
-
-    @unittest.skipIf(os.name == "nt", "Directory fsync is unavailable on Windows")
-    def test_directory_fsync_failure_after_attempt_publish_rolls_back_pair(
-        self,
-    ) -> None:
-        godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
-            self._existing_artifacts()
-        )
-        real_fsync = os.fsync
-        directory_fsync_failed = False
-        artifact_directory_stat = os.stat(manifest_path.parent)
-        artifact_directory_identity = (
-            artifact_directory_stat.st_dev,
-            artifact_directory_stat.st_ino,
-        )
-
-        def fail_first_directory_fsync(file_descriptor: int) -> None:
-            nonlocal directory_fsync_failed
-            descriptor_stat = os.fstat(file_descriptor)
-            if (
-                stat.S_ISDIR(descriptor_stat.st_mode)
-                and (descriptor_stat.st_dev, descriptor_stat.st_ino)
-                == artifact_directory_identity
-                and not directory_fsync_failed
-            ):
-                directory_fsync_failed = True
-                raise OSError("injected directory fsync failure")
-            real_fsync(file_descriptor)
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest.os.fsync",
-                side_effect=fail_first_directory_fsync,
-            ),
-            self.assertRaisesRegex(OSError, "injected directory fsync failure"),
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertTrue(directory_fsync_failed)
-        self.assertEqual(manifest_path.read_bytes(), manifest_before)
-        self.assertEqual(attempt_path.read_bytes(), attempt_before)
-        self.assertEqual(self._temporary_artifact_files(godot_dir), [])
-
-    @unittest.skipIf(os.name == "nt", "Directory fsync is unavailable on Windows")
-    def test_rollback_fsync_failure_retains_verified_recovery_copy(self) -> None:
-        godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
-            self._existing_artifacts()
-        )
-        real_replace = os.replace
-        real_directory_fsync = cast(
-            Callable[..., None],
-            getattr(conversion_manifest_module, "_fsync_artifact_directory"),
-        )
-        directory_fsync_calls = 0
-
-        def fail_canonical_publish(source: str, destination: str) -> None:
-            if Path(destination) == manifest_path and source.endswith(".tmp"):
-                raise OSError("canonical publish failed")
-            real_replace(source, destination)
-
-        def fail_rollback_fsync(*args: object, **kwargs: object) -> None:
-            nonlocal directory_fsync_calls
-            directory_fsync_calls += 1
-            if directory_fsync_calls == 2:
-                raise OSError("rollback directory fsync failed")
-            real_directory_fsync(*args, **kwargs)
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest.os.replace",
-                side_effect=fail_canonical_publish,
-            ),
-            patch(
-                "src.conversion.conversion_manifest._fsync_artifact_directory",
-                side_effect=fail_rollback_fsync,
-            ),
-            self.assertRaisesRegex(OSError, "canonical publish failed") as context,
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertEqual(manifest_path.read_bytes(), manifest_before)
-        self.assertEqual(attempt_path.read_bytes(), attempt_before)
-        recovery_files = list(
-            attempt_path.parent.glob(f".{attempt_path.name}.*.recovery.backup")
-        )
-        self.assertEqual(len(recovery_files), 1)
-        self.assertEqual(recovery_files[0].read_bytes(), attempt_before)
-        self.assertTrue(
-            any(
-                "rollback directory fsync failed" in note
-                and os.fspath(recovery_files[0]) in note
-                for note in getattr(context.exception, "__notes__", [])
-            )
-        )
-
-    def test_rollback_revalidates_restored_bytes_after_directory_fsync(self) -> None:
-        godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
-            self._existing_artifacts()
-        )
-        real_replace = os.replace
-        real_directory_fsync = cast(
-            Callable[..., None],
-            getattr(conversion_manifest_module, "_fsync_artifact_directory"),
-        )
-        directory_fsync_calls = 0
-        corrupted_attempt = b"corrupted during rollback fsync\n"
-
-        def fail_canonical_publish(source: str, destination: str) -> None:
-            if Path(destination) == manifest_path and source.endswith(".tmp"):
-                raise OSError("canonical publish failed")
-            real_replace(source, destination)
-
-        def tamper_during_rollback_fsync(*args: object, **kwargs: object) -> None:
-            nonlocal directory_fsync_calls
-            directory_fsync_calls += 1
-            real_directory_fsync(*args, **kwargs)
-            if directory_fsync_calls == 2:
-                attempt_path.write_bytes(corrupted_attempt)
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest.os.replace",
-                side_effect=fail_canonical_publish,
-            ),
-            patch(
-                "src.conversion.conversion_manifest._fsync_artifact_directory",
-                side_effect=tamper_during_rollback_fsync,
-            ),
-            self.assertRaisesRegex(OSError, "canonical publish failed") as context,
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertEqual(manifest_path.read_bytes(), manifest_before)
-        self.assertEqual(attempt_path.read_bytes(), corrupted_attempt)
-        recovery_files = list(
-            attempt_path.parent.glob(f".{attempt_path.name}.*.recovery.backup")
-        )
-        self.assertEqual(len(recovery_files), 1)
-        self.assertEqual(recovery_files[0].read_bytes(), attempt_before)
-        self.assertTrue(
-            any(
-                "rollback also failed" in note
-                and "content changed" in note
-                and os.fspath(recovery_files[0]) in note
-                for note in getattr(context.exception, "__notes__", [])
-            )
-        )
-
-    def test_rollback_revalidates_absence_after_directory_fsync(self) -> None:
-        godot_dir = self.temp_dir / "godot"
-        godot_dir.mkdir()
-        attempt_path = godot_dir / CONVERSION_ATTEMPT_RELATIVE_PATH
-        manifest_path = godot_dir / CONVERSION_MANIFEST_RELATIVE_PATH
-        real_replace = os.replace
-        real_directory_fsync = cast(
-            Callable[..., None],
-            getattr(conversion_manifest_module, "_fsync_artifact_directory"),
-        )
-        directory_fsync_calls = 0
-        recreated_attempt = b"recreated during rollback fsync\n"
-
-        def fail_canonical_publish(source: str, destination: str) -> None:
-            if Path(destination) == manifest_path and source.endswith(".tmp"):
-                raise OSError("canonical publish failed")
-            real_replace(source, destination)
-
-        def recreate_during_rollback_fsync(*args: object, **kwargs: object) -> None:
-            nonlocal directory_fsync_calls
-            directory_fsync_calls += 1
-            real_directory_fsync(*args, **kwargs)
-            if directory_fsync_calls == 2:
-                attempt_path.write_bytes(recreated_attempt)
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest.os.replace",
-                side_effect=fail_canonical_publish,
-            ),
-            patch(
-                "src.conversion.conversion_manifest._fsync_artifact_directory",
-                side_effect=recreate_during_rollback_fsync,
-            ),
-            self.assertRaisesRegex(OSError, "canonical publish failed") as context,
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertFalse(manifest_path.exists())
-        self.assertEqual(attempt_path.read_bytes(), recreated_attempt)
-        self.assertTrue(
-            any(
-                "rollback also failed" in note
-                and "reappeared during rollback" in note
-                for note in getattr(context.exception, "__notes__", [])
-            )
-        )
-
-    def test_multi_artifact_rollback_revalidates_every_restored_target(self) -> None:
-        godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
-            self._existing_artifacts()
-        )
-        real_directory_fsync = cast(
-            Callable[..., None],
-            getattr(conversion_manifest_module, "_fsync_artifact_directory"),
-        )
-        directory_fsync_calls = 0
-        corrupted_manifest = b"corrupted during later rollback\n"
-
-        def fail_publish_then_corrupt_restored_manifest(
-            *args: object,
-            **kwargs: object,
-        ) -> None:
-            nonlocal directory_fsync_calls
-            directory_fsync_calls += 1
-            real_directory_fsync(*args, **kwargs)
-            if directory_fsync_calls == 2:
-                raise OSError("second publish directory fsync failed")
-            if directory_fsync_calls == 4:
-                manifest_path.write_bytes(corrupted_manifest)
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest._fsync_artifact_directory",
-                side_effect=fail_publish_then_corrupt_restored_manifest,
-            ),
-            self.assertRaisesRegex(
-                OSError,
-                "second publish directory fsync failed",
-            ) as context,
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertEqual(attempt_path.read_bytes(), attempt_before)
-        self.assertEqual(manifest_path.read_bytes(), corrupted_manifest)
-        recovery_files = list(
-            manifest_path.parent.glob(f".{manifest_path.name}.*.recovery.backup")
-        )
-        self.assertEqual(len(recovery_files), 1)
-        self.assertEqual(recovery_files[0].read_bytes(), manifest_before)
-        self.assertTrue(
-            any(
-                "rollback also failed" in note
-                and "content changed" in note
-                and os.fspath(recovery_files[0]) in note
-                for note in getattr(context.exception, "__notes__", [])
-            )
-        )
-
-    def test_replace_that_mutates_then_raises_is_detected_and_rolled_back(self) -> None:
-        for failing_artifact in ("attempt", "manifest"):
-            with self.subTest(failing_artifact=failing_artifact):
-                test_root = self.temp_dir / failing_artifact
-                (
-                    godot_dir,
-                    manifest_path,
-                    attempt_path,
-                    manifest_before,
-                    attempt_before,
-                ) = self._existing_artifacts(test_root)
-                failing_path = (
-                    attempt_path if failing_artifact == "attempt" else manifest_path
-                )
-                real_replace = os.replace
-
-                def mutate_then_fail(source: str, destination: str) -> None:
-                    real_replace(source, destination)
-                    if Path(destination) == failing_path and source.endswith(".tmp"):
-                        raise OSError(f"{failing_artifact} replace mutated then failed")
-
-                with (
-                    patch(
-                        "src.conversion.conversion_manifest.os.replace",
-                        side_effect=mutate_then_fail,
-                    ),
-                    self.assertRaisesRegex(
-                        OSError,
-                        f"{failing_artifact} replace mutated then failed",
-                    ),
+                    self.assertRaisesRegex(OSError, message),
                 ):
                     self._write_artifacts(godot_dir)
 
@@ -1910,780 +1238,125 @@ class TestConversionManifest(unittest.TestCase):
                 self.assertEqual(attempt_path.read_bytes(), attempt_before)
                 self.assertEqual(self._temporary_artifact_files(godot_dir), [])
 
-    def test_rollback_replace_that_mutates_then_raises_counts_as_restored(self) -> None:
+    def test_final_publication_revalidates_the_complete_pair(self) -> None:
         godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
             self._existing_artifacts()
         )
-        real_replace = os.replace
+        corrupted_attempt = b"corrupted during canonical publication\n"
 
-        def fail_publish_and_mutating_rollback(
-            source: str,
-            destination: str,
+        def corrupt_attempt_after_canonical(
+            phase: str,
+            _directory_path: str,
+            name: str | None,
         ) -> None:
-            if Path(destination) == manifest_path and source.endswith(".tmp"):
-                raise OSError("canonical publish failed")
-            if Path(destination) == attempt_path and source.endswith(".backup"):
-                real_replace(source, destination)
-                raise OSError("rollback replace mutated then failed")
-            real_replace(source, destination)
+            if phase == "after_commit" and name == "conversion_manifest.json":
+                attempt_path.write_bytes(corrupted_attempt)
 
-        with patch(
-            "src.conversion.conversion_manifest.os.replace",
-            side_effect=fail_publish_and_mutating_rollback,
+        with (
+            patch(
+                "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                side_effect=corrupt_attempt_after_canonical,
+            ),
+            self.assertRaisesRegex(OSError, "content changed") as raised,
         ):
-            with self.assertRaisesRegex(OSError, "canonical publish failed") as context:
-                self._write_artifacts(godot_dir)
+            self._write_artifacts(godot_dir)
 
         self.assertEqual(manifest_path.read_bytes(), manifest_before)
-        self.assertEqual(attempt_path.read_bytes(), attempt_before)
-        self.assertFalse(
-            any(
-                "rollback also failed" in note
-                for note in getattr(context.exception, "__notes__", [])
-            )
-        )
-        self.assertEqual(self._temporary_artifact_files(godot_dir), [])
-
-    def test_rollback_failure_retains_recovery_backup_and_adds_exception_note(
-        self,
-    ) -> None:
-        godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
-            self._existing_artifacts()
-        )
-        real_replace = os.replace
-
-        def fail_publish_and_rollback(source: str, destination: str) -> None:
-            if Path(destination) == manifest_path and source.endswith(".tmp"):
-                raise OSError("canonical publish failed")
-            if Path(destination) == attempt_path and source.endswith(".backup"):
-                raise OSError("attempt rollback failed")
-            real_replace(source, destination)
-
-        with patch(
-            "src.conversion.conversion_manifest.os.replace",
-            side_effect=fail_publish_and_rollback,
-        ):
-            with self.assertRaisesRegex(OSError, "canonical publish failed") as context:
-                self._write_artifacts(godot_dir)
-
-        self.assertEqual(manifest_path.read_bytes(), manifest_before)
-        self.assertNotEqual(attempt_path.read_bytes(), attempt_before)
-        notes = getattr(context.exception, "__notes__", [])
-        self.assertTrue(
-            any("rollback also failed" in note for note in notes),
-            notes,
-        )
+        self.assertEqual(attempt_path.read_bytes(), corrupted_attempt)
         recovery_files = list(
             attempt_path.parent.glob(f".{attempt_path.name}.*.backup")
         )
         self.assertEqual(len(recovery_files), 1)
         self.assertEqual(recovery_files[0].read_bytes(), attempt_before)
         self.assertTrue(
-            any(os.fspath(recovery_files[0]) in note for note in notes),
-            notes,
-        )
-        self.assertEqual(
-            [
-                path
-                for path in self._temporary_artifact_files(godot_dir)
-                if path != recovery_files[0]
-            ],
-            [],
-        )
-
-    def test_windows_file_fingerprint_match_ignores_only_ctime(self) -> None:
-        fingerprints_match = cast(
-            Callable[
-                [tuple[int, int, int, int, int], tuple[int, int, int, int, int]],
-                bool,
-            ],
-            getattr(conversion_manifest_module, "_file_fingerprints_match"),
-        )
-        baseline = (11, 22, 33, 44, 55)
-        ctime_only_drift = (11, 22, 33, 44, 99)
-        real_drift = {
-            "device": (12, 22, 33, 44, 55),
-            "inode": (11, 23, 33, 44, 55),
-            "size": (11, 22, 34, 44, 55),
-            "mtime": (11, 22, 33, 45, 55),
-        }
-
-        with patch(
-            "src.conversion.conversion_manifest._uses_windows_file_fingerprint_semantics",
-            return_value=True,
-        ):
-            self.assertTrue(fingerprints_match(ctime_only_drift, baseline))
-            for field, fingerprint in real_drift.items():
-                with self.subTest(field=field):
-                    self.assertFalse(fingerprints_match(fingerprint, baseline))
-
-        with patch(
-            "src.conversion.conversion_manifest._uses_windows_file_fingerprint_semantics",
-            return_value=False,
-        ):
-            self.assertFalse(fingerprints_match(ctime_only_drift, baseline))
-
-    def test_windows_target_state_keeps_exact_path_ctime_guard(self) -> None:
-        artifact_path = self.temp_dir / "artifact.json"
-        artifact_path.write_bytes(b"stable artifact\n")
-        target_state = cast(
-            Callable[[str], object],
-            getattr(conversion_manifest_module, "_artifact_target_state"),
-        )(str(artifact_path))
-        verify_target_state = cast(
-            Callable[[str, object], None],
-            getattr(conversion_manifest_module, "_verify_artifact_target_state"),
-        )
-        real_fingerprint = cast(
-            Callable[[os.stat_result], tuple[int, int, int, int, int]],
-            getattr(conversion_manifest_module, "_file_fingerprint"),
-        )
-
-        def path_ctime_drift(
-            path_stat: os.stat_result,
-        ) -> tuple[int, int, int, int, int]:
-            fingerprint = real_fingerprint(path_stat)
-            return (*fingerprint[:4], fingerprint[4] + 1)
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest._uses_windows_file_fingerprint_semantics",
-                return_value=True,
-            ),
-            patch(
-                "src.conversion.conversion_manifest._file_fingerprint",
-                side_effect=path_ctime_drift,
-            ),
-            self.assertRaisesRegex(OSError, "changed during publication"),
-        ):
-            verify_target_state(str(artifact_path), target_state)
-
-    def test_windows_temporary_verification_accepts_ctime_only_divergence(
-        self,
-    ) -> None:
-        stage_artifact = cast(
-            Callable[..., Any],
-            getattr(conversion_manifest_module, "_stage_artifact_bytes"),
-        )
-        verify_artifact = cast(
-            Callable[..., None],
-            getattr(conversion_manifest_module, "_verify_temporary_artifact"),
-        )
-        file_fingerprint = cast(
-            Callable[[os.stat_result], tuple[int, int, int, int, int]],
-            getattr(conversion_manifest_module, "_file_fingerprint"),
-        )
-        artifact = stage_artifact(
-            str(self.temp_dir / "artifact.json"),
-            b"stable artifact\n",
-            mode=None,
-            suffix=".tmp",
-        )
-        fingerprint_call = 0
-
-        def ctime_divergent_fingerprint(
-            path_stat: os.stat_result,
-        ) -> tuple[int, int, int, int, int]:
-            nonlocal fingerprint_call
-            fingerprint_call += 1
-            fingerprint = file_fingerprint(path_stat)
-            return (*fingerprint[:4], fingerprint[4] + fingerprint_call)
-
-        try:
-            with (
-                patch(
-                    "src.conversion.conversion_manifest._uses_windows_file_fingerprint_semantics",
-                    return_value=True,
-                ),
-                patch(
-                    "src.conversion.conversion_manifest._file_fingerprint",
-                    side_effect=ctime_divergent_fingerprint,
-                ),
-            ):
-                verify_artifact(artifact)
-
-            fingerprint_call = 0
-            with (
-                patch(
-                    "src.conversion.conversion_manifest._uses_windows_file_fingerprint_semantics",
-                    return_value=False,
-                ),
-                patch(
-                    "src.conversion.conversion_manifest._file_fingerprint",
-                    side_effect=ctime_divergent_fingerprint,
-                ),
-                self.assertRaisesRegex(OSError, "content changed"),
-            ):
-                verify_artifact(artifact)
-        finally:
-            Path(artifact.path).unlink(missing_ok=True)
-
-    def test_windows_temporary_verification_rejects_content_and_mode_drift(
-        self,
-    ) -> None:
-        stage_artifact = cast(
-            Callable[..., Any],
-            getattr(conversion_manifest_module, "_stage_artifact_bytes"),
-        )
-        verify_artifact = cast(
-            Callable[..., None],
-            getattr(conversion_manifest_module, "_verify_temporary_artifact"),
-        )
-        original_content = b"original\n"
-        artifact = stage_artifact(
-            str(self.temp_dir / "artifact.json"),
-            original_content,
-            mode=None,
-            suffix=".tmp",
-        )
-        artifact_path = Path(artifact.path)
-
-        try:
-            artifact_path.write_bytes(b"tampered\n")
-            with (
-                patch(
-                    "src.conversion.conversion_manifest._uses_windows_file_fingerprint_semantics",
-                    return_value=True,
-                ),
-                self.assertRaisesRegex(OSError, "content changed"),
-            ):
-                verify_artifact(artifact)
-
-            artifact_path.write_bytes(original_content)
-            tampered_mode = artifact.staged_mode ^ stat.S_IWRITE
-            os.chmod(artifact_path, tampered_mode)
-            with (
-                patch(
-                    "src.conversion.conversion_manifest._uses_windows_file_fingerprint_semantics",
-                    return_value=True,
-                ),
-                self.assertRaisesRegex(OSError, "artifact changed"),
-            ):
-                verify_artifact(artifact)
-        finally:
-            os.chmod(artifact_path, artifact.staged_mode | stat.S_IWRITE)
-            artifact_path.unlink(missing_ok=True)
-
-    def test_windows_read_only_artifact_pair_is_replaced_without_read_only_temps(
-        self,
-    ) -> None:
-        godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
-            self._existing_artifacts()
-        )
-        for artifact_path in (manifest_path, attempt_path):
-            os.chmod(artifact_path, 0o444)
-        real_replace = os.replace
-        real_unlink = os.unlink
-        replaced_targets: list[Path] = []
-        removed_temporary_paths: list[Path] = []
-
-        def windows_replace(source: str, destination: str) -> None:
-            destination_path = Path(destination)
-            if destination_path.exists() and not (
-                stat.S_IMODE(os.lstat(destination_path).st_mode)
-                & stat.S_IWRITE
-            ):
-                raise PermissionError("Windows cannot replace a read-only target")
-            real_replace(source, destination)
-            replaced_targets.append(destination_path)
-
-        def windows_unlink(path: str | bytes) -> None:
-            decoded_path = Path(os.fsdecode(path))
-            if decoded_path.exists() and not (
-                stat.S_IMODE(os.lstat(decoded_path).st_mode)
-                & stat.S_IWRITE
-            ):
-                raise PermissionError("Windows cannot unlink a read-only file")
-            if decoded_path.name.startswith(".conversion_"):
-                removed_temporary_paths.append(decoded_path)
-            real_unlink(path)
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest._uses_windows_file_attribute_modes",
-                return_value=True,
-            ),
-            patch(
-                "src.conversion.conversion_manifest.os.replace",
-                side_effect=windows_replace,
-            ),
-            patch(
-                "src.conversion.conversion_manifest.os.unlink",
-                side_effect=windows_unlink,
-            ),
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertEqual(
-            replaced_targets,
-            [attempt_path, manifest_path],
-        )
-        self.assertTrue(removed_temporary_paths)
-        self.assertNotEqual(manifest_path.read_bytes(), manifest_before)
-        self.assertNotEqual(attempt_path.read_bytes(), attempt_before)
-        for artifact_path in (manifest_path, attempt_path):
-            self.assertEqual(
-                stat.S_IMODE(os.lstat(artifact_path).st_mode),
-                0o444,
+            any(
+                "rollback also failed" in note
+                for note in getattr(raised.exception, "__notes__", ())
             )
-        self.assertEqual(self._temporary_artifact_files(godot_dir), [])
+        )
 
-    def test_windows_read_only_pair_is_restored_after_second_replace_failure(
+    def test_stale_cleanup_preserves_canonical_recovery_until_canonical_update(
         self,
     ) -> None:
-        godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
-            self._existing_artifacts()
+        godot_dir, manifest_path, _, _, _ = self._existing_artifacts()
+        attempt_stale = manifest_path.parent / (
+            ".conversion_attempt.json.abcdefgh.backup"
         )
-        for artifact_path in (manifest_path, attempt_path):
-            os.chmod(artifact_path, 0o444)
-        real_replace = os.replace
-        real_unlink = os.unlink
-        canonical_failure_injected = False
+        manifest_recovery = manifest_path.parent / (
+            ".conversion_manifest.json.abcdefgh.recovery.backup"
+        )
+        attempt_stale.write_bytes(b"old attempt backup\n")
+        manifest_recovery.write_bytes(b"old canonical recovery\n")
 
-        def windows_replace(source: str, destination: str) -> None:
-            nonlocal canonical_failure_injected
-            destination_path = Path(destination)
-            if destination_path.exists() and not (
-                stat.S_IMODE(os.lstat(destination_path).st_mode)
-                & stat.S_IWRITE
-            ):
-                raise PermissionError("Windows cannot replace a read-only target")
-            if (
-                destination_path == manifest_path
-                and source.endswith(".tmp")
-            ):
-                canonical_failure_injected = True
-                raise OSError("injected read-only canonical publish failure")
-            real_replace(source, destination)
+        self._write_artifacts(
+            godot_dir,
+            manifest_outcome=None,
+            attempt_outcome=self._failed_outcome(),
+        )
 
-        def windows_unlink(path: str | bytes) -> None:
-            decoded_path = Path(os.fsdecode(path))
-            if decoded_path.exists() and not (
-                stat.S_IMODE(os.lstat(decoded_path).st_mode)
-                & stat.S_IWRITE
-            ):
-                raise PermissionError("Windows cannot unlink a read-only file")
-            real_unlink(path)
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest._uses_windows_file_attribute_modes",
-                return_value=True,
-            ),
-            patch(
-                "src.conversion.conversion_manifest.os.replace",
-                side_effect=windows_replace,
-            ),
-            patch(
-                "src.conversion.conversion_manifest.os.unlink",
-                side_effect=windows_unlink,
-            ),
-            self.assertRaisesRegex(
-                OSError,
-                "injected read-only canonical publish failure",
-            ),
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertTrue(canonical_failure_injected)
-        self.assertEqual(manifest_path.read_bytes(), manifest_before)
-        self.assertEqual(attempt_path.read_bytes(), attempt_before)
-        for artifact_path in (manifest_path, attempt_path):
-            self.assertEqual(
-                stat.S_IMODE(os.lstat(artifact_path).st_mode),
-                0o444,
-            )
-        self.assertEqual(self._temporary_artifact_files(godot_dir), [])
-
-    @unittest.skipIf(os.name == "nt", "POSIX permission modes are unavailable")
-    def test_existing_artifact_modes_are_preserved(self) -> None:
-        godot_dir, manifest_path, attempt_path, _, _ = self._existing_artifacts()
-        os.chmod(manifest_path, 0o640)
-        os.chmod(attempt_path, 0o604)
+        self.assertFalse(attempt_stale.exists())
+        self.assertEqual(
+            manifest_recovery.read_bytes(),
+            b"old canonical recovery\n",
+        )
 
         self._write_artifacts(godot_dir)
 
-        self.assertEqual(os.stat(manifest_path).st_mode & 0o777, 0o640)
-        self.assertEqual(os.stat(attempt_path).st_mode & 0o777, 0o604)
+        self.assertFalse(manifest_recovery.exists())
 
-    @unittest.skipIf(os.name == "nt", "POSIX permission modes are unavailable")
-    def test_existing_set_id_artifact_modes_are_preserved(self) -> None:
-        godot_dir, manifest_path, attempt_path, _, _ = self._existing_artifacts()
-        expected_modes = {
-            manifest_path: stat.S_ISUID | 0o640,
-            attempt_path: stat.S_ISGID | 0o640,
-        }
-        for artifact_path, expected_mode in expected_modes.items():
-            os.chmod(artifact_path, expected_mode)
-            if stat.S_IMODE(os.stat(artifact_path).st_mode) != expected_mode:
-                self.skipTest("Filesystem does not retain set-ID file modes")
+    @unittest.skipUnless(os.name == "posix", "POSIX links are required")
+    def test_stale_cleanup_refuses_redirected_and_hardlinked_lookalikes(
+        self,
+    ) -> None:
+        godot_dir, manifest_path, _, _, _ = self._existing_artifacts()
+        external = self.temp_dir / "external-stale.json"
+        external_content = b"external sentinel\n"
+        external.write_bytes(external_content)
+        symlink = manifest_path.parent / (
+            ".conversion_attempt.json.redirected.backup"
+        )
+        hardlink = manifest_path.parent / (
+            ".conversion_manifest.json.hardlinked.backup"
+        )
+        symlink.symlink_to(external)
+        os.link(external, hardlink)
 
         self._write_artifacts(godot_dir)
 
-        for artifact_path, expected_mode in expected_modes.items():
-            with self.subTest(artifact=artifact_path.name):
-                self.assertEqual(
-                    stat.S_IMODE(os.stat(artifact_path).st_mode),
-                    expected_mode,
-                )
+        self.assertTrue(symlink.is_symlink())
+        self.assertTrue(hardlink.is_file())
+        self.assertEqual(external.read_bytes(), external_content)
+        self.assertEqual(hardlink.read_bytes(), external_content)
 
-    @unittest.skipIf(os.name == "nt", "POSIX permission modes are unavailable")
-    def test_staged_mode_tampering_is_detected_before_publication(self) -> None:
-        godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
-            self._existing_artifacts()
-        )
-        os.chmod(manifest_path, 0o640)
-        real_stage = cast(
-            Callable[..., Any],
-            getattr(conversion_manifest_module, "_stage_artifact_bytes"),
-        )
-
-        def stage_then_chmod(
-            path: str,
-            content: bytes,
-            *,
-            mode: int | None,
-            suffix: str,
-        ) -> Any:
-            staged = real_stage(path, content, mode=mode, suffix=suffix)
-            if Path(path) == manifest_path and suffix == ".tmp":
-                os.chmod(staged.path, 0o666)
-            return staged
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest._stage_artifact_bytes",
-                side_effect=stage_then_chmod,
-            ),
-            self.assertRaisesRegex(OSError, "Staged conversion artifact changed") as context,
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertEqual(manifest_path.read_bytes(), manifest_before)
-        self.assertEqual(attempt_path.read_bytes(), attempt_before)
-        self.assertTrue(
-            any(
-                "cleanup failed" in note
-                for note in getattr(context.exception, "__notes__", [])
-            )
-        )
-
-    @unittest.skipIf(os.name == "nt", "POSIX permission modes are unavailable")
-    def test_stage_capture_window_mode_tampering_is_rejected(self) -> None:
-        godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
-            self._existing_artifacts()
-        )
-        real_lstat = os.lstat
-        tampered = False
-
-        def chmod_before_stage_stat(path: str | bytes) -> os.stat_result:
-            nonlocal tampered
-            decoded_path = os.fsdecode(path)
-            if (
-                not tampered
-                and decoded_path.endswith(".tmp")
-                and f".{attempt_path.name}." in os.path.basename(decoded_path)
-            ):
-                os.chmod(decoded_path, 0o666)
-                tampered = True
-            return real_lstat(path)
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest.os.lstat",
-                side_effect=chmod_before_stage_stat,
-            ),
-            self.assertRaisesRegex(OSError, "mode changed"),
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertTrue(tampered)
-        self.assertEqual(manifest_path.read_bytes(), manifest_before)
-        self.assertEqual(attempt_path.read_bytes(), attempt_before)
-        self.assertEqual(self._temporary_artifact_files(godot_dir), [])
-
-    @unittest.skipIf(os.name == "nt", "POSIX permission modes are unavailable")
-    def test_backup_mode_tampering_is_never_restored(self) -> None:
-        godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
-            self._existing_artifacts()
-        )
-        real_stage_existing = cast(
-            Callable[..., Any],
-            getattr(conversion_manifest_module, "_stage_existing_artifact"),
-        )
-        real_replace = os.replace
-
-        def backup_then_chmod(path: str, expected: object) -> Any:
-            backup = real_stage_existing(path, expected)
-            if Path(path) == attempt_path and backup is not None:
-                os.chmod(backup.path, 0o666)
-            return backup
-
-        def fail_canonical_publish(source: str, destination: str) -> None:
-            if Path(destination) == manifest_path and source.endswith(".tmp"):
-                raise OSError("canonical publish failed")
-            real_replace(source, destination)
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest._stage_existing_artifact",
-                side_effect=backup_then_chmod,
-            ),
-            patch(
-                "src.conversion.conversion_manifest.os.replace",
-                side_effect=fail_canonical_publish,
-            ),
-            self.assertRaisesRegex(OSError, "canonical publish failed") as context,
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertEqual(manifest_path.read_bytes(), manifest_before)
-        self.assertNotEqual(attempt_path.read_bytes(), attempt_before)
-        self.assertTrue(
-            any(
-                "rollback also failed" in note and "artifact changed" in note
-                for note in getattr(context.exception, "__notes__", [])
-            )
-        )
-
-    @unittest.skipIf(os.name == "nt", "POSIX permission modes are unavailable")
-    def test_backup_capture_window_mode_tampering_is_rejected(self) -> None:
-        godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
-            self._existing_artifacts()
-        )
-        real_lstat = os.lstat
-        tampered = False
-
-        def chmod_before_backup_stat(path: str | bytes) -> os.stat_result:
-            nonlocal tampered
-            decoded_path = os.fsdecode(path)
-            if (
-                not tampered
-                and decoded_path.endswith(".backup")
-                and f".{attempt_path.name}." in os.path.basename(decoded_path)
-            ):
-                os.chmod(decoded_path, 0o666)
-                tampered = True
-            return real_lstat(path)
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest.os.lstat",
-                side_effect=chmod_before_backup_stat,
-            ),
-            self.assertRaisesRegex(OSError, "mode changed"),
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertTrue(tampered)
-        self.assertEqual(manifest_path.read_bytes(), manifest_before)
-        self.assertEqual(attempt_path.read_bytes(), attempt_before)
-        self.assertEqual(self._temporary_artifact_files(godot_dir), [])
-
-    @unittest.skipIf(os.name == "nt", "POSIX permission modes are unavailable")
-    def test_new_artifact_modes_remain_restrictive(self) -> None:
-        godot_dir = self.temp_dir / "godot"
-        godot_dir.mkdir()
-
-        manifest_path_value, attempt_path_value = self._write_artifacts(godot_dir)
-
-        for artifact_path in (
-            Path(cast(str, manifest_path_value)),
-            Path(attempt_path_value),
-        ):
-            with self.subTest(artifact=artifact_path.name):
-                self.assertEqual(os.stat(artifact_path).st_mode & 0o077, 0)
-
-    @unittest.skipIf(os.name == "nt", "Symlink creation is not portable on Windows")
-    def test_refuses_redirected_root_and_artifact_targets(self) -> None:
-        real_root = self.temp_dir / "real-root"
-        real_root.mkdir()
-        redirected_root = self.temp_dir / "redirected-root"
-        redirected_root.symlink_to(real_root, target_is_directory=True)
-        with self.assertRaisesRegex(OSError, "redirected or non-directory"):
-            self._write_artifacts(redirected_root)
-
-        godot_dir = self.temp_dir / "godot"
-        artifact_dir = godot_dir / "gm2godot"
-        artifact_dir.mkdir(parents=True)
-        external = self.temp_dir / "external.json"
-        external.write_text("external\n", encoding="utf-8")
-        manifest_path = godot_dir / CONVERSION_MANIFEST_RELATIVE_PATH
-        manifest_path.symlink_to(external)
-
-        with self.assertRaisesRegex(OSError, "redirected or non-regular"):
-            self._write_artifacts(
-                godot_dir,
-                manifest_outcome=None,
-                attempt_outcome=self._failed_outcome(),
-            )
-
-        self.assertEqual(external.read_text(encoding="utf-8"), "external\n")
-        self.assertFalse((godot_dir / CONVERSION_ATTEMPT_RELATIVE_PATH).exists())
-
-    @unittest.skipIf(not hasattr(os, "mkfifo"), "FIFOs are unavailable")
-    def test_refuses_nonregular_artifact_target(self) -> None:
-        godot_dir = self.temp_dir / "godot"
-        attempt_path = godot_dir / CONVERSION_ATTEMPT_RELATIVE_PATH
-        attempt_path.parent.mkdir(parents=True)
-        os.mkfifo(attempt_path)
-
-        with self.assertRaisesRegex(OSError, "non-regular"):
-            self._write_artifacts(godot_dir)
-
-    def test_target_change_during_staging_is_detected_without_publication(self) -> None:
-        godot_dir, manifest_path, attempt_path, manifest_before, _ = (
-            self._existing_artifacts()
-        )
-        externally_changed_attempt = b"externally changed attempt\n"
-        real_stage = cast(
-            Callable[..., Any],
-            getattr(conversion_manifest_module, "_stage_artifact_bytes"),
-        )
-        stage_count = 0
-
-        def stage_then_change_target(
-            path: str,
-            content: bytes,
-            *,
-            mode: int | None,
-            suffix: str,
-        ) -> Any:
-            nonlocal stage_count
-            staged = real_stage(path, content, mode=mode, suffix=suffix)
-            stage_count += 1
-            if stage_count == 1:
-                attempt_path.write_bytes(externally_changed_attempt)
-            return staged
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest._stage_artifact_bytes",
-                side_effect=stage_then_change_target,
-            ),
-            self.assertRaisesRegex(OSError, "changed"),
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertEqual(manifest_path.read_bytes(), manifest_before)
-        self.assertEqual(attempt_path.read_bytes(), externally_changed_attempt)
-        self.assertEqual(self._temporary_artifact_files(godot_dir), [])
-
-    def test_in_place_stage_tampering_is_detected_before_publication(self) -> None:
-        godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
-            self._existing_artifacts()
-        )
-        real_stage = cast(
-            Callable[..., Any],
-            getattr(conversion_manifest_module, "_stage_artifact_bytes"),
-        )
-
-        def stage_then_tamper(
-            path: str,
-            content: bytes,
-            *,
-            mode: int | None,
-            suffix: str,
-        ) -> Any:
-            staged = real_stage(path, content, mode=mode, suffix=suffix)
-            if Path(path) == manifest_path and suffix == ".tmp":
-                Path(staged.path).write_bytes(b"tampered manifest stage\n")
-            return staged
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest._stage_artifact_bytes",
-                side_effect=stage_then_tamper,
-            ),
-            self.assertRaisesRegex(OSError, "content changed") as context,
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertEqual(manifest_path.read_bytes(), manifest_before)
-        self.assertEqual(attempt_path.read_bytes(), attempt_before)
-        self.assertTrue(
-            any(
-                "cleanup failed" in note
-                for note in getattr(context.exception, "__notes__", [])
-            )
-        )
-        self.assertEqual(len(self._temporary_artifact_files(godot_dir)), 1)
-
-    def test_in_place_backup_tampering_is_never_restored(self) -> None:
-        godot_dir, manifest_path, attempt_path, manifest_before, attempt_before = (
-            self._existing_artifacts()
-        )
-        real_stage_existing = cast(
-            Callable[..., Any],
-            getattr(conversion_manifest_module, "_stage_existing_artifact"),
-        )
-        real_replace = os.replace
-
-        def backup_then_tamper(path: str, expected: object) -> Any:
-            backup = real_stage_existing(path, expected)
-            if Path(path) == attempt_path and backup is not None:
-                Path(backup.path).write_bytes(b"tampered attempt backup\n")
-            return backup
-
-        def fail_canonical_publish(source: str, destination: str) -> None:
-            if Path(destination) == manifest_path and source.endswith(".tmp"):
-                raise OSError("canonical publish failed")
-            real_replace(source, destination)
-
-        with (
-            patch(
-                "src.conversion.conversion_manifest._stage_existing_artifact",
-                side_effect=backup_then_tamper,
-            ),
-            patch(
-                "src.conversion.conversion_manifest.os.replace",
-                side_effect=fail_canonical_publish,
-            ),
-            self.assertRaisesRegex(OSError, "canonical publish failed") as context,
-        ):
-            self._write_artifacts(godot_dir)
-
-        self.assertEqual(manifest_path.read_bytes(), manifest_before)
-        self.assertNotEqual(attempt_path.read_bytes(), attempt_before)
-        self.assertNotEqual(attempt_path.read_bytes(), b"tampered attempt backup\n")
-        self.assertTrue(
-            any(
-                "rollback also failed" in note and "content changed" in note
-                for note in getattr(context.exception, "__notes__", [])
-            )
-        )
-
-    def test_attempt_only_rejects_canonical_change_after_digesting(self) -> None:
+    def test_attempt_only_guard_rejects_canonical_change_after_digesting(
+        self,
+    ) -> None:
         godot_dir, manifest_path, attempt_path, _, attempt_before = (
             self._existing_artifacts()
         )
         external_manifest = b"externally changed manifest\n"
-        real_stage = cast(
-            Callable[..., Any],
-            getattr(conversion_manifest_module, "_stage_artifact_bytes"),
-        )
         changed = False
 
-        def stage_then_change_manifest(
-            path: str,
-            content: bytes,
-            *,
-            mode: int | None,
-            suffix: str,
-        ) -> Any:
+        def change_after_attempt_stage(
+            phase: str,
+            _directory_path: str,
+            name: str | None,
+        ) -> None:
             nonlocal changed
-            staged = real_stage(path, content, mode=mode, suffix=suffix)
-            if not changed:
-                manifest_path.write_bytes(external_manifest)
+            if (
+                not changed
+                and phase == "after_stage"
+                and name == "conversion_attempt.json"
+            ):
                 changed = True
-            return staged
+                manifest_path.write_bytes(external_manifest)
 
         with (
             patch(
-                "src.conversion.conversion_manifest._stage_artifact_bytes",
-                side_effect=stage_then_change_manifest,
+                "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                side_effect=change_after_attempt_stage,
             ),
-            self.assertRaisesRegex(OSError, "changed during publication"),
+            self.assertRaisesRegex(OSError, "Artifact changed"),
         ):
             self._write_artifacts(
                 godot_dir,
@@ -2691,9 +1364,309 @@ class TestConversionManifest(unittest.TestCase):
                 attempt_outcome=self._failed_outcome(),
             )
 
+        self.assertTrue(changed)
         self.assertEqual(manifest_path.read_bytes(), external_manifest)
         self.assertEqual(attempt_path.read_bytes(), attempt_before)
         self.assertEqual(self._temporary_artifact_files(godot_dir), [])
+
+    @unittest.skipIf(os.name == "nt", "Exact POSIX modes are unavailable")
+    def test_existing_and_new_artifact_modes_remain_exact(self) -> None:
+        godot_dir, manifest_path, attempt_path, _, _ = self._existing_artifacts()
+        os.chmod(manifest_path, 0o440)
+        os.chmod(attempt_path, 0o640)
+
+        self._write_artifacts(godot_dir)
+
+        self.assertEqual(stat.S_IMODE(os.lstat(manifest_path).st_mode), 0o440)
+        self.assertEqual(stat.S_IMODE(os.lstat(attempt_path).st_mode), 0o640)
+
+        fresh_dir = self.temp_dir / "fresh"
+        fresh_dir.mkdir()
+        manifest_value, attempt_value = self._write_artifacts(fresh_dir)
+        for artifact_path in (
+            Path(cast(str, manifest_value)),
+            Path(attempt_value),
+        ):
+            self.assertEqual(
+                stat.S_IMODE(os.lstat(artifact_path).st_mode) & 0o077,
+                0,
+            )
+
+    @unittest.skipUnless(os.name == "posix", "POSIX relocation is required")
+    def test_physical_replacement_never_mutates_replacement_at_any_pair_boundary(
+        self,
+    ) -> None:
+        cases = [
+            ("before_stale_recovery", None, 1),
+            ("before_stage", "conversion_attempt.json", 1),
+            ("before_stage", "conversion_manifest.json", 1),
+            ("before_backup", "conversion_attempt.json", 1),
+            ("before_backup", "conversion_manifest.json", 1),
+            ("before_commit", "conversion_attempt.json", 1),
+            ("before_commit", "conversion_manifest.json", 1),
+            ("before_durability", "conversion_attempt.json", 1),
+            ("before_durability", "conversion_manifest.json", 1),
+            ("before_sync", None, 1),
+            ("before_sync", None, 2),
+            ("before_sync", None, 3),
+            ("before_sync", None, 4),
+            ("before_cleanup", None, 1),
+            ("before_cleanup", None, 2),
+        ]
+        for index, (selected_phase, selected_name, selected_occurrence) in enumerate(
+            cases
+        ):
+            with self.subTest(
+                phase=selected_phase,
+                name=selected_name,
+                occurrence=selected_occurrence,
+            ):
+                godot_dir, _, _, _, _ = self._existing_artifacts(
+                    self.temp_dir / f"boundary-{index}"
+                )
+                artifact_directory = godot_dir / "gm2godot"
+                parked = godot_dir / "gm2godot.parked"
+                stale = artifact_directory / (
+                    ".conversion_attempt.json.stale.backup"
+                )
+                stale.write_bytes(b"owned stale backup\n")
+                outside = godot_dir / "outside-hardlink.json"
+                outside.write_bytes(b"outside hardlink sentinel\n")
+                matching_calls = 0
+                swapped = False
+                replacement_before: dict[
+                    str,
+                    tuple[int, int, int, bytes],
+                ] = {}
+
+                def replace_directory(
+                    phase: str,
+                    directory_path: str,
+                    name: str | None,
+                ) -> None:
+                    nonlocal matching_calls, replacement_before, swapped
+                    if (
+                        phase != selected_phase
+                        or name != selected_name
+                        or os.path.abspath(directory_path)
+                        != os.path.abspath(artifact_directory)
+                    ):
+                        return
+                    matching_calls += 1
+                    if matching_calls != selected_occurrence:
+                        return
+                    swapped = True
+                    os.rename(artifact_directory, parked)
+                    artifact_directory.mkdir()
+                    (
+                        artifact_directory / "conversion_attempt.json"
+                    ).write_bytes(b"replacement attempt\n")
+                    (
+                        artifact_directory / "conversion_manifest.json"
+                    ).write_bytes(b"replacement manifest\n")
+                    (artifact_directory / "sentinel.txt").write_bytes(
+                        b"replacement sentinel\n"
+                    )
+                    os.link(
+                        outside,
+                        artifact_directory
+                        / ".conversion_attempt.json.abcdefgh.backup",
+                    )
+                    replacement_before = _directory_snapshot(
+                        artifact_directory
+                    )
+
+                with (
+                    patch(
+                        "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                        side_effect=replace_directory,
+                    ),
+                    self.assertRaises(OSError),
+                ):
+                    self._write_artifacts(godot_dir)
+
+                self.assertTrue(swapped)
+                self.assertEqual(
+                    _directory_snapshot(artifact_directory),
+                    replacement_before,
+                )
+                self.assertEqual(
+                    outside.read_bytes(),
+                    b"outside hardlink sentinel\n",
+                )
+
+    @unittest.skipUnless(os.name == "posix", "POSIX relocation is required")
+    def test_rollback_and_recovery_stay_bound_after_physical_replacement(
+        self,
+    ) -> None:
+        cases = (
+            ("before_rollback", None),
+            ("before_recovery_stage", "conversion_attempt.json"),
+        )
+        for selected_phase, selected_name in cases:
+            with self.subTest(phase=selected_phase):
+                godot_dir, _, _, _, _ = self._existing_artifacts(
+                    self.temp_dir / selected_phase
+                )
+                artifact_directory = godot_dir / "gm2godot"
+                parked = godot_dir / "gm2godot.parked"
+                outside = godot_dir / "outside-hardlink.json"
+                outside.write_bytes(b"outside rollback sentinel\n")
+                swapped = False
+                replacement_before: dict[
+                    str,
+                    tuple[int, int, int, bytes],
+                ] = {}
+
+                def fail_then_replace(
+                    phase: str,
+                    directory_path: str,
+                    name: str | None,
+                ) -> None:
+                    nonlocal replacement_before, swapped
+                    if (
+                        phase == "before_commit"
+                        and name == "conversion_manifest.json"
+                    ):
+                        raise OSError("injected canonical failure")
+                    if (
+                        swapped
+                        or phase != selected_phase
+                        or name != selected_name
+                        or os.path.abspath(directory_path)
+                        != os.path.abspath(artifact_directory)
+                    ):
+                        return
+                    swapped = True
+                    os.rename(artifact_directory, parked)
+                    artifact_directory.mkdir()
+                    (
+                        artifact_directory / "conversion_attempt.json"
+                    ).write_bytes(b"replacement attempt\n")
+                    (
+                        artifact_directory / "conversion_manifest.json"
+                    ).write_bytes(b"replacement manifest\n")
+                    (artifact_directory / "sentinel.txt").write_bytes(
+                        b"replacement sentinel\n"
+                    )
+                    os.link(
+                        outside,
+                        artifact_directory
+                        / ".conversion_manifest.json.abcdefgh.recovery.backup",
+                    )
+                    replacement_before = _directory_snapshot(
+                        artifact_directory
+                    )
+
+                with (
+                    patch(
+                        "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                        side_effect=fail_then_replace,
+                    ),
+                    self.assertRaisesRegex(
+                        OSError,
+                        "injected canonical failure",
+                    ) as raised,
+                ):
+                    self._write_artifacts(godot_dir)
+
+                self.assertTrue(swapped)
+                self.assertEqual(
+                    _directory_snapshot(artifact_directory),
+                    replacement_before,
+                )
+                self.assertEqual(
+                    outside.read_bytes(),
+                    b"outside rollback sentinel\n",
+                )
+                self.assertTrue(
+                    any(
+                        "rollback also failed" in note
+                        for note in getattr(
+                            raised.exception,
+                            "__notes__",
+                            (),
+                        )
+                    )
+                )
+
+    @unittest.skipUnless(os.name == "nt", "Native Windows handles are required")
+    def test_windows_bindings_block_root_and_directory_relocation(self) -> None:
+        godot_dir, _, _, _, _ = self._existing_artifacts()
+        artifact_directory = godot_dir / "gm2godot"
+        parked_root = godot_dir.with_name("godot.parked")
+        parked_artifacts = godot_dir / "gm2godot.parked"
+        relocation_checked = False
+
+        def try_relocation(
+            phase: str,
+            _directory_path: str,
+            _name: str | None,
+        ) -> None:
+            nonlocal relocation_checked
+            if phase != "before_stage" or relocation_checked:
+                return
+            relocation_checked = True
+            with self.assertRaises(OSError):
+                os.rename(artifact_directory, parked_artifacts)
+            with self.assertRaises(OSError):
+                os.rename(godot_dir, parked_root)
+
+        with patch(
+            "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+            side_effect=try_relocation,
+        ):
+            self._write_artifacts(godot_dir)
+
+        self.assertTrue(relocation_checked)
+
+    @unittest.skipUnless(os.name == "nt", "Native Windows modes are required")
+    def test_windows_read_only_pair_is_replaced_and_rolled_back_exactly(
+        self,
+    ) -> None:
+        success_dir, success_manifest, success_attempt, manifest_before, attempt_before = (
+            self._existing_artifacts(self.temp_dir / "readonly-success")
+        )
+        for path in (success_manifest, success_attempt):
+            os.chmod(path, 0o444)
+
+        self._write_artifacts(success_dir)
+
+        self.assertNotEqual(success_manifest.read_bytes(), manifest_before)
+        self.assertNotEqual(success_attempt.read_bytes(), attempt_before)
+        for path in (success_manifest, success_attempt):
+            self.assertFalse(stat.S_IMODE(os.lstat(path).st_mode) & stat.S_IWRITE)
+
+        rollback_dir, rollback_manifest, rollback_attempt, manifest_before, attempt_before = (
+            self._existing_artifacts(self.temp_dir / "readonly-rollback")
+        )
+        for path in (rollback_manifest, rollback_attempt):
+            os.chmod(path, 0o444)
+
+        def fail_canonical_commit(
+            phase: str,
+            _directory_path: str,
+            name: str | None,
+        ) -> None:
+            if phase == "before_commit" and name == "conversion_manifest.json":
+                raise OSError("injected read-only canonical failure")
+
+        with (
+            patch(
+                "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                side_effect=fail_canonical_commit,
+            ),
+            self.assertRaisesRegex(
+                OSError,
+                "injected read-only canonical failure",
+            ),
+        ):
+            self._write_artifacts(rollback_dir)
+
+        self.assertEqual(rollback_manifest.read_bytes(), manifest_before)
+        self.assertEqual(rollback_attempt.read_bytes(), attempt_before)
+        for path in (rollback_manifest, rollback_attempt):
+            self.assertFalse(stat.S_IMODE(os.lstat(path).st_mode) & stat.S_IWRITE)
 
     def test_rejects_failed_or_cancelled_canonical_outcome_before_writing(self) -> None:
         godot_dir = self.temp_dir / "godot"
@@ -2854,6 +1827,22 @@ class TestConversionManifest(unittest.TestCase):
                 *artifact_dir.glob(".conversion_attempt.json.*.backup"),
             ]
         )
+
+
+def _directory_snapshot(
+    directory: Path,
+) -> dict[str, tuple[int, int, int, bytes]]:
+    snapshot: dict[str, tuple[int, int, int, bytes]] = {}
+    for path in sorted(directory.iterdir()):
+        path_stat = os.lstat(path)
+        content = path.read_bytes() if stat.S_ISREG(path_stat.st_mode) else b""
+        snapshot[path.name] = (
+            path_stat.st_ino,
+            path_stat.st_nlink,
+            stat.S_IMODE(path_stat.st_mode),
+            content,
+        )
+    return snapshot
 
 
 if __name__ == "__main__":

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_29(self) -> None:
-        self.assertEqual(get_version(), "0.7.29")
+    def test_release_version_is_0_7_30(self) -> None:
+        self.assertEqual(get_version(), "0.7.30")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- publish conversion attempts and canonical manifests through one retained verified-directory transaction while preserving attempt-first ordering, rollback, stale recovery, modes, receipts, and canonical digest trust
- add physical directory-replacement, hard-link sentinel, recovery, cleanup, native Windows relocation, and read-only regression coverage
- release the scoped change as 0.7.30 with the standard changelog, README, issue-template, Wiki, and version-test updates

## Test plan
- `./venv/bin/pyright --warnings`
- `./venv/bin/ruff check .`
- `./venv/bin/python -m unittest` (2212 tests, 70 skipped)
- `GODOT_BIN=/Applications/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest discover -s tests -p 'test_*_godot.py' -v` (71 tests; Godot `4.7.1.stable.official.a13da4feb`)

## Compatibility sources
Context7 discovery was unavailable after one retry. Compatibility was checked against the official GameMaker 2026.0 release notes (current IDE 16 / Runtime 23) and the official Godot 4.7.1 maintenance release (build `a13da4feb`); this change affects host-side artifact publication and does not alter GameMaker parsing or generated Godot APIs.

Closes #776