### PR TITLE
Anchor CLI static report transactions

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.30, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.31, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.31 - 2026-07-19
+
+- Anchored the four CLI static compatibility reports to one shared verified-directory byte-artifact transaction for exact snapshots, private staging, backups, deterministic ordered commits, durability barriers, rollback, cleanup, and final receipt validation.
+- Replaced destructive report-set invalidation with exact prior-byte and mode restoration after render, stage, replacement, sync, interruption, or validation failure, including portable mode preservation when descriptor chmod is unavailable.
+- Added focused failure, ordering, hard-link, physical POSIX directory-replacement, native Windows relocation, and exact Godot 4.7.1 regression coverage while preserving the stable report paths and GameMaker LTS 2026 compatibility surface.
+
 ## 0.7.30 - 2026-07-19
 
 - Anchored conversion-attempt and canonical-manifest staging, backup reads, attempt-first replacement, rollback, recovery retention, stale cleanup, durability barriers, and final receipts to one shared verified-directory byte-artifact transaction.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.30`.
+Current source version: `0.7.31`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.
@@ -212,6 +212,8 @@ python main.py validate --godot-project path/to/GodotProject --fail-on-unsupport
 You can also invoke the same headless interface directly with `python -m src.cli`.
 
 CLI reports are written under `gm2godot/` inside the selected report or Godot project directory. The diagnostic outputs are `conversion_diagnostics.json` and `conversion_diagnostics.md`; static compatibility outputs include `gml_manual_scope.md`, `gml_api_compatibility.md`, and the JSON/Markdown platform capability reports.
+
+The four static compatibility reports publish as one ordered transaction through a retained verified `gm2godot/` directory binding. Ordinary render or publication failures preserve the complete prior set with its exact modes instead of deleting it; successful return means all four new reports passed durability and final receipt validation.
 
 Every valid `convert` invocation prints exactly one terminal outcome summary after its buffered conversion logs. The diagnostic JSON report also includes a top-level `outcome` object with:
 

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.30 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.31 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.30 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.31 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.30 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.31 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -26,6 +26,8 @@ Paths below are relative to the generated Godot project unless a report director
 The JSON diagnostic entries can include `source_path`, line and column, resource and event/API context, a manifest entry, tracking issue, and workaround. Start with the first `error`, then unsupported warnings, then other warnings.
 
 The JSON/Markdown pair uses one verified report-directory binding for capture, staging, ordered replacement, rollback, invalidation and cleanup. POSIX hosts use descriptor-relative no-follow operations; Windows retains reparse-checked, no-delete-share handles and write-through moves. When an explicit external report root is missing, GM2Godot creates and durability-syncs each parent entry before descending. Ordinary failures restore the complete prior pair, but a hard crash between the two file commits is not yet pair-atomic, so keep the reports with the latest attempt evidence rather than treating either filename alone as a generation marker.
+
+The four static compatibility reports use the same retained binding as one deterministic ordered transaction. Rendering completes before publication; the transaction then snapshots and backs up every target, commits and durability-syncs each new report, and validates the complete result. An ordinary failure restores the prior bytes and modes or reports a verified recovery artifact when rollback cannot safely finish; it no longer deletes the prior set.
 
 ## Terminal outcomes
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.30 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.31 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -207,7 +207,7 @@ The exact schemas and transaction rules are defined by [`conversion_manifest.py`
 
 ### Anchored report publication confinement
 
-`architecture_policy.json` and the `conversion_diagnostics.json` / `.md` pair are staged, backed up, published, rolled back, recovered and cleaned through one destination-directory binding retained for each complete operation. Diagnostic snapshots and publication receipts bind both the report root and its exact `gm2godot/` child. An explicit external report root that does not exist is created one component at a time through its verified parent; each new directory entry crosses the parent durability barrier before creation descends further.
+`architecture_policy.json`, the `conversion_diagnostics.json` / `.md` pair, and the four CLI static compatibility reports are staged, backed up, published, rolled back, recovered and cleaned through one destination-directory binding retained for each complete operation. Diagnostic snapshots and publication receipts bind both the report root and its exact `gm2godot/` child. The static set commits `gml_manual_scope.md`, `gml_api_compatibility.md`, `platform_capability_report.json`, then `platform_capability_report.md`; ordinary failures restore every prior byte and exact mode rather than invalidating the set. An explicit external report root that does not exist is created one component at a time through its verified parent; each new directory entry crosses the parent durability barrier before creation descends further.
 
 On POSIX hosts with the required APIs, every child lookup and namespace mutation is relative to a no-follow directory descriptor and durability barriers call `fsync()` on that retained descriptor. Replacing the visible `gm2godot/` path therefore makes publication fail, but cannot redirect capture, restore, invalidation, cleanup or rollback into the replacement directory.
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.30 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.31 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.30;
+- GM2Godot 0.7.31;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.30 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.31 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 
@@ -46,7 +46,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.30`.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.31`.
 
 ## Run from source
 
@@ -133,6 +133,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.30`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.31`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.30 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.31 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.30 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.31 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-19
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -7,13 +7,13 @@ import os
 import signal
 import stat
 import sys
-import tempfile
 import threading
 from contextlib import redirect_stdout
 from dataclasses import dataclass, replace
 from types import FrameType
 from typing import Sequence, TypedDict, cast
 
+from src.conversion.anchored_artifacts import ArtifactSpec, ByteArtifactTransaction
 from src.conversion.conversion_outcome import ConversionOutcome
 from src.conversion.converter import CONVERSION_CATEGORIES, Converter
 from src.conversion.conversion_manifest import CONVERSION_MANIFEST_RELATIVE_PATH
@@ -44,6 +44,14 @@ from src.version import get_version
 
 DEFAULT_CONVERSION_GROUPS = ("assets", "project", "wip")
 _NON_CONVERTER_SETTING_KEYS = frozenset({"sound_group_folders"})
+_STATIC_REPORT_DIRECTORY = "gm2godot"
+_STATIC_REPORT_DIRECTORY_DESCRIPTION = "CLI static report directory"
+_STATIC_REPORT_FILENAMES = (
+    "gml_manual_scope.md",
+    "gml_api_compatibility.md",
+    "platform_capability_report.json",
+    "platform_capability_report.md",
+)
 
 
 class ConverterInventory(TypedDict):
@@ -1187,249 +1195,45 @@ def _print_converter_inventory(output_format: str) -> None:
 
 
 def _write_static_reports(report_dir: str, target_platform: str | None = None) -> None:
-    report_root = os.path.join(report_dir, "gm2godot")
-    report_filenames = (
-        "gml_manual_scope.md",
-        "gml_api_compatibility.md",
-        "platform_capability_report.json",
-        "platform_capability_report.md",
+    reports = (
+        (_STATIC_REPORT_FILENAMES[0], render_gml_manual_scope_markdown()),
+        (_STATIC_REPORT_FILENAMES[1], _render_api_compatibility_markdown()),
+        (
+            _STATIC_REPORT_FILENAMES[2],
+            json.dumps(
+                generate_platform_capability_report(target_platform),
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+        ),
+        (
+            _STATIC_REPORT_FILENAMES[3],
+            render_platform_capability_markdown(target_platform),
+        ),
     )
-    report_root_identity = _ensure_static_report_root(report_root)
-    try:
-        reports = (
-            (report_filenames[0], render_gml_manual_scope_markdown()),
-            (report_filenames[1], _render_api_compatibility_markdown()),
-            (
-                report_filenames[2],
-                json.dumps(
-                    generate_platform_capability_report(target_platform),
-                    indent=2,
-                    sort_keys=True,
-                )
-                + "\n",
-            ),
-            (
-                report_filenames[3],
-                render_platform_capability_markdown(target_platform),
-            ),
-        )
-    except BaseException as render_error:
-        _invalidate_static_report_set(
-            report_root,
-            report_filenames,
-            report_root_identity,
-            render_error,
-        )
-        raise
-    _publish_static_report_texts(
-        report_root,
-        reports,
-        expected_root_identity=report_root_identity,
-    )
+    _publish_static_report_texts(report_dir, reports)
 
 
 def _publish_static_report_texts(
-    report_root: str,
+    report_dir: str,
     reports: Sequence[tuple[str, str]],
-    *,
-    expected_root_identity: tuple[int, int] | None = None,
 ) -> None:
-    """Publish a complete report set or invalidate every report in the set."""
-    report_root_identity = (
-        expected_root_identity
-        if expected_root_identity is not None
-        else _ensure_static_report_root(report_root)
+    """Publish the complete report set while preserving its exact prior state."""
+    specs = tuple(
+        ArtifactSpec(filename, content.encode("utf-8"))
+        for filename, content in reports
     )
-    report_filenames = tuple(filename for filename, _content in reports)
-    staged_paths: dict[str, str] = {}
-    try:
-        _verify_static_report_root(report_root, report_root_identity)
-        existing_modes = {
-            filename: _existing_static_report_mode(
-                os.path.join(report_root, filename)
-            )
-            for filename in report_filenames
-        }
-        for filename, content in reports:
-            _verify_static_report_root(report_root, report_root_identity)
-            staged_paths[filename] = _stage_static_report_text(
-                report_root,
-                filename,
-                content,
-                existing_mode=existing_modes[filename],
-                expected_root_identity=report_root_identity,
-            )
-
-        for filename in report_filenames:
-            _verify_static_report_root(report_root, report_root_identity)
-            report_path = os.path.join(report_root, filename)
-            _existing_static_report_mode(report_path)
-            os.replace(staged_paths[filename], report_path)
-            del staged_paths[filename]
-        _verify_static_report_root(report_root, report_root_identity)
-    except BaseException as publish_error:
-        for staged_path in staged_paths.values():
-            _unlink_static_report_temp(
-                staged_path,
-                publish_error,
-                report_root=report_root,
-                expected_root_identity=report_root_identity,
-            )
-        _invalidate_static_report_set(
-            report_root,
-            report_filenames,
-            report_root_identity,
-            publish_error,
-        )
-        raise
-
-
-def _ensure_static_report_root(report_root: str) -> tuple[int, int]:
-    try:
-        report_root_stat = os.stat(report_root, follow_symlinks=False)
-    except FileNotFoundError:
-        try:
-            os.makedirs(report_root, exist_ok=True)
-        except FileExistsError:
-            pass
-        report_root_stat = os.stat(report_root, follow_symlinks=False)
-
-    is_junction = getattr(os.path, "isjunction", None)
-    redirected = stat.S_ISLNK(report_root_stat.st_mode) or (
-        callable(is_junction) and is_junction(report_root)
-    )
-    if redirected or not stat.S_ISDIR(report_root_stat.st_mode):
-        raise OSError(
-            "Refusing to use redirected or non-directory static report root: "
-            f"{report_root}"
-        )
-    return (report_root_stat.st_dev, report_root_stat.st_ino)
-
-
-def _verify_static_report_root(
-    report_root: str,
-    expected_identity: tuple[int, int],
-) -> None:
-    try:
-        report_root_stat = os.stat(report_root, follow_symlinks=False)
-    except OSError as error:
-        raise OSError(f"Static report root changed: {report_root}") from error
-    is_junction = getattr(os.path, "isjunction", None)
-    redirected = stat.S_ISLNK(report_root_stat.st_mode) or (
-        callable(is_junction) and is_junction(report_root)
-    )
-    if (
-        redirected
-        or not stat.S_ISDIR(report_root_stat.st_mode)
-        or (report_root_stat.st_dev, report_root_stat.st_ino)
-        != expected_identity
-    ):
-        raise OSError(f"Static report root changed: {report_root}")
-
-
-def _existing_static_report_mode(report_path: str) -> int | None:
-    try:
-        report_stat = os.stat(report_path, follow_symlinks=False)
-    except FileNotFoundError:
-        return None
-    if stat.S_ISREG(report_stat.st_mode):
-        return stat.S_IMODE(report_stat.st_mode)
-    if stat.S_ISLNK(report_stat.st_mode):
-        return None
-    raise OSError(f"Refusing to replace non-regular static report: {report_path}")
-
-
-def _stage_static_report_text(
-    report_root: str,
-    filename: str,
-    content: str,
-    *,
-    existing_mode: int | None,
-    expected_root_identity: tuple[int, int],
-) -> str:
-    file_descriptor, staged_path = tempfile.mkstemp(
-        dir=report_root,
-        prefix=f".{filename}.",
-        suffix=".tmp",
-    )
-    try:
-        staged_file = os.fdopen(
-            file_descriptor,
-            "w",
-            encoding="utf-8",
-            newline="",
-        )
-        file_descriptor = -1
-        with staged_file:
-            staged_file.write(content)
-            staged_file.flush()
-            fchmod = getattr(os, "fchmod", None)
-            if existing_mode is not None and callable(fchmod):
-                fchmod(staged_file.fileno(), existing_mode)
-            os.fsync(staged_file.fileno())
-        return staged_path
-    except BaseException as publish_error:
-        if file_descriptor >= 0:
-            try:
-                os.close(file_descriptor)
-            except OSError as close_error:
-                publish_error.add_note(
-                    f"Static report staging descriptor cleanup failed: {close_error}"
-                )
-        _unlink_static_report_temp(
-            staged_path,
-            publish_error,
-            report_root=report_root,
-            expected_root_identity=expected_root_identity,
-        )
-        raise
-
-
-def _unlink_static_report_temp(
-    path: str,
-    publish_error: BaseException,
-    *,
-    report_root: str | None = None,
-    expected_root_identity: tuple[int, int] | None = None,
-) -> None:
-    try:
-        if report_root is not None and expected_root_identity is not None:
-            _verify_static_report_root(report_root, expected_root_identity)
-        os.unlink(path)
-    except FileNotFoundError:
-        pass
-    except OSError as cleanup_error:
-        publish_error.add_note(
-            f"Static report temporary-file cleanup failed: {cleanup_error}"
-        )
-
-
-def _invalidate_static_report_set(
-    report_root: str,
-    filenames: Sequence[str],
-    expected_root_identity: tuple[int, int],
-    publish_error: BaseException,
-) -> None:
-    """Remove final report entries without following links or a replaced root."""
-    for filename in filenames:
-        report_path = os.path.join(report_root, filename)
-        try:
-            _verify_static_report_root(report_root, expected_root_identity)
-            report_stat = os.stat(report_path, follow_symlinks=False)
-            if not (
-                stat.S_ISREG(report_stat.st_mode)
-                or stat.S_ISLNK(report_stat.st_mode)
-            ):
-                raise OSError(
-                    f"Refusing to invalidate non-regular static report: {report_path}"
-                )
-            os.unlink(report_path)
-        except FileNotFoundError:
-            pass
-        except OSError as cleanup_error:
-            publish_error.add_note(
-                f"Static report-set invalidation failed: {cleanup_error}"
-            )
+    with ByteArtifactTransaction.open(
+        os.path.abspath(report_dir),
+        _STATIC_REPORT_DIRECTORY,
+        create=True,
+        create_root=True,
+        description=_STATIC_REPORT_DIRECTORY_DESCRIPTION,
+    ) as transaction:
+        receipts = transaction.publish_specs(specs)
+        if any(receipt is None for receipt in receipts):
+            raise AssertionError("Published static reports must all be present.")
 
 
 def _render_api_compatibility_markdown() -> str:

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.30"
+VERSION = "0.7.31"
 
 
 def get_version():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -151,6 +151,75 @@ class TestCLIReports(unittest.TestCase):
     def tearDown(self) -> None:
         shutil.rmtree(self.temp_dir)
 
+    def _write_static_report_baseline(
+        self,
+        report_root: str,
+    ) -> dict[str, tuple[bytes, int]]:
+        os.makedirs(report_root, exist_ok=True)
+        baseline: dict[str, tuple[bytes, int]] = {}
+        modes = (0o600, 0o640, 0o644, 0o660)
+        for index, (filename, mode) in enumerate(
+            zip(self._STATIC_REPORT_FILENAMES, modes, strict=True)
+        ):
+            content = f"previous static report {index}\n".encode()
+            path = os.path.join(report_root, filename)
+            with open(path, "wb") as report_file:
+                report_file.write(content)
+            os.chmod(path, mode)
+            baseline[filename] = (content, stat.S_IMODE(os.stat(path).st_mode))
+        return baseline
+
+    def _assert_static_report_baseline(
+        self,
+        report_root: str,
+        baseline: dict[str, tuple[bytes, int]],
+    ) -> None:
+        for filename, (expected_content, expected_mode) in baseline.items():
+            path = os.path.join(report_root, filename)
+            with open(path, "rb") as report_file:
+                self.assertEqual(report_file.read(), expected_content)
+            if os.name != "nt":
+                self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), expected_mode)
+
+    def _assert_no_static_report_transaction_debris(self, report_root: str) -> None:
+        self.assertFalse(
+            any(
+                entry.endswith(
+                    (".tmp", ".backup", ".recovery", ".tombstone")
+                )
+                for entry in os.listdir(report_root)
+            )
+        )
+
+    def _static_report_directory_snapshot(
+        self,
+        report_root: str,
+    ) -> dict[str, tuple[int, int, int, bytes]]:
+        snapshot: dict[str, tuple[int, int, int, bytes]] = {}
+        for entry in os.listdir(report_root):
+            path = os.path.join(report_root, entry)
+            path_stat = os.stat(path, follow_symlinks=False)
+            with open(path, "rb") as report_file:
+                content = report_file.read()
+            snapshot[entry] = (
+                path_stat.st_dev,
+                path_stat.st_ino,
+                stat.S_IMODE(path_stat.st_mode),
+                content,
+            )
+        return snapshot
+
+    def _publish_static_reports(
+        self,
+        report_dir: str,
+        target_platform: str | None = None,
+    ) -> None:
+        writer = cast(
+            Callable[[str, str | None], None],
+            getattr(cli, "_write_static_reports"),
+        )
+        writer(report_dir, target_platform)
+
     def _convert_args(self, *extra: str) -> list[str]:
         return [
             "convert",
@@ -351,19 +420,45 @@ class TestCLIReports(unittest.TestCase):
                 0o600,
             )
 
-    def test_static_report_publication_does_not_require_fchmod(self) -> None:
+    def test_static_report_modes_do_not_require_fchmod(self) -> None:
         report_dir = os.path.join(self.temp_dir, "no-fchmod-reports")
+        report_root = os.path.join(report_dir, "gm2godot")
+        baseline = self._write_static_report_baseline(report_root)
 
         with (
-            patch.object(cli.os, "fchmod", None, create=True),
+            patch(
+                "src.conversion.anchored_artifacts.os.fchmod",
+                None,
+                create=True,
+            ),
             patch.object(DiagnosticCollector, "write_reports"),
         ):
             exit_code = cli.main(["report", "--report-dir", report_dir])
 
         self.assertEqual(exit_code, 0)
-        report_root = os.path.join(report_dir, "gm2godot")
+        if os.name != "nt":
+            for filename, (_content, expected_mode) in baseline.items():
+                self.assertEqual(
+                    stat.S_IMODE(
+                        os.stat(os.path.join(report_root, filename)).st_mode
+                    ),
+                    expected_mode,
+                )
+
+        new_report_dir = os.path.join(self.temp_dir, "new-no-fchmod-reports")
+        with patch(
+            "src.conversion.anchored_artifacts.os.fchmod",
+            None,
+            create=True,
+        ):
+            self._publish_static_reports(new_report_dir)
+
+        new_report_root = os.path.join(new_report_dir, "gm2godot")
         for filename in self._STATIC_REPORT_FILENAMES:
-            self.assertTrue(os.path.isfile(os.path.join(report_root, filename)))
+            path = os.path.join(new_report_root, filename)
+            self.assertTrue(os.path.isfile(path))
+            if os.name != "nt":
+                self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), 0o600)
 
     @unittest.skipIf(os.name == "nt", "POSIX permission bits are required")
     def test_new_static_report_permissions_remain_private_under_umask(self) -> None:
@@ -382,7 +477,7 @@ class TestCLIReports(unittest.TestCase):
                 0o600,
             )
 
-    def test_static_report_replaces_symlink_without_touching_outside_file(self) -> None:
+    def test_static_report_refuses_symlink_without_touching_outside_file(self) -> None:
         report_dir = os.path.join(self.temp_dir, "symlink-reports")
         report_root = os.path.join(report_dir, "gm2godot")
         os.makedirs(report_root)
@@ -395,14 +490,12 @@ class TestCLIReports(unittest.TestCase):
         except (NotImplementedError, OSError) as error:
             self.skipTest(f"symlink creation unavailable: {error}")
 
-        exit_code = cli.main(["report", "--report-dir", report_dir])
+        with self.assertRaisesRegex(OSError, "non-regular artifact"):
+            cli.main(["report", "--report-dir", report_dir])
 
-        self.assertEqual(exit_code, 0)
-        self.assertFalse(os.path.islink(report_path))
+        self.assertTrue(os.path.islink(report_path))
         with open(outside_path, "r", encoding="utf-8") as outside_file:
             self.assertEqual(outside_file.read(), "do not overwrite\n")
-        with open(report_path, "r", encoding="utf-8") as report_file:
-            self.assertIn("GML Manual Scope Coverage", report_file.read())
 
     def test_static_report_refuses_symlink_report_root(self) -> None:
         report_dir = os.path.join(self.temp_dir, "symlink-root-reports")
@@ -415,7 +508,7 @@ class TestCLIReports(unittest.TestCase):
         except (NotImplementedError, OSError) as error:
             self.skipTest(f"symlink creation unavailable: {error}")
 
-        with self.assertRaisesRegex(OSError, "static report root"):
+        with self.assertRaisesRegex(OSError, "redirected"):
             cli.main(["report", "--report-dir", report_dir])
 
         self.assertTrue(os.path.islink(report_root))
@@ -432,7 +525,7 @@ class TestCLIReports(unittest.TestCase):
             return_value=True,
             create=True,
         ):
-            with self.assertRaisesRegex(OSError, "static report root"):
+            with self.assertRaisesRegex(OSError, "redirected"):
                 cli.main(["report", "--report-dir", report_dir])
 
         self.assertEqual(os.listdir(report_root), [])
@@ -444,7 +537,7 @@ class TestCLIReports(unittest.TestCase):
         with open(report_root, "w", encoding="utf-8") as report_root_file:
             report_root_file.write("not a report directory\n")
 
-        with self.assertRaisesRegex(OSError, "static report root"):
+        with self.assertRaises(OSError):
             cli.main(["report", "--report-dir", report_dir])
 
         with open(report_root, "r", encoding="utf-8") as report_root_file:
@@ -457,7 +550,7 @@ class TestCLIReports(unittest.TestCase):
         report_root = os.path.join(report_dir, "gm2godot")
         os.mkfifo(report_root)
 
-        with self.assertRaisesRegex(OSError, "static report root"):
+        with self.assertRaises(OSError):
             cli.main(["report", "--report-dir", report_dir])
 
         self.assertTrue(
@@ -493,23 +586,16 @@ class TestCLIReports(unittest.TestCase):
         )
         os.makedirs(non_regular_path)
 
-        with self.assertRaisesRegex(OSError, "non-regular static report"):
+        with self.assertRaisesRegex(OSError, "non-regular artifact"):
             cli.main(["report", "--report-dir", report_dir])
 
         self.assertTrue(os.path.isdir(non_regular_path))
         self.assertEqual(os.listdir(report_root), ["gml_api_compatibility.md"])
 
-    def test_static_report_renderer_failure_invalidates_previous_set(self) -> None:
+    def test_static_report_renderer_failure_preserves_previous_set(self) -> None:
         report_dir = os.path.join(self.temp_dir, "render-failure-reports")
         report_root = os.path.join(report_dir, "gm2godot")
-        os.makedirs(report_root)
-        for filename in self._STATIC_REPORT_FILENAMES:
-            with open(
-                os.path.join(report_root, filename),
-                "w",
-                encoding="utf-8",
-            ) as report_file:
-                report_file.write("previous report\n")
+        baseline = self._write_static_report_baseline(report_root)
 
         with patch(
             "src.cli._render_api_compatibility_markdown",
@@ -518,101 +604,179 @@ class TestCLIReports(unittest.TestCase):
             with self.assertRaisesRegex(OSError, "static report rendering failed"):
                 cli.main(["report", "--report-dir", report_dir])
 
-        self.assertEqual(os.listdir(report_root), [])
+        self._assert_static_report_baseline(report_root, baseline)
+        self._assert_no_static_report_transaction_debris(report_root)
 
-    def test_static_report_staging_failure_invalidates_entire_set_and_cleans_temps(
+    def test_static_report_staging_failure_preserves_previous_set_and_cleans_temps(
         self,
     ) -> None:
         report_dir = os.path.join(self.temp_dir, "stage-failure-reports")
         report_root = os.path.join(report_dir, "gm2godot")
-        os.makedirs(report_root)
-        for index, filename in enumerate(self._STATIC_REPORT_FILENAMES):
-            content = f"previous {index}\n"
-            with open(
-                os.path.join(report_root, filename),
-                "w",
-                encoding="utf-8",
-            ) as report_file:
-                report_file.write(content)
-
-        real_mkstemp = tempfile.mkstemp
-        stage_calls = 0
+        baseline = self._write_static_report_baseline(report_root)
 
         def fail_second_stage(
-            suffix: str | None = None,
-            prefix: str | None = None,
-            dir: str | os.PathLike[str] | None = None,
-            text: bool = False,
-        ) -> tuple[int, str]:
-            nonlocal stage_calls
-            if suffix == ".tmp":
-                stage_calls += 1
-                if stage_calls == 2:
-                    raise OSError("static report staging failed")
-            return real_mkstemp(
-                suffix=suffix,
-                prefix=prefix,
-                dir=dir,
-                text=text,
-            )
+            phase: str,
+            _directory_path: str,
+            name: str | None,
+        ) -> None:
+            if (
+                phase == "before_stage"
+                and name == self._STATIC_REPORT_FILENAMES[1]
+            ):
+                raise OSError("static report staging failed")
 
-        with patch("src.cli.tempfile.mkstemp", side_effect=fail_second_stage):
+        with patch(
+            "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+            side_effect=fail_second_stage,
+        ):
             with self.assertRaisesRegex(OSError, "static report staging failed"):
-                cli.main(["report", "--report-dir", report_dir])
+                self._publish_static_reports(report_dir)
 
-        self.assertEqual(os.listdir(report_root), [])
+        self._assert_static_report_baseline(report_root, baseline)
+        self._assert_no_static_report_transaction_debris(report_root)
 
-    def test_static_report_replace_failure_invalidates_entire_set_and_cleans_temps(
+    def test_static_report_commit_failure_restores_previous_set_and_modes(
         self,
     ) -> None:
-        report_dir = os.path.join(self.temp_dir, "replace-failure-reports")
+        report_dir = os.path.join(self.temp_dir, "commit-failure-reports")
         report_root = os.path.join(report_dir, "gm2godot")
-        os.makedirs(report_root)
-        for index, filename in enumerate(self._STATIC_REPORT_FILENAMES):
-            report_path = os.path.join(report_root, filename)
-            content = f"previous {index}\n"
-            mode = (0o600, 0o640, 0o644, 0o660)[index]
-            with open(report_path, "w", encoding="utf-8") as report_file:
-                report_file.write(content)
-            os.chmod(report_path, mode)
+        baseline = self._write_static_report_baseline(report_root)
 
-        failed_target = os.path.join(
-            report_root,
-            "gml_api_compatibility.md",
-        )
-        real_replace = os.replace
+        def fail_second_commit(
+            phase: str,
+            _directory_path: str,
+            name: str | None,
+        ) -> None:
+            if (
+                phase == "before_commit"
+                and name == self._STATIC_REPORT_FILENAMES[1]
+            ):
+                raise OSError("static report commit failed")
 
-        def fail_second_publish(source: str, destination: str) -> None:
-            if source.endswith(".tmp") and destination == failed_target:
-                raise OSError("static report publish failed")
-            real_replace(source, destination)
+        with patch(
+            "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+            side_effect=fail_second_commit,
+        ):
+            with self.assertRaisesRegex(OSError, "static report commit failed"):
+                self._publish_static_reports(report_dir)
 
-        with patch("src.cli.os.replace", side_effect=fail_second_publish):
-            with self.assertRaisesRegex(OSError, "static report publish failed"):
-                cli.main(["report", "--report-dir", report_dir])
+        self._assert_static_report_baseline(report_root, baseline)
+        self._assert_no_static_report_transaction_debris(report_root)
 
-        self.assertEqual(os.listdir(report_root), [])
+    def test_static_report_sync_failure_restores_previous_set(self) -> None:
+        report_dir = os.path.join(self.temp_dir, "sync-failure-reports")
+        report_root = os.path.join(report_dir, "gm2godot")
+        baseline = self._write_static_report_baseline(report_root)
 
-    def test_static_report_interrupt_after_replace_invalidates_entire_set(
+        def fail_second_sync(
+            phase: str,
+            _directory_path: str,
+            _name: str | None,
+        ) -> None:
+            if phase == (
+                "before_commit_"
+                f"{self._STATIC_REPORT_FILENAMES[1]}_durability"
+            ):
+                raise OSError("static report sync failed")
+
+        with patch(
+            "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+            side_effect=fail_second_sync,
+        ):
+            with self.assertRaisesRegex(OSError, "static report sync failed"):
+                self._publish_static_reports(report_dir)
+
+        self._assert_static_report_baseline(report_root, baseline)
+        self._assert_no_static_report_transaction_debris(report_root)
+
+    def test_static_report_interrupt_after_commit_restores_previous_set(
         self,
     ) -> None:
-        report_dir = os.path.join(self.temp_dir, "replace-interrupt-reports")
+        report_dir = os.path.join(self.temp_dir, "commit-interrupt-reports")
         report_root = os.path.join(report_dir, "gm2godot")
-        published_path = os.path.join(report_root, "gml_manual_scope.md")
-        real_replace = os.replace
+        baseline = self._write_static_report_baseline(report_root)
+        interrupted = False
 
-        def interrupt_after_publish(source: str, destination: str) -> None:
-            real_replace(source, destination)
-            if destination == published_path:
+        def interrupt_after_commit(
+            phase: str,
+            _directory_path: str,
+            name: str | None,
+        ) -> None:
+            nonlocal interrupted
+            if (
+                not interrupted
+                and phase == "after_commit"
+                and name == self._STATIC_REPORT_FILENAMES[0]
+            ):
+                interrupted = True
                 raise KeyboardInterrupt
 
-        with patch("src.cli.os.replace", side_effect=interrupt_after_publish):
+        with patch(
+            "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+            side_effect=interrupt_after_commit,
+        ):
             with self.assertRaises(KeyboardInterrupt):
-                cli.main(["report", "--report-dir", report_dir])
+                self._publish_static_reports(report_dir)
 
-        self.assertEqual(os.listdir(report_root), [])
+        self._assert_static_report_baseline(report_root, baseline)
+        self._assert_no_static_report_transaction_debris(report_root)
 
-    def test_static_report_failure_invalidates_links_without_mutating_referents(
+    def test_static_report_final_validation_failure_restores_previous_set(
+        self,
+    ) -> None:
+        report_dir = os.path.join(self.temp_dir, "validation-failure-reports")
+        report_root = os.path.join(report_dir, "gm2godot")
+        baseline = self._write_static_report_baseline(report_root)
+        real_receipt = cli.ByteArtifactTransaction.receipt
+
+        def fail_last_receipt(
+            transaction: Any,
+            name: str,
+            staged: Any,
+        ) -> Any:
+            if name == self._STATIC_REPORT_FILENAMES[-1]:
+                raise OSError("static report final validation failed")
+            return real_receipt(transaction, name, staged)
+
+        with patch.object(
+            cli.ByteArtifactTransaction,
+            "receipt",
+            new=fail_last_receipt,
+        ):
+            with self.assertRaisesRegex(
+                OSError,
+                "static report final validation failed",
+            ):
+                self._publish_static_reports(report_dir)
+
+        self._assert_static_report_baseline(report_root, baseline)
+        self._assert_no_static_report_transaction_debris(report_root)
+
+    def test_static_reports_commit_and_sync_in_declared_order(self) -> None:
+        report_dir = os.path.join(self.temp_dir, "ordered-reports")
+        commits: list[str] = []
+        durability: list[str] = []
+
+        def record_order(
+            phase: str,
+            _directory_path: str,
+            name: str | None,
+        ) -> None:
+            if phase == "before_commit" and name is not None:
+                commits.append(name)
+            if phase == "before_durability" and name is not None:
+                durability.append(name)
+
+        with patch(
+            "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+            side_effect=record_order,
+        ):
+            self._publish_static_reports(report_dir)
+
+        self.assertEqual(commits, list(self._STATIC_REPORT_FILENAMES))
+        self.assertEqual(durability, list(self._STATIC_REPORT_FILENAMES))
+
+    def test_static_report_refuses_linked_baseline_without_mutating_referents(
         self,
     ) -> None:
         report_dir = os.path.join(self.temp_dir, "linked-failure-reports")
@@ -643,18 +807,228 @@ class TestCLIReports(unittest.TestCase):
             ) as report_file:
                 report_file.write("old report\n")
 
-        with patch(
-            "src.cli.os.replace",
-            side_effect=OSError("static report publish failed"),
-        ):
-            with self.assertRaisesRegex(OSError, "static report publish failed"):
-                cli.main(["report", "--report-dir", report_dir])
+        with self.assertRaisesRegex(OSError, "non-regular artifact"):
+            self._publish_static_reports(report_dir)
 
-        self.assertEqual(os.listdir(report_root), [])
+        self.assertTrue(
+            os.path.islink(
+                os.path.join(report_root, self._STATIC_REPORT_FILENAMES[0])
+            )
+        )
+        self.assertTrue(
+            os.path.isfile(
+                os.path.join(report_root, self._STATIC_REPORT_FILENAMES[1])
+            )
+        )
         with open(symlink_referent, "r", encoding="utf-8") as outside_file:
             self.assertEqual(outside_file.read(), "symlink sentinel\n")
         with open(hardlink_referent, "r", encoding="utf-8") as outside_file:
             self.assertEqual(outside_file.read(), "hardlink sentinel\n")
+
+    @unittest.skipUnless(os.name == "posix", "POSIX directory relocation required")
+    def test_static_reports_never_mutate_physical_replacement_at_each_phase(
+        self,
+    ) -> None:
+        per_target_phases = (
+            "before_stage",
+            "before_backup",
+            "before_commit",
+            "before_durability",
+        )
+        cases = tuple(
+            (phase, filename)
+            for phase in per_target_phases
+            for filename in self._STATIC_REPORT_FILENAMES
+        ) + (
+            ("before_sync", None),
+            ("before_cleanup", None),
+        )
+
+        for index, (selected_phase, selected_name) in enumerate(cases):
+            with self.subTest(phase=selected_phase, name=selected_name):
+                report_dir = os.path.join(
+                    self.temp_dir,
+                    f"physical-replacement-{index}",
+                )
+                report_root = os.path.join(report_dir, "gm2godot")
+                parked_root = os.path.join(report_dir, "gm2godot.parked")
+                self._write_static_report_baseline(report_root)
+                swapped = False
+                replacement_before: dict[
+                    str,
+                    tuple[int, int, int, bytes],
+                ] = {}
+
+                def replace_report_directory(
+                    phase: str,
+                    directory_path: str,
+                    name: str | None,
+                ) -> None:
+                    nonlocal swapped, replacement_before
+                    if (
+                        swapped
+                        or phase != selected_phase
+                        or name != selected_name
+                        or os.path.abspath(directory_path)
+                        != os.path.abspath(report_root)
+                    ):
+                        return
+                    swapped = True
+                    os.rename(report_root, parked_root)
+                    os.makedirs(report_root)
+                    for filename in self._STATIC_REPORT_FILENAMES:
+                        with open(
+                            os.path.join(report_root, filename),
+                            "wb",
+                        ) as replacement_file:
+                            replacement_file.write(
+                                f"replacement {filename}\n".encode()
+                            )
+                    with open(
+                        os.path.join(report_root, "unrelated-sentinel.txt"),
+                        "wb",
+                    ) as sentinel_file:
+                        sentinel_file.write(b"do not mutate\n")
+                    with open(
+                        os.path.join(
+                            report_root,
+                            ".gml_manual_scope.md.collision.backup",
+                        ),
+                        "wb",
+                    ) as collision_file:
+                        collision_file.write(b"collision\n")
+                    replacement_before = self._static_report_directory_snapshot(
+                        report_root
+                    )
+
+                with (
+                    patch(
+                        "src.conversion.anchored_artifacts."
+                        "_before_anchored_artifact_phase",
+                        side_effect=replace_report_directory,
+                    ),
+                    self.assertRaises(OSError),
+                ):
+                    self._publish_static_reports(report_dir)
+
+                self.assertTrue(swapped)
+                self.assertEqual(
+                    self._static_report_directory_snapshot(report_root),
+                    replacement_before,
+                )
+
+    @unittest.skipUnless(os.name == "posix", "POSIX directory relocation required")
+    def test_static_report_rollback_stays_bound_after_physical_replacement(
+        self,
+    ) -> None:
+        report_dir = os.path.join(self.temp_dir, "rollback-replacement")
+        report_root = os.path.join(report_dir, "gm2godot")
+        parked_root = os.path.join(report_dir, "gm2godot.parked")
+        self._write_static_report_baseline(report_root)
+        publication_failed = False
+        swapped = False
+        replacement_before: dict[str, tuple[int, int, int, bytes]] = {}
+
+        def fail_then_replace_for_rollback(
+            phase: str,
+            directory_path: str,
+            name: str | None,
+        ) -> None:
+            nonlocal publication_failed, swapped, replacement_before
+            if (
+                not publication_failed
+                and phase == "after_commit"
+                and name == self._STATIC_REPORT_FILENAMES[1]
+            ):
+                publication_failed = True
+                raise OSError("static report post-commit failure")
+            if (
+                not publication_failed
+                or swapped
+                or phase != "before_rollback"
+                or os.path.abspath(directory_path)
+                != os.path.abspath(report_root)
+            ):
+                return
+            swapped = True
+            os.rename(report_root, parked_root)
+            os.makedirs(report_root)
+            for filename in self._STATIC_REPORT_FILENAMES:
+                with open(
+                    os.path.join(report_root, filename),
+                    "wb",
+                ) as replacement_file:
+                    replacement_file.write(
+                        f"rollback replacement {filename}\n".encode()
+                    )
+            with open(
+                os.path.join(report_root, "unrelated-sentinel.txt"),
+                "wb",
+            ) as sentinel_file:
+                sentinel_file.write(b"do not mutate\n")
+            replacement_before = self._static_report_directory_snapshot(
+                report_root
+            )
+
+        with (
+            patch(
+                "src.conversion.anchored_artifacts."
+                "_before_anchored_artifact_phase",
+                side_effect=fail_then_replace_for_rollback,
+            ),
+            self.assertRaisesRegex(
+                OSError,
+                "static report post-commit failure",
+            ) as raised,
+        ):
+            self._publish_static_reports(report_dir)
+
+        self.assertTrue(swapped)
+        self.assertEqual(
+            self._static_report_directory_snapshot(report_root),
+            replacement_before,
+        )
+        self.assertTrue(
+            any(
+                "verified recovery artifact preserved" in note
+                for note in getattr(raised.exception, "__notes__", ())
+            )
+        )
+
+    @unittest.skipUnless(os.name == "nt", "native Windows handles required")
+    def test_static_report_windows_binding_blocks_directory_relocation(self) -> None:
+        report_dir = os.path.join(self.temp_dir, "windows-binding")
+        report_root = os.path.join(report_dir, "gm2godot")
+        parked_root = os.path.join(report_dir, "gm2godot.parked")
+        self._write_static_report_baseline(report_root)
+        relocation_checked = False
+
+        def attempt_relocation(
+            phase: str,
+            _directory_path: str,
+            name: str | None,
+        ) -> None:
+            nonlocal relocation_checked
+            if (
+                relocation_checked
+                or phase != "before_stage"
+                or name != self._STATIC_REPORT_FILENAMES[0]
+            ):
+                return
+            relocation_checked = True
+            with self.assertRaises(OSError):
+                os.rename(report_root, parked_root)
+
+        with patch(
+            "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+            side_effect=attempt_relocation,
+        ):
+            self._publish_static_reports(report_dir)
+
+        self.assertTrue(relocation_checked)
+        self.assertFalse(os.path.exists(parked_root))
+        for filename in self._STATIC_REPORT_FILENAMES:
+            self.assertTrue(os.path.isfile(os.path.join(report_root, filename)))
 
     def test_version_flag_prints_current_version(self) -> None:
         output = io.StringIO()
@@ -926,21 +1300,28 @@ class TestCLIReports(unittest.TestCase):
         for filename in self._STATIC_REPORT_FILENAMES:
             self.assertTrue(os.path.isfile(os.path.join(static_report_root, filename)))
 
-    def test_convert_static_report_replace_failure_cleans_temp_and_fails_outcome(
+    def test_convert_static_report_commit_failure_cleans_temp_and_fails_outcome(
         self,
     ) -> None:
         outcome = _success_outcome()
-        report_dir = os.path.join(self.temp_dir, "static-replace-failure")
+        report_dir = os.path.join(self.temp_dir, "static-commit-failure")
         report_root = os.path.join(report_dir, "gm2godot")
-        failed_target = os.path.join(report_root, "gml_api_compatibility.md")
-        real_replace = os.replace
 
-        def fail_static_replace(source: str, destination: str) -> None:
-            if source.endswith(".tmp") and destination == failed_target:
-                raise OSError("static report replace failed")
-            real_replace(source, destination)
+        def fail_static_commit(
+            phase: str,
+            _directory_path: str,
+            name: str | None,
+        ) -> None:
+            if (
+                phase == "before_commit"
+                and name == self._STATIC_REPORT_FILENAMES[1]
+            ):
+                raise OSError("static report commit failed")
 
-        with patch("src.cli.os.replace", side_effect=fail_static_replace):
+        with patch(
+            "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+            side_effect=fail_static_commit,
+        ):
             exit_code, stdout, stderr = self._run_stubbed_convert(
                 _OutcomeConverterStub(outcome),
                 "--report-dir",
@@ -949,7 +1330,7 @@ class TestCLIReports(unittest.TestCase):
 
         self.assertEqual(exit_code, 1)
         self.assertIn("GM2Godot conversion outcome: failed", stdout)
-        self.assertIn("static report replace failed", stderr)
+        self.assertIn("static report commit failed", stderr)
         for filename in self._STATIC_REPORT_FILENAMES:
             self.assertFalse(os.path.lexists(os.path.join(report_root, filename)))
         self.assertFalse(

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_30(self) -> None:
-        self.assertEqual(get_version(), "0.7.30")
+    def test_release_version_is_0_7_31(self) -> None:
+        self.assertEqual(get_version(), "0.7.31")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- publish the four CLI static reports through one retained verified-directory byte-artifact transaction
- restore exact prior bytes and modes on ordinary failure while confining replacement, rollback, and cleanup across POSIX and Windows
- update release surfaces and transaction documentation for 0.7.31

## Test plan
- [x] `./venv/bin/pyright --warnings`
- [x] `./venv/bin/python -m ruff check .`
- [x] focused CLI report and version tests
- [x] `./venv/bin/python -m unittest` (2218 tests, 67 skipped)
- [x] official Godot 4.7.1 exact-version headless smoke suites
- [x] pinned GameMaker LTS 2026 SNAP and Adding conversion, validation, and boot tests

Closes #777