### PR TITLE
Bound Included Files recovery cleanup

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.53, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.54, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.54 - 2026-08-10
+
+- Skipped recorded file cleanup below a directory that was already identity-verified absent after Included Files generation publication.
+- Kept modeled Windows fallback ancestor work constant across flat absent subtrees instead of repeating missing-parent state probes for every recorded descendant.
+- Added deterministic operation-count coverage across different entry counts and preserved any directory that reappears after the absence proof as unknown external state.
+
 ## 0.7.53 - 2026-08-03
 
 - Split the native Windows 10,000-entry Included Files stress test from the broader artifact-transaction suite so both retain substantial margin under the unchanged 20-minute timeout.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Version 0.7.52 extracts dependency-only typed owners for shared GML phase data, 
 
 Version 0.7.53 keeps the native Windows artifact-transaction suite and the 10,000-entry Included Files publish/recovery stress gate in separate jobs under the same 20-minute timeout. The scale test remains part of ordinary local and full-suite discovery; only the paired broader Windows job may skip it, while a fail-closed dedicated runner requires the exact case to be the sole collected test and to execute successfully without a skip.
 
+Version 0.7.54 keeps Included Files recovery cleanup bounded after a staged generation directory has already been proven absent. Recorded file descendants below that directory are skipped instead of repeating Windows fallback ancestor probes, while a directory that reappears after the absence proof is treated as unknown external state and preserved.
+
 ## What GM2Godot Is and Isn't
 
 **GM2Godot is:**
@@ -84,7 +86,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.53`.
+Current source version: `0.7.54`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,8 +1,8 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.53 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.54 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-08-03
+> **Last reviewed:** 2026-08-10
 
 [Home](Home) · [Quick Start Conversion](Quick-Start-Conversion) · [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting)
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,8 +1,8 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.53 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.54 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-08-03
+> **Last reviewed:** 2026-08-10
 
 This page is the short contributor route map. The repository's [CONTRIBUTING.md](https://github.com/Infiland/GM2Godot/blob/main/CONTRIBUTING.md) and `AGENTS.md` remain authoritative for development rules.
 
@@ -189,6 +189,8 @@ Included Files transaction changes must retain the subprocess hard-exit recovery
 The publication tests stop the child process at every forward transaction phase from the staged journal through commit-marker retirement, then require both format-v1 and format-v2 recovery to select one complete generation. The size tests require byte-exact preflight before payload staging and keep the larger record for a changed 10,000-file generation below the unchanged 16 MiB cap. The two cleanup tests independently hard-exit after quarantine or removal for owned backup, staging, stable-record, and temporary-record state. Run the native Windows Included Files workflow when changing lock, move, junction, read-only, or cleanup behavior; modeled `os.name` tests are not a substitute for NTFS and Win32 coverage. Preserve the public `res://included_files/` and registry paths, reject unknown reserved-path state, and keep the documented prohibition on conversion alongside a live game or non-cooperating writer.
 
 Native Windows CI keeps the broad `windows-artifact-transactions` suite separate from `windows-included-files-scale`. The broad job may set `GM2GODOT_SKIP_WINDOWS_INCLUDED_FILES_SCALE_GATE=1` only under GitHub Actions; the dedicated job sets `GM2GODOT_REQUIRE_WINDOWS_INCLUDED_FILES_SCALE_GATE=1` and invokes `python -m scripts.run_windows_included_files_scale_gate` from the repository root. That fail-closed runner loads only `test_ten_thousand_entry_compact_records_publish_and_recover_below_cap`, requires exactly one collected and executed passing test, and rejects skips, failures, errors, expected failures, unexpected successes, and fixture exits. Workflow policy locks the dedicated step inventory and forbids conditional or continue-on-error execution. Simultaneous require/skip flags fail closed. Both jobs keep the pinned Windows 2025, CPython 3.12.10, dependency constraints, and 20-minute timeout. Never copy the skip flag into local commands or the dedicated scale job.
+
+Recorded-tree cleanup verifies directory state top-down. Once a recorded directory is proven absent under its expected identity-bound parent, cleanup skips every recorded file descendant below it instead of repeating missing-parent fallback probes. Retain `test_cleanup_skips_file_probes_below_proven_absent_directory` and its constant operation-count comparison across different entry counts. Also retain `test_cleanup_preserves_directory_that_reappears_after_absence_proof`: a directory or file that reappears after the proof is unknown external state and must be preserved by the later bottom-up directory/root cleanup.
 
 Worker-scheduling changes must also retain the deterministic 10,000-source submission bound, changed/unchanged failure and cancellation admission checks, and cross-worker output equivalence:
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,8 +1,8 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.53 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.54 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-08-03
+> **Last reviewed:** 2026-08-10
 
 [Home](Home) · [Quick Start Conversion](Quick-Start-Conversion) · [Compatibility and Limitations](Compatibility-and-Limitations)
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,8 +1,8 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.53 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.54 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-08-03
+> **Last reviewed:** 2026-08-10
 
 [Home](Home) · [Installation](Installation) · [Quick start](Quick-Start-Conversion) · [Compatibility](Compatibility-and-Limitations) · [Diagnostics](Diagnostics-and-Troubleshooting) · [Contributing](Contributing-and-Testing)
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,8 +1,8 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.53 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.54 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-08-03
+> **Last reviewed:** 2026-08-10
 
 GM2Godot converts supported GameMaker source projects and GML into editable Godot projects. It combines asset conversion, a GML-to-GDScript transpiler, generated runtime helpers, compatibility diagnostics, and headless Godot validation. It is a migration aid, not a promise of automatic one-to-one gameplay parity.
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.53;
+- GM2Godot 0.7.54;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,8 +1,8 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.53 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.54 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-08-03
+> **Last reviewed:** 2026-08-10
 
 Use a packaged release for the desktop interface, or run from source when you also need the headless CLI. The current packaging and dependency details live in the repository's [release workflow](https://github.com/Infiland/GM2Godot/blob/main/.github/workflows/release.yml), [`requirements.txt`](https://github.com/Infiland/GM2Godot/blob/main/requirements.txt), and [native dependency-lock workflow](https://github.com/Infiland/GM2Godot/blob/main/.github/workflows/dependency-locks.yml).
 
@@ -46,7 +46,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.53`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.54`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
 
 ## Run from source
 
@@ -133,6 +133,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.53`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.54`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,8 +1,8 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.53 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.54 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-08-03
+> **Last reviewed:** 2026-08-10
 
 This page documents the current maintainer path for a versioned release and for publishing the reviewed Wiki sources. It does not replace branch protection or repository settings.
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,8 +1,8 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.53 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.54 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-08-03
+> **Last reviewed:** 2026-08-10
 
 This guide covers a first conversion through either the desktop interface or the source CLI. GM2Godot converts source projects, so select the GameMaker project root that contains the `.yyp` file—not an exported or compiled game.
 

--- a/src/conversion/included_files.py
+++ b/src/conversion/included_files.py
@@ -7366,6 +7366,10 @@ def _cleanup_recorded_included_tree(
         reverse=True,
     ):
         parent_relative = posixpath.dirname(entry.relative_path)
+        if parent_relative in absent_directories:
+            # Bottom-up directory cleanup rechecks and preserves anything that
+            # reappears; probing every known-absent descendant is redundant.
+            continue
         parent_identity = directory_identities[parent_relative]
         if entry.content_sha256 is None:
             warnings.append(

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.53"
+VERSION = "0.7.54"
 
 
 def get_version():

--- a/tests/test_included_files.py
+++ b/tests/test_included_files.py
@@ -1076,6 +1076,168 @@ IncludedFilesConverter(
             self.assertEqual(sentinel_file.read(), b"late mount sentinel")
         self.assertTrue(os.path.isdir(root_path))
 
+    def test_cleanup_skips_file_probes_below_proven_absent_directory(
+        self,
+    ) -> None:
+        fallback_ancestor_counts: list[int] = []
+
+        for entry_count in (16, 256):
+            with self.subTest(entry_count=entry_count):
+                root_path = os.path.join(
+                    self.godot_dir,
+                    f"absent-stage-{entry_count}",
+                )
+                nested_path = os.path.join(root_path, "included_files")
+                os.makedirs(nested_path)
+                for index in range(entry_count):
+                    with open(
+                        os.path.join(nested_path, f"entry-{index:04d}.txt"),
+                        "wb",
+                    ) as entry_file:
+                        entry_file.write(b"x")
+
+                project_stat = os.lstat(self.godot_dir)
+                project_identity = (project_stat.st_dev, project_stat.st_ino)
+                snapshot = included_files_module._capture_included_tree(
+                    root_path,
+                    expected_parent_identity=project_identity,
+                )
+                published_path = os.path.join(
+                    self.godot_dir,
+                    f"published-{entry_count}",
+                )
+                os.rename(nested_path, published_path)
+                cleanup_file_state = (
+                    included_files_module._included_cleanup_file_state
+                )
+                capture_ancestors = (
+                    included_files_module._capture_fallback_directory_ancestors
+                )
+
+                with (
+                    patch.object(
+                        included_files_module,
+                        "_included_descriptor_paths_supported",
+                        return_value=False,
+                    ),
+                    patch.object(included_files_module.os, "name", "nt"),
+                    patch.object(
+                        included_files_module,
+                        "_included_cleanup_file_state",
+                        wraps=cleanup_file_state,
+                    ) as file_state_mock,
+                    patch.object(
+                        included_files_module,
+                        "_capture_fallback_directory_ancestors",
+                        wraps=capture_ancestors,
+                    ) as ancestor_mock,
+                ):
+                    warnings = (
+                        included_files_module._cleanup_recorded_included_tree(
+                            root_path,
+                            snapshot,
+                            project_identity,
+                            "a" * 32,
+                            "stage",
+                        )
+                    )
+
+                self.assertEqual(warnings, ())
+                self.assertEqual(file_state_mock.call_count, 0)
+                fallback_ancestor_counts.append(ancestor_mock.call_count)
+                self.assertFalse(os.path.lexists(root_path))
+                self.assertEqual(len(os.listdir(published_path)), entry_count)
+
+        self.assertEqual(
+            fallback_ancestor_counts,
+            [fallback_ancestor_counts[0]] * len(fallback_ancestor_counts),
+        )
+        self.assertLessEqual(fallback_ancestor_counts[0], 64)
+
+    def test_cleanup_preserves_directory_that_reappears_after_absence_proof(
+        self,
+    ) -> None:
+        root_path = os.path.join(self.godot_dir, "reappearing-stage")
+        nested_path = os.path.join(root_path, "included_files")
+        os.makedirs(nested_path)
+        owned_path = os.path.join(nested_path, "payload.txt")
+        with open(owned_path, "wb") as owned_file:
+            owned_file.write(b"owned payload")
+        project_stat = os.lstat(self.godot_dir)
+        project_identity = (project_stat.st_dev, project_stat.st_ino)
+        snapshot = included_files_module._capture_included_tree(
+            root_path,
+            expected_parent_identity=project_identity,
+        )
+        published_path = os.path.join(self.godot_dir, "published-owned")
+        os.rename(nested_path, published_path)
+        replacement_path = os.path.join(nested_path, "payload.txt")
+        nested_normalized = os.path.normcase(os.path.abspath(nested_path))
+        cleanup_directory_state = (
+            included_files_module._included_cleanup_directory_state
+        )
+        replacement_created = False
+
+        def create_replacement_after_absence(
+            path: str,
+            expected_identity: tuple[int, int],
+            expected_parent_identity: tuple[int, int],
+        ) -> bool | None:
+            nonlocal replacement_created
+            state = cleanup_directory_state(
+                path,
+                expected_identity,
+                expected_parent_identity,
+            )
+            if (
+                not replacement_created
+                and state is None
+                and os.path.normcase(os.path.abspath(path)) == nested_normalized
+            ):
+                os.mkdir(nested_path)
+                with open(replacement_path, "wb") as replacement_file:
+                    replacement_file.write(b"external replacement")
+                replacement_created = True
+            return state
+
+        with (
+            patch.object(
+                included_files_module,
+                "_included_descriptor_paths_supported",
+                return_value=False,
+            ),
+            patch.object(included_files_module.os, "name", "nt"),
+            patch.object(
+                included_files_module,
+                "_included_cleanup_directory_state",
+                side_effect=create_replacement_after_absence,
+            ),
+        ):
+            warnings = included_files_module._cleanup_recorded_included_tree(
+                root_path,
+                snapshot,
+                project_identity,
+                "b" * 32,
+                "stage",
+            )
+
+        self.assertTrue(replacement_created)
+        self.assertTrue(
+            any(
+                "unknown Included Files cleanup directory" in warning
+                for warning in warnings
+            ),
+            warnings,
+        )
+        with open(replacement_path, "rb") as replacement_file:
+            self.assertEqual(replacement_file.read(), b"external replacement")
+        with open(
+            os.path.join(published_path, "payload.txt"),
+            "rb",
+        ) as published_file:
+            self.assertEqual(published_file.read(), b"owned payload")
+        self.assertTrue(os.path.isdir(root_path))
+
     def test_owned_tree_cleanup_preserves_modeled_nested_mount(self) -> None:
         variants = [("fallback", False)]
         if (

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_53(self) -> None:
-        self.assertEqual(get_version(), "0.7.53")
+    def test_release_version_is_0_7_54(self) -> None:
+        self.assertEqual(get_version(), "0.7.54")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #826

## What changed

- Treat a recorded directory that is identity-verified absent during the top-down cleanup pass as an absent subtree, and skip its recorded file descendants.
- Keep the existing bottom-up directory and root checks authoritative. A directory that reappears, changes identity, or becomes otherwise unknown is preserved with a warning; cleanup does not traverse or delete the replacement.
- Add a deterministic 16-versus-256-entry operation-count regression requiring zero descendant file-state probes and bounded ancestor work independent of descendant count.
- Add an adversarial late-reappearance regression that preserves the external replacement bytes and retains the stage root.
- Bump the release surfaces to 0.7.54 (2026-08-10) and document the recovery invariant.
- Rebase onto merged #831 while preserving its v0.7.53 history and fail-closed Windows scale-gate contract.

## Why

The native Windows failure documented in #826 occurred after the moved stage's `included_files` directory had already been proven absent. Cleanup nevertheless repeated descendant file-state and fallback-ancestor work for every recorded file: about 20,000 unnecessary file-state probes and about 240,000 redundant `lstat` calls at 10,000 entries.

#831 separated the broad Windows transaction suite from the exact 10,000-entry scale gate without increasing either 20-minute timeout. That makes the gate reliable and independently observable, but it does not remove this production cleanup cost. This PR fixes the measured absent-subtree path. The distinct present-tree repeated-parent optimization remains scoped to #828 and is not a prerequisite for this fix.

## Windows CI contract

Fresh checks at the exact rebased head must satisfy both #831 jobs:

- `windows-artifact-transactions` runs the broad Windows transaction coverage on `windows-2025` / CPython 3.12.10 with `GM2GODOT_SKIP_WINDOWS_INCLUDED_FILES_SCALE_GATE=1`; only the exact 10,000-entry case may skip there.
- `windows-included-files-scale` runs `python -m scripts.run_windows_included_files_scale_gate` with `GM2GODOT_REQUIRE_WINDOWS_INCLUDED_FILES_SCALE_GATE=1`. Its fail-closed runner must collect and execute exactly the pinned 10,000-entry test, with no skip, failure, error, expected failure, unexpected success, or fixture exit.

Both jobs retain the unchanged 20-minute timeout. The broad job must pass, and the dedicated scale job must pass with substantial timing margin.

## Local validation at rebased head `4b6716a`

- Included Files module: 178 tests passed, 13 skipped.
- Exact fail-closed 10,000-entry runner: 1 test passed, 0 skipped, in 21.117s.
- Workflow-policy and runner coverage: 80 tests passed.
- Version and documentation health: 12 tests passed.
- Exact Godot 4.7.1 discovery: 83 tests passed against `4.7.1.stable.official.a13da4feb`.
- Godot validation, golden conversion, and project-settings coverage: 60 tests passed.
- Ruff passed repository-wide; Pyright reported 0 errors and 0 warnings.
- `git diff --check` passed; the diff is the intended 15-file scope.
- Three independent read-only reviews found no correctness, safety, reappearance, mount/link, or asymptotic blocker. Synthetic cleanup retained constant filesystem work through 10,000 absent descendants and near-linear in-memory iteration through 100,000 records.
- The full local run executed 2,428 tests and exposed three already-tracked load-sensitive failures outside this diff: the buffered Godot reader race (#827) and two 3-second Linux GUI verifier races (#832). Each exact case passed when rerun in its own fresh process. Fresh exact-head CI remains authoritative.

#831's workflow, fail-closed runner, and workflow-policy files are byte-identical to `main`.

## Exact-head acceptance

All 20 expected checks at `4b6716ae6b30424ed5318e65a579fbfeaa7d4f0d` completed with 17 successes and the 3 expected PR-only release skips; there were no failures, cancellations, duplicates, missing records, or unexpected checks.

- Windows broad transactions: 618 tests in 454.861s, both #826 regressions explicit `ok`, and only the exact 10,000-entry case delegated to the dedicated job. Whole job: 8m08s, leaving 11m52s.
- Dedicated Windows scale: exactly 1 pinned test in 606.388s, `OK`, zero skips. Whole job: 10m43s, leaving 9m17s.
- Windows crash recovery: 19 tests in 913.451s, `OK (skipped=2)`. Whole job: 15m48s.
- Linux full suite: 2,428 tests in 692.951s, `OK (skipped=151)`, 81.38% coverage; native bind-mount gate 1/1.
- Exact Godot smoke verified `4.7.1.stable.official.a13da4feb` and passed 83 + 60 tests.
- Ruff, Pyright, dependency locks, macOS transactions, TCC/LTS conversions, and all platform builds passed.

The PR is ready for a normal merge.