### PR TITLE
Add Python line and branch coverage floors

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,24 @@
+[run]
+branch = True
+relative_files = True
+source =
+    main
+    scripts
+    src
+omit =
+    build/*
+    dist/*
+    release/*
+    tests/*
+    venv/*
+
+[report]
+precision = 2
+show_missing = True
+
+[json]
+output = coverage-reports/coverage.json
+pretty_print = True
+
+[xml]
+output = coverage-reports/coverage.xml

--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.49, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.50, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     env:
       PIP_CONFIG_FILE: /dev/null
     steps:
@@ -41,10 +42,14 @@ jobs:
           python -m pip --isolated --disable-pip-version-check --no-input install --no-cache-dir --only-binary=:all: \
             --constraint constraints/requirements-linux-py312.txt \
             -r requirements.txt
+          python -m pip --isolated --disable-pip-version-check --no-input install --no-cache-dir --only-binary=:all: \
+            --constraint constraints/requirements-linux-py312.txt \
+            coverage==7.15.2
           python scripts/verify_dependency_environment.py \
             --constraint constraints/requirements-linux-py312.txt \
             --mode subset \
             --require pip \
+            --require coverage \
             --require Pillow \
             --require markdown2 \
             --require requests \
@@ -61,7 +66,17 @@ jobs:
           sudo apt-get install --yes --no-install-recommends libegl1 libgl1
 
       - name: Run unit tests
-        run: python -m unittest discover tests/ -v
+        run: |
+          python -m coverage erase
+          python -m coverage run -m unittest discover tests/ -v
+
+      - name: Generate Python coverage reports
+        if: ${{ !cancelled() }}
+        run: |
+          mkdir -p coverage-reports
+          python -m coverage report
+          python -m coverage json
+          python -m coverage xml
 
       - name: Run native Linux bind-mount transaction gate
         env:
@@ -69,6 +84,21 @@ jobs:
         run: >-
           python -m unittest -v
           tests.test_managed_output_crash_recovery.TestManagedOutputCrashRecovery.test_linux_bind_mount_is_rejected_without_reading_external_target
+
+      - name: Enforce Python line and branch coverage floors
+        run: python scripts/check_coverage.py --report coverage-reports/coverage.json
+
+      - name: Upload Python coverage reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-coverage-py3.12.13
+          path: |
+            coverage-reports/coverage.json
+            coverage-reports/coverage.xml
+          if-no-files-found: warn
+          retention-days: 7
+          archive: true
 
   macos-managed-output-transactions:
     runs-on: macos-26

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
+coverage-reports/
 .tox/
 .nox/
 .coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.50 - 2026-07-23
+
+- Added pinned coverage.py line and branch measurement for `main.py`, `src/`, and maintained `scripts/`, collecting the existing full unittest suite once and publishing JSON and Cobertura XML reports from required pull-request CI.
+- Enforced the measured clean-main overall floor plus separate converter-orchestration, manifest/diagnostic, project-parsing, and GML-transpiler line and branch floors with exact production-source inventory validation and actionable diagnostics.
+- Added controlled below-floor, source-scope, branch-configuration, dependency-lock, workflow, and artifact-publication tests, plus contributor guidance for reproducing and intentionally raising the reviewed floors.
+
 ## 0.7.49 - 2026-07-22
 
 - Expanded the clickable release-notes view from the latest release to the ten newest published GitHub release changelogs, each labeled and linked to its release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,57 @@ Fixture contributions should include:
 
 ## Testing
 
+### Python line and branch coverage
+
+The required Linux `Tests` job runs the full unittest discovery once under pinned
+coverage.py branch instrumentation. The measured production inventory is
+`main.py`, every Python file under `src/`, and every maintained Python file under
+`scripts/`. The explicit source inventory excludes tests and fixtures, virtual
+environments, build/distribution/release output, packaging-only hooks, and
+generated non-Python artifacts. `.coveragerc` adds no project-specific
+`exclude_lines` or `exclude_also` patterns.
+
+Run the same measurement, human-readable summary, machine-readable reports, and
+floor gate locally from the repository root:
+
+```bash
+./venv/bin/python -m coverage erase
+./venv/bin/python -m coverage run -m unittest discover tests/ -v
+mkdir -p coverage-reports
+./venv/bin/python -m coverage report
+./venv/bin/python -m coverage json
+./venv/bin/python -m coverage xml
+./venv/bin/python scripts/check_coverage.py \
+  --report coverage-reports/coverage.json
+```
+
+`coverage-policy.json` defines line coverage as covered executable statements
+divided by executable statements and branch coverage as covered branch
+destinations divided by all branch destinations. The gate checks those two
+percentages independently; it does not use coverage.py's combined `Cover`
+column. Separate scopes protect converter orchestration, manifests/diagnostics,
+project parsing, and the complete GML transpiler package from being hidden by
+unrelated utility coverage.
+
+To raise a floor intentionally, measure a clean `main` checkout with the exact
+command above, review the JSON counts and missing-line/branch summary, and update
+the corresponding baseline counts and floor in `coverage-policy.json` in the
+same test-focused pull request. Floors are the measured percentages truncated
+to two decimal places so the committed threshold never rounds above its own
+baseline. Update the workflow-policy assertions at the same time. Do not lower a
+floor to accommodate untested production paths.
+
+The configuration follows the official coverage.py
+[branch](https://coverage.readthedocs.io/en/latest/branch.html),
+[configuration](https://coverage.readthedocs.io/en/latest/config.html),
+[JSON](https://coverage.readthedocs.io/en/latest/commands/cmd_json.html), and
+[XML](https://coverage.readthedocs.io/en/latest/commands/cmd_xml.html)
+documentation and Python's
+[unittest discovery](https://docs.python.org/3.12/library/unittest.html#test-discovery)
+contract. CI retains both machine-readable reports using GitHub Actions
+[workflow artifacts](https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow),
+including when a floor fails.
+
 Before submitting a PR:
 - For Python or generated-code logic changes, run `./venv/bin/pyright --warnings` and fix all lint/type-check diagnostics
 - For code behavior changes, run the relevant tests; for broad code changes, run `./venv/bin/python -m unittest`

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Version 0.7.48 parses paired GameMaker GLSL ES shader stages before generating o
 
 Version 0.7.49 expands the clickable release-notes view to the ten newest published changelogs. Each entry is labeled and linked to its GitHub release, and **Show more** appends the next ten entries while preserving the history already displayed.
 
+Version 0.7.50 measures the full Python unittest suite once with pinned coverage.py branch instrumentation. Required pull-request CI publishes JSON and Cobertura XML reports and independently enforces the measured overall line/branch floor plus focused floors for converter orchestration, manifests and diagnostics, project parsing, and the GML transpiler.
+
 ## What GM2Godot Is and Isn't
 
 **GM2Godot is:**
@@ -76,7 +78,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.49`.
+Current source version: `0.7.50`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.

--- a/constraints/requirements-linux-py312.txt
+++ b/constraints/requirements-linux-py312.txt
@@ -14,6 +14,8 @@ charset-normalizer==3.4.9
     # via requests
 click==8.4.2
     # via pip-tools
+coverage==7.15.2
+    # via -r requirements-tooling.txt
 idna==3.18
     # via requests
 markdown2==2.5.5

--- a/constraints/requirements-macos-py312.txt
+++ b/constraints/requirements-macos-py312.txt
@@ -16,6 +16,8 @@ charset-normalizer==3.4.9
     # via requests
 click==8.4.2
     # via pip-tools
+coverage==7.15.2
+    # via -r requirements-tooling.txt
 idna==3.18
     # via requests
 macholib==1.16.4

--- a/constraints/requirements-windows-py312.txt
+++ b/constraints/requirements-windows-py312.txt
@@ -18,6 +18,8 @@ colorama==0.4.6
     # via
     #   build
     #   click
+coverage==7.15.2
+    # via -r requirements-tooling.txt
 idna==3.18
     # via requests
 markdown2==2.5.5

--- a/coverage-policy.json
+++ b/coverage-policy.json
@@ -1,0 +1,102 @@
+{
+  "schema_version": 1,
+  "baseline": {
+    "commit": "864f4effa970fe45310212b6b8c7bdd7d15da647",
+    "coverage": "7.15.2",
+    "python": "3.12.10",
+    "platform": "macos-arm64",
+    "command": "python -m coverage run -m unittest discover tests/ -v",
+    "runtime_seconds": 715,
+    "tests": 2386,
+    "skipped": 80
+  },
+  "source": {
+    "files": [
+      "main.py"
+    ],
+    "directories": [
+      "src",
+      "scripts"
+    ]
+  },
+  "floors": [
+    {
+      "name": "overall-production",
+      "include": [
+        "main.py",
+        "src/*",
+        "scripts/*"
+      ],
+      "line": 84.00,
+      "branch": 73.93,
+      "baseline": {
+        "covered_lines": 29837,
+        "statements": 35518,
+        "covered_branches": 9617,
+        "branches": 13008
+      }
+    },
+    {
+      "name": "converter-orchestration",
+      "include": [
+        "src/conversion/converter.py",
+        "src/conversion/conversion_context.py",
+        "src/conversion/conversion_plan.py"
+      ],
+      "line": 92.89,
+      "branch": 84.93,
+      "baseline": {
+        "covered_lines": 536,
+        "statements": 577,
+        "covered_branches": 124,
+        "branches": 146
+      }
+    },
+    {
+      "name": "manifests-diagnostics",
+      "include": [
+        "src/conversion/conversion_manifest.py",
+        "src/conversion/diagnostics.py"
+      ],
+      "line": 92.47,
+      "branch": 78.57,
+      "baseline": {
+        "covered_lines": 516,
+        "statements": 558,
+        "covered_branches": 132,
+        "branches": 168
+      }
+    },
+    {
+      "name": "project-parsing",
+      "include": [
+        "src/conversion/project_manifest.py",
+        "src/conversion/project_source_paths.py",
+        "src/conversion/resource_models.py"
+      ],
+      "line": 92.28,
+      "branch": 82.00,
+      "baseline": {
+        "covered_lines": 1052,
+        "statements": 1140,
+        "covered_branches": 351,
+        "branches": 428
+      }
+    },
+    {
+      "name": "gml-transpiler",
+      "include": [
+        "src/conversion/gml_transpiler.py",
+        "src/conversion/gml_transpiler_parts/*"
+      ],
+      "line": 89.28,
+      "branch": 81.51,
+      "baseline": {
+        "covered_lines": 4976,
+        "statements": 5573,
+        "covered_branches": 2103,
+        "branches": 2580
+      }
+    }
+  ]
+}

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,8 +1,8 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.49 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.50 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-07-22
+> **Last reviewed:** 2026-07-23
 
 [Home](Home) · [Quick Start Conversion](Quick-Start-Conversion) · [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting)
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,8 +1,8 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.49 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.50 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-07-22
+> **Last reviewed:** 2026-07-23
 
 This page is the short contributor route map. The repository's [CONTRIBUTING.md](https://github.com/Infiland/GM2Godot/blob/main/CONTRIBUTING.md) and `AGENTS.md` remain authoritative for development rules.
 
@@ -93,6 +93,37 @@ Fix every Pyright error and warning in changed code. Run the relevant focused te
 GODOT_BIN=/path/to/Godot-4.7.1 \
   ./venv/bin/python -m unittest discover -s tests -p 'test_*_godot.py'
 ```
+
+### Reproduce the Python coverage gate
+
+Required pull-request CI measures `main.py`, all Python under `src/`, and the
+maintained Python tools under `scripts/`. Tests and fixtures, virtual
+environments, build/distribution/release output, packaging-only hooks, and
+generated non-Python artifacts are outside that explicit production inventory.
+There are no project-specific coverage exclusion expressions.
+
+Run the same full-suite measurement and independent line/branch floors locally:
+
+```bash
+./venv/bin/python -m coverage erase
+./venv/bin/python -m coverage run -m unittest discover tests/ -v
+mkdir -p coverage-reports
+./venv/bin/python -m coverage report
+./venv/bin/python -m coverage json
+./venv/bin/python -m coverage xml
+./venv/bin/python scripts/check_coverage.py \
+  --report coverage-reports/coverage.json
+```
+
+Line coverage is covered executable statements divided by statements; branch
+coverage is covered branch destinations divided by branch destinations. The two
+floors are enforced separately. `coverage-policy.json` also defines focused
+floors for converter orchestration, manifests/diagnostics, project parsing, and
+the GML transpiler. To raise a floor, measure clean `main`, review the JSON and
+missing-line/branch summary, then commit the new baseline counts and the measured
+percentage truncated to two decimals together with the workflow-policy test.
+Do not lower a floor to bypass an untested path. The repository contributor
+guide links the official coverage.py and Python unittest references.
 
 Documentation-only changes do not require Pyright or the Python suite unless the change also touches tests/code or verification was explicitly requested. Link and page-source checks should still pass.
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,8 +1,8 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.49 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.50 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-07-22
+> **Last reviewed:** 2026-07-23
 
 [Home](Home) · [Quick Start Conversion](Quick-Start-Conversion) · [Compatibility and Limitations](Compatibility-and-Limitations)
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,8 +1,8 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.49 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.50 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-07-22
+> **Last reviewed:** 2026-07-23
 
 [Home](Home) · [Installation](Installation) · [Quick start](Quick-Start-Conversion) · [Compatibility](Compatibility-and-Limitations) · [Diagnostics](Diagnostics-and-Troubleshooting) · [Contributing](Contributing-and-Testing)
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,8 +1,8 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.49 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.50 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-07-22
+> **Last reviewed:** 2026-07-23
 
 GM2Godot converts supported GameMaker source projects and GML into editable Godot projects. It combines asset conversion, a GML-to-GDScript transpiler, generated runtime helpers, compatibility diagnostics, and headless Godot validation. It is a migration aid, not a promise of automatic one-to-one gameplay parity.
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.49;
+- GM2Godot 0.7.50;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,8 +1,8 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.49 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.50 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-07-22
+> **Last reviewed:** 2026-07-23
 
 Use a packaged release for the desktop interface, or run from source when you also need the headless CLI. The current packaging and dependency details live in the repository's [release workflow](https://github.com/Infiland/GM2Godot/blob/main/.github/workflows/release.yml), [`requirements.txt`](https://github.com/Infiland/GM2Godot/blob/main/requirements.txt), and [native dependency-lock workflow](https://github.com/Infiland/GM2Godot/blob/main/.github/workflows/dependency-locks.yml).
 
@@ -46,7 +46,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.49`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.50`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
 
 ## Run from source
 
@@ -133,6 +133,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.49`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.50`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,8 +1,8 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.49 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.50 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-07-22
+> **Last reviewed:** 2026-07-23
 
 This page documents the current maintainer path for a versioned release and for publishing the reviewed Wiki sources. It does not replace branch protection or repository settings.
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,8 +1,8 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.49 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.50 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-07-22
+> **Last reviewed:** 2026-07-23
 
 This guide covers a first conversion through either the desktop interface or the source CLI. GM2Godot converts source projects, so select the GameMaker project root that contains the `.yyp` file—not an exported or compiled game.
 

--- a/requirements-tooling.txt
+++ b/requirements-tooling.txt
@@ -1,3 +1,4 @@
+coverage==7.15.2
 pip==26.1.2
 pip-tools==7.6.0
 PyInstaller==6.21.0

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -1,0 +1,502 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation, ROUND_DOWN
+import fnmatch
+import json
+from pathlib import Path, PurePosixPath
+import sys
+from typing import Sequence, cast
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_POLICY_PATH = PROJECT_ROOT / "coverage-policy.json"
+DEFAULT_REPORT_PATH = PROJECT_ROOT / "coverage-reports" / "coverage.json"
+
+
+class CoveragePolicyError(ValueError):
+    """Raised when coverage policy or report data is malformed."""
+
+
+@dataclass(frozen=True)
+class CoverageCounts:
+    covered_lines: int
+    statements: int
+    covered_branches: int
+    branches: int
+
+    def add(self, other: CoverageCounts) -> CoverageCounts:
+        return CoverageCounts(
+            covered_lines=self.covered_lines + other.covered_lines,
+            statements=self.statements + other.statements,
+            covered_branches=self.covered_branches + other.covered_branches,
+            branches=self.branches + other.branches,
+        )
+
+
+@dataclass(frozen=True)
+class CoverageScope:
+    name: str
+    include: tuple[str, ...]
+    line_floor: Decimal
+    branch_floor: Decimal
+
+
+@dataclass(frozen=True)
+class CoveragePolicy:
+    source_files: tuple[str, ...]
+    source_directories: tuple[str, ...]
+    scopes: tuple[CoverageScope, ...]
+
+
+def _object_mapping(value: object, context: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise CoveragePolicyError(f"{context} must be a JSON object")
+    mapping = cast(dict[object, object], value)
+    if not all(isinstance(key, str) for key in mapping):
+        raise CoveragePolicyError(f"{context} keys must be strings")
+    return {cast(str, key): item for key, item in mapping.items()}
+
+
+def _object_sequence(value: object, context: str) -> tuple[object, ...]:
+    if not isinstance(value, list):
+        raise CoveragePolicyError(f"{context} must be a JSON array")
+    return tuple(cast(list[object], value))
+
+
+def _required_value(mapping: dict[str, object], key: str, context: str) -> object:
+    try:
+        return mapping[key]
+    except KeyError as error:
+        raise CoveragePolicyError(f"{context} is missing {key!r}") from error
+
+
+def _required_string(mapping: dict[str, object], key: str, context: str) -> str:
+    value = _required_value(mapping, key, context)
+    if not isinstance(value, str) or not value:
+        raise CoveragePolicyError(f"{context}.{key} must be a non-empty string")
+    return value
+
+
+def _required_string_sequence(
+    mapping: dict[str, object],
+    key: str,
+    context: str,
+) -> tuple[str, ...]:
+    values = _object_sequence(_required_value(mapping, key, context), f"{context}.{key}")
+    if not values or not all(isinstance(value, str) and value for value in values):
+        raise CoveragePolicyError(f"{context}.{key} must contain non-empty strings")
+    strings = cast(tuple[str, ...], values)
+    if len(strings) != len(set(strings)):
+        raise CoveragePolicyError(f"{context}.{key} must not contain duplicates")
+    return strings
+
+
+def _required_decimal(
+    mapping: dict[str, object],
+    key: str,
+    context: str,
+) -> Decimal:
+    value = _required_value(mapping, key, context)
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        raise CoveragePolicyError(f"{context}.{key} must be a decimal percentage")
+    try:
+        number = Decimal(str(value))
+    except InvalidOperation as error:
+        raise CoveragePolicyError(
+            f"{context}.{key} must be a decimal percentage"
+        ) from error
+    if not number.is_finite() or number < 0 or number > 100:
+        raise CoveragePolicyError(f"{context}.{key} must be between 0 and 100")
+    return number
+
+
+def _required_nonnegative_integer(
+    mapping: dict[str, object],
+    key: str,
+    context: str,
+) -> int:
+    value = _required_value(mapping, key, context)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise CoveragePolicyError(f"{context}.{key} must be a non-negative integer")
+    return value
+
+
+def _read_json_object(path: Path, context: str) -> dict[str, object]:
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise CoveragePolicyError(f"cannot read {context} {path}: {error}") from error
+    try:
+        raw_value = cast(object, json.loads(raw_text))
+    except json.JSONDecodeError as error:
+        raise CoveragePolicyError(f"{context} {path} is not valid JSON: {error}") from error
+    return _object_mapping(raw_value, context)
+
+
+def load_policy(path: Path) -> CoveragePolicy:
+    payload = _read_json_object(path, "coverage policy")
+    schema_version = _required_value(payload, "schema_version", "coverage policy")
+    if schema_version != 1:
+        raise CoveragePolicyError(
+            f"coverage policy schema_version must be 1, found {schema_version!r}"
+        )
+
+    measurement_baseline = _object_mapping(
+        _required_value(payload, "baseline", "coverage policy"),
+        "coverage policy.baseline",
+    )
+    baseline_commit = _required_string(
+        measurement_baseline,
+        "commit",
+        "coverage policy.baseline",
+    )
+    if len(baseline_commit) != 40 or any(
+        character not in "0123456789abcdef" for character in baseline_commit
+    ):
+        raise CoveragePolicyError(
+            "coverage policy.baseline.commit must be a full lowercase Git commit"
+        )
+    for key in ("coverage", "python", "platform", "command"):
+        _required_string(
+            measurement_baseline,
+            key,
+            "coverage policy.baseline",
+        )
+
+    source = _object_mapping(
+        _required_value(payload, "source", "coverage policy"),
+        "coverage policy.source",
+    )
+    source_files = _required_string_sequence(
+        source,
+        "files",
+        "coverage policy.source",
+    )
+    source_directories = _required_string_sequence(
+        source,
+        "directories",
+        "coverage policy.source",
+    )
+
+    raw_scopes = _object_sequence(
+        _required_value(payload, "floors", "coverage policy"),
+        "coverage policy.floors",
+    )
+    if not raw_scopes:
+        raise CoveragePolicyError("coverage policy.floors must not be empty")
+
+    scopes: list[CoverageScope] = []
+    for index, raw_scope in enumerate(raw_scopes):
+        context = f"coverage policy.floors[{index}]"
+        scope = _object_mapping(raw_scope, context)
+        baseline_context = f"{context}.baseline"
+        baseline = _object_mapping(
+            _required_value(scope, "baseline", context),
+            baseline_context,
+        )
+        baseline_counts = CoverageCounts(
+            covered_lines=_required_nonnegative_integer(
+                baseline,
+                "covered_lines",
+                baseline_context,
+            ),
+            statements=_required_nonnegative_integer(
+                baseline,
+                "statements",
+                baseline_context,
+            ),
+            covered_branches=_required_nonnegative_integer(
+                baseline,
+                "covered_branches",
+                baseline_context,
+            ),
+            branches=_required_nonnegative_integer(
+                baseline,
+                "branches",
+                baseline_context,
+            ),
+        )
+        if baseline_counts.statements == 0 or baseline_counts.branches == 0:
+            raise CoveragePolicyError(
+                f"{baseline_context} must contain line and branch opportunities"
+            )
+        if baseline_counts.covered_lines > baseline_counts.statements:
+            raise CoveragePolicyError(
+                f"{baseline_context}.covered_lines exceeds statements"
+            )
+        if baseline_counts.covered_branches > baseline_counts.branches:
+            raise CoveragePolicyError(
+                f"{baseline_context}.covered_branches exceeds branches"
+            )
+        line_floor = _required_decimal(scope, "line", context)
+        branch_floor = _required_decimal(scope, "branch", context)
+        expected_line_floor = _percentage(
+            baseline_counts.covered_lines,
+            baseline_counts.statements,
+        ).quantize(Decimal("0.01"), rounding=ROUND_DOWN)
+        expected_branch_floor = _percentage(
+            baseline_counts.covered_branches,
+            baseline_counts.branches,
+        ).quantize(Decimal("0.01"), rounding=ROUND_DOWN)
+        if line_floor != expected_line_floor:
+            raise CoveragePolicyError(
+                f"{context}.line must equal the baseline truncated to two "
+                f"decimals: {expected_line_floor}"
+            )
+        if branch_floor != expected_branch_floor:
+            raise CoveragePolicyError(
+                f"{context}.branch must equal the baseline truncated to two "
+                f"decimals: {expected_branch_floor}"
+            )
+        scopes.append(
+            CoverageScope(
+                name=_required_string(scope, "name", context),
+                include=_required_string_sequence(scope, "include", context),
+                line_floor=line_floor,
+                branch_floor=branch_floor,
+            )
+        )
+    names = [scope.name for scope in scopes]
+    if len(names) != len(set(names)):
+        raise CoveragePolicyError("coverage floor names must be unique")
+
+    return CoveragePolicy(
+        source_files=source_files,
+        source_directories=source_directories,
+        scopes=tuple(scopes),
+    )
+
+
+def _normalize_report_path(raw_path: str) -> str:
+    if "\\" in raw_path:
+        raise CoveragePolicyError(
+            f"coverage report path must use forward slashes: {raw_path!r}"
+        )
+    path = PurePosixPath(raw_path)
+    if path.is_absolute() or ".." in path.parts or str(path) != raw_path:
+        raise CoveragePolicyError(
+            f"coverage report path must be normalized and relative: {raw_path!r}"
+        )
+    return raw_path
+
+
+def load_report(path: Path) -> dict[str, CoverageCounts]:
+    payload = _read_json_object(path, "coverage report")
+    meta = _object_mapping(
+        _required_value(payload, "meta", "coverage report"),
+        "coverage report.meta",
+    )
+    if _required_value(meta, "branch_coverage", "coverage report.meta") is not True:
+        raise CoveragePolicyError(
+            "coverage report must be collected with branch_coverage=true"
+        )
+
+    raw_files = _object_mapping(
+        _required_value(payload, "files", "coverage report"),
+        "coverage report.files",
+    )
+    if not raw_files:
+        raise CoveragePolicyError("coverage report.files must not be empty")
+
+    files: dict[str, CoverageCounts] = {}
+    for raw_path, raw_file in raw_files.items():
+        normalized_path = _normalize_report_path(raw_path)
+        file_payload = _object_mapping(
+            raw_file,
+            f"coverage report.files[{raw_path!r}]",
+        )
+        summary = _object_mapping(
+            _required_value(
+                file_payload,
+                "summary",
+                f"coverage report.files[{raw_path!r}]",
+            ),
+            f"coverage report.files[{raw_path!r}].summary",
+        )
+        context = f"coverage report.files[{raw_path!r}].summary"
+        counts = CoverageCounts(
+            covered_lines=_required_nonnegative_integer(
+                summary,
+                "covered_lines",
+                context,
+            ),
+            statements=_required_nonnegative_integer(
+                summary,
+                "num_statements",
+                context,
+            ),
+            covered_branches=_required_nonnegative_integer(
+                summary,
+                "covered_branches",
+                context,
+            ),
+            branches=_required_nonnegative_integer(
+                summary,
+                "num_branches",
+                context,
+            ),
+        )
+        if counts.covered_lines > counts.statements:
+            raise CoveragePolicyError(
+                f"{context}.covered_lines exceeds num_statements"
+            )
+        if counts.covered_branches > counts.branches:
+            raise CoveragePolicyError(
+                f"{context}.covered_branches exceeds num_branches"
+            )
+        files[normalized_path] = counts
+    return files
+
+
+def expected_source_files(policy: CoveragePolicy, source_root: Path) -> set[str]:
+    expected = set(policy.source_files)
+    for relative_path in policy.source_files:
+        if not (source_root / relative_path).is_file():
+            raise CoveragePolicyError(
+                f"configured coverage source file does not exist: {relative_path}"
+            )
+    for relative_directory in policy.source_directories:
+        directory = source_root / relative_directory
+        if not directory.is_dir():
+            raise CoveragePolicyError(
+                f"configured coverage source directory does not exist: "
+                f"{relative_directory}"
+            )
+        expected.update(
+            path.relative_to(source_root).as_posix()
+            for path in directory.rglob("*.py")
+            if path.is_file()
+        )
+    return expected
+
+
+def _matches_any(path: str, patterns: tuple[str, ...]) -> bool:
+    return any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns)
+
+
+def _percentage(covered: int, total: int) -> Decimal:
+    if total == 0:
+        return Decimal(100)
+    return Decimal(covered) * Decimal(100) / Decimal(total)
+
+
+def _format_percentage(value: Decimal) -> str:
+    return f"{value:.2f}%"
+
+
+def evaluate_coverage(
+    policy: CoveragePolicy,
+    files: dict[str, CoverageCounts],
+    source_root: Path,
+) -> tuple[str, ...]:
+    expected = expected_source_files(policy, source_root)
+    observed = set(files)
+    missing = sorted(expected - observed)
+    unexpected = sorted(observed - expected)
+    if missing or unexpected:
+        details: list[str] = []
+        if missing:
+            details.append(f"missing production files: {', '.join(missing)}")
+        if unexpected:
+            details.append(f"unexpected files: {', '.join(unexpected)}")
+        raise CoveragePolicyError(
+            "coverage report source scope mismatch; " + "; ".join(details)
+        )
+
+    failures: list[str] = []
+    print(
+        "Coverage floors "
+        "(line = covered statements / statements; "
+        "branch = covered destinations / branch destinations):"
+    )
+    for scope in policy.scopes:
+        selected = [
+            counts
+            for path, counts in files.items()
+            if _matches_any(path, scope.include)
+        ]
+        if not selected:
+            raise CoveragePolicyError(
+                f"coverage floor {scope.name!r} matched no production files"
+            )
+        totals = CoverageCounts(0, 0, 0, 0)
+        for counts in selected:
+            totals = totals.add(counts)
+
+        line_percentage = _percentage(totals.covered_lines, totals.statements)
+        branch_percentage = _percentage(
+            totals.covered_branches,
+            totals.branches,
+        )
+        line_passed = line_percentage >= scope.line_floor
+        branch_passed = branch_percentage >= scope.branch_floor
+        status = "PASS" if line_passed and branch_passed else "FAIL"
+        print(
+            f"{status} {scope.name}: "
+            f"line {_format_percentage(line_percentage)} "
+            f"({totals.covered_lines}/{totals.statements}, "
+            f"floor {_format_percentage(scope.line_floor)}); "
+            f"branch {_format_percentage(branch_percentage)} "
+            f"({totals.covered_branches}/{totals.branches}, "
+            f"floor {_format_percentage(scope.branch_floor)})"
+        )
+        if not line_passed:
+            failures.append(
+                f"{scope.name} line coverage "
+                f"{_format_percentage(line_percentage)} is below "
+                f"{_format_percentage(scope.line_floor)}"
+            )
+        if not branch_passed:
+            failures.append(
+                f"{scope.name} branch coverage "
+                f"{_format_percentage(branch_percentage)} is below "
+                f"{_format_percentage(scope.branch_floor)}"
+            )
+    return tuple(failures)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Enforce measured line and branch coverage floors.",
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=DEFAULT_REPORT_PATH,
+        help="coverage.py JSON report path",
+    )
+    parser.add_argument(
+        "--policy",
+        type=Path,
+        default=DEFAULT_POLICY_PATH,
+        help="coverage floor policy path",
+    )
+    parser.add_argument(
+        "--source-root",
+        type=Path,
+        default=PROJECT_ROOT,
+        help="root containing the measured production source",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _build_parser().parse_args(argv)
+    try:
+        policy = load_policy(arguments.policy)
+        report = load_report(arguments.report)
+        failures = evaluate_coverage(policy, report, arguments.source_root)
+    except CoveragePolicyError as error:
+        print(f"Coverage configuration error: {error}", file=sys.stderr)
+        return 2
+    if failures:
+        for failure in failures:
+            print(f"Coverage floor failure: {failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.49"
+VERSION = "0.7.50"
 
 
 def get_version():

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -110,6 +110,7 @@ PIP_TOOLS_VERSION = "7.6.0"
 PYINSTALLER_VERSION = "6.21.0"
 PYRIGHT_VERSION = "1.1.411"
 RUFF_VERSION = "0.15.22"
+COVERAGE_VERSION = "7.15.2"
 PILLOW_VERSION = "12.3.0"
 PIP_HARDENED_INSTALL_FRAGMENT = (
     "-m pip --isolated --disable-pip-version-check --no-input install"
@@ -1272,7 +1273,7 @@ class TestCIWorkflows(unittest.TestCase):
                 with self.subTest(location=locations[-1]):
                     self.assertEqual(archive_inputs, ["true"])
 
-        self.assertEqual(len(locations), 6, locations)
+        self.assertEqual(len(locations), 7, locations)
         self.assertEqual(
             sum(location.startswith("dependency-locks.yml:") for location in locations),
             1,
@@ -3769,7 +3770,11 @@ class TestCIWorkflows(unittest.TestCase):
                     verifier,
                 ):
                     self.assertIn(required, script, f"{label}: missing {required!r}")
-                self.assertEqual(script.count(install_command), 2)
+                expected_install_count = 3 if label == "tests.yml:test" else 2
+                self.assertEqual(
+                    script.count(install_command),
+                    expected_install_count,
+                )
                 self.assertLess(script.index(guard), script.index(create))
                 self.assertLess(script.index(create), script.index(export_path))
                 self.assertLess(script.index(export_path), script.index(prefix_probe))
@@ -3899,6 +3904,10 @@ class TestCIWorkflows(unittest.TestCase):
                 {
                     (LINUX_CONSTRAINT, (f"pip=={PIP_VERSION}",)): 1,
                     (LINUX_CONSTRAINT, ("-r", "requirements.txt")): 1,
+                    (
+                        LINUX_CONSTRAINT,
+                        (f"coverage=={COVERAGE_VERSION}",),
+                    ): 1,
                     (MACOS_CONSTRAINT, (f"pip=={PIP_VERSION}",)): 1,
                     (MACOS_CONSTRAINT, ("-r", "requirements.txt")): 1,
                     (WINDOWS_CONSTRAINT, (f"pip=={PIP_VERSION}",)): 2,
@@ -4008,7 +4017,7 @@ class TestCIWorkflows(unittest.TestCase):
 
         self.assertEqual(actual_install_files, expected_install_files)
         self.assertEqual(actual_profiles, expected_profiles)
-        self.assertEqual(non_dependency_lock_command_count, 24)
+        self.assertEqual(non_dependency_lock_command_count, 25)
         self.assertEqual(dependency_lock_command_count, 6)
 
     def test_pip_inventory_classifies_continuations_and_rejects_escape_hatches(
@@ -4220,6 +4229,7 @@ class TestCIWorkflows(unittest.TestCase):
         self.assertEqual(
             tooling_pins,
             {
+                "coverage": COVERAGE_VERSION,
                 "pip": PIP_VERSION,
                 "pip-tools": PIP_TOOLS_VERSION,
                 "pyinstaller": PYINSTALLER_VERSION,
@@ -4247,6 +4257,10 @@ class TestCIWorkflows(unittest.TestCase):
             with self.subTest(constraint=constraint_name):
                 constraint_pins = _exact_requirement_pins(
                     PROJECT_ROOT / "constraints" / constraint_name
+                )
+                self.assertEqual(
+                    constraint_pins.get("coverage"),
+                    tooling_pins["coverage"],
                 )
                 self.assertEqual(constraint_pins.get("pip"), tooling_pins["pip"])
                 self.assertEqual(
@@ -4765,6 +4779,7 @@ class TestCIWorkflows(unittest.TestCase):
             "  macos-managed-output-transactions:"
         )]
         self.assertIn("runs-on: ubuntu-24.04", linux_job)
+        self.assertIn("timeout-minutes: 30", linux_job)
         self.assertIn("python-version: '3.12.13'", linux_job)
         self.assertIn("architecture: x64", linux_job)
         self.assertIn(
@@ -4773,7 +4788,18 @@ class TestCIWorkflows(unittest.TestCase):
             "            -r requirements.txt",
             linux_job,
         )
-        self.assertIn("python -m unittest discover tests/ -v", linux_job)
+        self.assertIn(
+            f"python {PIP_HARDENED_INSTALL_FRAGMENT} --no-cache-dir --only-binary=:all: \\\n"
+            f"            --constraint {LINUX_CONSTRAINT} \\\n"
+            f"            coverage=={COVERAGE_VERSION}",
+            linux_job,
+        )
+        self.assertIn("--require coverage", linux_job)
+        coverage_test_command = (
+            "python -m coverage run -m unittest discover tests/ -v"
+        )
+        self.assertEqual(linux_job.count(coverage_test_command), 1)
+        self.assertEqual(linux_job.count("unittest discover tests/ -v"), 1)
         self.assertIn(
             "GM2GODOT_REQUIRE_LINUX_BIND_MOUNT: '1'",
             linux_job,
@@ -4790,10 +4816,130 @@ class TestCIWorkflows(unittest.TestCase):
             linux_job.index(
                 "sudo apt-get install --yes --no-install-recommends libegl1 libgl1"
             ),
-            linux_job.index("python -m unittest discover tests/ -v"),
+            linux_job.index(coverage_test_command),
         )
         self.assertTrue((PROJECT_ROOT / "tests" / "test_golden_conversion.py").is_file())
         self.assertTrue((PROJECT_ROOT / "tests" / "test_cli.py").is_file())
+
+    def test_python_coverage_workflow_enforces_measured_branch_and_core_floors(
+        self,
+    ) -> None:
+        workflow = (
+            PROJECT_ROOT / ".github" / "workflows" / "tests.yml"
+        ).read_text(encoding="utf-8")
+        linux_job = workflow[
+            workflow.index("  test:"):
+            workflow.index("  macos-managed-output-transactions:")
+        ]
+        coverage_config = (PROJECT_ROOT / ".coveragerc").read_text(
+            encoding="utf-8"
+        )
+        policy = cast(
+            dict[str, object],
+            json.loads(
+                (PROJECT_ROOT / "coverage-policy.json").read_text(
+                    encoding="utf-8"
+                )
+            ),
+        )
+
+        self.assertRegex(coverage_config, r"(?m)^branch = True$")
+        self.assertRegex(
+            coverage_config,
+            r"(?ms)^source =\n    main\n    scripts\n    src$",
+        )
+        self.assertNotIn("exclude_lines", coverage_config)
+        self.assertNotIn("exclude_also", coverage_config)
+        self.assertNotIn("skip_empty = True", coverage_config)
+        self.assertIn(
+            "[json]\noutput = coverage-reports/coverage.json",
+            coverage_config,
+        )
+        self.assertIn(
+            "[xml]\noutput = coverage-reports/coverage.xml",
+            coverage_config,
+        )
+        for omitted_root in (
+            "build/*",
+            "dist/*",
+            "release/*",
+            "tests/*",
+            "venv/*",
+        ):
+            with self.subTest(omitted_root=omitted_root):
+                self.assertIn(f"    {omitted_root}", coverage_config)
+
+        self.assertEqual(
+            policy["baseline"],
+            {
+                "commit": "864f4effa970fe45310212b6b8c7bdd7d15da647",
+                "coverage": COVERAGE_VERSION,
+                "python": "3.12.10",
+                "platform": "macos-arm64",
+                "command": (
+                    "python -m coverage run -m unittest discover tests/ -v"
+                ),
+                "runtime_seconds": 715,
+                "tests": 2386,
+                "skipped": 80,
+            },
+        )
+        self.assertEqual(
+            policy["source"],
+            {
+                "files": ["main.py"],
+                "directories": ["src", "scripts"],
+            },
+        )
+        raw_floors = policy["floors"]
+        self.assertIsInstance(raw_floors, list)
+        floors = {
+            floor["name"]: (floor["line"], floor["branch"])
+            for floor in cast(list[dict[str, object]], raw_floors)
+        }
+        self.assertEqual(
+            floors,
+            {
+                "overall-production": (84.00, 73.93),
+                "converter-orchestration": (92.89, 84.93),
+                "manifests-diagnostics": (92.47, 78.57),
+                "project-parsing": (92.28, 82.00),
+                "gml-transpiler": (89.28, 81.51),
+            },
+        )
+
+        self.assertIn("python -m coverage erase", linux_job)
+        self.assertEqual(
+            linux_job.count(
+                "python -m coverage run -m unittest discover tests/ -v"
+            ),
+            1,
+        )
+        self.assertIn("- name: Generate Python coverage reports", linux_job)
+        self.assertIn("if: ${{ !cancelled() }}", linux_job)
+        self.assertIn("python -m coverage report", linux_job)
+        self.assertIn("python -m coverage json", linux_job)
+        self.assertIn("python -m coverage xml", linux_job)
+        self.assertIn(
+            "python scripts/check_coverage.py "
+            "--report coverage-reports/coverage.json",
+            linux_job,
+        )
+        upload_index = linux_job.index("- name: Upload Python coverage reports")
+        upload_step = linux_job[upload_index:]
+        self.assertIn("if: ${{ always() }}", upload_step)
+        self.assertIn("uses: actions/upload-artifact@", upload_step)
+        self.assertIn("coverage-reports/coverage.json", upload_step)
+        self.assertIn("coverage-reports/coverage.xml", upload_step)
+        self.assertIn("if-no-files-found: warn", upload_step)
+        self.assertIn("retention-days: 7", upload_step)
+        self.assertIn("archive: true", upload_step)
+        self.assertLess(
+            linux_job.index(
+                "- name: Enforce Python line and branch coverage floors"
+            ),
+            upload_index,
+        )
 
     def test_unit_workflow_runs_artifact_transactions_on_windows(self) -> None:
         workflow = PROJECT_ROOT / ".github" / "workflows" / "tests.yml"

--- a/tests/test_coverage_policy.py
+++ b/tests/test_coverage_policy.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from typing import cast
+
+from scripts import check_coverage
+
+
+class TestCoveragePolicy(unittest.TestCase):
+    def setUp(self) -> None:
+        self._temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self._temporary_directory.cleanup)
+        self.root = Path(self._temporary_directory.name)
+        (self.root / "src").mkdir()
+        (self.root / "scripts").mkdir()
+        (self.root / "main.py").write_text("value = 1\n", encoding="utf-8")
+        (self.root / "src" / "core.py").write_text("value = 1\n", encoding="utf-8")
+        (self.root / "scripts" / "tool.py").write_text("value = 1\n", encoding="utf-8")
+        self.policy_path = self.root / "coverage-policy.json"
+        self.report_path = self.root / "coverage.json"
+        self._write_json(self.policy_path, self._policy_payload())
+
+    @staticmethod
+    def _write_json(path: Path, payload: object) -> None:
+        path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    @staticmethod
+    def _policy_payload() -> dict[str, object]:
+        return {
+            "schema_version": 1,
+            "baseline": {
+                "commit": "0" * 40,
+                "coverage": "test",
+                "python": "test",
+                "platform": "test",
+                "command": "test",
+            },
+            "source": {
+                "files": ["main.py"],
+                "directories": ["src", "scripts"],
+            },
+            "floors": [
+                {
+                    "name": "overall-production",
+                    "include": ["main.py", "src/*", "scripts/*"],
+                    "line": 88.0,
+                    "branch": 75.0,
+                    "baseline": {
+                        "covered_lines": 22,
+                        "statements": 25,
+                        "covered_branches": 9,
+                        "branches": 12,
+                    },
+                },
+                {
+                    "name": "core",
+                    "include": ["src/*"],
+                    "line": 90.0,
+                    "branch": 66.66,
+                    "baseline": {
+                        "covered_lines": 9,
+                        "statements": 10,
+                        "covered_branches": 4,
+                        "branches": 6,
+                    },
+                },
+            ],
+        }
+
+    @staticmethod
+    def _file_payload(
+        *,
+        covered_lines: int,
+        statements: int,
+        covered_branches: int,
+        branches: int,
+    ) -> dict[str, object]:
+        return {
+            "summary": {
+                "covered_lines": covered_lines,
+                "num_statements": statements,
+                "covered_branches": covered_branches,
+                "num_branches": branches,
+            }
+        }
+
+    def _report_payload(self, *, branch_coverage: bool = True) -> dict[str, object]:
+        return {
+            "meta": {
+                "branch_coverage": branch_coverage,
+                "format": 3,
+                "version": "test",
+            },
+            "files": {
+                "main.py": self._file_payload(
+                    covered_lines=8,
+                    statements=10,
+                    covered_branches=3,
+                    branches=4,
+                ),
+                "src/core.py": self._file_payload(
+                    covered_lines=9,
+                    statements=10,
+                    covered_branches=4,
+                    branches=6,
+                ),
+                "scripts/tool.py": self._file_payload(
+                    covered_lines=5,
+                    statements=5,
+                    covered_branches=2,
+                    branches=2,
+                ),
+            },
+        }
+
+    def _invoke(self) -> tuple[int, str, str]:
+        stdout = StringIO()
+        stderr = StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            status = check_coverage.main(
+                [
+                    "--policy",
+                    str(self.policy_path),
+                    "--report",
+                    str(self.report_path),
+                    "--source-root",
+                    str(self.root),
+                ]
+            )
+        return status, stdout.getvalue(), stderr.getvalue()
+
+    def _assert_configuration_error(
+        self,
+        *,
+        policy: dict[str, object] | None = None,
+        report: dict[str, object] | None = None,
+        expected: str,
+    ) -> None:
+        self._write_json(
+            self.policy_path,
+            self._policy_payload() if policy is None else policy,
+        )
+        self._write_json(
+            self.report_path,
+            self._report_payload() if report is None else report,
+        )
+        status, _, stderr = self._invoke()
+        self.assertEqual(status, 2)
+        self.assertIn(expected, stderr)
+
+    def test_measured_line_and_branch_floors_pass_at_or_above_policy(self) -> None:
+        self._write_json(self.report_path, self._report_payload())
+
+        status, stdout, stderr = self._invoke()
+
+        self.assertEqual(status, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("PASS overall-production", stdout)
+        self.assertIn("line 88.00% (22/25, floor 88.00%)", stdout)
+        self.assertIn("branch 75.00% (9/12, floor 75.00%)", stdout)
+        self.assertIn("PASS core", stdout)
+
+    def test_controlled_report_below_line_and_branch_floors_fails(self) -> None:
+        payload = self._report_payload()
+        files = cast(dict[str, object], payload["files"])
+        files["src/core.py"] = self._file_payload(
+            covered_lines=8,
+            statements=10,
+            covered_branches=3,
+            branches=6,
+        )
+        self._write_json(self.report_path, payload)
+
+        status, stdout, stderr = self._invoke()
+
+        self.assertEqual(status, 1)
+        self.assertIn("FAIL overall-production", stdout)
+        self.assertIn("FAIL core", stdout)
+        self.assertIn("overall-production line coverage", stderr)
+        self.assertIn("overall-production branch coverage", stderr)
+        self.assertIn("core line coverage", stderr)
+        self.assertIn("core branch coverage", stderr)
+
+    def test_report_without_branch_measurement_is_rejected(self) -> None:
+        self._write_json(
+            self.report_path,
+            self._report_payload(branch_coverage=False),
+        )
+
+        status, stdout, stderr = self._invoke()
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("branch_coverage=true", stderr)
+
+    def test_floor_must_equal_recorded_baseline_truncated_to_two_decimals(
+        self,
+    ) -> None:
+        policy = self._policy_payload()
+        floors = cast(list[dict[str, object]], policy["floors"])
+        floors[0]["line"] = 87.99
+        self._write_json(self.policy_path, policy)
+        self._write_json(self.report_path, self._report_payload())
+
+        status, stdout, stderr = self._invoke()
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn(
+            "line must equal the baseline truncated to two decimals: 88.00",
+            stderr,
+        )
+
+    def test_policy_rejects_invalid_baseline_metadata_and_duplicate_scopes(
+        self,
+    ) -> None:
+        invalid_commit = self._policy_payload()
+        baseline = cast(dict[str, object], invalid_commit["baseline"])
+        baseline["commit"] = "not-a-commit"
+
+        duplicate_scope = self._policy_payload()
+        duplicate_floors = cast(
+            list[dict[str, object]],
+            duplicate_scope["floors"],
+        )
+        duplicate_floors.append(dict(duplicate_floors[0]))
+
+        branch_mismatch = self._policy_payload()
+        mismatch_floors = cast(
+            list[dict[str, object]],
+            branch_mismatch["floors"],
+        )
+        mismatch_floors[1]["branch"] = 66.65
+
+        for label, policy, expected in (
+            (
+                "commit",
+                invalid_commit,
+                "must be a full lowercase Git commit",
+            ),
+            ("duplicate-scope", duplicate_scope, "floor names must be unique"),
+            (
+                "branch-baseline",
+                branch_mismatch,
+                "branch must equal the baseline truncated to two decimals",
+            ),
+        ):
+            with self.subTest(label=label):
+                self._assert_configuration_error(
+                    policy=policy,
+                    expected=expected,
+                )
+
+    def test_report_rejects_unsafe_paths_and_impossible_counts(self) -> None:
+        unsafe_path = self._report_payload()
+        unsafe_files = cast(dict[str, object], unsafe_path["files"])
+        unsafe_files["src\\core.py"] = unsafe_files.pop("src/core.py")
+
+        impossible_count = self._report_payload()
+        impossible_files = cast(dict[str, object], impossible_count["files"])
+        core_file = cast(dict[str, object], impossible_files["src/core.py"])
+        core_summary = cast(dict[str, object], core_file["summary"])
+        core_summary["covered_lines"] = 11
+
+        empty_report = self._report_payload()
+        empty_report["files"] = {}
+
+        for label, report, expected in (
+            ("unsafe-path", unsafe_path, "must use forward slashes"),
+            (
+                "impossible-count",
+                impossible_count,
+                "covered_lines exceeds num_statements",
+            ),
+            ("empty-report", empty_report, "files must not be empty"),
+        ):
+            with self.subTest(label=label):
+                self._assert_configuration_error(
+                    report=report,
+                    expected=expected,
+                )
+
+    def test_configured_sources_and_floor_patterns_must_resolve(self) -> None:
+        missing_directory = self._policy_payload()
+        source = cast(dict[str, object], missing_directory["source"])
+        directories = cast(list[str], source["directories"])
+        directories.append("missing")
+
+        unmatched_scope = self._policy_payload()
+        floors = cast(list[dict[str, object]], unmatched_scope["floors"])
+        floors[1]["include"] = ["unmatched/*"]
+
+        for label, policy, expected in (
+            (
+                "missing-directory",
+                missing_directory,
+                "source directory does not exist: missing",
+            ),
+            ("unmatched-scope", unmatched_scope, "matched no production files"),
+        ):
+            with self.subTest(label=label):
+                self._assert_configuration_error(
+                    policy=policy,
+                    expected=expected,
+                )
+
+    def test_missing_or_malformed_report_is_actionable(self) -> None:
+        self.report_path.unlink(missing_ok=True)
+        status, stdout, stderr = self._invoke()
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("cannot read coverage report", stderr)
+
+        self.report_path.write_text("{", encoding="utf-8")
+        status, stdout, stderr = self._invoke()
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("is not valid JSON", stderr)
+
+    def test_report_must_cover_exact_configured_production_scope(self) -> None:
+        payload = self._report_payload()
+        files = cast(dict[str, object], payload["files"])
+        del files["scripts/tool.py"]
+        files["tests/test_core.py"] = self._file_payload(
+            covered_lines=1,
+            statements=1,
+            covered_branches=0,
+            branches=0,
+        )
+        self._write_json(self.report_path, payload)
+
+        status, stdout, stderr = self._invoke()
+
+        self.assertEqual(status, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("missing production files: scripts/tool.py", stderr)
+        self.assertIn("unexpected files: tests/test_core.py", stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_49(self) -> None:
-        self.assertEqual(get_version(), "0.7.49")
+    def test_release_version_is_0_7_50(self) -> None:
+        self.assertEqual(get_version(), "0.7.50")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")

--- a/todo-list/07-testing-codebase-improvements.md
+++ b/todo-list/07-testing-codebase-improvements.md
@@ -126,7 +126,7 @@ This file tracks engineering work that will make full transpilation safer to bui
 - [ ] Make tests import source through package configuration rather than repeated `sys.path` mutation.
 - [ ] Add shared test utility for Godot binary discovery.
 - [ ] Add shared fixture-writing helpers.
-- [ ] Add Python coverage reporting and coverage floor for core modules.
+- [x] Add Python coverage reporting and coverage floor for core modules.
 
 ## P2: Runtime Maintainability
 


### PR DESCRIPTION
Closes #796

## Summary
- Pin coverage.py 7.15.2 in tooling and every native constraint, then collect the existing full unittest discovery once with branch measurement over `main.py`, `src/`, and maintained `scripts/`.
- Publish human-readable missing-line/branch output plus JSON and Cobertura XML artifacts before enforcing independent overall and core line/branch floors.
- Validate the exact production source inventory, reject reports without branch data, and prove controlled below-floor failure, workflow wiring, and artifact upload behavior.
- Document local reproduction/floor raises, complete the coverage checklist item, and move the release surfaces from 0.7.49 to 0.7.50.

## Measured baseline and floors
Clean `main` at `864f4effa970fe45310212b6b8c7bdd7d15da647`, coverage.py 7.15.2, macOS arm64, CPython 3.12.10, and `python -m coverage run -m unittest discover tests/ -v` measured 2,386 tests (80 skipped) in 703.636 seconds; report/gate completion took 715 seconds.

Committed floors are each clean-main percentage truncated to two decimals:
- Overall production: line 84.00% from 29,837/35,518; branch 73.93% from 9,617/13,008.
- Converter orchestration: line 92.89% from 536/577; branch 84.93% from 124/146.
- Manifests/diagnostics: line 92.47% from 516/558; branch 78.57% from 132/168.
- Project parsing: line 92.28% from 1,052/1,140; branch 82.00% from 351/428.
- GML transpiler: line 89.28% from 4,976/5,573; branch 81.51% from 2,103/2,580.

The same local Python 3.14.5 environment moved overall line coverage from 84.0011% to 84.0514% and branch coverage from 73.9314% to 73.9652%. The final local coverage run executed 2,396 tests (80 skipped), passed every floor, emitted both reports, and completed in 636 seconds.

Line means covered executable statements / executable statements. Branch means covered branch destinations / all branch destinations; the gate does not use coverage.py's combined `Cover` value.

## Scope, exclusions, and CI runtime
The source inventory is exactly `main.py`, all `src/**/*.py`, and all maintained `scripts/**/*.py`. Tests/fixtures, `venv/`, build/distribution/release output, packaging-only hooks, and generated non-Python artifacts are outside that explicit production scope. There are no project `exclude_lines`/`exclude_also` rules and this change adds no coverage pragmas.

The required Linux test job has a 30-minute timeout, runs the full suite once, generates reports before gating, and uploads JSON/XML for seven days with `always()` so a floor failure keeps its diagnostics.

## Test plan
- `./venv/bin/python -m coverage erase`
- `./venv/bin/python -m coverage run -m unittest discover tests/ -v`
- `./venv/bin/python -m coverage report && ./venv/bin/python -m coverage json && ./venv/bin/python -m coverage xml`
- `./venv/bin/python scripts/check_coverage.py --report coverage-reports/coverage.json`
- `./venv/bin/pyright --warnings`
- `./venv/bin/python -m ruff check .`
- `GODOT_BIN=/Applications/Godot.app/Contents/MacOS/Godot ./venv/bin/python -m unittest` (2,396 tests; exact `4.7.1.stable.official.a13da4feb`)
- Focused coverage-policy, workflow, dependency-lock, version, and documentation tests
- Native macOS CPython 3.12.10 constraint regeneration and complete locked-environment verification
- Pinned SimpleTopDown, The Colorful Creature, Monophobia, SNAP, and Adding conversion/validation/boot gates (35 tests)

## Sources
Context7 was attempted and retried once, but both calls returned `Monthly quota exceeded`. Implementation therefore used the primary coverage.py branch/config/report/JSON/XML documentation, Python 3.12 unittest discovery documentation, and GitHub Actions artifact/status-function documentation linked from `CONTRIBUTING.md`.
