### PR TITLE
Add release history to What's New

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.48, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.49, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.49 - 2026-07-22
+
+- Expanded the clickable release-notes view from the latest release to the ten newest published GitHub release changelogs, each labeled and linked to its release.
+- Added a localized **Show more** action that requests subsequent ten-release pages, appends them without discarding visible history, and remains retryable after a transient failure.
+- Added strict GitHub response validation plus focused network, pagination, rendering, localization, and failure-preservation tests.
+
 ## 0.7.48 - 2026-07-22
 
 - Replaced heuristic shader substitutions with a tokenized GameMaker GLSL ES declaration parser that handles multi-line, array, and comma-separated attributes, varyings, uniforms, constants, and precision declarations before merging paired stages.

--- a/Languages/de.json
+++ b/Languages/de.json
@@ -175,6 +175,7 @@
 "Prompt_Path_Godot" : "Wählen Sie Ihr Godot-Projekt aus",
 
 "ReleaseNotes_Title" : "Versionshinweise",
+"ReleaseNotes_ShowMore" : "Mehr anzeigen",
 "ReleaseNotes_Error_NoInternet" : ["Fehler", "Versionshinweise können nicht abgerufen werden. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut."],
 "ReleaseNotes_Error_Generic" : "Fehler beim Abrufen der Versionshinweise: {error}",
 

--- a/Languages/eng.json
+++ b/Languages/eng.json
@@ -175,6 +175,7 @@
 "Prompt_Path_Godot" : "Select your Godot Project",
 
 "ReleaseNotes_Title" : "Release Notes",
+"ReleaseNotes_ShowMore" : "Show more",
 "ReleaseNotes_Error_NoInternet" : ["Error", "Unable to fetch release notes. Please check your internet connection and try again."],
 "ReleaseNotes_Error_Generic" : "Error fetching release notes: {error}",
 

--- a/Languages/template/template.json
+++ b/Languages/template/template.json
@@ -133,6 +133,7 @@
 "Prompt_Path_Godot" : "Select your GameMaker Project",
 
 "ReleaseNotes_Title" : "Release Notes",
+"ReleaseNotes_ShowMore" : "Show more",
 "ReleaseNotes_Error_NoInternet" : ["Error", "Unable to fetch release notes. Please check your internet connection and try again."],
 "ReleaseNotes_Error_Generic" : "Error fetching release notes: {error}",
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Version 0.7.47 converts supported authored sequence asset and parameter tracks i
 
 Version 0.7.48 parses paired GameMaker GLSL ES shader stages before generating one Godot CanvasItem shader. The supported 2D subset maps `in_Position`, `in_Colour`/`in_Colour0`, `in_TextureCoord`, varyings, custom uniforms and arrays, `gm_BaseTexture`, and fixed world/view/projection matrix constants. Multi-line and comma-separated declarations are normalized without regex-only inference. Custom/normal vertex attributes, unsupported clip-space or 3D transforms, preprocessor directives, stage conflicts, and unlinked varyings fail the logical shader resource with source-linked diagnostics instead of publishing plausible but incorrect output.
 
+Version 0.7.49 expands the clickable release-notes view to the ten newest published changelogs. Each entry is labeled and linked to its GitHub release, and **Show more** appends the next ten entries while preserving the history already displayed.
+
 ## What GM2Godot Is and Isn't
 
 **GM2Godot is:**
@@ -74,7 +76,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.48`.
+Current source version: `0.7.49`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.48 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.49 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-22
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.48 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.49 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-22
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.48 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.49 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-22
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.48 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.49 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-22
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.48 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.49 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-22
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.48;
+- GM2Godot 0.7.49;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.48 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.49 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-22
 
@@ -46,7 +46,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.48`.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.49`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
 
 ## Run from source
 
@@ -133,6 +133,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.48`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.49`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.48 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.49 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-22
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.48 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.49 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-07-22
 

--- a/src/gui/dialogs/release_notes_dialog.py
+++ b/src/gui/dialogs/release_notes_dialog.py
@@ -1,40 +1,147 @@
-import requests
-import markdown2  # type: ignore[reportMissingTypeStubs]
-from typing import Any, cast
+from __future__ import annotations
 
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QTextBrowser, QMessageBox, QWidget
+from collections.abc import Mapping
+from dataclasses import dataclass
+import html
+import re
+from typing import cast
+
+import markdown2  # type: ignore[reportMissingTypeStubs]
+import requests
+
+from PySide6.QtWidgets import (
+    QDialog,
+    QMessageBox,
+    QPushButton,
+    QTextBrowser,
+    QVBoxLayout,
+    QWidget,
+)
 
 from src.gui.theme import THEME
 from src.localization import get_localized, get_localized_list
 
 
-class ReleaseNotesDialog:
-    def __init__(self, parent: QWidget) -> None:
-        self._parent = parent
+RELEASES_API_URL = "https://api.github.com/repos/Infiland/GM2Godot/releases"
+RELEASES_PER_PAGE = 10
+GITHUB_API_HEADERS = {
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2026-03-10",
+}
+_NEXT_LINK_PATTERN = re.compile(r'<[^>]+>\s*;\s*rel="next"')
 
-    def show(self) -> None:
-        notes = self._fetch()
-        if notes:
-            self._display(notes)
-        else:
-            errors = get_localized_list("ReleaseNotes_Error_NoInternet")
-            QMessageBox.critical(self._parent, errors[0], errors[1])
 
-    def _fetch(self) -> str | None:
+@dataclass(frozen=True)
+class ReleaseNote:
+    title: str
+    tag: str
+    body: str
+    url: str
+
+
+@dataclass(frozen=True)
+class ReleaseNotesPage:
+    notes: tuple[ReleaseNote, ...]
+    has_more: bool
+
+
+class ReleaseNotesFetchError(RuntimeError):
+    pass
+
+
+class ReleaseNotesClient:
+    def fetch_page(self, page: int) -> ReleaseNotesPage:
+        if page < 1:
+            raise ValueError("Release page must be positive")
+
+        response: requests.Response | None = None
         try:
             response = requests.get(
-                "https://api.github.com/repos/Infiland/GM2Godot/releases/latest",
+                RELEASES_API_URL,
+                params={"per_page": RELEASES_PER_PAGE, "page": page},
+                headers=GITHUB_API_HEADERS,
                 timeout=10,
             )
-            if response.status_code == 200:
-                data = cast(dict[str, Any], response.json())
-                return str(data["body"])
-            return None
-        except Exception as e:
-            print(get_localized("ReleaseNotes_Error_Generic").format(error=e))
-            return None
+            response.raise_for_status()
+            payload: object = response.json()
+            link_header = response.headers.get("Link", "")
+            return ReleaseNotesPage(
+                notes=self._parse_notes(payload),
+                has_more=_NEXT_LINK_PATTERN.search(link_header) is not None,
+            )
+        except ReleaseNotesFetchError:
+            raise
+        except (requests.RequestException, TypeError, ValueError) as error:
+            raise ReleaseNotesFetchError(str(error)) from error
+        finally:
+            if response is not None:
+                response.close()
 
-    def _display(self, notes: str) -> None:
+    @staticmethod
+    def _parse_notes(payload: object) -> tuple[ReleaseNote, ...]:
+        if not isinstance(payload, list):
+            raise ReleaseNotesFetchError("GitHub returned a non-list release payload")
+
+        notes: list[ReleaseNote] = []
+        for raw_release in cast(list[object], payload):
+            if not isinstance(raw_release, dict):
+                raise ReleaseNotesFetchError("GitHub returned a malformed release entry")
+            release = cast(Mapping[object, object], raw_release)
+
+            tag = release.get("tag_name")
+            name = release.get("name")
+            body = release.get("body")
+            url = release.get("html_url")
+            if not isinstance(tag, str) or not tag:
+                raise ReleaseNotesFetchError("A GitHub release is missing its tag")
+            if name is not None and not isinstance(name, str):
+                raise ReleaseNotesFetchError(f"GitHub release {tag} has an invalid name")
+            if body is not None and not isinstance(body, str):
+                raise ReleaseNotesFetchError(f"GitHub release {tag} has invalid notes")
+            if not isinstance(url, str) or not url:
+                raise ReleaseNotesFetchError(f"GitHub release {tag} is missing its URL")
+
+            notes.append(
+                ReleaseNote(
+                    title=name or tag,
+                    tag=tag,
+                    body=body or "",
+                    url=url,
+                )
+            )
+        return tuple(notes)
+
+
+class ReleaseNotesDialog:
+    def __init__(
+        self,
+        parent: QWidget,
+        *,
+        client: ReleaseNotesClient | None = None,
+    ) -> None:
+        self._parent = parent
+        self._client = client or ReleaseNotesClient()
+        self._dialog: QDialog | None = None
+        self._browser: QTextBrowser | None = None
+        self._show_more_button: QPushButton | None = None
+        self._notes: list[ReleaseNote] = []
+        self._next_page = 1
+
+    def show(self) -> None:
+        try:
+            first_page = self._client.fetch_page(1)
+        except ReleaseNotesFetchError as error:
+            self._report_fetch_error(error, critical=True)
+            return
+
+        if not first_page.notes:
+            errors = get_localized_list("ReleaseNotes_Error_NoInternet")
+            QMessageBox.critical(self._parent, errors[0], errors[1])
+            return
+
+        self._display(first_page)
+
+    def _display(self, first_page: ReleaseNotesPage) -> None:
         dialog = QDialog(self._parent)
         dialog.setWindowTitle(get_localized("ReleaseNotes_Title"))
         dialog.resize(750, 600)
@@ -49,8 +156,71 @@ class ReleaseNotesDialog:
             f"color: {THEME['fg_white']}; "
             f"border: none; border-radius: 6px; padding: 10px;"
         )
-        html = cast(str, markdown2.markdown(notes, extras=["fenced-code-blocks"]))
-        browser.setHtml(html)
-        layout.addWidget(browser)
+        layout.addWidget(browser, stretch=1)
+
+        show_more_button = QPushButton(get_localized("ReleaseNotes_ShowMore"))
+        show_more_button.setAutoDefault(False)
+        show_more_button.clicked.connect(self._load_more)
+        layout.addWidget(show_more_button)
+
+        self._dialog = dialog
+        self._browser = browser
+        self._show_more_button = show_more_button
+        self._notes = list(first_page.notes)
+        self._next_page = 2
+        self._render_notes()
+        show_more_button.setVisible(first_page.has_more)
 
         dialog.exec()
+
+    def _load_more(self, _checked: bool = False) -> None:
+        button = self._show_more_button
+        if button is None:
+            return
+
+        button.setEnabled(False)
+        try:
+            page = self._client.fetch_page(self._next_page)
+        except ReleaseNotesFetchError as error:
+            button.setEnabled(True)
+            self._report_fetch_error(error, critical=False)
+            return
+
+        self._notes.extend(page.notes)
+        self._next_page += 1
+        self._render_notes()
+        button.setVisible(page.has_more)
+        button.setEnabled(True)
+
+    def _render_notes(self) -> None:
+        if self._browser is None:
+            return
+
+        sections: list[str] = []
+        for note in self._notes:
+            title = html.escape(note.title)
+            tag = html.escape(note.tag)
+            url = html.escape(note.url, quote=True)
+            body = cast(
+                str,
+                markdown2.markdown(note.body, extras=["fenced-code-blocks"]),
+            )
+            sections.append(
+                f'<section><h2><a href="{url}">{title}</a></h2>'
+                f"<p><code>{tag}</code></p>{body}</section>"
+            )
+        self._browser.setHtml("<hr>".join(sections))
+
+    def _report_fetch_error(
+        self,
+        error: ReleaseNotesFetchError,
+        *,
+        critical: bool,
+    ) -> None:
+        message = get_localized("ReleaseNotes_Error_Generic").format(error=error)
+        print(message)
+        errors = get_localized_list("ReleaseNotes_Error_NoInternet")
+        if critical:
+            QMessageBox.critical(self._parent, errors[0], errors[1])
+        else:
+            QMessageBox.warning(self._parent, errors[0], message)

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.48"
+VERSION = "0.7.49"
 
 
 def get_version():

--- a/tests/test_release_notes_dialog.py
+++ b/tests/test_release_notes_dialog.py
@@ -1,0 +1,254 @@
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtWidgets import QApplication, QDialog, QWidget
+
+from src.gui.dialogs.release_notes_dialog import (
+    RELEASES_API_URL,
+    RELEASES_PER_PAGE,
+    ReleaseNote,
+    ReleaseNotesClient,
+    ReleaseNotesDialog,
+    ReleaseNotesFetchError,
+    ReleaseNotesPage,
+)
+
+
+def _release_payload(index: int) -> dict[str, object]:
+    return {
+        "name": f"GM2Godot v0.7.{index}",
+        "tag_name": f"v0.7.{index}",
+        "body": f"Changes for release {index}.",
+        "html_url": f"https://github.com/Infiland/GM2Godot/releases/tag/v0.7.{index}",
+    }
+
+
+def _release_note(index: int) -> ReleaseNote:
+    payload = _release_payload(index)
+    return ReleaseNote(
+        title=str(payload["name"]),
+        tag=str(payload["tag_name"]),
+        body=str(payload["body"]),
+        url=str(payload["html_url"]),
+    )
+
+
+class _StubReleaseNotesClient(ReleaseNotesClient):
+    def __init__(
+        self,
+        outcomes: Mapping[int, ReleaseNotesPage | ReleaseNotesFetchError],
+    ) -> None:
+        self._outcomes = outcomes
+        self.requested_pages: list[int] = []
+
+    def fetch_page(self, page: int) -> ReleaseNotesPage:
+        self.requested_pages.append(page)
+        outcome = self._outcomes[page]
+        if isinstance(outcome, ReleaseNotesFetchError):
+            raise outcome
+        return outcome
+
+
+class ReleaseNotesClientTests(unittest.TestCase):
+    def test_fetches_ten_releases_and_detects_the_next_page(self) -> None:
+        response = MagicMock()
+        response.json.return_value = [_release_payload(index) for index in range(48, 38, -1)]
+        response.headers = {
+            "Link": (
+                '<https://api.github.com/repositories/123/releases?per_page=10&page=2>; '
+                'rel="next", '
+                '<https://api.github.com/repositories/123/releases?per_page=10&page=5>; '
+                'rel="last"'
+            )
+        }
+
+        with patch(
+            "src.gui.dialogs.release_notes_dialog.requests.get",
+            return_value=response,
+        ) as request_get:
+            page = ReleaseNotesClient().fetch_page(1)
+
+        self.assertEqual(len(page.notes), RELEASES_PER_PAGE)
+        self.assertEqual(page.notes[0].tag, "v0.7.48")
+        self.assertEqual(page.notes[-1].tag, "v0.7.39")
+        self.assertTrue(page.has_more)
+        request_get.assert_called_once_with(
+            RELEASES_API_URL,
+            params={"per_page": RELEASES_PER_PAGE, "page": 1},
+            headers={
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2026-03-10",
+            },
+            timeout=10,
+        )
+        response.raise_for_status.assert_called_once_with()
+        response.close.assert_called_once_with()
+
+    def test_accepts_nullable_release_name_and_body(self) -> None:
+        response = MagicMock()
+        response.json.return_value = [
+            {
+                "name": None,
+                "tag_name": "v0.1.0",
+                "body": None,
+                "html_url": "https://github.com/Infiland/GM2Godot/releases/tag/v0.1.0",
+            }
+        ]
+        response.headers = {}
+
+        with patch(
+            "src.gui.dialogs.release_notes_dialog.requests.get",
+            return_value=response,
+        ):
+            page = ReleaseNotesClient().fetch_page(3)
+
+        self.assertEqual(
+            page.notes,
+            (
+                ReleaseNote(
+                    title="v0.1.0",
+                    tag="v0.1.0",
+                    body="",
+                    url="https://github.com/Infiland/GM2Godot/releases/tag/v0.1.0",
+                ),
+            ),
+        )
+        self.assertFalse(page.has_more)
+        response.close.assert_called_once_with()
+
+    def test_rejects_malformed_payload_and_closes_response(self) -> None:
+        response = MagicMock()
+        response.json.return_value = {"tag_name": "v0.7.48"}
+        response.headers = {}
+
+        with (
+            patch(
+                "src.gui.dialogs.release_notes_dialog.requests.get",
+                return_value=response,
+            ),
+            self.assertRaisesRegex(ReleaseNotesFetchError, "non-list"),
+        ):
+            ReleaseNotesClient().fetch_page(1)
+
+        response.close.assert_called_once_with()
+
+    def test_rejects_non_positive_pages_without_a_request(self) -> None:
+        with (
+            patch("src.gui.dialogs.release_notes_dialog.requests.get") as request_get,
+            self.assertRaisesRegex(ValueError, "positive"),
+        ):
+            ReleaseNotesClient().fetch_page(0)
+
+        request_get.assert_not_called()
+
+
+class ReleaseNotesDialogTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        existing_app = QApplication.instance()
+        cls.app = existing_app if isinstance(existing_app, QApplication) else QApplication([])
+
+    def setUp(self) -> None:
+        self.parent = QWidget()
+
+    def tearDown(self) -> None:
+        self.parent.deleteLater()
+
+    def test_initial_history_shows_ten_notes_and_loads_more_on_click(self) -> None:
+        first_page = ReleaseNotesPage(
+            notes=tuple(_release_note(index) for index in range(48, 38, -1)),
+            has_more=True,
+        )
+        second_page = ReleaseNotesPage(
+            notes=tuple(_release_note(index) for index in range(38, 28, -1)),
+            has_more=False,
+        )
+        client = _StubReleaseNotesClient({1: first_page, 2: second_page})
+        release_dialog = ReleaseNotesDialog(self.parent, client=client)
+
+        with patch.object(QDialog, "exec", return_value=0):
+            release_dialog.show()
+
+        browser = release_dialog._browser
+        button = release_dialog._show_more_button
+        self.assertIsNotNone(browser)
+        self.assertIsNotNone(button)
+        assert browser is not None
+        assert button is not None
+        initial_text = browser.toPlainText()
+        self.assertIn("GM2Godot v0.7.48", initial_text)
+        self.assertIn("GM2Godot v0.7.39", initial_text)
+        self.assertNotIn("GM2Godot v0.7.38", initial_text)
+        self.assertEqual(button.text(), "Show more")
+        self.assertFalse(button.isHidden())
+
+        button.click()
+
+        expanded_text = browser.toPlainText()
+        self.assertIn("GM2Godot v0.7.38", expanded_text)
+        self.assertIn("GM2Godot v0.7.29", expanded_text)
+        self.assertTrue(button.isHidden())
+        self.assertEqual(client.requested_pages, [1, 2])
+
+    def test_load_more_failure_preserves_history_and_allows_retry(self) -> None:
+        first_page = ReleaseNotesPage(notes=(_release_note(48),), has_more=True)
+        client = _StubReleaseNotesClient(
+            {
+                1: first_page,
+                2: ReleaseNotesFetchError("temporary outage"),
+            }
+        )
+        release_dialog = ReleaseNotesDialog(self.parent, client=client)
+
+        with patch.object(QDialog, "exec", return_value=0):
+            release_dialog.show()
+
+        browser = release_dialog._browser
+        button = release_dialog._show_more_button
+        self.assertIsNotNone(browser)
+        self.assertIsNotNone(button)
+        assert browser is not None
+        assert button is not None
+        initial_text = browser.toPlainText()
+
+        with (
+            patch("src.gui.dialogs.release_notes_dialog.QMessageBox.warning") as warning,
+            patch("builtins.print"),
+        ):
+            button.click()
+
+        self.assertEqual(browser.toPlainText(), initial_text)
+        self.assertTrue(button.isEnabled())
+        self.assertFalse(button.isHidden())
+        self.assertEqual(client.requested_pages, [1, 2])
+        warning.assert_called_once()
+
+    def test_initial_failure_reports_error_without_opening_dialog(self) -> None:
+        client = _StubReleaseNotesClient(
+            {1: ReleaseNotesFetchError("connection refused")}
+        )
+        release_dialog = ReleaseNotesDialog(self.parent, client=client)
+
+        with (
+            patch("src.gui.dialogs.release_notes_dialog.QMessageBox.critical") as critical,
+            patch.object(QDialog, "exec") as execute,
+            patch("builtins.print"),
+        ):
+            release_dialog.show()
+
+        critical.assert_called_once()
+        execute.assert_not_called()
+        self.assertEqual(client.requested_pages, [1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_48(self) -> None:
-        self.assertEqual(get_version(), "0.7.48")
+    def test_release_version_is_0_7_49(self) -> None:
+        self.assertEqual(get_version(), "0.7.49")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- show the ten newest published GitHub release changelogs instead of only the latest release
- add a localized **Show more** action that appends each subsequent ten-release page and preserves visible history on fetch failures
- validate release payloads, label and link each entry, add focused GUI/network regressions, and bump 0.7.48 to 0.7.49

## Scope and non-goals
This changes only the clickable release-notes dialog and its release-version/documentation surfaces. It does not change update selection/download behavior, conversion semantics, generated Godot output, or GameMaker compatibility.

## Validation
- `./venv/bin/python -m unittest tests.test_release_notes_dialog tests.test_version` — 9 tests
- `./venv/bin/python -m ruff check .`
- `./venv/bin/pyright --warnings` — 0 errors, 0 warnings
- `./venv/bin/python -m unittest` — 2,386 tests, 80 intentional skips
- exact `Godot 4.7.1.stable.official.a13da4feb` smoke suite — 83 tests
- exact-Godot validation, golden conversion, and project settings — 60 tests
- pinned GameMaker LTS 2026 SNAP and Adding conversions, resource validation, and boots — 3 tests
- live GitHub REST pages 1 and 2 returned ten entries each (`v0.7.48` through `v0.7.29`)

## Documentation sources
Context7 resolution and its required retry were both quota-blocked. The implementation was therefore checked against current primary Qt for Python `QTextBrowser`/`QPushButton` docs, GitHub REST API version `2026-03-10` release-list and pagination docs, GameMaker LTS 2026 release notes (IDE 16 / GMS2 Runtime 23), and the official Godot 4.7.1 release/docs.

Closes #763
