### PR TITLE
Bound Included Files worker submission

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.32, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.33, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.33 - 2026-07-20
+
+- Bounded unchanged-generation receipt validation and changed-generation Included Files staging to at most twice the configured worker count, so future and submission bookkeeping no longer scales with the complete source set.
+- Stopped admitting work after cancellation or the first observed terminal worker failure, then cancelled or drained only the bounded remainder while preserving the previous complete root/registry generation.
+- Added a deterministic 10,000-source window probe, failure/cancellation admission tests, cross-worker output/receipt/diagnostic equivalence coverage, and exact Godot 4.7.1 and GameMaker LTS 2026 compatibility validation.
+
 ## 0.7.32 - 2026-07-19
 
 - Published `conversion_attempt.json` and the optional canonical `conversion_manifest.json` as one recoverable generation using a durable transaction journal and persistent commit pointer while preserving both stable public paths and JSON schemas.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.32`.
+Current source version: `0.7.33`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,8 +1,8 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.32 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.33 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-07-19
+> **Last reviewed:** 2026-07-20
 
 [Home](Home) · [Quick Start Conversion](Quick-Start-Conversion) · [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting)
 
@@ -65,6 +65,8 @@ The packaged Linux GUI intentionally excludes Qt's optional TIFF image-format pl
 ## Conversion concurrency and recovery generations
 
 Only one GM2Godot converter may recover or publish Included Files for a destination project at a time. A cooperative operating-system lock rejects a second converter; retry it after the active conversion exits. If the process or machine stops during publication, the next conversion uses a durable journal and commit marker to restore the complete previous Included Files root/registry pair or finalize the complete committed pair. Do not delete transaction artifacts by hand: unknown or changed reserved-path content is deliberately preserved and rejected so GM2Godot cannot mistake user data for its own.
+
+Within one conversion, Included File receipt and copy workers use a bounded submission window of at most twice the configured worker count. Cancellation or a terminal worker failure stops further admission and preserves the prior complete generation; increasing the worker count changes throughput, not path assignment, registry receipts, or sorted diagnostics.
 
 The conversion attempt/canonical-manifest pair has its own persistent `.gm2godot-conversion.lock`, durable transaction journal, and generation pointer inside `gm2godot/`. Interruption before the pointer switch restores the complete previous pair; interruption after it verifies and finalizes the complete new pair. The stable public filenames and existing consumer schemas remain unchanged. Recovery records are size-bounded, and malformed, redirected, mounted, hard-linked, replaced, or unknown reserved state is preserved and rejected without following or deleting it.
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,8 +1,8 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.32 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.33 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-07-19
+> **Last reviewed:** 2026-07-20
 
 This page is the short contributor route map. The repository's [CONTRIBUTING.md](https://github.com/Infiland/GM2Godot/blob/main/CONTRIBUTING.md) and `AGENTS.md` remain authoritative for development rules.
 
@@ -106,6 +106,17 @@ Included Files transaction changes must retain the subprocess hard-exit recovery
 ```
 
 The publication test stops the child process at every forward transaction phase from the staged journal through commit-marker retirement, then requires recovery to select one complete generation. The two cleanup tests independently hard-exit after quarantine or removal for owned backup, staging, stable-record, and temporary-record state. Run the native Windows Included Files workflow when changing lock, move, junction, read-only, or cleanup behavior; modeled `os.name` tests are not a substitute for NTFS and Win32 coverage. Preserve the public `res://included_files/` and registry paths, reject unknown reserved-path state, and keep the documented prohibition on conversion alongside a live game or non-cooperating writer.
+
+Worker-scheduling changes must also retain the deterministic 10,000-source submission bound, changed/unchanged failure and cancellation admission checks, and cross-worker output equivalence:
+
+```bash
+./venv/bin/python -m unittest \
+  tests.test_included_files.TestIncludedFilesManagedRootTransaction.test_worker_window_bounds_ten_thousand_sources \
+  tests.test_included_files.TestIncludedFilesManagedRootTransaction.test_changed_generation_stops_admission_after_worker_failure \
+  tests.test_included_files.TestIncludedFilesManagedRootTransaction.test_unchanged_receipts_stop_admission_after_worker_failure \
+  tests.test_included_files.TestIncludedFilesManagedRootTransaction.test_cancellation_stops_worker_admission_within_window \
+  tests.test_included_files.TestIncludedFilesManagedRootTransaction.test_worker_counts_produce_identical_output_and_diagnostics
+```
 
 Conversion attempt/manifest generation changes must run both process-kill matrices on POSIX and native Windows:
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,8 +1,8 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.32 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.33 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-07-19
+> **Last reviewed:** 2026-07-20
 
 [Home](Home) · [Quick Start Conversion](Quick-Start-Conversion) · [Compatibility and Limitations](Compatibility-and-Limitations)
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,8 +1,8 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.32 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.33 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-07-19
+> **Last reviewed:** 2026-07-20
 
 [Home](Home) · [Installation](Installation) · [Quick start](Quick-Start-Conversion) · [Compatibility](Compatibility-and-Limitations) · [Diagnostics](Diagnostics-and-Troubleshooting) · [Contributing](Contributing-and-Testing)
 
@@ -53,6 +53,8 @@ GameMaker Included Files from `datafiles/` are emitted under `res://included_fil
 For relative file and buffer reads, the generated runtime checks the exact `user://gm2godot/<path>` first and then the normalized `res://included_files/<path>`. Writes target user storage. A saved user file therefore overrides its packaged default, and deleting the saved copy reveals the packaged file again. `file_exists()`, text-file reads, and `buffer_load()` share this precedence.
 
 When source paths collapse to the same packaged name, or when one normalized file path would block another file's directory, GM2Godot reserves natural names and deterministically assigns `_2`, `_3`, and later suffixes before the extension. The emitted files, asset registry, and conversion manifest use the same assignments. `GM2GD-INCLUDED-FILE-PATH-COLLISION` reports the mapping; rename these conflicts in GameMaker because normalized lookup cannot distinguish every original alias. Publication also rejects redirected or non-regular paths in the managed `included_files/` output tree instead of writing through them.
+
+Unchanged-generation receipt validation and changed-generation staging keep at most twice the configured worker count unfinished. The source plan and completed receipt map still scale with the Included File count, but queued futures and submission bookkeeping do not. Once cancellation or the first terminal worker failure is observed, GM2Godot admits no further source work, cancels pending tasks where possible, drains only the bounded running remainder, and leaves the previous public generation unchanged.
 
 `res://included_files/` and `res://gm2godot/gml_included_file_registry.gd` form one recoverable converter-owned generation. Before replacing either public path, GM2Godot durably publishes `.gm2godot-included-files-transaction.json`, which records the exact previous and staged identities, bytes, hashes, and transaction paths. After both new paths have been published and verified, it durably publishes `.gm2godot-included-files-commit.json`; the marker embeds the complete cleanup manifest so recovery remains possible if journal retirement was interrupted. At the start of the next Included Files conversion, a prepared transaction with no matching commit marker is rolled back to the complete previous pair; a transaction with the matching marker is verified as the complete new pair and its cleanup is finalized. The public `res://` paths do not change, so existing projects need no path migration.
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,8 +1,8 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.32 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.33 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-07-19
+> **Last reviewed:** 2026-07-20
 
 GM2Godot converts supported GameMaker source projects and GML into editable Godot projects. It combines asset conversion, a GML-to-GDScript transpiler, generated runtime helpers, compatibility diagnostics, and headless Godot validation. It is a migration aid, not a promise of automatic one-to-one gameplay parity.
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.32;
+- GM2Godot 0.7.33;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,8 +1,8 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.32 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.33 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-07-19
+> **Last reviewed:** 2026-07-20
 
 Use a packaged release for the desktop interface, or run from source when you also need the headless CLI. The current packaging and dependency details live in the repository's [release workflow](https://github.com/Infiland/GM2Godot/blob/main/.github/workflows/release.yml), [`requirements.txt`](https://github.com/Infiland/GM2Godot/blob/main/requirements.txt), and [native dependency-lock workflow](https://github.com/Infiland/GM2Godot/blob/main/.github/workflows/dependency-locks.yml).
 
@@ -46,7 +46,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.32`.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.33`.
 
 ## Run from source
 
@@ -133,6 +133,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.32`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.33`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,8 +1,8 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.32 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.33 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-07-19
+> **Last reviewed:** 2026-07-20
 
 This page documents the current maintainer path for a versioned release and for publishing the reviewed Wiki sources. It does not replace branch protection or repository settings.
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,8 +1,8 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.32 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.33 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-07-19
+> **Last reviewed:** 2026-07-20
 
 This guide covers a first conversion through either the desktop interface or the source CLI. GM2Godot converts source projects, so select the GameMaker project root that contains the `.yyp` file—not an exported or compiled game.
 

--- a/src/conversion/included_files.py
+++ b/src/conversion/included_files.py
@@ -11,10 +11,10 @@ import secrets
 import stat
 import sys
 import tempfile
-from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Any, BinaryIO, Callable, cast
+from typing import Any, BinaryIO, Callable, Iterable, TypeVar, cast
 
 from src.localization import get_localized
 from src.conversion.atomic_generated_text import (
@@ -84,6 +84,7 @@ _INCLUDED_FILES_COMMIT_TEMP_PREFIX = ".gm2godot-included-files-commit."
 _INCLUDED_FILES_STAGE_MARKER_NAME = ".gm2godot-included-files-stage.json"
 _INCLUDED_FILES_CLEANUP_PREFIX = ".gm2godot-included-cleanup."
 _INCLUDED_FILES_RECOVERY_FORMAT_VERSION = 1
+_INCLUDED_FILES_WORKER_WINDOW_MULTIPLIER = 2
 # Recovery records duplicate tree metadata and registry generations. A
 # representative committed record is about 2 KiB per Included File, so 16 MiB
 # accommodates roughly 8,000 files while keeping adversarial JSON object
@@ -102,6 +103,76 @@ _WINDOWS_RESERVED_RECOVERY_DEVICE_NAMES = frozenset(
     | {f"COM{suffix}" for suffix in "123456789¹²³"}
     | {f"LPT{suffix}" for suffix in "123456789¹²³"}
 )
+
+_IncludedWorkerItem = TypeVar("_IncludedWorkerItem")
+_IncludedWorkerResult = TypeVar("_IncludedWorkerResult")
+
+
+def _run_bounded_included_worker_phase(
+    items: Iterable[_IncludedWorkerItem],
+    *,
+    max_workers: int,
+    conversion_running: ConversionRunning,
+    submit: Callable[
+        [ThreadPoolExecutor, _IncludedWorkerItem],
+        Future[_IncludedWorkerResult],
+    ],
+    consume: Callable[
+        [_IncludedWorkerItem, Future[_IncludedWorkerResult]],
+        bool,
+    ],
+) -> bool:
+    """Run an Included Files phase with concurrency-proportional bookkeeping."""
+    if max_workers < 1:
+        raise ValueError("Included Files max_workers must be at least one")
+
+    window_size = max_workers * _INCLUDED_FILES_WORKER_WINDOW_MULTIPLIER
+    item_iterator = iter(items)
+    pending: dict[Future[_IncludedWorkerResult], _IncludedWorkerItem] = {}
+    input_exhausted = False
+    accepting_work = conversion_running()
+    executor = ThreadPoolExecutor(max_workers=max_workers)
+    try:
+        while accepting_work:
+            while not input_exhausted and len(pending) < window_size:
+                if not conversion_running():
+                    accepting_work = False
+                    break
+                try:
+                    item = next(item_iterator)
+                except StopIteration:
+                    input_exhausted = True
+                    break
+                pending[submit(executor, item)] = item
+
+            if not accepting_work or not pending:
+                break
+
+            done, _not_done = wait(
+                tuple(pending),
+                return_when=FIRST_COMPLETED,
+            )
+            completed = tuple(
+                (future, pending[future])
+                for future in tuple(pending)
+                if future in done
+            )
+            for future, _item in completed:
+                del pending[future]
+
+            for future, item in completed:
+                if not consume(item, future):
+                    accepting_work = False
+                    break
+                if not conversion_running():
+                    accepting_work = False
+                    break
+
+        return accepting_work and input_exhausted and not pending
+    finally:
+        for future in pending:
+            future.cancel()
+        executor.shutdown(wait=True, cancel_futures=True)
 
 
 @dataclass(frozen=True)
@@ -8373,21 +8444,33 @@ class IncludedFilesConverter(BaseConverter):
         deny_writes: bool,
     ) -> dict[str, _IncludedNoOpSourceReceipt]:
         receipts: dict[str, _IncludedNoOpSourceReceipt] = {}
-        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            futures: dict[
-                Future[_IncludedNoOpSourceReceipt],
-                _IncludedFileSource,
-            ] = {
-                executor.submit(
-                    self._capture_unchanged_source_receipt,
-                    source,
-                    deny_writes=deny_writes,
-                ): source
-                for source in sources
-            }
-            for future in as_completed(futures):
-                source = futures[future]
-                receipts[source.relative_path] = future.result()
+
+        def submit_receipt(
+            executor: ThreadPoolExecutor,
+            source: _IncludedFileSource,
+        ) -> Future[_IncludedNoOpSourceReceipt]:
+            return executor.submit(
+                self._capture_unchanged_source_receipt,
+                source,
+                deny_writes=deny_writes,
+            )
+
+        def consume_receipt(
+            source: _IncludedFileSource,
+            future: Future[_IncludedNoOpSourceReceipt],
+        ) -> bool:
+            receipts[source.relative_path] = future.result()
+            return True
+
+        phase_completed = _run_bounded_included_worker_phase(
+            sources,
+            max_workers=self.max_workers,
+            conversion_running=self.conversion_running,
+            submit=submit_receipt,
+            consume=consume_receipt,
+        )
+        if not phase_completed:
+            raise _IncludedOutputSetCancelled()
         return receipts
 
     def _revalidate_unchanged_source_bindings(
@@ -9168,61 +9251,72 @@ class IncludedFilesConverter(BaseConverter):
             processed_files = 0
             total_files = len(all_files)
             try:
-                with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-                    futures_map: dict[
-                        Future[
-                            tuple[
-                                str,
-                                bool,
-                                _IncludedCopyReceipt | None,
-                            ]
-                            | None
-                        ],
-                        str,
-                    ] = {}
-                    for source in all_files:
-                        assignment = assignments_by_source[source.relative_path]
-                        staged_output_path = os.path.join(
-                            staged_root_path,
-                            *assignment.assigned_output_path.split("/"),
-                        )
-                        future = executor.submit(
-                            self._process_file,
-                            source.filesystem_path,
-                            staged_output_path,
-                            source.relative_path,
-                            source.owner_source_path,
-                        )
-                        futures_map[future] = source.relative_path
+                def submit_copy(
+                    executor: ThreadPoolExecutor,
+                    source: _IncludedFileSource,
+                ) -> Future[
+                    tuple[str, bool, _IncludedCopyReceipt | None] | None
+                ]:
+                    assignment = assignments_by_source[source.relative_path]
+                    staged_output_path = os.path.join(
+                        staged_root_path,
+                        *assignment.assigned_output_path.split("/"),
+                    )
+                    return executor.submit(
+                        self._process_file,
+                        source.filesystem_path,
+                        staged_output_path,
+                        source.relative_path,
+                        source.owner_source_path,
+                    )
 
-                    for future in as_completed(futures_map):
-                        try:
-                            result = future.result()
-                        except BaseException as error:
-                            worker_failed = True
-                            if first_worker_error is None:
-                                first_worker_error = error
-                            continue
-                        if result is None:
-                            worker_cancelled = True
-                            continue
-                        processed_files += 1
-                        relative_path, copied, copy_receipt = result
-                        if copied:
-                            if copy_receipt is None:
-                                worker_failed = True
-                                continue
-                            successful_logical_paths.add(relative_path)
-                            copy_receipts[relative_path] = copy_receipt
-                        else:
-                            worker_failed = True
-                        if total_files:
-                            self._safe_progress(
-                                min(
-                                    99,
-                                    int((processed_files / total_files) * 99),
-                                )
+                def consume_copy(
+                    _source: _IncludedFileSource,
+                    future: Future[
+                        tuple[str, bool, _IncludedCopyReceipt | None] | None
+                    ],
+                ) -> bool:
+                    nonlocal worker_failed
+                    nonlocal worker_cancelled
+                    nonlocal first_worker_error
+                    nonlocal processed_files
+
+                    try:
+                        result = future.result()
+                    except BaseException as error:
+                        worker_failed = True
+                        if first_worker_error is None:
+                            first_worker_error = error
+                        return False
+                    if result is None:
+                        worker_cancelled = True
+                        return False
+
+                    processed_files += 1
+                    relative_path, copied, copy_receipt = result
+                    if copied and copy_receipt is not None:
+                        successful_logical_paths.add(relative_path)
+                        copy_receipts[relative_path] = copy_receipt
+                    else:
+                        worker_failed = True
+                    if total_files:
+                        self._safe_progress(
+                            min(
+                                99,
+                                int((processed_files / total_files) * 99),
                             )
+                        )
+                    return not worker_failed
+
+                phase_completed = _run_bounded_included_worker_phase(
+                    all_files,
+                    max_workers=self.max_workers,
+                    conversion_running=self.conversion_running,
+                    submit=submit_copy,
+                    consume=consume_copy,
+                )
+                if not phase_completed and not worker_failed:
+                    worker_cancelled = True
             finally:
                 self._active_output_project_path = None
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.32"
+VERSION = "0.7.33"
 
 
 def get_version():

--- a/tests/test_included_files.py
+++ b/tests/test_included_files.py
@@ -13,6 +13,7 @@ import threading
 import tracemalloc
 import unittest
 from collections.abc import Collection, Iterable, Mapping
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import replace
 from types import SimpleNamespace
 from typing import BinaryIO, Callable
@@ -7386,6 +7387,289 @@ os._exit(88)
         self.assertFalse(os.path.lexists(os.path.join(root_path, "foo_bar_2")))
         self.assertEqual(os.listdir(root_path), ["foo_bar"])
         self._assert_no_transaction_debris()
+
+    def test_worker_window_bounds_ten_thousand_sources(self) -> None:
+        max_workers = 4
+        expected_window = 2 * max_workers
+        release_workers = threading.Event()
+        window_filled = threading.Event()
+        state_lock = threading.Lock()
+        submitted = 0
+        unfinished = 0
+        max_unfinished = 0
+        tracked_futures: set[Future[int]] = set()
+        processed: list[int] = []
+        phase_results: list[bool] = []
+        phase_errors: list[BaseException] = []
+
+        def worker(item: int) -> int:
+            if not release_workers.wait(timeout=10):
+                raise TimeoutError("bounded worker release timed out")
+            return item
+
+        def submit(
+            executor: ThreadPoolExecutor,
+            item: int,
+        ) -> Future[int]:
+            nonlocal submitted
+            nonlocal unfinished
+            nonlocal max_unfinished
+
+            future = executor.submit(worker, item)
+            with state_lock:
+                submitted += 1
+                tracked_futures.add(future)
+                unfinished = sum(
+                    not tracked_future.done()
+                    for tracked_future in tracked_futures
+                )
+                max_unfinished = max(max_unfinished, unfinished)
+                if submitted == expected_window:
+                    window_filled.set()
+
+            def finished(completed_future: Future[int]) -> None:
+                nonlocal unfinished
+                with state_lock:
+                    tracked_futures.discard(completed_future)
+                    unfinished = sum(
+                        not tracked_future.done()
+                        for tracked_future in tracked_futures
+                    )
+
+            future.add_done_callback(finished)
+            return future
+
+        def consume(item: int, future: Future[int]) -> bool:
+            result = future.result()
+            if result != item:
+                raise AssertionError("bounded worker returned the wrong item")
+            processed.append(result)
+            return True
+
+        def run_phase() -> None:
+            try:
+                phase_results.append(
+                    included_files_module._run_bounded_included_worker_phase(
+                        range(10_000),
+                        max_workers=max_workers,
+                        conversion_running=lambda: True,
+                        submit=submit,
+                        consume=consume,
+                    )
+                )
+            except BaseException as error:
+                phase_errors.append(error)
+
+        phase_thread = threading.Thread(target=run_phase)
+        phase_thread.start()
+        try:
+            self.assertTrue(window_filled.wait(timeout=5))
+            with state_lock:
+                self.assertEqual(submitted, expected_window)
+                self.assertEqual(unfinished, expected_window)
+                self.assertEqual(max_unfinished, expected_window)
+        finally:
+            release_workers.set()
+            phase_thread.join(timeout=15)
+
+        self.assertFalse(phase_thread.is_alive())
+        self.assertEqual(phase_errors, [])
+        self.assertEqual(phase_results, [True])
+        self.assertEqual(submitted, 10_000)
+        self.assertEqual(sorted(processed), list(range(10_000)))
+        self.assertLessEqual(max_unfinished, expected_window)
+
+    def test_changed_generation_stops_admission_after_worker_failure(self) -> None:
+        converter = self._converter(max_workers=1)
+        self._write("old.txt", "old")
+        converter.convert_all()
+        previous_pair = self._pair_snapshot()
+        os.unlink(os.path.join(self.datafiles_dir, "old.txt"))
+        for index in range(20):
+            self._write(f"{index:02}.txt", str(index))
+        original_process = converter._process_file
+        started: list[str] = []
+
+        def fail_first(
+            gm_file_path: str,
+            godot_file_path: str,
+            relative_path: str,
+            owner_source_path: str,
+        ) -> tuple[str, bool, object | None] | None:
+            started.append(relative_path)
+            if relative_path == "00.txt":
+                return relative_path, False, None
+            return original_process(
+                gm_file_path,
+                godot_file_path,
+                relative_path,
+                owner_source_path,
+            )
+
+        with patch.object(
+            converter,
+            "_process_file",
+            side_effect=fail_first,
+        ):
+            with self.assertRaisesRegex(OSError, "output-set staging failed"):
+                converter.convert_all()
+
+        self.assertEqual(started[0], "00.txt")
+        self.assertLessEqual(len(started), 2)
+        self.assertEqual(self._pair_snapshot(), previous_pair)
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(requested=20, executed=20, failed=20),
+        )
+        self._assert_no_transaction_debris()
+
+    def test_unchanged_receipts_stop_admission_after_worker_failure(self) -> None:
+        converter = self._converter(max_workers=1)
+        for index in range(20):
+            self._write(f"{index:02}.txt", str(index))
+        converter.convert_all()
+        previous_pair = self._pair_snapshot()
+        original_capture = converter._capture_unchanged_source_receipt
+        started: list[str] = []
+
+        def fail_first(
+            source: included_files_module._IncludedFileSource,
+            *,
+            deny_writes: bool,
+        ) -> included_files_module._IncludedNoOpSourceReceipt:
+            started.append(source.relative_path)
+            if source.relative_path == "00.txt":
+                raise OSError("injected receipt failure")
+            return original_capture(source, deny_writes=deny_writes)
+
+        with patch.object(
+            converter,
+            "_capture_unchanged_source_receipt",
+            side_effect=fail_first,
+        ):
+            with self.assertRaisesRegex(OSError, "injected receipt failure"):
+                converter.convert_all()
+
+        self.assertEqual(started[0], "00.txt")
+        self.assertLessEqual(len(started), 2)
+        self.assertEqual(self._pair_snapshot(), previous_pair)
+        self._assert_no_transaction_debris()
+
+    def test_cancellation_stops_worker_admission_within_window(self) -> None:
+        converter = self._converter(max_workers=2)
+        self._write("old.txt", "old")
+        converter.convert_all()
+        previous_pair = self._pair_snapshot()
+        os.unlink(os.path.join(self.datafiles_dir, "old.txt"))
+        for index in range(20):
+            self._write(f"{index:02}.txt", str(index))
+        original_process = converter._process_file
+        started: list[str] = []
+        started_lock = threading.Lock()
+        cancellation_observed = threading.Event()
+
+        def cancel_first(
+            gm_file_path: str,
+            godot_file_path: str,
+            relative_path: str,
+            owner_source_path: str,
+        ) -> tuple[str, bool, object | None] | None:
+            with started_lock:
+                started.append(relative_path)
+            if relative_path == "00.txt":
+                self.running.clear()
+                cancellation_observed.set()
+                return None
+            if not cancellation_observed.wait(timeout=5):
+                raise TimeoutError("worker cancellation was not observed")
+            return original_process(
+                gm_file_path,
+                godot_file_path,
+                relative_path,
+                owner_source_path,
+            )
+
+        with patch.object(
+            converter,
+            "_process_file",
+            side_effect=cancel_first,
+        ):
+            converter.convert_all()
+
+        self.assertGreaterEqual(len(started), 1)
+        self.assertLessEqual(len(started), 4)
+        self.assertEqual(self._pair_snapshot(), previous_pair)
+        self.assertEqual(
+            converter.conversion_step_result(
+                finalize_unfinished_as=None,
+            ).resources,
+            ConversionCounts(requested=20, executed=0, skipped=20),
+        )
+        self.assertTrue(converter.conversion_step_result().cancelled)
+        self._assert_no_transaction_debris()
+
+    def test_worker_counts_produce_identical_output_and_diagnostics(self) -> None:
+        for index in range(12):
+            self._write(f"nested/{index:02}.txt", f"payload {index}")
+        self._write("Alpha Beta.txt", "first collision")
+        self._write("alpha_beta.txt", "second collision")
+        second_godot_dir = tempfile.mkdtemp()
+        self.addCleanup(
+            shutil.rmtree,
+            second_godot_dir,
+            onexc=self._retry_windows_read_only_cleanup,
+        )
+
+        def convert_with_workers(
+            godot_path: str,
+            max_workers: int,
+        ) -> tuple[tuple[tuple[str, bytes], ...], bytes, str]:
+            diagnostics = DiagnosticCollector()
+            IncludedFilesConverter(
+                self.gm_dir,
+                godot_path,
+                log_callback=lambda _message: None,
+                progress_callback=lambda _value: None,
+                conversion_running=lambda: True,
+                max_workers=max_workers,
+                diagnostics=diagnostics,
+            ).convert_all()
+            root_path = os.path.join(godot_path, "included_files")
+            files: list[tuple[str, bytes]] = []
+            for directory, _subdirectories, filenames in os.walk(root_path):
+                for filename in filenames:
+                    path = os.path.join(directory, filename)
+                    relative_path = os.path.relpath(path, root_path).replace(
+                        os.sep,
+                        "/",
+                    )
+                    with open(path, "rb") as output_file:
+                        files.append((relative_path, output_file.read()))
+            with open(
+                os.path.join(
+                    godot_path,
+                    INCLUDED_FILE_REGISTRY_RELATIVE_PATH,
+                ),
+                "rb",
+            ) as registry_file:
+                registry_content = registry_file.read()
+            return (
+                tuple(sorted(files)),
+                registry_content,
+                diagnostics.to_json(),
+            )
+
+        single_worker = convert_with_workers(self.godot_dir, 1)
+        four_workers = convert_with_workers(second_godot_dir, 4)
+
+        self.assertEqual(single_worker, four_workers)
+        self._assert_no_transaction_debris()
+        self.assertEqual(
+            _included_files_transaction_debris(second_godot_dir),
+            (),
+        )
 
     def test_worker_failure_preserves_previous_pair_and_fails_all_files(self) -> None:
         converter = self._converter(max_workers=1)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_32(self) -> None:
-        self.assertEqual(get_version(), "0.7.32")
+    def test_release_version_is_0_7_33(self) -> None:
+        self.assertEqual(get_version(), "0.7.33")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- bound unchanged receipt and changed-generation copy submission to at most twice the configured worker count
- stop admission on cancellation or the first terminal worker failure while preserving the prior complete generation
- add deterministic scaling, rollback, equivalence, documentation, and 0.7.33 release coverage

## Test plan
- [x] `./venv/bin/pyright --warnings`
- [x] `./venv/bin/ruff check .`
- [x] `./venv/bin/python -m unittest` (2,234 tests, 71 skipped)
- [x] `./venv/bin/python -m unittest tests.test_included_files`
- [x] exact `4.7.1.stable.official.a13da4feb` Included Files Godot smoke tests
- [x] documentation health and version-surface tests

Closes #769