### PR TITLE
Complete GameMaker shader semantics beyond paired stages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 
-# Preserve the licensed upstream fixture byte-for-byte, including trailing spaces.
+# Preserve licensed upstream fixtures byte-for-byte, including trailing spaces.
 tests/fixtures/real_world/snap/SnapBufferReadYAML.gml whitespace=-trailing-space
+tests/fixtures/shader_corpus/tcc_wave/tcc_wave.fsh whitespace=-trailing-space

--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.47, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.48, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.48 - 2026-07-22
+
+- Replaced heuristic shader substitutions with a tokenized GameMaker GLSL ES declaration parser that handles multi-line, array, and comma-separated attributes, varyings, uniforms, constants, and precision declarations before merging paired stages.
+- Mapped supported 2D position, colour, texture-coordinate, base-texture, varying, and world/view/projection semantics to Godot 4.7.1 CanvasItem shaders while retaining custom uniforms instead of guessing time semantics.
+- Added source-linked fail-closed diagnostics and failed-resource accounting for unsupported attributes, matrix/clip-space paths, scalar matrix constructors, Godot built-in name collisions, preprocessor directives, conflicting declarations/functions, and unlinked varyings, plus a provenance-pinned real shader corpus compiled and loaded by exact Godot 4.7.1.
+
 ## 0.7.47 - 2026-07-22
 
 - Converted supported authored GameMaker sprite, instance, audio, text, nested-sequence, and audio-effect tracks into deterministic managed sequence descriptors with ordered asset/parameter keys, assign/linear interpolation, transforms, playback speed modes, draw order, and nested runtime evaluation.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Version 0.7.46 converts authored GameMaker particle systems into stable `.tres` 
 
 Version 0.7.47 converts supported authored sequence asset and parameter tracks into managed `.tres` descriptors and deterministic runtime nodes. Sprite, instance, audio, text, nested-sequence, mapped audio-effect, moment, and broadcast keys preserve playback speed modes, assign/linear interpolation, transforms, draw/action order, and nesting; timeline moment GML runs in frame order without skipped intermediate moments. Unsupported track/key/effect/action types produce source-linked partial-conversion diagnostics instead of being dropped.
 
+Version 0.7.48 parses paired GameMaker GLSL ES shader stages before generating one Godot CanvasItem shader. The supported 2D subset maps `in_Position`, `in_Colour`/`in_Colour0`, `in_TextureCoord`, varyings, custom uniforms and arrays, `gm_BaseTexture`, and fixed world/view/projection matrix constants. Multi-line and comma-separated declarations are normalized without regex-only inference. Custom/normal vertex attributes, unsupported clip-space or 3D transforms, preprocessor directives, stage conflicts, and unlinked varyings fail the logical shader resource with source-linked diagnostics instead of publishing plausible but incorrect output.
+
 ## What GM2Godot Is and Isn't
 
 **GM2Godot is:**
@@ -63,7 +65,7 @@ Version 0.7.47 converts supported authored sequence asset and parameter tracks i
 **GM2Godot isn't:**
 - A perfect 1:1 conversion tool
 - A complete implementation of every current GameMaker GML Code and GML Reference page yet
-- A guarantee that converted gameplay semantics match GameMaker without manual review, especially for unsupported platform services, runtime-authored masks or sequence tracks, sequence animation-curve/clip-mask keys, advanced particle modifiers, Godot physics fixtures, shaders, and target-specific runtime APIs
+- A guarantee that converted gameplay semantics match GameMaker without manual review, especially for unsupported platform services, runtime-authored masks or sequence tracks, sequence animation-curve/clip-mask keys, advanced particle modifiers, Godot physics fixtures, custom/3D/macro-driven or multi-pass shaders, and target-specific runtime APIs
 - A tool for converting compiled GM projects (use [UndertaleToolMod](https://github.com/UnderminersTeam/UndertaleModTool) instead)
 
 ## Compatibility Todo List
@@ -72,7 +74,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.47`.
+Current source version: `0.7.48`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.47 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.48 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-22
 
@@ -90,6 +90,8 @@ Version 0.7.46 implements #706 only. Authored GameMaker particle assets now prod
 
 Version 0.7.47 implements #707 only. Supported authored sprite, instance, audio, text, nested-sequence, mapped audio-effect, moment, and broadcast tracks now produce managed descriptors and deterministic runtime evaluation. Length, frames-per-second or frames-per-game-frame speed, assign/linear interpolation, transforms, top-to-bottom draw order, eager object creation, nested playback, same-frame moment-before-broadcast order, broadcast `event_data`, and crossed legacy timeline GML moments are covered under exact Godot 4.7.1. Unsupported track/key/effect/action types emit `GM2GD-SEQUENCE-TRACK-UNSUPPORTED`, `GM2GD-SEQUENCE-KEY-UNSUPPORTED`, `GM2GD-SEQUENCE-EFFECT-UNSUPPORTED`, or `GM2GD-TIMELINE-ACTION-UNSUPPORTED` against the source field and make that resource partial. Animation-curve keys, clip masks/groups, particle sequence tracks, sequence lifecycle event bindings, runtime track/key authoring, object-track overrides, unmapped text/audio effects, and #708 shader semantics are not implied.
 
+Version 0.7.48 implements #708 only. Paired GameMaker GLSL ES stages are tokenized before their declarations and functions share one Godot scope. The supported 2D CanvasItem path maps `in_Position` to local `VERTEX` with a zero Z component, `in_Colour`/`in_Colour0` to vertex `COLOR`, `in_TextureCoord` to `UV`, `gm_BaseTexture` to `TEXTURE`, and fixed world/view/projection constants to `MODEL_MATRIX`, `CANVAS_MATRIX`, and `SCREEN_MATRIX`. A standard GameMaker clip transform is lowered back to local `VERTEX` so Godot applies its transform once. Matching varyings, custom uniforms, constants, fixed one-dimensional arrays, precision qualifiers, and multi-line/comma-separated declarations are supported. Custom or normal vertex attributes, extra colour/texture-coordinate streams, dynamic matrices, arbitrary clip-space/3D transforms, global mutable state, preprocessor directives, conflicting stage declarations/functions, and unlinked fragment varyings emit source-linked `GM2GD-SHADER-*` diagnostics and fail that logical shader resource without publishing output. Full GLSL ES, custom vertex-buffer binding, multi-pass effects, renderer-state parity, and visual equivalence remain non-goals.
+
 These locks serialize cooperating GM2Godot publishers; they do not authorize conversion while the generated game or another non-cooperating process is using the destination. A running Godot process does not participate and may retain open files or startup-established content verification. Close the game and any editor operation that is actively loading generated outputs, let conversion or recovery finish, and reopen it afterward. Stable public paths preserve existing `res://included_files/`, attempt-ledger, and canonical-manifest references across recovered generations.
 
 ## Known limitation areas
@@ -98,7 +100,7 @@ The following areas require especially careful manual review. This list is inten
 
 - Exact GameMaker value, coercion, lookup, lifecycle, and event-order edge cases can differ from GDScript and Godot callbacks.
 - Imported static/per-frame precise sprite masks are supported by the generated compatibility runtime; runtime-authored masks, `mask_index`, skeletal/tile masks, and GameMaker physics fixtures are not guaranteed to match Godot physics.
-- Shader translation, surfaces, GPU/draw state, cameras, the application surface, GUI scaling, and render ordering can need manual Godot work.
+- Supported 2D shader inputs and transforms convert with fail-closed diagnostics, but custom vertex streams, 3D/clip-space logic, macros, multi-pass effects, surfaces, GPU/draw state, cameras, the application surface, GUI scaling, and render ordering still need manual Godot work and visual review.
 - Authored particle assets and room elements convert through the documented approximation; advanced particle modifiers, dynamic particle APIs, room/layer mutation, tilemaps, texture groups, sequences, timelines, animation curves, and dynamic asset APIs still have partial or metadata-only areas.
 - Audio groups, streaming/compression, positional audio, async payload timing, networking, and filesystem sandbox behavior can vary by target.
 - Native extensions, marketplace SDKs, Steam, IAP, cloud, push, console, browser, and mobile services require explicit Godot plugins, permissions, or project-specific bridges; metadata and stubs are not working SDK integrations.

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.47 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.48 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-22
 
@@ -151,6 +151,20 @@ Included Files tree-traversal changes must retain the deterministic depth probe 
 ```
 
 The depth probe exercises 25, 50, 100, and 200 nested directories, requires at most `16 * depth + 64` binding checks, and limits each doubling to 2.25x work. Run the native Windows Included Files workflow for path-fallback and junction coverage; POSIX-only descriptor results do not substitute for the Windows path.
+
+Shader translation changes must run the token/declaration, converter outcome, stale-output, real-corpus, and exact Godot load coverage:
+
+```bash
+GODOT_BIN=/path/to/Godot-4.7.1 \
+  ./venv/bin/python -m unittest \
+  tests.test_shader_translation \
+  tests.test_shaders \
+  tests.test_shaders_godot \
+  tests.test_stale_managed_output_invalidation \
+  tests.test_resource_matrix_godot
+```
+
+Keep `tests/fixtures/shader_corpus/manifest.json` provenance and SHA-256 values pinned. Every supported corpus pair must produce one collision-safe `.gdshader` and load under `4.7.1.stable.official.a13da4feb`. Every unsupported construct must retain a source-linked `GM2GD-SHADER-*` diagnostic and failed logical-resource count without a placeholder output. Do not replace parser coverage with regex substitutions or broaden a bounded 2D mapping into guessed custom vertex-buffer, 3D, macro, multi-pass, or renderer-state semantics.
 
 Authored sequence/timeline changes must run their descriptor, registry, runtime-segment, API-manifest, generated timeline GML, and exact Godot playback/order coverage:
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.47 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.48 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-22
 
@@ -26,6 +26,8 @@ Paths below are relative to the generated Godot project unless a report director
 The JSON diagnostic entries can include `source_path`, line and column, resource and event/API context, a manifest entry, tracking issue, and workaround. Start with the first `error`, then unsupported warnings, then other warnings.
 
 For authored sequences and timelines, `GM2GD-SEQUENCE-TRACK-UNSUPPORTED`, `GM2GD-SEQUENCE-KEY-UNSUPPORTED`, `GM2GD-SEQUENCE-EFFECT-UNSUPPORTED`, and `GM2GD-TIMELINE-ACTION-UNSUPPORTED` identify the exact `.yy` track/key/effect/action path that was deliberately omitted. The affected sequence or timeline is recorded as skipped in an otherwise usable partial conversion; supported sibling tracks remain in its descriptor. Do not hand-edit the generated descriptor to remove the warning—change the authored asset or add a tested converter/runtime mapping.
+
+For shaders, `GM2GD-SHADER-*` identifies the exact `.vsh` or `.fsh` line/column, stage, construct, resource, and workaround that prevented safe translation. Unsupported attributes, position/matrix paths, declarations, directives, function conflicts, or varying links fail that logical shader and produce no `.gdshader`; the overall completed conversion is `partial` and a successful rerun removes any prior managed shader/registry row. Fix the GameMaker source to the documented 2D subset or port the pair manually outside managed output. Do not copy an older generated shader back into `res://shaders/`.
 
 The JSON/Markdown pair uses one verified report-directory binding for capture, staging, ordered replacement, rollback, invalidation and cleanup. POSIX hosts use descriptor-relative no-follow operations; Windows retains reparse-checked, no-delete-share handles and write-through moves. When an explicit external report root is missing, GM2Godot creates and durability-syncs each parent entry before descending. Ordinary failures restore the complete prior pair, but a hard crash between the two file commits is not yet pair-atomic, so keep the reports with the latest attempt evidence rather than treating either filename alone as a generation marker.
 
@@ -137,6 +139,7 @@ With a binary available, validation asks Godot to import supported asset types a
 | Preflight exits `2` and no managed generation was published | Use a missing or empty destination, or a valid existing Godot project with a regular `project.godot`. GM2Godot refuses a non-empty non-project directory and unsafe redirected or conflicting managed-output paths. Recovery and lock acquisition precede preflight, so the persistent private lock/workspace parent may be initialized, but no attempt, canonical report, or managed project file is published. |
 | “No `.yyp` found” or the wrong project is analyzed | Pass the GameMaker project root that directly contains the `.yyp`. The GUI rejects multiple `.yyp` files; `analyze` warns about them, while headless project readers select the sorted first valid candidate. Separating projects is safer. |
 | Outcome is `partial` | Read `outcome.resources`, the ordered `steps` ledger, and warning/error rows in `conversion_diagnostics.json`. Search the generated compatibility reports for the affected API or resource family before choosing `--allow-partial`. |
+| A shader has no generated `.gdshader` | Filter diagnostics for `GM2GD-SHADER-`. Use its `source_path`, line/column, `event` stage, `manifest_entry` construct, and workaround. Custom/normal vertex streams, arbitrary clip-space/3D transforms, macros, mutable globals, and conflicting stage declarations require source simplification or a manual Godot shader. |
 | Unsupported GML call or extension | Use the diagnostic's `api`, `manifest_entry`, `issue_number`, and `workaround`. Native extensions and service SDKs need a reviewed Godot addon/GDExtension or explicit local mapping; a generated stub is not a working native integration. |
 | Runtime says a custom Godot `Callable` lacks explicit receiver metadata | Do not add or remove guessed arguments. Use a transpiled GML function/method or the generated script registry path so GM2Godot can preserve the receiver contract. If converter-generated output reaches this error without hand edits or an extension bridge, report the minimal GML source and generated call site. |
 | Godot validation is `skipped` | Fix `--godot-bin`/`GODOT_BIN`, check executable permissions, and confirm `--version` reports the official 4.7.1 build. |

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.47 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.48 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-22
 
@@ -136,6 +136,14 @@ Disabled converters retain the prior byte-, mode-, and digest-exact inventory by
 Version 0.7.47 adds each generated sequence descriptor `.tres` as the required private output of its logical sequence resource under the `asset_registry` owner. A removed, rejected, or partial sequence therefore cannot leave an earlier descriptor masquerading as current output; supported partial descriptors are regenerated with their source-linked unsupported-type diagnostics.
 
 The source-of-truth policy follows GameMaker LTS 2026's official [Project Format](https://manual.gamemaker.io/lts/en/Additional_Information/Project_Format.htm): the root YYP describes project resources, while each YY describes one resource and its associated files. Shader ownership follows the LTS [Shader Editor](https://manual.gamemaker.io/lts/en/The_Asset_Editors/Shaders.htm) two-stage asset model, and timeline action ownership follows the LTS [Timeline Editor](https://manual.gamemaker.io/lts/en/The_Asset_Editors/Timelines.htm) moment/code model. Validation uses Godot 4.7's documented [`--import`](https://docs.godotengine.org/en/4.7/tutorials/editor/command_line_tutorial.html) scan and [import process](https://docs.godotengine.org/en/4.7/tutorials/assets_pipeline/import_process.html), under which project assets are rescanned from files while imported cache state lives under `.godot/` and can be regenerated.
+
+### Shader translation boundary
+
+Version 0.7.48 parses both GameMaker GLSL ES stages into declarations and function spans before generating one `shader_type canvas_item` resource. GameMaker's standard 2D vertex inputs map to Godot processing inputs: `in_Position` becomes `vec3(VERTEX, 0.0)`, `in_Colour`/`in_Colour0` becomes vertex `COLOR`, and `in_TextureCoord` becomes `UV`. The converter removes the GameMaker world/view/projection prefix from supported `gl_Position` assignments and writes the resulting local XY value to `VERTEX`; Godot then applies `MODEL_MATRIX`, `CANVAS_MATRIX`, and `SCREEN_MATRIX` exactly once. Other fixed `gm_Matrices` accesses map to those matrices or their documented products. Fragment `gm_BaseTexture`, `texture2D`, and `gl_FragColor` map to `TEXTURE`, `texture`, and `COLOR`.
+
+Matching varyings and shared uniforms are emitted once. Fixed one-dimensional arrays, constants, precision qualifiers, and multi-line/comma-separated global declarations are normalized into unambiguous declarations. A conflict, Godot built-in name collision, unsupported scalar matrix constructor, unsupported attribute or matrix, arbitrary clip-space/3D transform, preprocessor directive, mutable global, or unlinked fragment varying produces a source-line `GM2GD-SHADER-*` diagnostic, fails the shader resource, and publishes no `.gdshader`; a committed partial rerun therefore cannot retain the old managed shader or registry row. The supported corpus is compiled and loaded under exact Godot `4.7.1.stable.official.a13da4feb`. Custom vertex formats, macro expansion, multi-pass effects, renderer state, and visual parity still require manual Godot work.
+
+The mapping boundary follows the official GameMaker LTS [shader guide](https://manual.gamemaker.io/lts/en/Additional_Information/Guide_To_Using_Shaders.htm), [built-in shader constants](https://manual.gamemaker.io/lts/en/GameMaker_Language/GML_Reference/Asset_Management/Shaders/Shader_Constants.htm), and [vertex-format mapping](https://manual.gamemaker.io/lts/en/Additional_Information/Guide_To_Primitives_And_Vertex_Building.htm), together with Godot 4.7's [CanvasItem built-ins](https://docs.godotengine.org/en/4.7/tutorials/shaders/shader_reference/canvas_item_shader.html), [GLSL conversion guidance](https://docs.godotengine.org/en/4.7/tutorials/shaders/converting_glsl_to_godot_shaders.html), and [shading-language declaration/array/varying rules](https://docs.godotengine.org/en/4.7/tutorials/shaders/shader_reference/shading_language.html).
 
 `Converter.convert()` is the direct-library contract used by the GUI worker and CLI. A cooperative `conversion_running` flag cleared during converter/finalizer/validation work, or during recovery before new work begins, yields `cancelled` only before publication and leaves the verified prior generation public. Once publication starts, cancellation is deferred until the old-or-new decision and cannot relabel a committed generation. Exceptions expose `last_outcome`, but public trust comes from the canonical evidence plus any recovery artifact—not from return-versus-exception alone.
 
@@ -367,7 +375,7 @@ Use the full mapping, platform-hook, and callback-schema contract in [`extension
 | Runtime-authored collision masks | Imported static and per-frame precise sprite masks are generated exactly within the documented complexity bound; runtime mask mutation, `mask_index`, skeletal/tile masks, and physics fixtures still need project-specific review. |
 | Advanced particle behavior | Authored systems and room elements instantiate managed emitters, but legacy field modifiers and engine-specific distribution, timing, wiggle, flipbook, and secondary-spawn details need diagnostics-guided visual review. |
 | Persistent rooms | Persistent instances are carried across room changes, but full persistent room state is not retained. |
-| Shaders and GPU state | GameMaker GLSL ES and Godot shader language/state do not map one-to-one; generated output needs visual review. |
+| Shaders and GPU state | Supported 2D attributes, varyings, uniforms, base-texture sampling, and matrix transforms compile under exact Godot 4.7.1; custom vertex streams, macros, 3D/clip-space logic, multi-pass effects, GPU state, and visual parity remain manual review areas. |
 | Native extensions and platform services | Closed binaries, entitlements, permissions and SDK initialization require explicit reviewed Godot integrations. |
 | `game_end` | Maps to `SceneTree.quit()`; platform-specific close prompts and window behavior are not emulated. |
 | Custom Godot callbacks/signals | Only generated manager queues participate in the GameMaker ordering contract. Direct custom callbacks can observe a different order. |

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.47 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.48 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-22
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.47;
+- GM2Godot 0.7.48;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.47 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.48 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-22
 
@@ -46,7 +46,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.47`.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.48`.
 
 ## Run from source
 
@@ -133,6 +133,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.47`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.48`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.47 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.48 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-22
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.47 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.48 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-22
 

--- a/src/conversion/shader_translation.py
+++ b/src/conversion/shader_translation.py
@@ -1,0 +1,1717 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, TypeAlias
+
+
+ShaderStage: TypeAlias = Literal["vertex", "fragment"]
+
+_STORAGE_QUALIFIERS = frozenset(
+    {"attribute", "const", "in", "out", "uniform", "varying"}
+)
+_PRECISION_QUALIFIERS = frozenset({"lowp", "mediump", "highp"})
+_SUPPORTED_TYPES = frozenset(
+    {
+        "bool",
+        "bvec2",
+        "bvec3",
+        "bvec4",
+        "float",
+        "int",
+        "ivec2",
+        "ivec3",
+        "ivec4",
+        "mat2",
+        "mat3",
+        "mat4",
+        "sampler2D",
+        "samplerCube",
+        "uint",
+        "uvec2",
+        "uvec3",
+        "uvec4",
+        "vec2",
+        "vec3",
+        "vec4",
+    }
+)
+_MATRIX_REPLACEMENTS = {
+    "MATRIX_WORLD": "MODEL_MATRIX",
+    "MATRIX_VIEW": "CANVAS_MATRIX",
+    "MATRIX_PROJECTION": "SCREEN_MATRIX",
+    "MATRIX_WORLD_VIEW": "(CANVAS_MATRIX * MODEL_MATRIX)",
+    "MATRIX_WORLD_VIEW_PROJECTION": (
+        "(SCREEN_MATRIX * CANVAS_MATRIX * MODEL_MATRIX)"
+    ),
+}
+_GODOT_RESERVED_GLOBAL_NAMES = frozenset(
+    {
+        "AT_LIGHT_PASS",
+        "CANVAS_MATRIX",
+        "COLOR",
+        "CUSTOM0",
+        "CUSTOM1",
+        "E",
+        "FRAGCOORD",
+        "INSTANCE_CUSTOM",
+        "INSTANCE_ID",
+        "MODEL_MATRIX",
+        "NORMAL",
+        "NORMAL_TEXTURE",
+        "PI",
+        "POINT_COORD",
+        "POINT_SIZE",
+        "REGION_RECT",
+        "SCREEN_MATRIX",
+        "SCREEN_PIXEL_SIZE",
+        "SCREEN_UV",
+        "TAU",
+        "TEXTURE",
+        "TEXTURE_PIXEL_SIZE",
+        "TIME",
+        "UV",
+        "VERTEX",
+        "VERTEX_ID",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ShaderStageSource:
+    stage: ShaderStage
+    source: str
+
+
+@dataclass(frozen=True)
+class ShaderTranslationIssue:
+    code: str
+    message: str
+    stage: ShaderStage
+    line: int
+    column: int
+    construct: str
+    workaround: str
+
+
+@dataclass(frozen=True)
+class ShaderTranslationResult:
+    source: str | None
+    issues: tuple[ShaderTranslationIssue, ...]
+
+
+@dataclass(frozen=True)
+class _Token:
+    kind: str
+    text: str
+    start: int
+    end: int
+    line: int
+    column: int
+
+
+@dataclass(frozen=True)
+class _Edit:
+    start: int
+    end: int
+    replacement: str
+
+
+@dataclass(frozen=True)
+class _Declarator:
+    name: str
+    array_suffix: str
+    initializer: str | None
+    name_token: _Token
+
+
+@dataclass(frozen=True)
+class _Declaration:
+    qualifier: str
+    precision: str | None
+    type_name: str
+    declarator: _Declarator
+    stage: ShaderStage
+
+    @property
+    def name(self) -> str:
+        return self.declarator.name
+
+    @property
+    def signature(self) -> tuple[str, str | None, str, str, str | None]:
+        return (
+            self.qualifier,
+            self.precision,
+            self.type_name,
+            self.declarator.array_suffix,
+            _normalized_code(self.declarator.initializer),
+        )
+
+    def render(self) -> str:
+        parts = [self.qualifier]
+        if self.precision is not None:
+            parts.append(self.precision)
+        parts.extend((self.type_name, self.name + self.declarator.array_suffix))
+        rendered = " ".join(parts)
+        if self.declarator.initializer is not None:
+            rendered += " = " + self.declarator.initializer.strip()
+        return rendered + ";"
+
+
+@dataclass(frozen=True)
+class _Function:
+    name: str
+    signature: str
+    name_token: _Token
+    body_start: int
+    body_end: int
+    stage: ShaderStage
+
+
+@dataclass(frozen=True)
+class _StageTranslation:
+    stage: ShaderStage
+    body: str
+    declarations: tuple[_Declaration, ...]
+    functions: tuple[_Function, ...]
+    varying_references: frozenset[str]
+    issues: tuple[ShaderTranslationIssue, ...]
+
+
+def translate_gamemaker_shader(
+    stages: tuple[ShaderStageSource, ...],
+) -> ShaderTranslationResult:
+    """Translate a bounded GLSL ES shader pair into one Godot CanvasItem shader."""
+    if not stages:
+        return ShaderTranslationResult(source=None, issues=())
+
+    seen_stages: set[ShaderStage] = set()
+    translated_stages: list[_StageTranslation] = []
+    duplicate_issues: list[ShaderTranslationIssue] = []
+    for stage_source in stages:
+        if stage_source.stage in seen_stages:
+            duplicate_issues.append(
+                ShaderTranslationIssue(
+                    code="GM2GD-SHADER-STAGE-CONFLICT",
+                    message=(
+                        f"Unsupported duplicate GameMaker {stage_source.stage} "
+                        "shader stage prevents deterministic selection."
+                    ),
+                    stage=stage_source.stage,
+                    line=1,
+                    column=1,
+                    construct="duplicate stage",
+                    workaround=(
+                        "Keep exactly one .vsh and one .fsh file for each "
+                        "GameMaker shader resource."
+                    ),
+                )
+            )
+            continue
+        seen_stages.add(stage_source.stage)
+        translated_stages.append(
+            _StageTranslator(stage_source.stage, stage_source.source).translate()
+        )
+
+    issues = [
+        *duplicate_issues,
+        *(
+            issue
+            for translated_stage in translated_stages
+            for issue in translated_stage.issues
+        ),
+    ]
+    declarations, declaration_issues = _merge_declarations(translated_stages)
+    issues.extend(declaration_issues)
+    issues.extend(_validate_varying_links(translated_stages))
+    issues.extend(_validate_function_links(translated_stages))
+    if issues:
+        return ShaderTranslationResult(
+            source=None,
+            issues=tuple(_deduplicated_issues(issues)),
+        )
+
+    bodies = [
+        translated_stage.body.strip()
+        for translated_stage in translated_stages
+        if translated_stage.body.strip()
+    ]
+    sections = [
+        "shader_type canvas_item;",
+        *(declaration.render() for declaration in declarations),
+        *bodies,
+    ]
+    return ShaderTranslationResult(
+        source="\n\n".join(sections).rstrip() + "\n",
+        issues=(),
+    )
+
+
+class _StageTranslator:
+    def __init__(self, stage: ShaderStage, source: str) -> None:
+        self.stage: ShaderStage = stage
+        self.source = source
+        self.tokens, lexer_issues = _lex_shader(source, stage)
+        self.significant = [
+            token
+            for token in self.tokens
+            if token.kind not in {"whitespace", "comment"}
+        ]
+        self.issues: list[ShaderTranslationIssue] = list(lexer_issues)
+        self.edits: list[_Edit] = []
+        self.declarations: list[_Declaration] = []
+        self.attributes: list[_Declaration] = []
+        self.global_declarations: dict[str, _Declaration] = {}
+        self.declaration_ranges: list[tuple[int, int]] = []
+        self.functions: list[_Function] = []
+        self.varying_references: set[str] = set()
+
+    def translate(self) -> _StageTranslation:
+        self._parse_top_level()
+        self._validate_and_translate_functions()
+        body = _apply_edits(self.source, self.edits)
+        return _StageTranslation(
+            stage=self.stage,
+            body=body,
+            declarations=tuple(self.declarations),
+            functions=tuple(self.functions),
+            varying_references=frozenset(self.varying_references),
+            issues=tuple(_deduplicated_issues(self.issues)),
+        )
+
+    def _parse_top_level(self) -> None:
+        index = 0
+        main_count = 0
+        while index < len(self.significant):
+            token = self.significant[index]
+            if token.kind == "directive":
+                self._issue(
+                    token,
+                    "GM2GD-SHADER-CONSTRUCT-UNSUPPORTED",
+                    "preprocessor directive",
+                    "GameMaker shader preprocessor directives are not yet "
+                    "merged safely across vertex and fragment stages.",
+                    "Inline the directive for this shader or port the pair to "
+                    "one reviewed .gdshader file.",
+                )
+                index += 1
+                continue
+
+            if token.text == "precision":
+                end_index = self._statement_end(index)
+                if end_index is None:
+                    index += 1
+                    continue
+                statement = self.significant[index : end_index + 1]
+                if not self._valid_precision_statement(statement):
+                    self._issue(
+                        token,
+                        "GM2GD-SHADER-DECLARATION-UNSUPPORTED",
+                        "precision declaration",
+                        "GameMaker precision declaration is malformed or uses "
+                        "an unsupported type.",
+                        "Use `precision lowp|mediump|highp float|int;` or move "
+                        "precision qualifiers onto individual declarations.",
+                    )
+                self._remove_statement(statement)
+                index = end_index + 1
+                continue
+
+            if token.text in _STORAGE_QUALIFIERS:
+                end_index = self._statement_end(index)
+                if end_index is None:
+                    index += 1
+                    continue
+                statement = self.significant[index : end_index + 1]
+                self._parse_declaration(statement)
+                self._remove_statement(statement)
+                index = end_index + 1
+                continue
+
+            function_end = self._parse_function(index)
+            if function_end is not None:
+                function = self.functions[-1]
+                if function.name == "main":
+                    main_count += 1
+                    self.edits.append(
+                        _Edit(
+                            function.name_token.start,
+                            function.name_token.end,
+                            self.stage,
+                        )
+                    )
+                index = function_end + 1
+                continue
+
+            self._issue(
+                token,
+                "GM2GD-SHADER-CONSTRUCT-UNSUPPORTED",
+                "top-level construct",
+                f"Unsupported GameMaker shader top-level construct starts with "
+                f"{token.text!r}.",
+                "Keep global declarations to attributes, varyings, uniforms, "
+                "constants, precision declarations, and function definitions.",
+            )
+            index = self._skip_unknown_top_level(index)
+
+        if main_count != 1:
+            token = self.significant[0] if self.significant else _origin_token()
+            self._issue(
+                token,
+                "GM2GD-SHADER-ENTRYPOINT-UNSUPPORTED",
+                "main entry point",
+                f"GameMaker {self.stage} stage must contain exactly one "
+                f"`void main()` entry point; found {main_count}.",
+                "Provide one parameterless `void main()` function in each "
+                "authored stage.",
+            )
+
+    def _statement_end(self, start_index: int) -> int | None:
+        paren_depth = 0
+        bracket_depth = 0
+        for index in range(start_index, len(self.significant)):
+            token = self.significant[index]
+            if token.text == "(":
+                paren_depth += 1
+            elif token.text == ")":
+                paren_depth -= 1
+            elif token.text == "[":
+                bracket_depth += 1
+            elif token.text == "]":
+                bracket_depth -= 1
+            elif token.text == "{" and paren_depth == 0 and bracket_depth == 0:
+                break
+            elif token.text == ";" and paren_depth == 0 and bracket_depth == 0:
+                return index
+            if paren_depth < 0 or bracket_depth < 0:
+                break
+        self._issue(
+            self.significant[start_index],
+            "GM2GD-SHADER-DECLARATION-UNSUPPORTED",
+            "unterminated declaration",
+            "GameMaker shader declaration has no unambiguous terminating semicolon.",
+            "Terminate the declaration with `;` and balance all parentheses and "
+            "array brackets.",
+        )
+        return None
+
+    @staticmethod
+    def _valid_precision_statement(statement: list[_Token]) -> bool:
+        return (
+            len(statement) == 4
+            and statement[1].text in _PRECISION_QUALIFIERS
+            and statement[2].text in {"float", "int"}
+            and statement[3].text == ";"
+        )
+
+    def _parse_declaration(self, statement: list[_Token]) -> None:
+        qualifier = statement[0].text
+        cursor = 1
+        precision: str | None = None
+        if cursor < len(statement) and statement[cursor].text in _PRECISION_QUALIFIERS:
+            precision = statement[cursor].text
+            cursor += 1
+        if cursor >= len(statement) - 1 or statement[cursor].kind != "identifier":
+            self._declaration_issue(
+                statement[0],
+                "Declaration has no supported type name.",
+            )
+            return
+        type_name = statement[cursor].text
+        cursor += 1
+        if type_name not in _SUPPORTED_TYPES:
+            self._declaration_issue(
+                statement[cursor - 1],
+                f"Shader type {type_name!r} is outside the supported GLSL ES "
+                "to Godot declaration subset.",
+            )
+            return
+        declarator_tokens = statement[cursor:-1]
+        segments = _split_top_level(declarator_tokens, ",")
+        if not segments or any(not segment for segment in segments):
+            self._declaration_issue(
+                statement[0],
+                "Declaration contains an empty comma-separated declarator.",
+            )
+            return
+
+        parsed: list[_Declarator] = []
+        for segment in segments:
+            declarator = self._parse_declarator(segment)
+            if declarator is None:
+                return
+            parsed.append(declarator)
+
+        for declarator in parsed:
+            declaration = _Declaration(
+                qualifier=qualifier,
+                precision=precision,
+                type_name=type_name,
+                declarator=declarator,
+                stage=self.stage,
+            )
+            if not self._validate_declaration(declaration):
+                continue
+            previous = self.global_declarations.get(declaration.name)
+            if previous is not None:
+                token = declaration.declarator.name_token
+                self._issue(
+                    token,
+                    "GM2GD-SHADER-DECLARATION-UNSUPPORTED",
+                    declaration.name,
+                    f"Unsupported duplicate {self.stage} shader global "
+                    f"{declaration.name!r} has more than one declaration.",
+                    "Declare each attribute, varying, uniform, constant, or "
+                    "GameMaker built-in at most once per stage.",
+                )
+                continue
+            self.global_declarations[declaration.name] = declaration
+            if declaration.qualifier == "attribute":
+                self.attributes.append(declaration)
+            elif not self._is_gamemaker_builtin_declaration(declaration):
+                self.declarations.append(declaration)
+
+    def _parse_declarator(self, tokens: list[_Token]) -> _Declarator | None:
+        if not tokens or tokens[0].kind != "identifier":
+            token = tokens[0] if tokens else _origin_token()
+            self._declaration_issue(
+                token,
+                "Each declaration must start with an identifier.",
+            )
+            return None
+        name_token = tokens[0]
+        cursor = 1
+        array_suffix = ""
+        if cursor < len(tokens) and tokens[cursor].text == "[":
+            end = _matching_token(tokens, cursor, "[", "]")
+            if end is None or end == cursor + 1:
+                self._declaration_issue(
+                    tokens[cursor],
+                    "Array declaration has no fixed size or closing bracket.",
+                )
+                return None
+            array_suffix = "".join(token.text for token in tokens[cursor : end + 1])
+            cursor = end + 1
+            if cursor < len(tokens) and tokens[cursor].text == "[":
+                self._declaration_issue(
+                    tokens[cursor],
+                    "Multi-dimensional shader arrays are not in the supported subset.",
+                )
+                return None
+
+        initializer: str | None = None
+        if cursor < len(tokens):
+            if tokens[cursor].text != "=" or cursor + 1 >= len(tokens):
+                self._declaration_issue(
+                    tokens[cursor],
+                    "Unexpected tokens follow the shader declarator.",
+                )
+                return None
+            initializer_tokens = tokens[cursor + 1 :]
+            initializer = _render_tokens(initializer_tokens)
+            cursor = len(tokens)
+        if cursor != len(tokens):
+            self._declaration_issue(
+                tokens[cursor],
+                "Shader declarator could not be parsed unambiguously.",
+            )
+            return None
+        return _Declarator(
+            name=name_token.text,
+            array_suffix=array_suffix,
+            initializer=initializer,
+            name_token=name_token,
+        )
+
+    def _validate_declaration(self, declaration: _Declaration) -> bool:
+        token = declaration.declarator.name_token
+        if declaration.qualifier in {"in", "out"}:
+            self._issue(
+                token,
+                "GM2GD-SHADER-DECLARATION-UNSUPPORTED",
+                f"{declaration.qualifier} interface declaration",
+                "Modern GLSL stage `in`/`out` declarations cannot be merged "
+                "unambiguously into a Godot CanvasItem shader.",
+                "Use GameMaker LTS `attribute` and `varying` declarations for "
+                "the supported 2D shader subset.",
+            )
+            return False
+        if declaration.qualifier == "attribute" and self.stage != "vertex":
+            self._declaration_issue(
+                token,
+                "Attributes are only valid in the GameMaker vertex stage.",
+            )
+            return False
+        if declaration.qualifier != "const" and declaration.declarator.initializer is not None:
+            self._declaration_issue(
+                token,
+                "Only global `const` declarations may have initializers in the "
+                "supported subset.",
+            )
+            return False
+        if declaration.qualifier == "const" and declaration.declarator.initializer is None:
+            self._declaration_issue(
+                token,
+                "Global `const` declaration has no initializer.",
+            )
+            return False
+        if (
+            declaration.qualifier in {"attribute", "varying"}
+            and declaration.type_name.startswith("sampler")
+        ):
+            self._declaration_issue(
+                token,
+                "Samplers cannot be vertex attributes or varyings.",
+            )
+            return False
+        if declaration.name == "gm_BaseTexture":
+            if (
+                declaration.qualifier != "uniform"
+                or declaration.type_name != "sampler2D"
+                or declaration.declarator.array_suffix
+                or self.stage != "fragment"
+            ):
+                self._declaration_issue(
+                    token,
+                    "`gm_BaseTexture` must be a non-array `uniform sampler2D` "
+                    "in the fragment stage.",
+                )
+                return False
+        if declaration.name == "gm_Matrices":
+            if (
+                declaration.qualifier != "uniform"
+                or declaration.type_name != "mat4"
+                or not declaration.declarator.array_suffix
+                or self.stage != "vertex"
+            ):
+                self._declaration_issue(
+                    token,
+                    "`gm_Matrices` must be a vertex-stage `uniform mat4` array.",
+                )
+                return False
+        if declaration.name in _GODOT_RESERVED_GLOBAL_NAMES:
+            self._issue(
+                token,
+                "GM2GD-SHADER-DECLARATION-UNSUPPORTED",
+                declaration.name,
+                f"GameMaker global {declaration.name!r} collides with a Godot "
+                "CanvasItem built-in and cannot share the generated scope.",
+                "Rename the GameMaker global or port the shader manually while "
+                "preserving any runtime uniform name contract.",
+            )
+            return False
+        if (
+            declaration.declarator.initializer is not None
+            and _uses_scalar_matrix_constructor(
+                declaration.type_name,
+                declaration.declarator.initializer,
+                self.stage,
+            )
+        ):
+            self._issue(
+                token,
+                "GM2GD-SHADER-CONSTRUCTOR-UNSUPPORTED",
+                declaration.name,
+                f"GameMaker {declaration.type_name} scalar-list constructor "
+                "for {declaration.name!r} is not accepted by Godot's matrix "
+                "constructor grammar.",
+                "Construct the matrix from column vectors in GameMaker or port "
+                "this declaration manually.",
+            )
+            return False
+        return True
+
+    @staticmethod
+    def _is_gamemaker_builtin_declaration(declaration: _Declaration) -> bool:
+        return declaration.qualifier == "attribute" or declaration.name in {
+            "gm_BaseTexture",
+            "gm_Matrices",
+        }
+
+    def _parse_function(self, start_index: int) -> int | None:
+        open_paren_index: int | None = None
+        for index in range(start_index, len(self.significant)):
+            text = self.significant[index].text
+            if text == "(":
+                open_paren_index = index
+                break
+            if text in {";", "{", "}"}:
+                return None
+        if open_paren_index is None or open_paren_index - start_index < 2:
+            return None
+        name_token = self.significant[open_paren_index - 1]
+        return_tokens = self.significant[start_index : open_paren_index - 1]
+        if (
+            name_token.kind != "identifier"
+            or not return_tokens
+            or any(
+                token.kind != "identifier"
+                or (
+                    token.text not in _PRECISION_QUALIFIERS
+                    and token.text != "void"
+                    and token.text not in _SUPPORTED_TYPES
+                )
+                for token in return_tokens
+            )
+        ):
+            return None
+        close_paren_index = _matching_token(
+            self.significant,
+            open_paren_index,
+            "(",
+            ")",
+        )
+        if close_paren_index is None:
+            self._issue(
+                name_token,
+                "GM2GD-SHADER-FUNCTION-UNSUPPORTED",
+                "function declaration",
+                f"Shader function {name_token.text!r} has an unterminated "
+                "parameter list.",
+                "Balance the function parameter parentheses.",
+            )
+            return len(self.significant) - 1
+        if close_paren_index + 1 >= len(self.significant):
+            return None
+        open_brace_index = close_paren_index + 1
+        if self.significant[open_brace_index].text != "{":
+            return None
+        close_brace_index = _matching_token(
+            self.significant,
+            open_brace_index,
+            "{",
+            "}",
+        )
+        if close_brace_index is None:
+            self._issue(
+                name_token,
+                "GM2GD-SHADER-FUNCTION-UNSUPPORTED",
+                "function definition",
+                f"Shader function {name_token.text!r} has an unterminated body.",
+                "Balance the function body braces.",
+            )
+            return len(self.significant) - 1
+
+        parameters = self.significant[open_paren_index + 1 : close_paren_index]
+        return_type = return_tokens[-1].text
+        if name_token.text == "main" and (return_type != "void" or parameters):
+            self._issue(
+                name_token,
+                "GM2GD-SHADER-ENTRYPOINT-UNSUPPORTED",
+                "main entry point",
+                f"GameMaker {self.stage} entry point must be parameterless "
+                "`void main()`.",
+                "Remove entry-point parameters and return values.",
+            )
+        signature = (
+            return_type
+            + " "
+            + name_token.text
+            + "("
+            + "".join(token.text for token in parameters)
+            + ")"
+        )
+        self.functions.append(
+            _Function(
+                name=name_token.text,
+                signature=signature,
+                name_token=name_token,
+                body_start=self.significant[open_brace_index].end,
+                body_end=self.significant[close_brace_index].start,
+                stage=self.stage,
+            )
+        )
+        return close_brace_index
+
+    def _validate_and_translate_functions(self) -> None:
+        attributes = {
+            declaration.name: declaration
+            for declaration in self._all_parsed_attribute_declarations()
+        }
+        varying_names = {
+            declaration.name
+            for declaration in self.declarations
+            if declaration.qualifier == "varying"
+        }
+        for function in self.functions:
+            body_tokens = [
+                token
+                for token in self.significant
+                if function.body_start <= token.start < function.body_end
+            ]
+            if function.name == "main" and self.stage == "vertex":
+                position_ranges = self._translate_position_assignments(body_tokens)
+            else:
+                position_ranges = []
+            self._translate_function_tokens(
+                function,
+                body_tokens,
+                attributes,
+                varying_names,
+                position_ranges,
+            )
+
+    def _all_parsed_attribute_declarations(self) -> tuple[_Declaration, ...]:
+        return tuple(self.attributes)
+
+    def _translate_position_assignments(
+        self,
+        body_tokens: list[_Token],
+    ) -> list[tuple[int, int]]:
+        ranges: list[tuple[int, int]] = []
+        position_tokens = [
+            (index, token)
+            for index, token in enumerate(body_tokens)
+            if token.text == "gl_Position"
+        ]
+        assignment_count = 0
+        for index, token in position_tokens:
+            if _inside_ranges(token.start, ranges):
+                continue
+            if index + 1 >= len(body_tokens) or body_tokens[index + 1].text != "=":
+                self._issue(
+                    token,
+                    "GM2GD-SHADER-POSITION-UNSUPPORTED",
+                    "gl_Position access",
+                    "`gl_Position` is read or updated with an unsupported "
+                    "operation instead of a direct assignment.",
+                    "Assign `gl_Position` from a supported GameMaker matrix "
+                    "transform and do not read it.",
+                )
+                continue
+            semicolon_index = _expression_semicolon(body_tokens, index + 2)
+            if semicolon_index is None:
+                self._issue(
+                    token,
+                    "GM2GD-SHADER-POSITION-UNSUPPORTED",
+                    "gl_Position assignment",
+                    "`gl_Position` assignment has no unambiguous terminating "
+                    "semicolon.",
+                    "Terminate the assignment and balance its expression.",
+                )
+                continue
+            expression = body_tokens[index + 2 : semicolon_index]
+            local_expression = self._local_position_expression(expression)
+            end_token = body_tokens[semicolon_index]
+            assignment_range = (token.start, end_token.end)
+            ranges.append(assignment_range)
+            assignment_count += 1
+            if local_expression is None:
+                continue
+            translated_expression = self._translate_expression(local_expression)
+            if translated_expression is None:
+                continue
+            self.edits.append(
+                _Edit(
+                    token.start,
+                    end_token.end,
+                    f"VERTEX = ({translated_expression}).xy;",
+                )
+            )
+
+        if assignment_count == 0:
+            token = next(
+                (
+                    function.name_token
+                    for function in self.functions
+                    if function.name == "main"
+                ),
+                _origin_token(),
+            )
+            self._issue(
+                token,
+                "GM2GD-SHADER-POSITION-UNSUPPORTED",
+                "missing gl_Position assignment",
+                "GameMaker vertex entry point does not assign `gl_Position`.",
+                "Assign a 2D position through "
+                "`gm_Matrices[MATRIX_WORLD_VIEW_PROJECTION]`.",
+            )
+        return ranges
+
+    def _local_position_expression(
+        self,
+        expression: list[_Token],
+    ) -> list[_Token] | None:
+        expression = _strip_outer_parentheses(expression)
+        first_matrix = _matrix_access_at(expression, 0)
+        if first_matrix is None:
+            self._position_expression_issue(expression)
+            return None
+        matrix_name, cursor = first_matrix
+        if cursor >= len(expression) or expression[cursor].text != "*":
+            self._position_expression_issue(expression)
+            return None
+        cursor += 1
+
+        if matrix_name == "MATRIX_WORLD_VIEW_PROJECTION":
+            local_expression = expression[cursor:]
+        elif matrix_name == "MATRIX_PROJECTION":
+            second_matrix = _matrix_access_at(expression, cursor)
+            if second_matrix is None:
+                self._position_expression_issue(expression)
+                return None
+            second_name, cursor = second_matrix
+            if cursor >= len(expression) or expression[cursor].text != "*":
+                self._position_expression_issue(expression)
+                return None
+            cursor += 1
+            if second_name == "MATRIX_WORLD_VIEW":
+                local_expression = expression[cursor:]
+            elif second_name == "MATRIX_VIEW":
+                third_matrix = _matrix_access_at(expression, cursor)
+                if third_matrix is None:
+                    self._position_expression_issue(expression)
+                    return None
+                third_name, cursor = third_matrix
+                if (
+                    third_name != "MATRIX_WORLD"
+                    or cursor >= len(expression)
+                    or expression[cursor].text != "*"
+                ):
+                    self._position_expression_issue(expression)
+                    return None
+                local_expression = expression[cursor + 1 :]
+            else:
+                self._position_expression_issue(expression)
+                return None
+        else:
+            self._position_expression_issue(expression)
+            return None
+
+        local_expression = _strip_outer_parentheses(local_expression)
+        if not local_expression:
+            self._position_expression_issue(expression)
+            return None
+        return local_expression
+
+    def _position_expression_issue(self, expression: list[_Token]) -> None:
+        token = expression[0] if expression else _origin_token()
+        self._issue(
+            token,
+            "GM2GD-SHADER-POSITION-UNSUPPORTED",
+            "gl_Position transform",
+            "GameMaker clip-space position is not a supported 2D "
+            "world/view/projection transform.",
+            "Use `MATRIX_WORLD_VIEW_PROJECTION * local_position`, "
+            "`MATRIX_PROJECTION * MATRIX_WORLD_VIEW * local_position`, or "
+            "`MATRIX_PROJECTION * MATRIX_VIEW * MATRIX_WORLD * local_position`; "
+            "port perspective, custom clip-space, and 3D transforms manually.",
+        )
+
+    def _translate_expression(self, tokens: list[_Token]) -> str | None:
+        parts: list[str] = []
+        index = 0
+        valid = True
+        attributes = {
+            declaration.name: declaration
+            for declaration in self._all_parsed_attribute_declarations()
+        }
+        while index < len(tokens):
+            token = tokens[index]
+            matrix_access = (
+                _matrix_access_at(tokens, index)
+                if token.text == "gm_Matrices"
+                else None
+            )
+            if matrix_access is not None:
+                matrix_name, index = matrix_access
+                replacement = _MATRIX_REPLACEMENTS.get(matrix_name)
+                if replacement is None:
+                    self._matrix_issue(token, matrix_name)
+                    valid = False
+                else:
+                    parts.append(replacement)
+                continue
+            replacement = self._identifier_replacement(
+                token,
+                attributes,
+            )
+            if replacement is None:
+                if self._is_unsupported_special_identifier(token):
+                    valid = False
+                parts.append(token.text)
+            else:
+                parts.append(replacement)
+            index += 1
+        return " ".join(parts) if valid else None
+
+    def _translate_function_tokens(
+        self,
+        function: _Function,
+        tokens: list[_Token],
+        attributes: dict[str, _Declaration],
+        varying_names: set[str],
+        excluded_ranges: list[tuple[int, int]],
+    ) -> None:
+        index = 0
+        while index < len(tokens):
+            token = tokens[index]
+            if _inside_ranges(token.start, excluded_ranges):
+                index += 1
+                continue
+            if token.text in varying_names:
+                self.varying_references.add(token.text)
+                if (
+                    function.name != "main"
+                    and index + 1 < len(tokens)
+                    and tokens[index + 1].text
+                    in {"=", "+=", "-=", "*=", "/=", "++", "--"}
+                ):
+                    self._issue(
+                        token,
+                        "GM2GD-SHADER-VARYING-WRITE-UNSUPPORTED",
+                        f"{function.name}:{token.text}",
+                        f"Helper function {function.name!r} assigns varying "
+                        f"{token.text!r}, which Godot only permits in a "
+                        "processing function.",
+                        "Return the value from the helper and assign the varying "
+                        "inside `main()`.",
+                    )
+            if _scalar_matrix_constructor_end(tokens, index) is not None:
+                self._issue(
+                    token,
+                    "GM2GD-SHADER-CONSTRUCTOR-UNSUPPORTED",
+                    f"{token.text} scalar-list constructor",
+                    f"GameMaker {token.text} scalar-list constructor is not "
+                    "accepted by Godot's matrix constructor grammar.",
+                    "Construct the matrix from column vectors in GameMaker or "
+                    "port this expression manually.",
+                )
+            if token.text == "gm_Matrices":
+                matrix_access = _matrix_access_at(tokens, index)
+                if matrix_access is None:
+                    self._matrix_issue(token, "dynamic or malformed index")
+                    index += 1
+                    continue
+                matrix_name, next_index = matrix_access
+                replacement = _MATRIX_REPLACEMENTS.get(matrix_name)
+                if function.name != "main":
+                    self._helper_builtin_issue(token, function, "gm_Matrices")
+                elif replacement is None:
+                    self._matrix_issue(token, matrix_name)
+                else:
+                    self.edits.append(
+                        _Edit(
+                            token.start,
+                            tokens[next_index - 1].end,
+                            replacement,
+                        )
+                    )
+                index = next_index
+                continue
+
+            if function.name != "main" and (
+                token.text in attributes
+                or token.text in {"gm_BaseTexture", "gl_FragColor"}
+            ):
+                self._helper_builtin_issue(token, function, token.text)
+                index += 1
+                continue
+            replacement = self._identifier_replacement(
+                token,
+                attributes,
+            )
+            if replacement is not None:
+                self.edits.append(_Edit(token.start, token.end, replacement))
+            else:
+                self._is_unsupported_special_identifier(token)
+            index += 1
+
+    def _identifier_replacement(
+        self,
+        token: _Token,
+        attributes: dict[str, _Declaration],
+    ) -> str | None:
+        if token.text in attributes:
+            declaration = attributes[token.text]
+            return self._attribute_replacement(declaration, token)
+        if token.text in {
+            "in_Position",
+            "in_Normal",
+            "in_Colour",
+            "in_Colour0",
+            "in_TextureCoord",
+        }:
+            self._issue(
+                token,
+                "GM2GD-SHADER-ATTRIBUTE-UNSUPPORTED",
+                token.text,
+                f"GameMaker built-in attribute {token.text!r} is used without "
+                "a matching parsed vertex declaration.",
+                "Declare the attribute once with its documented GameMaker type.",
+            )
+            return None
+        if token.text == "gm_BaseTexture":
+            if self.stage != "fragment":
+                self._issue(
+                    token,
+                    "GM2GD-SHADER-BUILTIN-UNSUPPORTED",
+                    "gm_BaseTexture",
+                    "`gm_BaseTexture` can only map to Godot `TEXTURE` in the "
+                    "fragment stage.",
+                    "Sample the base texture from the fragment stage.",
+                )
+                return None
+            return "TEXTURE"
+        if token.text == "texture2D":
+            return "texture"
+        if token.text == "gl_FragColor":
+            if self.stage != "fragment":
+                self._issue(
+                    token,
+                    "GM2GD-SHADER-BUILTIN-UNSUPPORTED",
+                    "gl_FragColor",
+                    "`gl_FragColor` can only map to Godot `COLOR` in the "
+                    "fragment stage.",
+                    "Write the fragment result from the fragment stage.",
+                )
+                return None
+            return "COLOR"
+        return None
+
+    def _attribute_replacement(
+        self,
+        declaration: _Declaration,
+        token: _Token,
+    ) -> str | None:
+        if self.stage != "vertex":
+            self._attribute_issue(token, declaration.name)
+            return None
+        if declaration.name == "in_Position":
+            if declaration.type_name == "vec2":
+                return "VERTEX"
+            if declaration.type_name == "vec3":
+                return "vec3(VERTEX, 0.0)"
+        elif (
+            declaration.name in {"in_Colour", "in_Colour0"}
+            and declaration.type_name == "vec4"
+        ):
+            return "COLOR"
+        elif (
+            declaration.name == "in_TextureCoord"
+            and declaration.type_name == "vec2"
+        ):
+            return "UV"
+        self._attribute_issue(token, declaration.name)
+        return None
+
+    def _attribute_issue(self, token: _Token, attribute_name: str) -> None:
+        if attribute_name == "in_Normal":
+            detail = (
+                "GameMaker normal attributes have no CanvasItem vertex input "
+                "equivalent."
+            )
+        elif attribute_name.startswith("in_Colour") and attribute_name not in {
+            "in_Colour",
+            "in_Colour0",
+        }:
+            detail = (
+                "Additional GameMaker colour attributes have no CanvasItem "
+                "vertex input equivalent."
+            )
+        else:
+            detail = (
+                "Custom GameMaker vertex-format attributes cannot be bound to "
+                "Godot CanvasItem inputs."
+            )
+        self._issue(
+            token,
+            "GM2GD-SHADER-ATTRIBUTE-UNSUPPORTED",
+            attribute_name,
+            f"{detail} Attribute {attribute_name!r} was not converted.",
+            "Use the supported in_Position, in_Colour/in_Colour0, and "
+            "in_TextureCoord attributes, or port the custom vertex-buffer "
+            "pipeline manually.",
+        )
+
+    def _is_unsupported_special_identifier(self, token: _Token) -> bool:
+        if token.text == "gl_Position":
+            self._issue(
+                token,
+                "GM2GD-SHADER-POSITION-UNSUPPORTED",
+                "gl_Position access",
+                "Unconverted `gl_Position` access remains in the shader.",
+                "Use a direct supported matrix assignment in the vertex entry point.",
+            )
+            return True
+        if token.text.startswith("gl_"):
+            self._issue(
+                token,
+                "GM2GD-SHADER-BUILTIN-UNSUPPORTED",
+                token.text,
+                f"GLSL ES built-in {token.text!r} has no defined mapping in "
+                "the supported CanvasItem subset.",
+                "Replace it with a documented Godot 4.7 CanvasItem built-in or "
+                "port the shader manually.",
+            )
+            return True
+        if token.text == "gm_Matrices" or token.text.startswith("MATRIX_"):
+            self._matrix_issue(token, token.text)
+            return True
+        return False
+
+    def _matrix_issue(self, token: _Token, matrix_name: str) -> None:
+        self._issue(
+            token,
+            "GM2GD-SHADER-MATRIX-UNSUPPORTED",
+            f"gm_Matrices[{matrix_name}]",
+            f"GameMaker matrix access {matrix_name!r} is dynamic, malformed, "
+            "or outside the supported world/view/projection constants.",
+            "Use MATRIX_WORLD, MATRIX_VIEW, MATRIX_PROJECTION, "
+            "MATRIX_WORLD_VIEW, or MATRIX_WORLD_VIEW_PROJECTION with a fixed "
+            "index.",
+        )
+
+    def _helper_builtin_issue(
+        self,
+        token: _Token,
+        function: _Function,
+        builtin_name: str,
+    ) -> None:
+        self._issue(
+            token,
+            "GM2GD-SHADER-HELPER-UNSUPPORTED",
+            f"{function.name}:{builtin_name}",
+            f"GameMaker helper function {function.name!r} reads or writes "
+            f"stage built-in {builtin_name!r}, which Godot exposes only in "
+            "the processing entry point.",
+            "Pass the built-in value into the helper as a parameter, return "
+            "the result, and read or write the built-in inside `main()`.",
+        )
+
+    def _remove_statement(self, statement: list[_Token]) -> None:
+        start = statement[0].start
+        end = statement[-1].end
+        self.declaration_ranges.append((start, end))
+        self.edits.append(_Edit(start, end, ""))
+
+    def _declaration_issue(self, token: _Token, detail: str) -> None:
+        self._issue(
+            token,
+            "GM2GD-SHADER-DECLARATION-UNSUPPORTED",
+            "global declaration",
+            detail,
+            "Split the declaration into supported GLSL ES attribute, varying, "
+            "uniform, or const declarators with fixed one-dimensional arrays.",
+        )
+
+    def _issue(
+        self,
+        token: _Token,
+        code: str,
+        construct: str,
+        message: str,
+        workaround: str,
+    ) -> None:
+        self.issues.append(
+            ShaderTranslationIssue(
+                code=code,
+                message=message,
+                stage=self.stage,
+                line=token.line,
+                column=token.column,
+                construct=construct,
+                workaround=workaround,
+            )
+        )
+
+    def _skip_unknown_top_level(self, index: int) -> int:
+        depth = 0
+        while index < len(self.significant):
+            text = self.significant[index].text
+            if text in {"(", "[", "{"}:
+                depth += 1
+            elif text in {")", "]", "}"}:
+                depth = max(0, depth - 1)
+            index += 1
+            if depth == 0 and text in {";", "}"}:
+                break
+        return index
+
+
+def _merge_declarations(
+    stages: list[_StageTranslation],
+) -> tuple[list[_Declaration], list[ShaderTranslationIssue]]:
+    merged: list[_Declaration] = []
+    by_name: dict[str, _Declaration] = {}
+    issues: list[ShaderTranslationIssue] = []
+    for stage in stages:
+        for declaration in stage.declarations:
+            previous = by_name.get(declaration.name)
+            if previous is None:
+                by_name[declaration.name] = declaration
+                merged.append(declaration)
+                continue
+            if previous.signature == declaration.signature:
+                continue
+            token = declaration.declarator.name_token
+            issues.append(
+                ShaderTranslationIssue(
+                    code="GM2GD-SHADER-DECLARATION-CONFLICT",
+                    message=(
+                        f"Unsupported cross-stage shader global "
+                        f"{declaration.name!r} has incompatible {previous.stage} "
+                        f"and {declaration.stage} declarations."
+                    ),
+                    stage=declaration.stage,
+                    line=token.line,
+                    column=token.column,
+                    construct=declaration.name,
+                    workaround=(
+                        "Use the same qualifier, precision, type, array size, "
+                        "and initializer in both stages."
+                    ),
+                )
+            )
+    return merged, issues
+
+
+def _validate_varying_links(
+    stages: list[_StageTranslation],
+) -> list[ShaderTranslationIssue]:
+    vertex = next((stage for stage in stages if stage.stage == "vertex"), None)
+    fragment = next((stage for stage in stages if stage.stage == "fragment"), None)
+    if fragment is None:
+        return []
+    vertex_varyings: set[str] = set()
+    if vertex is not None:
+        vertex_varyings = {
+            declaration.name
+            for declaration in vertex.declarations
+            if declaration.qualifier == "varying"
+        }
+    fragment_varyings = {
+        declaration.name: declaration
+        for declaration in fragment.declarations
+        if declaration.qualifier == "varying"
+    }
+    issues: list[ShaderTranslationIssue] = []
+    for name in sorted(fragment.varying_references):
+        if name in vertex_varyings:
+            continue
+        declaration = fragment_varyings.get(name)
+        token = (
+            declaration.declarator.name_token
+            if declaration is not None
+            else _origin_token()
+        )
+        issues.append(
+            ShaderTranslationIssue(
+                code="GM2GD-SHADER-VARYING-UNLINKED",
+                message=(
+                    f"Unsupported fragment varying {name!r} has no matching "
+                    "vertex-stage declaration, so its interpolated value is "
+                    "undefined."
+                ),
+                stage="fragment",
+                line=token.line,
+                column=token.column,
+                construct=name,
+                workaround=(
+                    "Declare the same varying type and array size in both stages "
+                    "and assign it from the vertex entry point."
+                ),
+            )
+        )
+    return issues
+
+
+def _validate_function_links(
+    stages: list[_StageTranslation],
+) -> list[ShaderTranslationIssue]:
+    seen: dict[str, _Function] = {}
+    issues: list[ShaderTranslationIssue] = []
+    for stage in stages:
+        for function in stage.functions:
+            if function.name == "main":
+                continue
+            previous = seen.get(function.signature)
+            if previous is None:
+                seen[function.signature] = function
+                continue
+            token = function.name_token
+            issues.append(
+                ShaderTranslationIssue(
+                    code="GM2GD-SHADER-FUNCTION-CONFLICT",
+                    message=(
+                        f"Unsupported helper function {function.signature!r} is "
+                        "defined in both shader stages and cannot share one "
+                        "Godot scope."
+                    ),
+                    stage=function.stage,
+                    line=token.line,
+                    column=token.column,
+                    construct=function.signature,
+                    workaround=(
+                        "Keep one shared helper definition or give stage-specific "
+                        "helpers distinct signatures."
+                    ),
+                )
+            )
+    return issues
+
+
+def _lex_shader(
+    source: str,
+    stage: ShaderStage,
+) -> tuple[list[_Token], list[ShaderTranslationIssue]]:
+    tokens: list[_Token] = []
+    issues: list[ShaderTranslationIssue] = []
+    index = 0
+    line = 1
+    column = 1
+    line_has_code = False
+
+    def consume(text: str) -> None:
+        nonlocal line, column, line_has_code
+        for character in text:
+            if character == "\n":
+                line += 1
+                column = 1
+                line_has_code = False
+            else:
+                column += 1
+
+    def add(kind: str, end: int) -> None:
+        nonlocal index, line_has_code
+        text = source[index:end]
+        tokens.append(
+            _Token(
+                kind=kind,
+                text=text,
+                start=index,
+                end=end,
+                line=line,
+                column=column,
+            )
+        )
+        consume(text)
+        if kind not in {"whitespace", "comment"}:
+            line_has_code = not text.endswith(("\n", "\r"))
+        index = end
+
+    while index < len(source):
+        character = source[index]
+        if character.isspace():
+            end = index + 1
+            while end < len(source) and source[end].isspace():
+                end += 1
+            add("whitespace", end)
+            continue
+        if source.startswith("//", index):
+            end = source.find("\n", index + 2)
+            add("comment", len(source) if end < 0 else end)
+            continue
+        if source.startswith("/*", index):
+            end = source.find("*/", index + 2)
+            if end < 0:
+                token = _Token(
+                    kind="comment",
+                    text=source[index:],
+                    start=index,
+                    end=len(source),
+                    line=line,
+                    column=column,
+                )
+                tokens.append(token)
+                issues.append(
+                    ShaderTranslationIssue(
+                        code="GM2GD-SHADER-LEX-UNSUPPORTED",
+                        message="GameMaker shader contains an unterminated block comment.",
+                        stage=stage,
+                        line=line,
+                        column=column,
+                        construct="block comment",
+                        workaround="Close the comment with `*/`.",
+                    )
+                )
+                break
+            add("comment", end + 2)
+            continue
+        if character == "#" and not line_has_code:
+            end = index
+            while end < len(source):
+                newline = source.find("\n", end)
+                if newline < 0:
+                    end = len(source)
+                    break
+                backslash = newline - 1
+                while backslash >= index and source[backslash] in {" ", "\t", "\r"}:
+                    backslash -= 1
+                end = newline + 1
+                if backslash < index or source[backslash] != "\\":
+                    break
+            add("directive", end)
+            continue
+        if character.isalpha() or character == "_":
+            end = index + 1
+            while end < len(source) and (
+                source[end].isalnum() or source[end] == "_"
+            ):
+                end += 1
+            add("identifier", end)
+            continue
+        if character.isdigit() or (
+            character == "."
+            and index + 1 < len(source)
+            and source[index + 1].isdigit()
+        ):
+            end = index + 1
+            while end < len(source):
+                if source[end].isalnum() or source[end] in {".", "_"}:
+                    end += 1
+                    continue
+                if (
+                    source[end] in {"+", "-"}
+                    and end > index
+                    and source[end - 1] in {"e", "E"}
+                ):
+                    end += 1
+                    continue
+                break
+            add("number", end)
+            continue
+        if character in {'"', "'"}:
+            quote = character
+            end = index + 1
+            escaped = False
+            while end < len(source):
+                current = source[end]
+                end += 1
+                if escaped:
+                    escaped = False
+                elif current == "\\":
+                    escaped = True
+                elif current == quote:
+                    break
+            add("string", end)
+            continue
+        matched_operator = next(
+            (
+                operator
+                for operator in (
+                    "<<=",
+                    ">>=",
+                    "++",
+                    "--",
+                    "+=",
+                    "-=",
+                    "*=",
+                    "/=",
+                    "%=",
+                    "==",
+                    "!=",
+                    "<=",
+                    ">=",
+                    "&&",
+                    "||",
+                    "<<",
+                    ">>",
+                )
+                if source.startswith(operator, index)
+            ),
+            None,
+        )
+        add("symbol", index + len(matched_operator or character))
+    return tokens, issues
+
+
+def _split_top_level(tokens: list[_Token], separator: str) -> list[list[_Token]]:
+    result: list[list[_Token]] = []
+    current: list[_Token] = []
+    paren_depth = 0
+    bracket_depth = 0
+    brace_depth = 0
+    for token in tokens:
+        if token.text == "(":
+            paren_depth += 1
+        elif token.text == ")":
+            paren_depth -= 1
+        elif token.text == "[":
+            bracket_depth += 1
+        elif token.text == "]":
+            bracket_depth -= 1
+        elif token.text == "{":
+            brace_depth += 1
+        elif token.text == "}":
+            brace_depth -= 1
+        if (
+            token.text == separator
+            and paren_depth == 0
+            and bracket_depth == 0
+            and brace_depth == 0
+        ):
+            result.append(current)
+            current = []
+        else:
+            current.append(token)
+    result.append(current)
+    return result
+
+
+def _matching_token(
+    tokens: list[_Token],
+    start_index: int,
+    opening: str,
+    closing: str,
+) -> int | None:
+    if start_index >= len(tokens) or tokens[start_index].text != opening:
+        return None
+    depth = 0
+    for index in range(start_index, len(tokens)):
+        if tokens[index].text == opening:
+            depth += 1
+        elif tokens[index].text == closing:
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def _matrix_access_at(
+    tokens: list[_Token],
+    index: int,
+) -> tuple[str, int] | None:
+    if index >= len(tokens):
+        return None
+    if tokens[index].text == "(":
+        close = _matching_token(tokens, index, "(", ")")
+        if close is not None:
+            inner = _matrix_access_at(tokens[index + 1 : close], 0)
+            if inner is not None and inner[1] == close - index - 1:
+                return inner[0], close + 1
+    if (
+        index + 3 < len(tokens)
+        and tokens[index].text == "gm_Matrices"
+        and tokens[index + 1].text == "["
+        and tokens[index + 2].kind == "identifier"
+        and tokens[index + 3].text == "]"
+    ):
+        return tokens[index + 2].text, index + 4
+    return None
+
+
+def _scalar_matrix_constructor_end(
+    tokens: list[_Token],
+    index: int,
+) -> int | None:
+    dimensions = {"mat2": 2, "mat3": 3, "mat4": 4}
+    dimension = dimensions.get(tokens[index].text) if index < len(tokens) else None
+    if (
+        dimension is None
+        or index + 1 >= len(tokens)
+        or tokens[index + 1].text != "("
+    ):
+        return None
+    close = _matching_token(tokens, index + 1, "(", ")")
+    if close is None:
+        return None
+    arguments = _split_top_level(tokens[index + 2 : close], ",")
+    if len(arguments) != dimension * dimension or any(
+        not argument for argument in arguments
+    ):
+        return None
+    return close + 1
+
+
+def _uses_scalar_matrix_constructor(
+    type_name: str,
+    initializer: str,
+    stage: ShaderStage,
+) -> bool:
+    if type_name not in {"mat2", "mat3", "mat4"}:
+        return False
+    tokens, _issues = _lex_shader(initializer, stage)
+    significant = [
+        token
+        for token in tokens
+        if token.kind not in {"whitespace", "comment"}
+    ]
+    end = _scalar_matrix_constructor_end(significant, 0)
+    return end == len(significant)
+
+
+def _strip_outer_parentheses(tokens: list[_Token]) -> list[_Token]:
+    result = tokens
+    while result and result[0].text == "(":
+        close = _matching_token(result, 0, "(", ")")
+        if close != len(result) - 1:
+            break
+        result = result[1:-1]
+    return result
+
+
+def _expression_semicolon(tokens: list[_Token], start_index: int) -> int | None:
+    paren_depth = 0
+    bracket_depth = 0
+    brace_depth = 0
+    for index in range(start_index, len(tokens)):
+        text = tokens[index].text
+        if text == "(":
+            paren_depth += 1
+        elif text == ")":
+            paren_depth -= 1
+        elif text == "[":
+            bracket_depth += 1
+        elif text == "]":
+            bracket_depth -= 1
+        elif text == "{":
+            brace_depth += 1
+        elif text == "}":
+            brace_depth -= 1
+        elif (
+            text == ";"
+            and paren_depth == 0
+            and bracket_depth == 0
+            and brace_depth == 0
+        ):
+            return index
+        if paren_depth < 0 or bracket_depth < 0 or brace_depth < 0:
+            return None
+    return None
+
+
+def _render_tokens(tokens: list[_Token]) -> str:
+    return " ".join(token.text for token in tokens)
+
+
+def _normalized_code(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return "".join(value.split())
+
+
+def _inside_ranges(offset: int, ranges: list[tuple[int, int]]) -> bool:
+    return any(start <= offset < end for start, end in ranges)
+
+
+def _apply_edits(source: str, edits: list[_Edit]) -> str:
+    if not edits:
+        return source.strip()
+    ordered = sorted(edits, key=lambda edit: (edit.start, edit.end))
+    parts: list[str] = []
+    cursor = 0
+    for edit in ordered:
+        if edit.start < cursor:
+            continue
+        parts.append(source[cursor : edit.start])
+        parts.append(edit.replacement)
+        cursor = edit.end
+    parts.append(source[cursor:])
+    return "".join(parts).strip()
+
+
+def _deduplicated_issues(
+    issues: list[ShaderTranslationIssue],
+) -> list[ShaderTranslationIssue]:
+    return list(dict.fromkeys(issues))
+
+
+def _origin_token() -> _Token:
+    return _Token(
+        kind="origin",
+        text="",
+        start=0,
+        end=0,
+        line=1,
+        column=1,
+    )

--- a/src/conversion/shaders.py
+++ b/src/conversion/shaders.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import re
 import tempfile
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
@@ -19,6 +18,12 @@ from src.conversion.project_source_paths import (
     ProjectSourcePathError,
     ResolvedProjectSourcePath,
     validate_project_resource_source_path,
+)
+from src.conversion.shader_translation import (
+    ShaderStage,
+    ShaderStageSource,
+    ShaderTranslationIssue,
+    translate_gamemaker_shader,
 )
 from src.conversion.type_defs import ConversionRunning, LogCallback, ProgressCallback, StrPath
 from src.localization import get_localized
@@ -76,13 +81,10 @@ class _ShaderConversionPlan:
     skipped_names: tuple[str, ...]
 
 
-_FUNCTION_START_RE = re.compile(
-    r"^\s*[A-Za-z_]\w*(?:\s*\[[^\]]+\])?\s+[A-Za-z_]\w*\s*\(",
-)
-_DECLARATION_RE = re.compile(
-    r"^\s*(uniform|varying|const|in|out)\b.*?\b([A-Za-z_]\w*)\s*"
-    r"(?:\[[^\]]*\])?\s*;\s*$",
-)
+@dataclass(frozen=True)
+class _ShaderRenderResult:
+    source: str | None
+    reported_failure: bool = False
 
 
 class ShaderConverter(BaseConverter):
@@ -112,87 +114,38 @@ class ShaderConverter(BaseConverter):
             return
         with open(resolved_input.filesystem_path, 'r', encoding='utf-8') as f:
             content = f.read()
-        stage = (
+        stage: ShaderStage = (
             "vertex"
             if resolved_input.filesystem_path.lower().endswith(".vsh")
             else "fragment"
         )
-        translated = self._translate_shader_source(content, stage)
-        self._atomic_write_text(
-            output_file,
-            self._merge_shader_sources((translated,)),
+        translation = translate_gamemaker_shader(
+            (ShaderStageSource(stage=stage, source=content),)
         )
-
-    @staticmethod
-    def _translate_shader_source(content: str, stage: str) -> str:
-        content = re.sub(
-            r"(?m)^\s*precision\s+(?:lowp|mediump|highp)\s+\w+\s*;\s*$",
-            "",
-            content,
-        )
-        content = re.sub(
-            r"(?m)^\s*shader_type\s+\w+\s*;\s*$",
-            "",
-            content,
-        )
-        content = re.sub(
-            r"(?m)^\s*uniform\s+sampler2D\s+gm_BaseTexture\s*;\s*$",
-            "",
-            content,
-        )
-
-        content = re.sub(r'\battribute\b', 'in', content)
-        content = re.sub(r'gl_FragColor', 'COLOR', content)
-        content = re.sub(r'texture2D', 'texture', content)
-        content = re.sub(r'gl_Position', 'VERTEX', content)
-
-        if stage == "vertex":
-            content = re.sub(r'void main\(\)', 'void vertex()', content)
-        else:
-            content = re.sub(r'void main\(\)', 'void fragment()', content)
-
-        content = re.sub(r'gm_BaseTexture', 'TEXTURE', content)
-        content = re.sub(r'gm_Matrices\[MATRIX_WORLD_VIEW_PROJECTION\]',
-                         'PROJECTION_MATRIX * MODELVIEW_MATRIX', content)
-
-        if 'u_fTime' in content:
-            content = content.replace('u_fTime', 'TIME')
-
-        return content.strip()
-
-    @classmethod
-    def _merge_shader_sources(cls, sources: tuple[str, ...]) -> str:
-        preambles: list[str] = []
-        bodies: list[str] = []
-        seen_declarations: set[tuple[str, str]] = set()
-        for source in sources:
-            preamble, body = cls._split_shader_source(source)
-            filtered_preamble: list[str] = []
-            for line in preamble.splitlines():
-                declaration = _DECLARATION_RE.match(line)
-                if declaration is not None:
-                    key = (declaration.group(1), declaration.group(2))
-                    if key in seen_declarations:
-                        continue
-                    seen_declarations.add(key)
-                filtered_preamble.append(line)
-            rendered_preamble = "\n".join(filtered_preamble).strip()
-            if rendered_preamble:
-                preambles.append(rendered_preamble)
-            rendered_body = body.strip()
-            if rendered_body:
-                bodies.append(rendered_body)
-
-        sections = ["shader_type canvas_item;", *preambles, *bodies]
-        return "\n\n".join(sections).rstrip() + "\n"
-
-    @staticmethod
-    def _split_shader_source(source: str) -> tuple[str, str]:
-        lines = source.splitlines()
-        for index, line in enumerate(lines):
-            if _FUNCTION_START_RE.match(line):
-                return ("\n".join(lines[:index]), "\n".join(lines[index:]))
-        return (source, "")
+        if translation.source is None:
+            self._report_shader_translation_issues(
+                _ShaderAsset(
+                    name=os.path.splitext(
+                        os.path.basename(resolved_input.filesystem_path)
+                    )[0],
+                    subfolder="",
+                    owner_path=resolved_input.source_path,
+                    vertex_path=(
+                        resolved_input.filesystem_path
+                        if stage == "vertex"
+                        else None
+                    ),
+                    fragment_path=(
+                        resolved_input.filesystem_path
+                        if stage == "fragment"
+                        else None
+                    ),
+                ),
+                translation.issues,
+                {stage: resolved_input.filesystem_path},
+            )
+            return
+        self._atomic_write_text(output_file, translation.source)
 
     @staticmethod
     def _atomic_write_text(output_file: str, content: str) -> None:
@@ -221,12 +174,14 @@ class ShaderConverter(BaseConverter):
                 except FileNotFoundError:
                     pass
 
-    def _render_shader_asset(self, asset: _ShaderAsset) -> str | None:
-        translated_sources: list[str] = []
-        for stage, source_path in (
+    def _render_shader_asset(self, asset: _ShaderAsset) -> _ShaderRenderResult:
+        stage_sources: list[ShaderStageSource] = []
+        source_paths: dict[ShaderStage, str] = {}
+        stage_paths: tuple[tuple[ShaderStage, str | None], ...] = (
             ("vertex", asset.vertex_path),
             ("fragment", asset.fragment_path),
-        ):
+        )
+        for stage, source_path in stage_paths:
             if source_path is None:
                 continue
             resolved_source = self._resolve_discovered_project_source(
@@ -239,7 +194,7 @@ class ShaderConverter(BaseConverter):
             if resolved_source is None or not os.path.isfile(
                 resolved_source.filesystem_path
             ):
-                return None
+                return _ShaderRenderResult(source=None)
             try:
                 with open(
                     resolved_source.filesystem_path,
@@ -248,16 +203,58 @@ class ShaderConverter(BaseConverter):
                 ) as source_file:
                     source = source_file.read()
             except OSError:
-                return None
+                return _ShaderRenderResult(source=None)
             if not source.strip():
-                return None
-            translated_source = self._translate_shader_source(source, stage)
-            if not translated_source.strip():
-                return None
-            translated_sources.append(translated_source)
-        if not translated_sources:
-            return None
-        return self._merge_shader_sources(tuple(translated_sources))
+                return _ShaderRenderResult(source=None)
+            stage_sources.append(ShaderStageSource(stage=stage, source=source))
+            source_paths[stage] = resolved_source.filesystem_path
+        if not stage_sources:
+            return _ShaderRenderResult(source=None)
+        translation = translate_gamemaker_shader(tuple(stage_sources))
+        if translation.source is None:
+            self._report_shader_translation_issues(
+                asset,
+                translation.issues,
+                source_paths,
+            )
+            return _ShaderRenderResult(source=None, reported_failure=True)
+        return _ShaderRenderResult(source=translation.source)
+
+    def _report_shader_translation_issues(
+        self,
+        asset: _ShaderAsset,
+        issues: tuple[ShaderTranslationIssue, ...],
+        source_paths: dict[ShaderStage, str],
+    ) -> None:
+        for issue in issues:
+            source_path = self._diagnostic_source_path(
+                source_paths.get(issue.stage)
+            )
+            location = (
+                f"{source_path or asset.source_label}:"
+                f"{issue.line}:{issue.column}"
+            )
+            message = (
+                f"Warning: GameMaker shader {asset.name!r} {issue.stage} "
+                f"stage at {location}: {issue.message}"
+            )
+            with self._lock:
+                if self.diagnostics is not None:
+                    self.diagnostics.add(
+                        "warning",
+                        issue.code,
+                        message,
+                        source_path=source_path,
+                        line=issue.line,
+                        column=issue.column,
+                        resource=asset.name,
+                        resource_type="shader",
+                        event=issue.stage,
+                        manifest_entry=issue.construct,
+                        issue_number=708,
+                        workaround=issue.workaround,
+                    )
+                self.log_callback(message)
 
     def _process_shader(
         self,
@@ -278,14 +275,15 @@ class ShaderConverter(BaseConverter):
                 else self.godot_shaders_path
             )
             output_path = os.path.join(output_dir, output_name)
-        shader_source = self._render_shader_asset(asset)
-        if shader_source is None:
-            self._safe_log(
-                f"Warning: GameMaker shader {asset.name} does not have a "
-                "complete, non-empty readable stage set during conversion."
-            )
+        render_result = self._render_shader_asset(asset)
+        if render_result.source is None:
+            if not render_result.reported_failure:
+                self._safe_log(
+                    f"Warning: GameMaker shader {asset.name} does not have a "
+                    "complete, non-empty readable stage set during conversion."
+                )
             return None
-        self._atomic_write_text(output_path, shader_source)
+        self._atomic_write_text(output_path, render_result.source)
         return (asset.source_label, output_name)
 
     def _process_shader_with_outcome(

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.47"
+VERSION = "0.7.48"
 
 
 def get_version():

--- a/tests/fixtures/part2/projects/resource_matrix/shaders/shd_matrix/shd_matrix.fsh
+++ b/tests/fixtures/part2/projects/resource_matrix/shaders/shd_matrix/shd_matrix.fsh
@@ -1,7 +1,9 @@
 precision highp float;
 varying vec2 v_vTexcoord;
+varying vec4 v_vColour;
 uniform sampler2D gm_BaseTexture;
+uniform vec4 tint;
 
 void main() {
-    gl_FragColor = texture2D(gm_BaseTexture, v_vTexcoord);
+    gl_FragColor = texture2D(gm_BaseTexture, v_vTexcoord) * v_vColour * tint;
 }

--- a/tests/fixtures/shader_corpus/README.md
+++ b/tests/fixtures/shader_corpus/README.md
@@ -1,0 +1,10 @@
+# GameMaker shader corpus
+
+`tcc_wave` and `tcc_grayscale` are preserved from The Colorful Creature at
+commit `4b6e942caca4d58af49dc006a037404d2f2a348c`, which is distributed under
+Apache-2.0. `standard_color` is a GM2Godot regression pair authored for issue
+#708. The manifest records each pair's exact origin and exercised semantics.
+
+These are source `.vsh` + `.fsh` pairs, not expected Godot output. Tests convert
+every manifest case and require exact Godot 4.7.1 to load the resulting
+`.gdshader`.

--- a/tests/fixtures/shader_corpus/manifest.json
+++ b/tests/fixtures/shader_corpus/manifest.json
@@ -1,0 +1,60 @@
+{
+  "format_version": 1,
+  "cases": [
+    {
+      "name": "tcc_wave",
+      "vertex": "tcc_wave/tcc_wave.vsh",
+      "fragment": "tcc_wave/tcc_wave.fsh",
+      "vertex_sha256": "e149adaa8ee80d69ce3ea92c17191efc27442b1fd4031d1d7987fe4eaf5903a3",
+      "fragment_sha256": "942b4f336b5c64a77269ffb82e95272959c7e09326360e292b552355dcd1b203",
+      "origin": "https://github.com/Infiland/TheColorfulCreature/tree/4b6e942caca4d58af49dc006a037404d2f2a348c/shaders/shd_wave",
+      "license": "Apache-2.0",
+      "features": [
+        "MATRIX_WORLD_VIEW_PROJECTION",
+        "in_Position",
+        "in_TextureCoord",
+        "custom uniforms",
+        "varying",
+        "gm_BaseTexture"
+      ]
+    },
+    {
+      "name": "tcc_grayscale",
+      "vertex": "tcc_grayscale/tcc_grayscale.vsh",
+      "fragment": "tcc_grayscale/tcc_grayscale.fsh",
+      "vertex_sha256": "a7befc2c4604fe095299dfa0841cfe12a10a454227b40cd03f9be6378e2b6c11",
+      "fragment_sha256": "ed001ca868eedd31ce24b3fc89982b8df8c017e44b8ed9d3282f61645018fe68",
+      "origin": "https://github.com/Infiland/TheColorfulCreature/tree/4b6e942caca4d58af49dc006a037404d2f2a348c/shaders/xot_cbs_shGrayscale",
+      "license": "Apache-2.0",
+      "features": [
+        "MATRIX_WORLD_VIEW_PROJECTION",
+        "in_Position.xyz",
+        "in_TextureCoord",
+        "const",
+        "varying",
+        "gm_BaseTexture"
+      ]
+    },
+    {
+      "name": "standard_color",
+      "vertex": "standard_color/standard_color.vsh",
+      "fragment": "standard_color/standard_color.fsh",
+      "vertex_sha256": "0869b2689044c6ab8210a6fcafad97c84d8c2a0602c68ac42c1aff63bfb6b7a1",
+      "fragment_sha256": "ed8ba175b8caea1d2203a823852a364cd205951d33f4072073398c11a684928a",
+      "origin": "GM2Godot issue #708 regression fixture",
+      "license": "Apache-2.0",
+      "features": [
+        "MATRIX_WORLD_VIEW_PROJECTION",
+        "in_Position",
+        "in_Colour",
+        "in_TextureCoord",
+        "multi-line declarations",
+        "array declarations",
+        "comma-separated declarations",
+        "custom uniforms",
+        "varyings",
+        "gm_BaseTexture"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/shader_corpus/standard_color/standard_color.fsh
+++ b/tests/fixtures/shader_corpus/standard_color/standard_color.fsh
@@ -1,0 +1,16 @@
+precision mediump float;
+
+varying vec2 v_vTexcoord;
+varying vec4 v_vColour;
+
+uniform sampler2D
+    gm_BaseTexture;
+uniform vec4 tint,
+             channel_weights[2];
+
+void main()
+{
+    vec4 sampled = texture2D(gm_BaseTexture, v_vTexcoord);
+    gl_FragColor = sampled * v_vColour * tint
+        * mix(channel_weights[0], channel_weights[1], sampled.a);
+}

--- a/tests/fixtures/shader_corpus/standard_color/standard_color.vsh
+++ b/tests/fixtures/shader_corpus/standard_color/standard_color.vsh
@@ -1,13 +1,22 @@
-attribute vec3 in_Position;
+precision highp float;
+
+attribute
+    vec3
+    in_Position;
 attribute vec4 in_Colour;
 attribute vec2 in_TextureCoord;
-varying vec2 v_vTexcoord;
-varying vec4 v_vColour;
-uniform float vertex_offset;
 
-void main() {
+varying vec2
+    v_vTexcoord;
+varying vec4 v_vColour;
+
+uniform float x_offset,
+              weights[2];
+
+void main()
+{
     vec4 local_position = vec4(
-        in_Position.xy + vec2(vertex_offset, 0.0),
+        in_Position.xy + vec2(x_offset * weights[0], 0.0),
         in_Position.z,
         1.0
     );

--- a/tests/fixtures/shader_corpus/tcc_grayscale/tcc_grayscale.fsh
+++ b/tests/fixtures/shader_corpus/tcc_grayscale/tcc_grayscale.fsh
@@ -1,0 +1,9 @@
+varying vec2 vTc;
+void main()
+{
+const vec3 ww=vec3(0.2125,0.7154,0.0721);
+vec3 irgb=texture2D(gm_BaseTexture,vTc).rgb;
+float alpha=texture2D(gm_BaseTexture,vTc).a;
+float luminance=dot(irgb,ww);
+gl_FragColor=vec4(luminance,luminance,luminance,alpha);
+}

--- a/tests/fixtures/shader_corpus/tcc_grayscale/tcc_grayscale.vsh
+++ b/tests/fixtures/shader_corpus/tcc_grayscale/tcc_grayscale.vsh
@@ -1,0 +1,8 @@
+attribute vec3 in_Position;
+attribute vec2 in_TextureCoord;
+varying vec2 vTc;
+void main()
+{
+gl_Position = gm_Matrices[MATRIX_WORLD_VIEW_PROJECTION]*vec4(in_Position.xyz,1.);
+vTc=in_TextureCoord;
+}

--- a/tests/fixtures/shader_corpus/tcc_wave/tcc_wave.fsh
+++ b/tests/fixtures/shader_corpus/tcc_wave/tcc_wave.fsh
@@ -1,0 +1,17 @@
+varying vec2 v_texcoord;
+
+uniform float time;
+uniform vec2 mouse_pos;
+uniform vec2 resolution;
+uniform float wave_amount;
+uniform float wave_distortion;
+uniform float wave_speed;
+
+void main()
+{ 
+    vec2 uv = v_texcoord;
+    uv.x = uv.x+cos(uv.y*wave_amount+time*wave_speed)/wave_distortion;
+    uv.y = uv.y+sin(uv.x*wave_amount+time*wave_speed)/wave_distortion;
+ 
+    gl_FragColor = texture2D(gm_BaseTexture,uv);
+}

--- a/tests/fixtures/shader_corpus/tcc_wave/tcc_wave.vsh
+++ b/tests/fixtures/shader_corpus/tcc_wave/tcc_wave.vsh
@@ -1,0 +1,11 @@
+attribute vec3 in_Position;
+attribute vec4 in_Colour;
+attribute vec2 in_TextureCoord;
+
+varying vec2 v_texcoord;
+
+void main()
+{
+    gl_Position = gm_Matrices[MATRIX_WORLD_VIEW_PROJECTION] * vec4(in_Position, 1.0);
+    v_texcoord = in_TextureCoord;
+}

--- a/tests/fixtures/tcc_expected_skipped_resources.json
+++ b/tests/fixtures/tcc_expected_skipped_resources.json
@@ -247,5 +247,18 @@
   ],
   "sequences": [
     "seq_magentaswing"
+  ],
+  "shaders": [
+    "__shd_scribble",
+    "__shd_scribble_bake_effect_4dir",
+    "__shd_scribble_bake_effect_8dir",
+    "__shd_scribble_bake_effect_8dir_2px",
+    "__shd_scribble_bake_outline_4dir",
+    "__shd_scribble_bake_outline_8dir",
+    "__shd_scribble_bake_outline_8dir_2px",
+    "__shd_scribble_bake_shadow",
+    "xot_cbs_shDeuteranopia",
+    "xot_cbs_shProtanopia",
+    "xot_cbs_shTritanopia"
   ]
 }

--- a/tests/test_shader_translation.py
+++ b/tests/test_shader_translation.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import unittest
+
+from src.conversion.shader_translation import (
+    ShaderStageSource,
+    translate_gamemaker_shader,
+)
+
+
+VERTEX_PREAMBLE = """\
+attribute vec3 in_Position;
+attribute vec4 in_Colour;
+attribute vec2 in_TextureCoord;
+varying vec2 v_uv;
+varying vec4 v_color;
+"""
+
+
+class TestGameMakerShaderTranslation(unittest.TestCase):
+    def test_translates_multiline_comma_and_array_declarations(self) -> None:
+        vertex = """\
+precision highp float;
+attribute
+    highp vec3
+    in_Position;
+attribute vec4 in_Colour;
+attribute vec2 in_TextureCoord;
+varying highp vec2
+    v_uv,
+    v_offsets[2];
+varying vec4 v_color;
+uniform float amount,
+    weights[3];
+const float gain = 1.0,
+    bias = 0.25;
+
+void main()
+{
+    vec4 local_position = vec4(in_Position.xy + vec2(amount), in_Position.z, 1.0);
+    gl_Position = gm_Matrices[MATRIX_WORLD_VIEW_PROJECTION] * local_position;
+    v_uv = in_TextureCoord;
+    v_offsets[0] = in_TextureCoord + vec2(weights[0]);
+    v_offsets[1] = in_TextureCoord + vec2(weights[1]);
+    v_color = in_Colour * gain + vec4(bias);
+}
+"""
+        fragment = """\
+precision mediump float;
+varying highp vec2 v_uv, v_offsets[2];
+varying vec4 v_color;
+uniform float amount, weights[3];
+uniform sampler2D
+    gm_BaseTexture,
+    overlay;
+
+void main()
+{
+    vec4 base = texture2D(gm_BaseTexture, v_uv + v_offsets[0] * amount);
+    gl_FragColor = base * v_color + texture2D(overlay, v_offsets[1]) * weights[2];
+}
+"""
+
+        result = translate_gamemaker_shader(
+            (
+                ShaderStageSource("vertex", vertex),
+                ShaderStageSource("fragment", fragment),
+            )
+        )
+
+        self.assertEqual(result.issues, ())
+        self.assertIsNotNone(result.source)
+        source = result.source or ""
+        self.assertNotIn("attribute", source)
+        self.assertNotIn("gm_BaseTexture", source)
+        self.assertNotIn("gm_Matrices", source)
+        self.assertNotIn("gl_Position", source)
+        self.assertNotIn("gl_FragColor", source)
+        self.assertNotIn("texture2D", source)
+        self.assertEqual(source.count("varying highp vec2 v_uv;"), 1)
+        self.assertEqual(source.count("varying highp vec2 v_offsets[2];"), 1)
+        self.assertEqual(source.count("uniform float amount;"), 1)
+        self.assertEqual(source.count("uniform float weights[3];"), 1)
+        self.assertIn("uniform sampler2D overlay;", source)
+        self.assertIn("const float gain = 1.0;", source)
+        self.assertIn("const float bias = 0.25;", source)
+        self.assertIn("VERTEX = (local_position).xy;", source)
+        self.assertIn("vec3(VERTEX, 0.0).xy", source)
+        self.assertIn("v_uv = UV;", source)
+        self.assertIn("v_color = COLOR", source)
+        self.assertIn("COLOR = base * v_color", source)
+        self.assertIn("texture(TEXTURE, v_uv", source)
+
+    def test_maps_supported_matrix_constants_without_time_name_heuristics(
+        self,
+    ) -> None:
+        vertex = VERTEX_PREAMBLE + """\
+uniform float u_fTime;
+void main()
+{
+    mat4 world = gm_Matrices[MATRIX_WORLD];
+    mat4 view = gm_Matrices[MATRIX_VIEW];
+    mat4 projection = gm_Matrices[MATRIX_PROJECTION];
+    mat4 world_view = gm_Matrices[MATRIX_WORLD_VIEW];
+    vec4 local_position = vec4(in_Position.xy + vec2(u_fTime), 0.0, 1.0);
+    gl_Position = gm_Matrices[MATRIX_WORLD_VIEW_PROJECTION] * local_position;
+    v_uv = in_TextureCoord;
+    v_color = in_Colour;
+}
+"""
+        fragment = """\
+varying vec2 v_uv;
+varying vec4 v_color;
+uniform float u_fTime;
+void main()
+{
+    gl_FragColor = v_color * texture2D(gm_BaseTexture, v_uv + vec2(u_fTime));
+}
+"""
+
+        result = translate_gamemaker_shader(
+            (
+                ShaderStageSource("vertex", vertex),
+                ShaderStageSource("fragment", fragment),
+            )
+        )
+
+        self.assertEqual(result.issues, ())
+        source = result.source or ""
+        self.assertIn("mat4 world = MODEL_MATRIX;", source)
+        self.assertIn("mat4 view = CANVAS_MATRIX;", source)
+        self.assertIn("mat4 projection = SCREEN_MATRIX;", source)
+        self.assertIn(
+            "mat4 world_view = (CANVAS_MATRIX * MODEL_MATRIX);",
+            source,
+        )
+        self.assertEqual(source.count("uniform float u_fTime;"), 1)
+        self.assertGreaterEqual(source.count("u_fTime"), 3)
+        self.assertNotIn("TIME", source)
+
+    def test_accepts_explicit_projection_view_world_position_chain(self) -> None:
+        vertex = """\
+attribute vec3 in_Position;
+void main()
+{
+    gl_Position =
+        gm_Matrices[MATRIX_PROJECTION]
+        * gm_Matrices[MATRIX_VIEW]
+        * gm_Matrices[MATRIX_WORLD]
+        * vec4(in_Position, 1.0);
+}
+"""
+        result = translate_gamemaker_shader(
+            (ShaderStageSource("vertex", vertex),)
+        )
+
+        self.assertEqual(result.issues, ())
+        self.assertIn(
+            "VERTEX = (vec4 ( vec3(VERTEX, 0.0) , 1.0 )).xy;",
+            result.source or "",
+        )
+
+    def test_rejects_custom_and_normal_attributes_when_referenced(self) -> None:
+        vertex = """\
+attribute vec3 in_Position;
+attribute vec3 in_Normal;
+attribute vec2 in_CustomTexcoord;
+void main()
+{
+    vec2 offset = in_Normal.xy + in_CustomTexcoord;
+    gl_Position = gm_Matrices[MATRIX_WORLD_VIEW_PROJECTION]
+        * vec4(in_Position.xy + offset, 0.0, 1.0);
+}
+"""
+
+        result = translate_gamemaker_shader(
+            (ShaderStageSource("vertex", vertex),)
+        )
+
+        self.assertIsNone(result.source)
+        self.assertEqual(
+            {issue.code for issue in result.issues},
+            {"GM2GD-SHADER-ATTRIBUTE-UNSUPPORTED"},
+        )
+        self.assertEqual(
+            {issue.construct for issue in result.issues},
+            {"in_Normal", "in_CustomTexcoord"},
+        )
+
+    def test_rejects_clip_space_position_without_supported_matrix_chain(
+        self,
+    ) -> None:
+        vertex = """\
+attribute vec3 in_Position;
+void main()
+{
+    gl_Position = vec4(in_Position, 1.0);
+}
+"""
+
+        result = translate_gamemaker_shader(
+            (ShaderStageSource("vertex", vertex),)
+        )
+
+        self.assertIsNone(result.source)
+        issue = next(
+            issue
+            for issue in result.issues
+            if issue.code == "GM2GD-SHADER-POSITION-UNSUPPORTED"
+        )
+        self.assertEqual((issue.line, issue.column), (4, 19))
+        self.assertIn("world/view/projection", issue.message)
+
+    def test_rejects_unlinked_fragment_varying(self) -> None:
+        fragment = """\
+varying vec2 v_uv;
+void main()
+{
+    gl_FragColor = texture2D(gm_BaseTexture, v_uv);
+}
+"""
+
+        result = translate_gamemaker_shader(
+            (ShaderStageSource("fragment", fragment),)
+        )
+
+        self.assertIsNone(result.source)
+        self.assertEqual(
+            [issue.code for issue in result.issues],
+            ["GM2GD-SHADER-VARYING-UNLINKED"],
+        )
+        self.assertEqual(result.issues[0].construct, "v_uv")
+
+    def test_rejects_incompatible_cross_stage_declarations(self) -> None:
+        vertex = """\
+attribute vec3 in_Position;
+varying vec2 v_uv;
+uniform float amount;
+void main()
+{
+    gl_Position = gm_Matrices[MATRIX_WORLD_VIEW_PROJECTION] * vec4(in_Position, 1.0);
+    v_uv = vec2(amount);
+}
+"""
+        fragment = """\
+varying vec3 v_uv;
+uniform vec2 amount;
+void main()
+{
+    gl_FragColor = vec4(v_uv, amount.x);
+}
+"""
+
+        result = translate_gamemaker_shader(
+            (
+                ShaderStageSource("vertex", vertex),
+                ShaderStageSource("fragment", fragment),
+            )
+        )
+
+        self.assertIsNone(result.source)
+        conflicts = [
+            issue
+            for issue in result.issues
+            if issue.code == "GM2GD-SHADER-DECLARATION-CONFLICT"
+        ]
+        self.assertEqual(
+            {issue.construct for issue in conflicts},
+            {"v_uv", "amount"},
+        )
+
+    def test_rejects_godot_builtin_names_and_scalar_matrix_constructors(
+        self,
+    ) -> None:
+        fragment = """\
+const float PI = 3.14159265359;
+const mat4 colour_matrix = mat4(
+    1.0, 0.0, 0.0, 0.0,
+    0.0, 1.0, 0.0, 0.0,
+    0.0, 0.0, 1.0, 0.0,
+    0.0, 0.0, 0.0, 1.0
+);
+void main()
+{
+    mat2 local_matrix = mat2(1.0, 0.0, 0.0, 1.0);
+    gl_FragColor = vec4(local_matrix[0], PI, colour_matrix[0][0]);
+}
+"""
+
+        result = translate_gamemaker_shader(
+            (ShaderStageSource("fragment", fragment),)
+        )
+
+        self.assertIsNone(result.source)
+        self.assertIn(
+            "GM2GD-SHADER-DECLARATION-UNSUPPORTED",
+            {issue.code for issue in result.issues},
+        )
+        self.assertIn(
+            "GM2GD-SHADER-CONSTRUCTOR-UNSUPPORTED",
+            {issue.code for issue in result.issues},
+        )
+
+    def test_rejects_preprocessor_directive(self) -> None:
+        fragment = """\
+#define OUTPUT_COLOUR vec4(1.0)
+void main()
+{
+    gl_FragColor = OUTPUT_COLOUR;
+}
+"""
+
+        result = translate_gamemaker_shader(
+            (ShaderStageSource("fragment", fragment),)
+        )
+
+        self.assertIsNone(result.source)
+        self.assertEqual(
+            {issue.code for issue in result.issues},
+            {"GM2GD-SHADER-CONSTRUCT-UNSUPPORTED"},
+        )
+
+    def test_rejects_stage_builtin_access_inside_fragment_helper(self) -> None:
+        fragment = """\
+vec4 sample_base(vec2 uv)
+{
+    return texture2D(gm_BaseTexture, uv);
+}
+void main()
+{
+    gl_FragColor = sample_base(vec2(0.5));
+}
+"""
+
+        result = translate_gamemaker_shader(
+            (ShaderStageSource("fragment", fragment),)
+        )
+
+        self.assertIsNone(result.source)
+        helper_issues = [
+            issue
+            for issue in result.issues
+            if issue.code == "GM2GD-SHADER-HELPER-UNSUPPORTED"
+        ]
+        self.assertEqual(len(helper_issues), 1, helper_issues)
+        self.assertEqual(
+            helper_issues[0].construct,
+            "sample_base:gm_BaseTexture",
+        )
+
+    def test_declaration_like_comments_do_not_change_parser_results(self) -> None:
+        vertex = """\
+// attribute vec3 fake;
+/* varying vec4 also_fake, second_fake[2]; */
+attribute vec3 in_Position;
+void main()
+{
+    // gl_Position = vec4(0.0);
+    gl_Position = gm_Matrices[MATRIX_WORLD_VIEW_PROJECTION] * vec4(in_Position, 1.0);
+}
+"""
+
+        result = translate_gamemaker_shader(
+            (ShaderStageSource("vertex", vertex),)
+        )
+
+        self.assertEqual(result.issues, ())
+        source = result.source or ""
+        self.assertIn("// attribute vec3 fake;", source)
+        self.assertIn("/* varying vec4 also_fake, second_fake[2]; */", source)
+        self.assertIn("// gl_Position = vec4(0.0);", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shaders.py
+++ b/tests/test_shaders.py
@@ -19,14 +19,11 @@ from src.conversion.project_source_paths import ResolvedProjectSourcePath
 
 SAMPLE_FSH = """\
 precision highp float;
-varying vec2 v_vTexcoord;
-varying vec4 v_vColour;
 uniform sampler2D gm_BaseTexture;
 
 void main()
 {
-    vec4 col = texture2D(gm_BaseTexture, v_vTexcoord);
-    gl_FragColor = col * v_vColour;
+    gl_FragColor = texture2D(gm_BaseTexture, vec2(0.5));
 }
 """
 
@@ -139,7 +136,9 @@ class TestShaderConverterBasic(unittest.TestCase):
         with open(vertex_path, "w", encoding="utf-8") as vertex_file:
             vertex_file.write(
                 "attribute vec3 in_Position;\n"
-                "void main() { gl_Position = vec4(in_Position, 1.0); }\n"
+                "void main() { gl_Position = "
+                "gm_Matrices[MATRIX_WORLD_VIEW_PROJECTION] * "
+                "vec4(in_Position, 1.0); }\n"
             )
         fragment_path = self.fsh_path
 
@@ -398,11 +397,13 @@ class TestShaderAssetOwnershipAndStages(unittest.TestCase):
     def test_dual_stage_asset_publishes_one_complete_shader(self) -> None:
         vertex_source = """\
 precision highp float;
+attribute vec3 in_Position;
 varying vec2 v_shared;
 uniform float amount;
 
 void main()
 {
+    gl_Position = gm_Matrices[MATRIX_WORLD_VIEW_PROJECTION] * vec4(in_Position, 1.0);
     v_shared = vec2(amount);
 }
 // VERTEX_MARKER
@@ -564,6 +565,113 @@ class TestShaderManifestOutcomeAccounting(unittest.TestCase):
             outcome.converters,
             ConversionCounts(requested=1, executed=1, completed=1),
         )
+
+    def test_unsupported_construct_fails_resource_with_structured_diagnostic(
+        self,
+    ) -> None:
+        shader_name = "shd_unsupported_normal"
+        shader_directory = os.path.join(
+            self.gm_dir,
+            "shaders",
+            shader_name,
+        )
+        os.makedirs(shader_directory)
+        with open(
+            os.path.join(shader_directory, shader_name + ".yy"),
+            "w",
+            encoding="utf-8",
+        ) as metadata_file:
+            json.dump(
+                {"name": shader_name, "resourceType": "GMShader"},
+                metadata_file,
+            )
+        with open(
+            os.path.join(shader_directory, shader_name + ".vsh"),
+            "w",
+            encoding="utf-8",
+        ) as vertex_file:
+            vertex_file.write(
+                "attribute vec3 in_Position;\n"
+                "attribute vec3 in_Normal;\n"
+                "void main()\n"
+                "{\n"
+                "    vec2 offset = in_Normal.xy;\n"
+                "    gl_Position = "
+                "gm_Matrices[MATRIX_WORLD_VIEW_PROJECTION] * "
+                "vec4(in_Position.xy + offset, 0.0, 1.0);\n"
+                "}\n"
+            )
+        with open(
+            os.path.join(shader_directory, shader_name + ".fsh"),
+            "w",
+            encoding="utf-8",
+        ) as fragment_file:
+            fragment_file.write(SAMPLE_FSH)
+        self._write_yyp(
+            [
+                self._shader_declaration(
+                    shader_name,
+                    f"shaders/{shader_name}/{shader_name}.yy",
+                )
+            ]
+        )
+        running = threading.Event()
+        running.set()
+        converter = Converter(
+            log_callback=self.logs.append,
+            progress_callback=lambda _value: None,
+            status_callback=lambda _message: None,
+            conversion_running=running,
+            max_workers=1,
+        )
+
+        outcome = converter.convert(
+            self.gm_dir,
+            "windows",
+            self.godot_dir,
+            {"shaders": _EnabledSetting()},
+        )
+
+        self.assertEqual(outcome.state, "partial")
+        self.assertEqual(
+            outcome.resources,
+            ConversionCounts(requested=1, executed=1, failed=1),
+        )
+        self.assertFalse(
+            os.path.exists(
+                os.path.join(
+                    self.godot_dir,
+                    "shaders",
+                    shader_name + ".gdshader",
+                )
+            )
+        )
+        with open(
+            os.path.join(
+                self.godot_dir,
+                "gm2godot",
+                "conversion_diagnostics.json",
+            ),
+            encoding="utf-8",
+        ) as diagnostics_file:
+            diagnostics = json.load(diagnostics_file)
+        unsupported = [
+            diagnostic
+            for diagnostic in diagnostics["diagnostics"]
+            if diagnostic["code"] == "GM2GD-SHADER-ATTRIBUTE-UNSUPPORTED"
+        ]
+        self.assertEqual(len(unsupported), 1, unsupported)
+        self.assertEqual(unsupported[0]["resource"], shader_name)
+        self.assertEqual(unsupported[0]["resource_type"], "shader")
+        self.assertEqual(unsupported[0]["event"], "vertex")
+        self.assertEqual(unsupported[0]["source_path"], (
+            f"shaders/{shader_name}/{shader_name}.vsh"
+        ))
+        self.assertEqual(unsupported[0]["line"], 5)
+        self.assertEqual(unsupported[0]["column"], 19)
+        self.assertEqual(unsupported[0]["manifest_entry"], "in_Normal")
+        self.assertEqual(unsupported[0]["issue_number"], 708)
+        self.assertTrue(unsupported[0]["workaround"])
 
     def test_safe_and_missing_manifest_shaders_have_strict_counts(self) -> None:
         safe_directory = os.path.join(

--- a/tests/test_shaders_godot.py
+++ b/tests/test_shaders_godot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import shutil
@@ -7,9 +8,39 @@ import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from typing import TypedDict, cast
 
 from src.conversion.asset_output_paths import build_asset_output_paths
 from src.conversion.shaders import ShaderConverter
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SHADER_CORPUS_ROOT = PROJECT_ROOT / "tests" / "fixtures" / "shader_corpus"
+
+
+class _ShaderCorpusCase(TypedDict):
+    name: str
+    vertex: str
+    fragment: str
+    vertex_sha256: str
+    fragment_sha256: str
+    origin: str
+    license: str
+    features: list[str]
+
+
+class _ShaderCorpusManifest(TypedDict):
+    format_version: int
+    cases: list[_ShaderCorpusCase]
+
+
+def _load_shader_corpus() -> _ShaderCorpusManifest:
+    return cast(
+        _ShaderCorpusManifest,
+        json.loads(
+            (SHADER_CORPUS_ROOT / "manifest.json").read_text(encoding="utf-8")
+        ),
+    )
 
 
 def _find_godot_binary() -> str | None:
@@ -24,6 +55,199 @@ def _find_godot_binary() -> str | None:
 
 
 class TestConvertedShaderGodotSmoke(unittest.TestCase):
+    def test_supported_corpus_compiles_and_loads_in_exact_godot_4_7_1(
+        self,
+    ) -> None:
+        godot_binary = _find_godot_binary()
+        if godot_binary is None:
+            self.skipTest("Godot binary not available")
+        corpus = _load_shader_corpus()
+        self.assertEqual(corpus["format_version"], 1)
+        self.assertGreaterEqual(len(corpus["cases"]), 3)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            gm_directory = root / "gamemaker"
+            godot_directory = root / "godot"
+            godot_directory.mkdir()
+            resources: list[dict[str, object]] = []
+            for case in corpus["cases"]:
+                shader_name = case["name"]
+                shader_directory = gm_directory / "shaders" / shader_name
+                shader_directory.mkdir(parents=True)
+                vertex_source = (
+                    SHADER_CORPUS_ROOT / case["vertex"]
+                ).read_text(encoding="utf-8")
+                fragment_source = (
+                    SHADER_CORPUS_ROOT / case["fragment"]
+                ).read_text(encoding="utf-8")
+                self.assertEqual(
+                    hashlib.sha256(vertex_source.encode("utf-8")).hexdigest(),
+                    case["vertex_sha256"],
+                )
+                self.assertEqual(
+                    hashlib.sha256(fragment_source.encode("utf-8")).hexdigest(),
+                    case["fragment_sha256"],
+                )
+                (shader_directory / f"{shader_name}.vsh").write_text(
+                    vertex_source,
+                    encoding="utf-8",
+                )
+                (shader_directory / f"{shader_name}.fsh").write_text(
+                    fragment_source,
+                    encoding="utf-8",
+                )
+                (shader_directory / f"{shader_name}.yy").write_text(
+                    json.dumps(
+                        {
+                            "name": shader_name,
+                            "resourceType": "GMShader",
+                            "parent": {
+                                "name": "Shaders",
+                                "path": "folders/Shaders.yy",
+                            },
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                resources.append(
+                    {
+                        "id": {
+                            "name": shader_name,
+                            "path": (
+                                f"shaders/{shader_name}/{shader_name}.yy"
+                            ),
+                        }
+                    }
+                )
+            (gm_directory / "ShaderCorpus.yyp").write_text(
+                json.dumps({"%Name": "ShaderCorpus", "resources": resources}),
+                encoding="utf-8",
+            )
+
+            converter = ShaderConverter(
+                gm_directory,
+                godot_directory,
+                log_callback=lambda _message: None,
+                progress_callback=lambda _value: None,
+                conversion_running=lambda: True,
+                max_workers=3,
+            )
+            converter.convert_all()
+            counts = converter.conversion_step_result().resources
+            self.assertEqual(counts.requested, len(corpus["cases"]))
+            self.assertEqual(counts.completed, len(corpus["cases"]))
+            self.assertEqual(counts.failed, 0)
+            output_paths = build_asset_output_paths(
+                gm_directory,
+                godot_directory,
+            )["shaders"]
+            for case in corpus["cases"]:
+                generated_path = (
+                    godot_directory
+                    / output_paths[case["name"]].removeprefix("res://")
+                )
+                generated_source = generated_path.read_text(encoding="utf-8")
+                self.assertNotIn("gm_Matrices", generated_source)
+                self.assertNotIn("gm_BaseTexture", generated_source)
+                self.assertNotIn("gl_Position", generated_source)
+                self.assertNotIn("gl_FragColor", generated_source)
+
+            (godot_directory / "project.godot").write_text(
+                '[application]\nrun/main_scene="res://smoke.tscn"\n',
+                encoding="utf-8",
+            )
+            script_lines = [
+                "extends Node",
+                "",
+                "func _ready():",
+            ]
+            for index, case in enumerate(corpus["cases"]):
+                resource_path = output_paths[case["name"]]
+                script_lines.extend(
+                    (
+                        f'\tvar shader_{index} = load("{resource_path}")',
+                        f"\tif shader_{index} == null:",
+                        (
+                            '\t\tpush_error("shader corpus load failed: '
+                            f'{case["name"]}")'
+                        ),
+                        "\t\tget_tree().quit(1)",
+                        "\t\treturn",
+                        f"\tvar material_{index} = ShaderMaterial.new()",
+                        f"\tmaterial_{index}.shader = shader_{index}",
+                        f"\tif material_{index}.shader == null:",
+                        (
+                            '\t\tpush_error("shader corpus compile failed: '
+                            f'{case["name"]}")'
+                        ),
+                        "\t\tget_tree().quit(1)",
+                        "\t\treturn",
+                        (
+                            f"\tvar uniforms_{index} = "
+                            f"shader_{index}.get_shader_uniform_list()"
+                        ),
+                        (
+                            f'\tprint("SHADER_COMPILED:{case["name"]}:", '
+                            f"uniforms_{index}.size())"
+                        ),
+                    )
+                )
+            script_lines.extend(
+                (
+                    '\tprint("SHADER_CORPUS_OK")',
+                    "\tget_tree().quit(0)",
+                    "",
+                )
+            )
+            (godot_directory / "smoke.gd").write_text(
+                "\n".join(script_lines),
+                encoding="utf-8",
+            )
+            (godot_directory / "smoke.tscn").write_text(
+                "\n".join(
+                    (
+                        "[gd_scene load_steps=2 format=3]",
+                        "",
+                        (
+                            '[ext_resource type="Script" '
+                            'path="res://smoke.gd" id="1"]'
+                        ),
+                        "",
+                        '[node name="Smoke" type="Node"]',
+                        'script = ExtResource("1")',
+                        "",
+                    )
+                ),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    godot_binary,
+                    "--headless",
+                    "--path",
+                    os.fspath(godot_directory),
+                    "smoke.tscn",
+                ],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                timeout=30,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn(
+            "Godot Engine v4.7.1.stable.official.a13da4feb",
+            result.stdout,
+        )
+        self.assertIn("SHADER_CORPUS_OK", result.stdout)
+        self.assertNotIn("SHADER ERROR:", result.stdout)
+        self.assertNotIn("Shader compilation failed", result.stdout)
+        self.assertNotIn("ERROR:", result.stdout)
+        self.assertNotIn("SCRIPT ERROR:", result.stdout)
+
     def test_dual_stage_shader_loads_in_exact_godot_4_7_1(self) -> None:
         godot_binary = _find_godot_binary()
         if godot_binary is None:
@@ -53,9 +277,14 @@ class TestConvertedShaderGodotSmoke(unittest.TestCase):
                 "\n".join(
                     (
                         "precision highp float;",
+                        "attribute vec3 in_Position;",
                         "varying vec2 v_shared;",
                         "uniform float amount;",
-                        "void main() { v_shared = vec2(amount); }",
+                        "void main() {",
+                        "    gl_Position = gm_Matrices[MATRIX_WORLD_VIEW_PROJECTION]",
+                        "        * vec4(in_Position, 1.0);",
+                        "    v_shared = vec2(amount);",
+                        "}",
                         "",
                     )
                 ),
@@ -119,6 +348,8 @@ class TestConvertedShaderGodotSmoke(unittest.TestCase):
                         "\t\treturn",
                         "\tvar material = ShaderMaterial.new()",
                         "\tmaterial.shader = shader",
+                        "\tvar uniforms = shader.get_shader_uniform_list()",
+                        '\tprint("PAIRED_SHADER_COMPILED:", uniforms.size())',
                         '\tprint("PAIRED_SHADER_OK")',
                         "\tget_tree().quit(0)",
                         "",
@@ -159,6 +390,9 @@ class TestConvertedShaderGodotSmoke(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout)
         self.assertIn("Godot Engine v4.7.1.stable", result.stdout)
         self.assertIn("PAIRED_SHADER_OK", result.stdout)
+        self.assertIn("PAIRED_SHADER_COMPILED:", result.stdout)
+        self.assertNotIn("SHADER ERROR:", result.stdout)
+        self.assertNotIn("Shader compilation failed", result.stdout)
         self.assertNotIn("ERROR:", result.stdout)
         self.assertNotIn("SCRIPT ERROR:", result.stdout)
 

--- a/tests/test_stale_managed_output_invalidation.py
+++ b/tests/test_stale_managed_output_invalidation.py
@@ -359,12 +359,10 @@ class TestStaleManagedOutputInvalidation(unittest.TestCase):
     def _valid_shader_source() -> str:
         return (
             "precision highp float;\n"
-            "varying vec2 v_vTexcoord;\n"
-            "varying vec4 v_vColour;\n"
             "uniform sampler2D gm_BaseTexture;\n"
             "void main() {\n"
             "    gl_FragColor = texture2D("
-            "gm_BaseTexture, v_vTexcoord) * v_vColour;\n"
+            "gm_BaseTexture, vec2(0.5));\n"
             "}\n"
         )
 
@@ -541,6 +539,45 @@ class TestStaleManagedOutputInvalidation(unittest.TestCase):
         self.assertIsNone(self._manifest_resource(self.SHADER_NAME))
         self.assertNotIn(f'"name": "{self.SHADER_NAME}"', self._registry())
         self._assert_absent_from_inventory((output,))
+        self._assert_user_file_preserved()
+
+    def test_unsupported_shader_removes_prior_output_with_diagnostic(
+        self,
+    ) -> None:
+        self._write_shader(
+            "#define SAMPLE_AT(uv) texture2D(gm_BaseTexture, uv)\n"
+            "void main() {\n"
+            "    gl_FragColor = SAMPLE_AT(vec2(0.5));\n"
+            "}\n"
+        )
+
+        outcome = self._convert()
+
+        output = self._shader_output()
+        self.assertEqual(outcome.state, "partial")
+        self.assertEqual(outcome.resources.failed, 1)
+        self.assertFalse(output.exists())
+        self.assertIsNone(self._manifest_resource(self.SHADER_NAME))
+        self.assertNotIn(f'"name": "{self.SHADER_NAME}"', self._registry())
+        self._assert_absent_from_inventory((output,))
+        diagnostics = json.loads(
+            (
+                self.godot_dir
+                / "gm2godot"
+                / "conversion_diagnostics.json"
+            ).read_text(encoding="utf-8")
+        )
+        shader_diagnostics = [
+            diagnostic
+            for diagnostic in diagnostics["diagnostics"]
+            if diagnostic["code"] == "GM2GD-SHADER-CONSTRUCT-UNSUPPORTED"
+        ]
+        self.assertEqual(len(shader_diagnostics), 1, shader_diagnostics)
+        self.assertEqual(
+            shader_diagnostics[0]["source_path"],
+            f"shaders/{self.SHADER_NAME}/{self.SHADER_NAME}.fsh",
+        )
+        self.assertEqual(shader_diagnostics[0]["line"], 1)
         self._assert_user_file_preserved()
 
     def test_timeline_transpile_failure_removes_prior_action_script_reference(

--- a/tests/test_tcc_conversion.py
+++ b/tests/test_tcc_conversion.py
@@ -96,8 +96,12 @@ class TestTCCConversion(unittest.TestCase):
                 # step now also skips its 166 object/room rows whose required
                 # generated outputs are absent, plus the authored sequence whose
                 # embedded animation curve is intentionally diagnosed by #707.
-                completed=4979,
-                skipped=407,
+                # Eleven shaders fail closed for custom vertex data, reserved
+                # Godot globals, or unsupported scalar matrix constructors and
+                # are omitted once more from the registry.
+                completed=4957,
+                skipped=418,
+                failed=11,
             ),
         )
         if outcome != expected_outcome:
@@ -336,6 +340,27 @@ class TestTCCConversion(unittest.TestCase):
             if diagnostic.get("code") == "GM2GD-SEQUENCE-KEY-UNSUPPORTED"
         }
         self.assertEqual(unsupported_sequence_keys, {"seq_magentaswing"})
+        unsupported_shaders = {
+            str(diagnostic.get("resource", ""))
+            for diagnostic in diagnostic_entries
+            if str(diagnostic.get("code", "")).startswith("GM2GD-SHADER-")
+        }
+        self.assertEqual(
+            unsupported_shaders,
+            {
+                "__shd_scribble",
+                "__shd_scribble_bake_effect_4dir",
+                "__shd_scribble_bake_effect_8dir",
+                "__shd_scribble_bake_effect_8dir_2px",
+                "__shd_scribble_bake_outline_4dir",
+                "__shd_scribble_bake_outline_8dir",
+                "__shd_scribble_bake_outline_8dir_2px",
+                "__shd_scribble_bake_shadow",
+                "xot_cbs_shDeuteranopia",
+                "xot_cbs_shProtanopia",
+                "xot_cbs_shTritanopia",
+            },
+        )
 
         expected_skipped_resources_path = os.path.join(
             PROJECT_ROOT,
@@ -357,6 +382,7 @@ class TestTCCConversion(unittest.TestCase):
             ),
             "rooms": sorted(room_creation_missing_resources | room_transpile_resources),
             "sequences": sorted(unsupported_sequence_keys),
+            "shaders": sorted(unsupported_shaders),
         }
         self.assertEqual(actual_skipped_resources, expected_skipped_resources)
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_47(self) -> None:
-        self.assertEqual(get_version(), "0.7.47")
+    def test_release_version_is_0_7_48(self) -> None:
+        self.assertEqual(get_version(), "0.7.48")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")

--- a/todo-list/01-current-coverage.md
+++ b/todo-list/01-current-coverage.md
@@ -71,9 +71,11 @@ This file records what the current codebase appears to support. Partial features
 - [x] Preserve tile size, separation, margins, tile count, and subfolders.
 - [ ] Partial: TileDataFormat variants, animated tiles, brushes, autotile metadata, tile transforms, tile collisions, and runtime tilemap APIs.
 
-- [x] Convert shader files into `.gdshader` files with basic string substitutions.
+- [x] Parse paired shader stages and convert the supported 2D attribute, varying, uniform, base-texture, and matrix subset into one `.gdshader`.
+- [x] Parse multi-line, array, and comma-separated declarations and fail unsupported constructs with source-linked diagnostics.
+- [x] Compile and load the provenance-pinned supported shader corpus under exact Godot 4.7.1.
 - [ ] Partial: full GLSL ES to Godot shader language translation.
-- [ ] Partial: attributes, varyings, uniforms, samplers, macros, precision qualifiers, multi-pass effects, and shader compiler diagnostics.
+- [ ] Partial: custom/normal vertex streams, macros, arbitrary clip-space and 3D transforms, mutable globals, multi-pass effects, renderer state, and visual parity.
 
 - [x] Generate an asset registry covering sprites, sounds, rooms, objects, scripts, fonts, paths, shaders, tilesets, timelines, sequences, and included files.
 - [x] Generate stable asset IDs and metadata for many resource types.

--- a/todo-list/05-assets-project-import.md
+++ b/todo-list/05-assets-project-import.md
@@ -104,16 +104,23 @@ This file tracks GameMaker project/resource data that the converter must eventua
 
 ## Shaders
 
-- [x] Copy/convert shader files into `.gdshader` with basic replacements.
+- [x] Group vertex and fragment stages into one collision-safe `.gdshader`.
+- [x] Tokenize global declarations instead of relying on line regexes.
+- [x] Map the supported 2D GameMaker position, colour, texture-coordinate, base-texture, varying, uniform, and matrix subset.
+- [x] Parse fixed arrays plus multi-line and comma-separated declarations.
+- [x] Emit source-linked diagnostics and fail the logical shader resource for unsupported constructs.
+- [x] Compile and load every supported pinned-corpus case through exact Godot 4.7.1.
 - [ ] Full vertex shader translation.
 - [ ] Full fragment shader translation.
-- [ ] Attribute mapping.
-- [ ] Varying mapping.
-- [ ] Uniform mapping and runtime binding.
-- [ ] Sampler/texture mapping.
-- [ ] Precision qualifier handling.
+- [ ] Custom/normal/additional vertex attribute streams and custom vertex-buffer binding.
+- [ ] Arbitrary clip-space, perspective, and 3D matrix semantics.
+- [x] Standard varying mapping with cross-stage declaration validation.
+- [x] Custom uniform preservation and runtime binding for the supported declaration subset.
+- [x] `gm_BaseTexture` and `texture2D` mapping for the supported fragment subset.
+- [x] Default and declaration-level precision qualifier handling.
+- [ ] Preprocessor directives, global mutable state, and unsupported GLSL ES types/built-ins.
 - [ ] Multi-pass effect conversion.
-- [ ] Shader compile validation through Godot headless.
+- [ ] Visual and renderer-state parity across target renderers and platforms.
 
 ## Rooms And Layers
 

--- a/todo-list/07-testing-codebase-improvements.md
+++ b/todo-list/07-testing-codebase-improvements.md
@@ -44,7 +44,7 @@ This file tracks engineering work that will make full transpilation safer to bui
 - [ ] Emit conversion report for unsupported syntax.
 - [ ] Emit conversion report for unsupported GML APIs.
 - [ ] Emit conversion report for skipped resources.
-- [ ] Emit conversion report for unsupported shaders.
+- [x] Emit source-linked conversion diagnostics for unsupported shader constructs and failed logical shader resources.
 - [ ] Emit conversion report for unsupported platform services.
 - [ ] Emit conversion report for generated invalid GDScript.
 - [ ] Add fail-on-unsupported mode.


### PR DESCRIPTION
## Summary
- replace regex-only shader substitutions with a tokenized GLSL ES declaration/function parser for paired stages, including multi-line, array, and comma-separated declarations
- map the supported 2D GameMaker position, colour, texture-coordinate, varying, uniform, base-texture, and fixed world/view/projection semantics to one Godot CanvasItem shader
- fail unsupported constructs as source-linked `GM2GD-SHADER-*` diagnostics and failed logical resources, add a provenance-pinned real shader corpus, and bump 0.7.47 to 0.7.48

## Supported behavior
- `in_Position`, `in_Colour`/`in_Colour0`, and `in_TextureCoord`
- matching varyings, custom uniforms, constants, precision qualifiers, and fixed one-dimensional arrays
- `gm_BaseTexture`, `texture2D`, `gl_FragColor`, and fixed `gm_Matrices` world/view/projection constants
- standard WVP position lowering without applying Godot transforms twice

## Diagnostics and non-goals
Custom/normal/additional vertex streams, dynamic matrices, arbitrary clip-space or 3D transforms, scalar-list matrix constructors, Godot built-in name collisions, preprocessor directives, mutable globals, processing built-ins inside helpers, stage conflicts, and unlinked fragment varyings fail closed without a placeholder shader. Full GLSL ES, custom vertex-buffer binding, macros, multi-pass effects, renderer state, and visual parity remain out of scope.

## Validation
- `./venv/bin/pyright --warnings` — 0 errors, 0 warnings
- `./venv/bin/ruff check .`
- `GODOT_BIN=/Applications/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest` — 2,379 tests, 76 intentional skips
- exact `Godot 4.7.1.stable.official.a13da4feb` corpus compilation via `Shader.get_shader_uniform_list()`, resource-matrix load, stale-output, and paired-stage tests
- pinned GameMaker LTS 2026 SNAP (`2026.0.0.15`) and Adding (`2026.0.0.16`) conversions, resource loads, and two-frame boots
- pinned The Colorful Creature conversion: 19 tests; 11 unsupported shaders now fail closed instead of publishing invalid Godot shader code

## Documentation sources
Context7 discovery and one retry both returned no matching MCP server/tool in this session. Semantics were therefore validated against the primary GameMaker LTS shader guide, built-in shader constants, vertex-format guide, and 2026.0 release notes; Godot behavior was validated against the official 4.7 CanvasItem, GLSL conversion, shading-language, and Shader API documentation plus the pinned 4.7.1 binary.

Closes #708