### PR TITLE
Revalidate exact artifact mutation boundaries

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.54, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.55, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.55 - 2026-09-02
+
+- Revalidated the immutable staged source and expected destination identity, mode, bytes, and SHA-256 after the observable replace/unlink hook and immediately before each namespace mutation.
+- Made publish, absent publish, restore displacement, and both rollback directions preserve same-inode external changes while retaining exact recovery material when a safe rollback cannot proceed.
+- Preserved deliberate native-Windows writable-mode preparation and restored the original mode through hard-link races, with deterministic equal-size, restored-mtime, constant-ctime, and native Windows transaction coverage.
+
 ## 0.7.54 - 2026-08-10
 
 - Skipped recorded file cleanup below a directory that was already identity-verified absent after Included Files generation publication.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Version 0.7.53 keeps the native Windows artifact-transaction suite and the 10,00
 
 Version 0.7.54 keeps Included Files recovery cleanup bounded after a staged generation directory has already been proven absent. Recorded file descendants below that directory are skipped instead of repeating Windows fallback ancestor probes, while a directory that reappears after the absence proof is treated as unknown external state and preserved.
 
+Version 0.7.55 closes the observable-hook gap in the shared byte-artifact transaction. Replace and unlink now revalidate the immutable staged source and expected destination identity, allowed mode, bytes, and SHA-256 after the `before_replace` / `before_unlink` hook and any deliberate Windows writable-mode preparation, immediately before the namespace syscall. Same-inode equal-size writes with restored timestamps therefore abort publication, absence, restore displacement, and rollback without overwriting or unlinking external bytes; verified recovery material remains retained when rollback cannot safely proceed.
+
 ## What GM2Godot Is and Isn't
 
 **GM2Godot is:**
@@ -86,7 +88,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.54`.
+Current source version: `0.7.55`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,8 +1,8 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.54 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.55 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-08-10
+> **Last reviewed:** 2026-09-02
 
 [Home](Home) · [Quick Start Conversion](Quick-Start-Conversion) · [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting)
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,8 +1,8 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.54 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.55 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-08-10
+> **Last reviewed:** 2026-09-02
 
 This page is the short contributor route map. The repository's [CONTRIBUTING.md](https://github.com/Infiland/GM2Godot/blob/main/CONTRIBUTING.md) and `AGENTS.md` remain authoritative for development rules.
 
@@ -191,6 +191,8 @@ The publication tests stop the child process at every forward transaction phase 
 Native Windows CI keeps the broad `windows-artifact-transactions` suite separate from `windows-included-files-scale`. The broad job may set `GM2GODOT_SKIP_WINDOWS_INCLUDED_FILES_SCALE_GATE=1` only under GitHub Actions; the dedicated job sets `GM2GODOT_REQUIRE_WINDOWS_INCLUDED_FILES_SCALE_GATE=1` and invokes `python -m scripts.run_windows_included_files_scale_gate` from the repository root. That fail-closed runner loads only `test_ten_thousand_entry_compact_records_publish_and_recover_below_cap`, requires exactly one collected and executed passing test, and rejects skips, failures, errors, expected failures, unexpected successes, and fixture exits. Workflow policy locks the dedicated step inventory and forbids conditional or continue-on-error execution. Simultaneous require/skip flags fail closed. Both jobs keep the pinned Windows 2025, CPython 3.12.10, dependency constraints, and 20-minute timeout. Never copy the skip flag into local commands or the dedicated scale job.
 
 Recorded-tree cleanup verifies directory state top-down. Once a recorded directory is proven absent under its expected identity-bound parent, cleanup skips every recorded file descendant below it instead of repeating missing-parent fallback probes. Retain `test_cleanup_skips_file_probes_below_proven_absent_directory` and its constant operation-count comparison across different entry counts. Also retain `test_cleanup_preserves_directory_that_reappears_after_absence_proof`: a directory or file that reappears after the proof is unknown external state and must be preserved by the later bottom-up directory/root cleanup.
+
+Artifact writable-mode preparation must remain fail-closed when a hard link appears before, during, or immediately after the mode syscall. Retain the modeled Windows target and stage hard-link tests: the transaction must restore only the exact temporary mode it set, through the retained descriptor where available, and must preserve a different external mode rather than overwriting it during abort cleanup. Native Windows hard-link and read-only tests remain authoritative for Win32 metadata behavior.
 
 Worker-scheduling changes must also retain the deterministic 10,000-source submission bound, changed/unchanged failure and cancellation admission checks, and cross-worker output equivalence:
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,8 +1,8 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.54 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.55 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-08-10
+> **Last reviewed:** 2026-09-02
 
 [Home](Home) · [Quick Start Conversion](Quick-Start-Conversion) · [Compatibility and Limitations](Compatibility-and-Limitations)
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,8 +1,8 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.54 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.55 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-08-10
+> **Last reviewed:** 2026-09-02
 
 [Home](Home) · [Installation](Installation) · [Quick start](Quick-Start-Conversion) · [Compatibility](Compatibility-and-Limitations) · [Diagnostics](Diagnostics-and-Troubleshooting) · [Contributing](Contributing-and-Testing)
 
@@ -339,7 +339,7 @@ On Windows, GM2Godot opens both the report root and the exact captured `gm2godot
 
 If a non-Windows host lacks descriptor-relative open, stat, mkdir, rename or unlink, `O_NOFOLLOW`, `O_DIRECTORY`, or descriptor chmod, the transaction selects a `verified_path` fallback before staging. That fallback verifies the root and destination identities before and after each full-path operation. It rejects links and changed directories but narrows rather than eliminates the final non-cooperating path-resolution race. The backend is fixed for the transaction and never downgrades after a stage exists.
 
-The retained directory binding does not lock individual artifact names against a non-cooperating writer. Exact inode, mode, byte and digest checks run after staging, before every ordered mutation, and again at the native replace/unlink boundary. A process that races the final system call can still win the remaining leaf-entry interval on platforms without a suitable handle-relative primitive. Close editors, games and other writers while conversion or recovery is running; unexpected exact-state changes fail the transaction and preserve verified recovery material instead of authorizing an overwrite.
+The retained directory binding does not lock individual artifact names against a non-cooperating writer. Exact identity, allowed-mode, byte, and SHA-256 checks run after staging, before every ordered mutation, and again after the observable `before_replace` / `before_unlink` hook and any deliberate Windows writable-mode preparation, immediately before the native namespace mutation. Replace revalidates both its immutable source stage and expected destination; unlink revalidates its exact target. Same-inode equal-size changes remain detectable even when their timestamps are restored. If a hard link appears while Windows writable-mode preparation is in progress, the transaction restores the original mode through the retained descriptor and aborts; later abort cleanup restores only the exact temporary mode it set, so an unrelated external mode change is not overwritten. A process that races the final system call can still win the remaining leaf-entry interval on platforms without a suitable handle-relative primitive. Close editors, games and other writers while conversion or recovery is running; unexpected exact-state changes fail the transaction and preserve verified recovery material instead of authorizing an overwrite.
 
 The two diagnostic files retain stable public paths and ordinary-exception rollback, but they are still separate ordered replacements. A hard process or machine crash between their durability barriers can therefore expose one old file and one new file. Treat the pair as belonging to one successful invocation only when their outcome and surrounding attempt evidence agree; a future generation protocol is required for old-or-new crash atomicity across the pair.
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,8 +1,8 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.54 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.55 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-08-10
+> **Last reviewed:** 2026-09-02
 
 GM2Godot converts supported GameMaker source projects and GML into editable Godot projects. It combines asset conversion, a GML-to-GDScript transpiler, generated runtime helpers, compatibility diagnostics, and headless Godot validation. It is a migration aid, not a promise of automatic one-to-one gameplay parity.
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.54;
+- GM2Godot 0.7.55;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,8 +1,8 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.54 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.55 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-08-10
+> **Last reviewed:** 2026-09-02
 
 Use a packaged release for the desktop interface, or run from source when you also need the headless CLI. The current packaging and dependency details live in the repository's [release workflow](https://github.com/Infiland/GM2Godot/blob/main/.github/workflows/release.yml), [`requirements.txt`](https://github.com/Infiland/GM2Godot/blob/main/requirements.txt), and [native dependency-lock workflow](https://github.com/Infiland/GM2Godot/blob/main/.github/workflows/dependency-locks.yml).
 
@@ -46,7 +46,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.54`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.55`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
 
 ## Run from source
 
@@ -133,6 +133,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.54`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.55`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,8 +1,8 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.54 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.55 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-08-10
+> **Last reviewed:** 2026-09-02
 
 This page documents the current maintainer path for a versioned release and for publishing the reviewed Wiki sources. It does not replace branch protection or repository settings.
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,8 +1,8 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.54 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.55 · GameMaker LTS 2026 · Godot 4.7.1
 >
-> **Last reviewed:** 2026-08-10
+> **Last reviewed:** 2026-09-02
 
 This guide covers a first conversion through either the desktop interface or the source CLI. GM2Godot converts source projects, so select the GameMaker project root that contains the `.yyp` file—not an exported or compiled game.
 

--- a/src/conversion/anchored_artifacts.py
+++ b/src/conversion/anchored_artifacts.py
@@ -733,6 +733,10 @@ class VerifiedDirectory(AbstractContextManager["VerifiedDirectory"]):
         *,
         expected_source: PathIdentity,
         expected_destination: PathIdentity | None,
+        prepare_source: Callable[[], None] | None = None,
+        prepare_destination: Callable[[], None] | None = None,
+        verify_source: Callable[[], None] | None = None,
+        verify_destination: Callable[[], None] | None = None,
     ) -> BaseException | None:
         source_leaf = _safe_leaf(source)
         destination_leaf = _safe_leaf(destination)
@@ -750,6 +754,14 @@ class VerifiedDirectory(AbstractContextManager["VerifiedDirectory"]):
                 )
         else:
             self.verify_regular_identity(destination_leaf, expected_destination)
+        if prepare_source is not None:
+            prepare_source()
+        if prepare_destination is not None:
+            prepare_destination()
+        if verify_source is not None:
+            verify_source()
+        if verify_destination is not None:
+            verify_destination()
         if self.strategy == "posix_dir_fd":
             os.rename(
                 source_leaf,
@@ -793,10 +805,16 @@ class VerifiedDirectory(AbstractContextManager["VerifiedDirectory"]):
         name: str,
         *,
         expected_identity: PathIdentity,
+        prepare_target: Callable[[], None] | None = None,
+        verify_target: Callable[[], None] | None = None,
     ) -> BaseException | None:
         leaf = _safe_leaf(name)
         _before_anchored_artifact_phase("before_unlink", self.path, leaf)
         self.verify_regular_identity(leaf, expected_identity)
+        if prepare_target is not None:
+            prepare_target()
+        if verify_target is not None:
+            verify_target()
         if self.strategy == "posix_dir_fd":
             os.unlink(leaf, dir_fd=self.descriptor)
         else:
@@ -817,6 +835,7 @@ class VerifiedDirectory(AbstractContextManager["VerifiedDirectory"]):
         mode: int,
         *,
         require_single_link: bool = False,
+        expected_current_mode: int | None = None,
     ) -> int:
         leaf = _safe_leaf(name)
         current = self.stat(leaf)
@@ -829,6 +848,14 @@ class VerifiedDirectory(AbstractContextManager["VerifiedDirectory"]):
         current_mode = stat.S_IMODE(current.st_mode)
         if modes_match(current_mode, mode):
             return current_mode
+        if expected_current_mode is not None and not modes_match(
+            current_mode,
+            expected_current_mode,
+        ):
+            raise OSError(
+                "Artifact transaction file mode changed: "
+                f"{self.child_path(leaf)}"
+            )
         descriptor = self.open_file(leaf, os.O_RDONLY)
         try:
             opened = os.fstat(descriptor)
@@ -840,25 +867,83 @@ class VerifiedDirectory(AbstractContextManager["VerifiedDirectory"]):
                 raise OSError(
                     f"Artifact transaction file changed: {self.child_path(leaf)}"
                 )
+            opened_mode = stat.S_IMODE(opened.st_mode)
+            if expected_current_mode is not None and not modes_match(
+                opened_mode,
+                expected_current_mode,
+            ):
+                raise OSError(
+                    "Artifact transaction file mode changed: "
+                    f"{self.child_path(leaf)}"
+                )
             fchmod_candidate: object = getattr(os, "fchmod", None)
+            descriptor_chmod: Callable[[int], None] | None = None
             if callable(fchmod_candidate):
                 fchmod = cast(Callable[[int, int], None], fchmod_candidate)
-                fchmod(descriptor, mode)
+                descriptor_chmod = lambda exact_mode: fchmod(
+                    descriptor,
+                    exact_mode,
+                )
+                descriptor_chmod(mode)
             elif os.chmod in os.supports_fd:
-                os.chmod(descriptor, mode)
+                descriptor_chmod = lambda exact_mode: os.chmod(
+                    descriptor,
+                    exact_mode,
+                )
+                descriptor_chmod(mode)
             else:
                 self.verify_regular_identity(leaf, identity)
                 os.chmod(self.child_path(leaf), mode)
                 self.verify_regular_identity(leaf, identity)
+            changed = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(changed.st_mode)
+                or (changed.st_dev, changed.st_ino) != identity
+                or (require_single_link and changed.st_nlink != 1)
+            ):
+                error = OSError(
+                    f"Artifact transaction file changed: {self.child_path(leaf)}"
+                )
+                if modes_match(stat.S_IMODE(changed.st_mode), mode):
+                    try:
+                        if descriptor_chmod is not None:
+                            descriptor_chmod(opened_mode)
+                        else:
+                            self.verify_regular_identity(leaf, identity)
+                            os.chmod(self.child_path(leaf), opened_mode)
+                    except Exception as restore_error:
+                        error.add_note(
+                            "Failed to restore artifact mode after a boundary "
+                            f"change: {restore_error}"
+                        )
+                raise error
         finally:
             os.close(descriptor)
         self.verify_regular_identity(leaf, identity)
-        current_mode = stat.S_IMODE(self.stat(leaf).st_mode)
-        if not modes_match(current_mode, mode):
+        final_stat = self.stat(leaf)
+        final_mode = stat.S_IMODE(final_stat.st_mode)
+        if not modes_match(final_mode, mode):
             raise OSError(
                 f"Artifact transaction file mode did not update: {self.child_path(leaf)}"
             )
-        return current_mode
+        if require_single_link and final_stat.st_nlink != 1:
+            error = OSError(
+                f"Artifact transaction file changed: {self.child_path(leaf)}"
+            )
+            try:
+                self.chmod_exact(
+                    leaf,
+                    identity,
+                    current_mode,
+                    expected_current_mode=mode,
+                )
+            except Exception as restore_error:
+                error.add_note(
+                    "Failed to restore artifact mode after a late hard-link "
+                    f"change: {restore_error}"
+                )
+            raise error
+        return final_mode
 
     def verify_regular_identity(self, name: str, identity: PathIdentity) -> None:
         leaf = _safe_leaf(name)
@@ -1121,6 +1206,9 @@ class ArtifactSnapshot:
     @property
     def present(self) -> bool:
         return self.fingerprint is not None
+
+
+_ArtifactExpectation: TypeAlias = ArtifactSnapshot | StagedArtifact | None
 
 
 @dataclass(frozen=True)
@@ -1440,11 +1528,15 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
         *,
         name: str | None = None,
         verify_mode: bool = True,
+        expected_mode: int | None = None,
     ) -> bytes:
         selected_name = staged.name if name is None else _safe_leaf(name)
-        expected_mode = (
-            staged.mode if selected_name == staged.name else staged.target_mode
-        )
+        if expected_mode is not None:
+            selected_mode = expected_mode
+        elif selected_name == staged.name:
+            selected_mode = staged.mode
+        else:
+            selected_mode = staged.target_mode
         descriptor = self.directory.open_file(selected_name, os.O_RDONLY)
         try:
             opened_before = os.fstat(descriptor)
@@ -1457,7 +1549,7 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
                     verify_mode
                     and not modes_match(
                         stat.S_IMODE(opened_before.st_mode),
-                        expected_mode,
+                        selected_mode,
                     )
                 )
             ):
@@ -1479,14 +1571,14 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
                     verify_mode
                     and not modes_match(
                         stat.S_IMODE(opened_after.st_mode),
-                        expected_mode,
+                        selected_mode,
                     )
                 )
                 or (
                     verify_mode
                     and not modes_match(
                         stat.S_IMODE(path_after.st_mode),
-                        expected_mode,
+                        selected_mode,
                     )
                 )
                 or not fingerprints_match(
@@ -1515,8 +1607,15 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
         staged: StagedArtifact,
         *,
         name: str | None = None,
+        verify_mode: bool = True,
+        expected_mode: int | None = None,
     ) -> None:
-        self.read_staged(staged, name=name)
+        self.read_staged(
+            staged,
+            name=name,
+            verify_mode=verify_mode,
+            expected_mode=expected_mode,
+        )
 
     def path_matches_stage(self, name: str, staged: StagedArtifact) -> bool:
         try:
@@ -1525,12 +1624,138 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
             return False
         return True
 
-    def _make_target_replaceable(self, name: str) -> _ReplaceTarget | None:
+    @staticmethod
+    def _expectation_identity(
+        expected: _ArtifactExpectation,
+    ) -> PathIdentity | None:
+        if expected is None:
+            return None
+        if isinstance(expected, StagedArtifact):
+            return expected.identity
+        if expected.fingerprint is None:
+            return None
+        return expected.fingerprint[0], expected.fingerprint[1]
+
+    @staticmethod
+    def _expectation_mode(expected: _ArtifactExpectation) -> int | None:
+        if expected is None:
+            return None
+        if isinstance(expected, StagedArtifact):
+            return expected.target_mode
+        return expected.mode
+
+    def _verify_artifact_expectation(
+        self,
+        name: str,
+        expected: _ArtifactExpectation,
+        *,
+        replaceable_mode: bool,
+        require_single_link: bool = False,
+    ) -> None:
         leaf = _safe_leaf(name)
+        if expected is None:
+            self.verify_target_state(
+                leaf,
+                ArtifactTargetState(fingerprint=None, mode=None),
+            )
+            return
+        if isinstance(expected, StagedArtifact):
+            expected_mode = (
+                _replaceable_mode(expected.target_mode)
+                if replaceable_mode
+                else expected.target_mode
+            )
+            self.verify_staged(
+                expected,
+                name=leaf,
+                expected_mode=expected_mode,
+            )
+            return
+        self._validate_snapshot(expected)
+        if expected.name != leaf:
+            raise ValueError("Artifact expectation belongs to another target.")
+        state = self._snapshot_state(expected)
+        if not expected.present:
+            self.verify_target_state(leaf, state)
+            return
+        assert expected.mode is not None
+        assert expected.content is not None
+        assert expected.sha256 is not None
+        boundary_mode = (
+            _replaceable_mode(expected.mode) if replaceable_mode else expected.mode
+        )
+        boundary_state = ArtifactTargetState(
+            fingerprint=state.fingerprint,
+            mode=boundary_mode,
+        )
+        if replaceable_mode:
+            prepared_state = self.target_state(leaf)
+            if (
+                prepared_state.fingerprint is None
+                or state.fingerprint is None
+                or prepared_state.fingerprint[:4] != state.fingerprint[:4]
+                or prepared_state.mode is None
+                or not modes_match(prepared_state.mode, boundary_mode)
+            ):
+                raise OSError(
+                    "Artifact changed during replaceable-mode preparation: "
+                    f"{self.directory.child_path(leaf)}"
+                )
+            boundary_state = prepared_state
+        if require_single_link:
+            boundary_stat = self.directory.stat(leaf)
+            expected_identity = self._expectation_identity(expected)
+            if (
+                not stat.S_ISREG(boundary_stat.st_mode)
+                or expected_identity is None
+                or (boundary_stat.st_dev, boundary_stat.st_ino) != expected_identity
+                or boundary_stat.st_nlink != 1
+            ):
+                raise OSError(
+                    "Refusing a multiply-linked artifact at the mutation "
+                    f"boundary: {self.directory.child_path(leaf)}"
+                )
+        self.verify_target_state(leaf, boundary_state)
+        content = self.read_target_bytes(leaf, boundary_state)
+        if content != expected.content or _sha256_bytes(content) != expected.sha256:
+            raise OSError(
+                f"Artifact content changed: {self.directory.child_path(leaf)}"
+            )
+        if require_single_link:
+            boundary_stat = self.directory.stat(leaf)
+            expected_identity = self._expectation_identity(expected)
+            if (
+                not stat.S_ISREG(boundary_stat.st_mode)
+                or expected_identity is None
+                or (boundary_stat.st_dev, boundary_stat.st_ino) != expected_identity
+                or boundary_stat.st_nlink != 1
+            ):
+                raise OSError(
+                    "Refusing a multiply-linked artifact at the mutation "
+                    f"boundary: {self.directory.child_path(leaf)}"
+                )
+
+    def _inspect_replace_target(
+        self,
+        name: str,
+        expected: _ArtifactExpectation,
+    ) -> _ReplaceTarget | None:
+        leaf = _safe_leaf(name)
+        self._verify_artifact_expectation(
+            leaf,
+            expected,
+            replaceable_mode=False,
+        )
+        expected_identity = self._expectation_identity(expected)
+        expected_mode = self._expectation_mode(expected)
+        if expected_identity is None:
+            return None
         try:
             path_stat = self.directory.stat(leaf)
         except FileNotFoundError:
-            return None
+            raise OSError(
+                f"Artifact disappeared before replacement: {self.directory.child_path(leaf)}"
+            )
         path = self.directory.child_path(leaf)
         if _path_is_redirected(path, path_stat) or not stat.S_ISREG(
             path_stat.st_mode
@@ -1538,20 +1763,37 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
             raise OSError(f"Refusing redirected or non-regular artifact: {path}")
         identity = (path_stat.st_dev, path_stat.st_ino)
         mode = stat.S_IMODE(path_stat.st_mode)
+        if (
+            identity != expected_identity
+            or expected_mode is None
+            or not modes_match(mode, expected_mode)
+        ):
+            raise OSError(f"Artifact changed before replacement: {path}")
         mode_changed = _is_windows_platform() and not mode & stat.S_IWUSR
-        if mode_changed:
-            if path_stat.st_nlink != 1:
-                raise OSError(
-                    "Refusing to change a read-only multiply-linked artifact: "
-                    f"{path}"
-                )
-            self.directory.chmod_exact(
-                leaf,
-                identity,
-                _replaceable_mode(mode),
-                require_single_link=True,
+        target = _ReplaceTarget(
+            identity=identity,
+            mode=mode,
+            mode_changed=mode_changed,
+        )
+        if mode_changed and path_stat.st_nlink != 1:
+            raise OSError(
+                f"Refusing to change a read-only multiply-linked artifact: {path}"
             )
-        return _ReplaceTarget(identity=identity, mode=mode, mode_changed=mode_changed)
+        return target
+
+    def _prepare_replace_target_mode(
+        self,
+        name: str,
+        target: _ReplaceTarget | None,
+    ) -> None:
+        if target is None or not target.mode_changed:
+            return
+        self.directory.chmod_exact(
+            name,
+            target.identity,
+            _replaceable_mode(target.mode),
+            require_single_link=True,
+        )
 
     def _restore_replace_target_mode(
         self,
@@ -1562,7 +1804,12 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
         if target is None or not target.mode_changed:
             return
         try:
-            self.directory.chmod_exact(name, target.identity, target.mode)
+            self.directory.chmod_exact(
+                name,
+                target.identity,
+                target.mode,
+                expected_current_mode=_replaceable_mode(target.mode),
+            )
         except Exception as mode_error:
             error.add_note(
                 f"Failed to restore replaced artifact target mode: {mode_error}"
@@ -1574,22 +1821,70 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
         target_name: str,
     ) -> BaseException | None:
         target_leaf = _safe_leaf(target_name)
+        expected_target = self.capture_snapshot(target_leaf)
+        return self._replace_staged_exact(
+            staged,
+            target_leaf,
+            expected_target,
+        )
+
+    def _replace_staged_exact(
+        self,
+        staged: StagedArtifact,
+        target_name: str,
+        expected_target: _ArtifactExpectation,
+    ) -> BaseException | None:
+        target_leaf = _safe_leaf(target_name)
         self.phase("before_commit", target_leaf)
         self.verify_staged(staged)
-        target_state = self._make_target_replaceable(target_leaf)
-        try:
+        self._verify_artifact_expectation(
+            target_leaf,
+            expected_target,
+            replaceable_mode=False,
+        )
+        expected_identity = self._expectation_identity(expected_target)
+        target_state: _ReplaceTarget | None = None
+
+        def prepare_target() -> None:
+            nonlocal target_state
+            target_state = self._inspect_replace_target(
+                target_leaf,
+                expected_target,
+            )
+            self._prepare_replace_target_mode(target_leaf, target_state)
+
+        def prepare_stage() -> None:
             self.directory.chmod_exact(
                 staged.name,
                 staged.identity,
                 staged.target_mode,
+                require_single_link=True,
             )
+
+        def verify_target() -> None:
+            target_mode_changed = (
+                target_state is not None and target_state.mode_changed
+            )
+            self._verify_artifact_expectation(
+                target_leaf,
+                expected_target,
+                replaceable_mode=target_mode_changed,
+                require_single_link=target_mode_changed,
+            )
+
+        try:
             completion_error = self.directory.replace(
                 staged.name,
                 target_leaf,
                 expected_source=staged.identity,
-                expected_destination=(
-                    None if target_state is None else target_state.identity
+                expected_destination=expected_identity,
+                prepare_source=prepare_stage,
+                prepare_destination=prepare_target,
+                verify_source=lambda: self.verify_staged(
+                    staged,
+                    expected_mode=staged.target_mode,
                 ),
+                verify_destination=verify_target,
             )
         except BaseException as error:
             if self.path_matches_stage(target_leaf, staged):
@@ -1599,6 +1894,7 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
                     staged.name,
                     staged.identity,
                     staged.mode,
+                    expected_current_mode=staged.target_mode,
                 )
             except Exception as mode_error:
                 error.add_note(
@@ -1623,18 +1919,52 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
     ) -> BaseException | None:
         target_leaf = _safe_leaf(target_name)
         self.verify_staged(staged_copy)
-        target_state = self._make_target_replaceable(target_leaf)
-        if target_state is None:
-            raise OSError(
-                f"Artifact disappeared before displacement: "
-                f"{self.directory.child_path(target_leaf)}"
+        self._verify_artifact_expectation(
+            target_leaf,
+            displaced_target,
+            replaceable_mode=False,
+        )
+        target_state: _ReplaceTarget | None = None
+
+        def prepare_target() -> None:
+            nonlocal target_state
+            prepared = self._inspect_replace_target(
+                target_leaf,
+                displaced_target,
             )
+            if prepared is None:
+                raise OSError(
+                    "Artifact disappeared before displacement: "
+                    f"{self.directory.child_path(target_leaf)}"
+                )
+            target_state = prepared
+            self._prepare_replace_target_mode(target_leaf, target_state)
+
+        def verify_target() -> None:
+            if target_state is None:
+                raise OSError(
+                    "Artifact was not prepared for displacement: "
+                    f"{self.directory.child_path(target_leaf)}"
+                )
+            self.verify_staged(
+                displaced_target,
+                name=target_leaf,
+                expected_mode=(
+                    _replaceable_mode(displaced_target.target_mode)
+                    if target_state.mode_changed
+                    else displaced_target.target_mode
+                ),
+            )
+
         try:
             completion_error = self.directory.replace(
                 target_leaf,
                 staged_copy.name,
-                expected_source=target_state.identity,
+                expected_source=displaced_target.identity,
                 expected_destination=staged_copy.identity,
+                prepare_source=prepare_target,
+                verify_source=verify_target,
+                verify_destination=lambda: self.verify_staged(staged_copy),
             )
         except BaseException as error:
             if self.path_matches_stage(staged_copy.name, displaced_target):
@@ -1695,13 +2025,34 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
                     )
                 raise
             return displaced, completion_error
-        target_state = self._make_target_replaceable(leaf)
-        if target_state is None:
-            return None, None
+        target_state: _ReplaceTarget | None = None
+
+        def prepare_target() -> None:
+            nonlocal target_state
+            target_state = self._inspect_replace_target(leaf, staged)
+            self._prepare_replace_target_mode(leaf, target_state)
+
+        def verify_target() -> None:
+            if target_state is None:
+                raise OSError(
+                    f"Artifact was not prepared for unlink: {self.directory.child_path(leaf)}"
+                )
+            self.verify_staged(
+                staged,
+                name=leaf,
+                expected_mode=(
+                    _replaceable_mode(staged.target_mode)
+                    if target_state.mode_changed
+                    else staged.target_mode
+                ),
+            )
+
         try:
             completion_error = self.directory.unlink(
                 leaf,
-                expected_identity=target_state.identity,
+                expected_identity=staged.identity,
+                prepare_target=prepare_target,
+                verify_target=verify_target,
             )
         except BaseException as error:
             if not self.directory.lexists(leaf):
@@ -1723,6 +2074,7 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
             completion_error = self.directory.unlink(
                 staged.name,
                 expected_identity=staged.identity,
+                verify_target=lambda: self.verify_staged(staged),
             )
             if completion_error is not None:
                 raise completion_error
@@ -1765,6 +2117,7 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
                 completion_error = self.directory.unlink(
                     temporary_name,
                     expected_identity=staged.identity,
+                    verify_target=lambda staged=staged: self.verify_staged(staged),
                 )
                 temporary_files.pop(temporary_name, None)
                 removed = True
@@ -1976,7 +2329,11 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
                     self._verify_snapshot_current(snapshot)
                     verify_guards()
                 if desired is not None:
-                    completion_error = self.replace_staged(desired, spec.name)
+                    completion_error = self._replace_staged_exact(
+                        desired,
+                        spec.name,
+                        snapshot,
+                    )
                     mutation_started = True
                     temporary_files.pop(desired.name, None)
                 elif snapshot.present:
@@ -2146,7 +2503,11 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
                     if completion_error is not None:
                         raise completion_error
                 if restored is not None:
-                    completion_error = self.replace_staged(restored, snapshot.name)
+                    completion_error = self._replace_staged_exact(
+                        restored,
+                        snapshot.name,
+                        None,
+                    )
                     mutation_started = True
                     temporary_files.pop(restored.name, None)
                     if recorded_mutation is None:
@@ -2232,7 +2593,11 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
                         phase_name="recovery_stage",
                     )
                     temporary_files[recovery.name] = recovery
-                    completion_error = self.replace_staged(backup, name)
+                    completion_error = self._replace_staged_exact(
+                        backup,
+                        name,
+                        desired,
+                    )
                     temporary_files.pop(backup.name, None)
                     if completion_error is not None:
                         raise completion_error
@@ -2305,7 +2670,11 @@ class ByteArtifactTransaction(AbstractContextManager["ByteArtifactTransaction"])
                         suffix=".recovery.backup",
                     )
                     temporary_files[recovery.name] = recovery
-                    completion_error = self.replace_staged(receipt_backup, name)
+                    completion_error = self._replace_staged_exact(
+                        receipt_backup,
+                        name,
+                        mutation.restored if mutation.restored_committed else None,
+                    )
                     temporary_files.pop(receipt_backup.name, None)
                     if completion_error is not None:
                         raise completion_error

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.54"
+VERSION = "0.7.55"
 
 
 def get_version():

--- a/tests/test_anchored_artifacts.py
+++ b/tests/test_anchored_artifacts.py
@@ -264,6 +264,647 @@ class TestAnchoredArtifacts(unittest.TestCase):
         finally:
             target.chmod(0o600)
 
+    def test_modeled_windows_rejects_late_readonly_target_hardlink(self) -> None:
+        target = self.artifact_directory / "report.json"
+        alias = self.root / "report-alias.json"
+        target.write_bytes(b"old\n")
+        target.chmod(0o444)
+        linked = False
+
+        def link_target_at_replace(
+            phase: str,
+            _directory_path: str,
+            name: str | None,
+        ) -> None:
+            nonlocal linked
+            if phase != "before_replace" or name != "report.json" or linked:
+                return
+            os.link(target, alias)
+            linked = True
+
+        try:
+            with ByteArtifactTransaction.open(
+                str(self.root),
+                "gm2godot",
+                create=False,
+                description="test artifact directory",
+            ) as transaction:
+                with (
+                    patch(
+                        "src.conversion.anchored_artifacts._is_windows_platform",
+                        return_value=True,
+                    ),
+                    patch(
+                        "src.conversion.anchored_artifacts._file_fingerprint",
+                        side_effect=self._stable_ctime_fingerprint,
+                    ),
+                    patch(
+                        "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                        side_effect=link_target_at_replace,
+                    ),
+                    self.assertRaisesRegex(
+                        OSError,
+                        "read-only multiply-linked artifact",
+                    ),
+                ):
+                    transaction.publish_specs((ArtifactSpec("report.json", b"new\n"),))
+
+            self.assertTrue(linked)
+            self.assertEqual(target.read_bytes(), b"old\n")
+            self.assertEqual(alias.read_bytes(), b"old\n")
+            self.assertEqual(
+                (target.stat().st_dev, target.stat().st_ino),
+                (alias.stat().st_dev, alias.stat().st_ino),
+            )
+            self.assertFalse(stat.S_IMODE(target.stat().st_mode) & stat.S_IWUSR)
+            self.assertFalse(stat.S_IMODE(alias.stat().st_mode) & stat.S_IWUSR)
+            self.assertEqual(
+                sorted(path.name for path in self.artifact_directory.iterdir()),
+                ["report.json"],
+            )
+        finally:
+            target.chmod(0o600)
+
+    def test_modeled_windows_late_stage_hardlink_keeps_original_mode(self) -> None:
+        target = self.artifact_directory / "report.json"
+        alias = self.root / "stage-alias.json"
+        target.write_bytes(b"old\n")
+        target.chmod(0o444)
+        staged_path: Path | None = None
+        alias_mode_at_hook: int | None = None
+
+        def link_stage_at_replace(
+            phase: str,
+            _directory_path: str,
+            name: str | None,
+        ) -> None:
+            nonlocal alias_mode_at_hook, staged_path
+            if phase != "before_replace" or name != "report.json":
+                return
+            candidates = tuple(self.artifact_directory.glob(".report.json.*.tmp"))
+            self.assertEqual(len(candidates), 1)
+            staged_path = candidates[0]
+            os.link(staged_path, alias)
+            alias_mode_at_hook = stat.S_IMODE(alias.stat().st_mode)
+
+        try:
+            with ByteArtifactTransaction.open(
+                str(self.root),
+                "gm2godot",
+                create=False,
+                description="test artifact directory",
+            ) as transaction:
+                with (
+                    patch(
+                        "src.conversion.anchored_artifacts._is_windows_platform",
+                        return_value=True,
+                    ),
+                    patch(
+                        "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                        side_effect=link_stage_at_replace,
+                    ),
+                    self.assertRaisesRegex(OSError, "transaction file changed"),
+                ):
+                    transaction.publish_specs((ArtifactSpec("report.json", b"new\n"),))
+
+            self.assertEqual(target.read_bytes(), b"old\n")
+            self.assertFalse(stat.S_IMODE(target.stat().st_mode) & stat.S_IWUSR)
+            self.assertIsNotNone(staged_path)
+            assert staged_path is not None
+            self.assertTrue(staged_path.is_file())
+            self.assertEqual(staged_path.read_bytes(), b"new\n")
+            self.assertEqual(alias.read_bytes(), b"new\n")
+            self.assertEqual(
+                (staged_path.stat().st_dev, staged_path.stat().st_ino),
+                (alias.stat().st_dev, alias.stat().st_ino),
+            )
+            self.assertIsNotNone(alias_mode_at_hook)
+            self.assertArtifactModeEqual(
+                stat.S_IMODE(alias.stat().st_mode),
+                cast(int, alias_mode_at_hook),
+            )
+        finally:
+            target.chmod(0o600)
+
+    def test_modeled_windows_post_stage_chmod_hardlink_restores_alias_mode(
+        self,
+    ) -> None:
+        target = self.artifact_directory / "report.json"
+        alias = self.root / "stage-alias.json"
+        target.write_bytes(b"old\n")
+        target.chmod(0o444)
+        staged_path: Path | None = None
+        linked = False
+
+        try:
+            with ByteArtifactTransaction.open(
+                str(self.root),
+                "gm2godot",
+                create=False,
+                description="test artifact directory",
+            ) as transaction:
+                real_chmod = transaction.directory.chmod_exact
+
+                def link_after_stage_chmod(
+                    name: str,
+                    identity: tuple[int, int],
+                    mode: int,
+                    **kwargs: Any,
+                ) -> int:
+                    nonlocal linked, staged_path
+                    result = real_chmod(name, identity, mode, **kwargs)
+                    if (
+                        not linked
+                        and name.startswith(".report.json.")
+                        and not mode & stat.S_IWUSR
+                    ):
+                        staged_path = self.artifact_directory / name
+                        os.link(staged_path, alias)
+                        linked = True
+                    return result
+
+                with (
+                    patch(
+                        "src.conversion.anchored_artifacts._is_windows_platform",
+                        return_value=True,
+                    ),
+                    patch.object(
+                        transaction.directory,
+                        "chmod_exact",
+                        side_effect=link_after_stage_chmod,
+                    ),
+                    self.assertRaisesRegex(OSError, "Staged artifact changed"),
+                ):
+                    transaction.publish_specs((ArtifactSpec("report.json", b"new\n"),))
+
+            self.assertTrue(linked)
+            self.assertIsNotNone(staged_path)
+            assert staged_path is not None
+            self.assertEqual(staged_path.read_bytes(), b"new\n")
+            self.assertEqual(alias.read_bytes(), b"new\n")
+            self.assertTrue(stat.S_IMODE(staged_path.stat().st_mode) & stat.S_IWUSR)
+            self.assertTrue(stat.S_IMODE(alias.stat().st_mode) & stat.S_IWUSR)
+            self.assertEqual(target.read_bytes(), b"old\n")
+            self.assertFalse(stat.S_IMODE(target.stat().st_mode) & stat.S_IWUSR)
+        finally:
+            target.chmod(0o600)
+
+    def test_modeled_windows_post_preparation_failure_restores_target_mode(
+        self,
+    ) -> None:
+        target = self.artifact_directory / "report.json"
+        target.write_bytes(b"old\n")
+        target.chmod(0o444)
+        failed_after_preparation = False
+
+        try:
+            with ByteArtifactTransaction.open(
+                str(self.root),
+                "gm2godot",
+                create=False,
+                description="test artifact directory",
+            ) as transaction:
+                real_prepare = cast(
+                    Callable[[str, Any], None],
+                    getattr(transaction, "_prepare_replace_target_mode"),
+                )
+
+                def fail_after_target_preparation(
+                    name: str,
+                    prepared: Any,
+                ) -> None:
+                    nonlocal failed_after_preparation
+                    real_prepare(name, prepared)
+                    if name == "report.json" and not failed_after_preparation:
+                        failed_after_preparation = True
+                        raise OSError("injected post-preparation failure")
+
+                with (
+                    patch(
+                        "src.conversion.anchored_artifacts._is_windows_platform",
+                        return_value=True,
+                    ),
+                    patch.object(
+                        transaction,
+                        "_prepare_replace_target_mode",
+                        side_effect=fail_after_target_preparation,
+                    ),
+                    self.assertRaisesRegex(OSError, "post-preparation failure"),
+                ):
+                    transaction.publish_specs((ArtifactSpec("report.json", b"new\n"),))
+
+            self.assertTrue(failed_after_preparation)
+            self.assertEqual(target.read_bytes(), b"old\n")
+            self.assertFalse(stat.S_IMODE(target.stat().st_mode) & stat.S_IWUSR)
+            self.assertEqual(
+                sorted(path.name for path in self.artifact_directory.iterdir()),
+                ["report.json"],
+            )
+        finally:
+            target.chmod(0o600)
+
+    @unittest.skipUnless(
+        callable(getattr(os, "fchmod", None)),
+        "descriptor chmod is unavailable",
+    )
+    def test_modeled_windows_hardlink_during_fchmod_restores_alias_mode(
+        self,
+    ) -> None:
+        target = self.artifact_directory / "report.json"
+        alias = self.root / "report-alias.json"
+        target.write_bytes(b"old\n")
+        target.chmod(0o444)
+        target_identity = (target.stat().st_dev, target.stat().st_ino)
+        real_fchmod = os.fchmod
+        linked = False
+
+        def link_before_fchmod(descriptor: int, mode: int) -> None:
+            nonlocal linked
+            opened = os.fstat(descriptor)
+            if (
+                not linked
+                and (opened.st_dev, opened.st_ino) == target_identity
+                and mode & stat.S_IWUSR
+            ):
+                os.link(target, alias)
+                linked = True
+            real_fchmod(descriptor, mode)
+
+        try:
+            with ByteArtifactTransaction.open(
+                str(self.root),
+                "gm2godot",
+                create=False,
+                description="test artifact directory",
+            ) as transaction:
+                with (
+                    patch(
+                        "src.conversion.anchored_artifacts._is_windows_platform",
+                        return_value=True,
+                    ),
+                    patch(
+                        "src.conversion.anchored_artifacts.os.fchmod",
+                        side_effect=link_before_fchmod,
+                    ),
+                    self.assertRaisesRegex(OSError, "transaction file changed"),
+                ):
+                    transaction.publish_specs((ArtifactSpec("report.json", b"new\n"),))
+
+            self.assertTrue(linked)
+            self.assertEqual(target.read_bytes(), b"old\n")
+            self.assertEqual(alias.read_bytes(), b"old\n")
+            self.assertEqual(
+                (target.stat().st_dev, target.stat().st_ino),
+                (alias.stat().st_dev, alias.stat().st_ino),
+            )
+            self.assertFalse(stat.S_IMODE(target.stat().st_mode) & stat.S_IWUSR)
+            self.assertFalse(stat.S_IMODE(alias.stat().st_mode) & stat.S_IWUSR)
+        finally:
+            target.chmod(0o600)
+
+    def test_modeled_windows_hardlink_during_path_chmod_restores_alias_mode(
+        self,
+    ) -> None:
+        target = self.artifact_directory / "report.json"
+        alias = self.root / "report-alias.json"
+        target.write_bytes(b"old\n")
+        target.chmod(0o444)
+        target_identity = (target.stat().st_dev, target.stat().st_ino)
+        real_chmod = os.chmod
+        linked = False
+
+        def link_before_path_chmod(
+            path: str | bytes | os.PathLike[str] | os.PathLike[bytes] | int,
+            mode: int,
+            *args: Any,
+            **kwargs: Any,
+        ) -> None:
+            nonlocal linked
+            if not isinstance(path, int):
+                candidate = Path(os.fsdecode(path))
+                candidate_stat = os.lstat(candidate)
+                if (
+                    not linked
+                    and (candidate_stat.st_dev, candidate_stat.st_ino)
+                    == target_identity
+                    and mode & stat.S_IWUSR
+                ):
+                    os.link(target, alias)
+                    linked = True
+            real_chmod(path, mode, *args, **kwargs)
+
+        try:
+            with ByteArtifactTransaction.open(
+                str(self.root),
+                "gm2godot",
+                create=False,
+                description="test artifact directory",
+            ) as transaction:
+                with (
+                    patch(
+                        "src.conversion.anchored_artifacts._is_windows_platform",
+                        return_value=True,
+                    ),
+                    patch(
+                        "src.conversion.anchored_artifacts.os.fchmod",
+                        None,
+                        create=True,
+                    ),
+                    patch(
+                        "src.conversion.anchored_artifacts.os.chmod",
+                        side_effect=link_before_path_chmod,
+                    ),
+                    self.assertRaisesRegex(OSError, "transaction file changed"),
+                ):
+                    transaction.publish_specs((ArtifactSpec("report.json", b"new\n"),))
+
+            self.assertTrue(linked)
+            self.assertEqual(target.read_bytes(), b"old\n")
+            self.assertEqual(alias.read_bytes(), b"old\n")
+            self.assertEqual(
+                (target.stat().st_dev, target.stat().st_ino),
+                (alias.stat().st_dev, alias.stat().st_ino),
+            )
+            self.assertFalse(stat.S_IMODE(target.stat().st_mode) & stat.S_IWUSR)
+            self.assertFalse(stat.S_IMODE(alias.stat().st_mode) & stat.S_IWUSR)
+        finally:
+            target.chmod(0o600)
+
+    @unittest.skipUnless(
+        callable(getattr(os, "fchmod", None)),
+        "descriptor chmod is unavailable",
+    )
+    def test_modeled_windows_fchmod_race_preserves_external_mode(self) -> None:
+        target = self.artifact_directory / "report.json"
+        alias = self.root / "report-alias.json"
+        target.write_bytes(b"old\n")
+        target.chmod(0o444)
+        target_identity = (target.stat().st_dev, target.stat().st_ino)
+        real_fchmod = os.fchmod
+        changed = False
+
+        def change_mode_and_link(descriptor: int, mode: int) -> None:
+            nonlocal changed
+            opened = os.fstat(descriptor)
+            real_fchmod(descriptor, mode)
+            if (
+                not changed
+                and (opened.st_dev, opened.st_ino) == target_identity
+                and mode & stat.S_IWUSR
+            ):
+                target.chmod(0o400)
+                os.link(target, alias)
+                changed = True
+
+        try:
+            with ByteArtifactTransaction.open(
+                str(self.root),
+                "gm2godot",
+                create=False,
+                description="test artifact directory",
+            ) as transaction:
+                with (
+                    patch(
+                        "src.conversion.anchored_artifacts._is_windows_platform",
+                        return_value=True,
+                    ),
+                    patch(
+                        "src.conversion.anchored_artifacts.os.fchmod",
+                        side_effect=change_mode_and_link,
+                    ),
+                    self.assertRaisesRegex(OSError, "transaction file changed"),
+                ):
+                    transaction.publish_specs((ArtifactSpec("report.json", b"new\n"),))
+
+            self.assertTrue(changed)
+            self.assertEqual(target.read_bytes(), b"old\n")
+            self.assertEqual(alias.read_bytes(), b"old\n")
+            self.assertArtifactModeEqual(stat.S_IMODE(target.stat().st_mode), 0o400)
+            self.assertArtifactModeEqual(stat.S_IMODE(alias.stat().st_mode), 0o400)
+        finally:
+            target.chmod(0o600)
+
+    def test_modeled_windows_path_chmod_race_preserves_external_mode(self) -> None:
+        target = self.artifact_directory / "report.json"
+        alias = self.root / "report-alias.json"
+        target.write_bytes(b"old\n")
+        target.chmod(0o444)
+        target_identity = (target.stat().st_dev, target.stat().st_ino)
+        real_chmod = os.chmod
+        changed = False
+
+        def change_mode_and_link(
+            path: str | bytes | os.PathLike[str] | os.PathLike[bytes] | int,
+            mode: int,
+            *args: Any,
+            **kwargs: Any,
+        ) -> None:
+            nonlocal changed
+            candidate_stat: os.stat_result | None = None
+            if not isinstance(path, int):
+                candidate_stat = os.lstat(Path(os.fsdecode(path)))
+            real_chmod(path, mode, *args, **kwargs)
+            if (
+                not changed
+                and candidate_stat is not None
+                and (candidate_stat.st_dev, candidate_stat.st_ino)
+                == target_identity
+                and mode & stat.S_IWUSR
+            ):
+                real_chmod(target, 0o400)
+                os.link(target, alias)
+                changed = True
+
+        try:
+            with ByteArtifactTransaction.open(
+                str(self.root),
+                "gm2godot",
+                create=False,
+                description="test artifact directory",
+            ) as transaction:
+                with (
+                    patch(
+                        "src.conversion.anchored_artifacts._is_windows_platform",
+                        return_value=True,
+                    ),
+                    patch(
+                        "src.conversion.anchored_artifacts.os.fchmod",
+                        None,
+                        create=True,
+                    ),
+                    patch(
+                        "src.conversion.anchored_artifacts.os.chmod",
+                        side_effect=change_mode_and_link,
+                    ),
+                    self.assertRaisesRegex(OSError, "transaction file changed"),
+                ):
+                    transaction.publish_specs((ArtifactSpec("report.json", b"new\n"),))
+
+            self.assertTrue(changed)
+            self.assertEqual(target.read_bytes(), b"old\n")
+            self.assertEqual(alias.read_bytes(), b"old\n")
+            self.assertArtifactModeEqual(stat.S_IMODE(target.stat().st_mode), 0o400)
+            self.assertArtifactModeEqual(stat.S_IMODE(alias.stat().st_mode), 0o400)
+        finally:
+            target.chmod(0o600)
+
+    def test_modeled_windows_late_hardlink_restores_prepared_target_mode(
+        self,
+    ) -> None:
+        target = self.artifact_directory / "report.json"
+        alias = self.root / "report-alias.json"
+        target.write_bytes(b"old\n")
+        target.chmod(0o444)
+        linked = False
+
+        try:
+            with ByteArtifactTransaction.open(
+                str(self.root),
+                "gm2godot",
+                create=False,
+                description="test artifact directory",
+            ) as transaction:
+                real_prepare = cast(
+                    Callable[[str, Any], None],
+                    getattr(transaction, "_prepare_replace_target_mode"),
+                )
+
+                def link_after_target_preparation(
+                    name: str,
+                    prepared: Any,
+                ) -> None:
+                    nonlocal linked
+                    real_prepare(name, prepared)
+                    if name == "report.json" and not linked:
+                        os.link(target, alias)
+                        linked = True
+
+                with (
+                    patch(
+                        "src.conversion.anchored_artifacts._is_windows_platform",
+                        return_value=True,
+                    ),
+                    patch.object(
+                        transaction,
+                        "_prepare_replace_target_mode",
+                        side_effect=link_after_target_preparation,
+                    ),
+                    self.assertRaisesRegex(
+                        OSError,
+                        "multiply-linked artifact at the mutation boundary",
+                    ),
+                ):
+                    transaction.publish_specs((ArtifactSpec("report.json", b"new\n"),))
+
+            self.assertTrue(linked)
+            self.assertEqual(target.read_bytes(), b"old\n")
+            self.assertEqual(alias.read_bytes(), b"old\n")
+            self.assertFalse(stat.S_IMODE(target.stat().st_mode) & stat.S_IWUSR)
+            self.assertFalse(stat.S_IMODE(alias.stat().st_mode) & stat.S_IWUSR)
+        finally:
+            target.chmod(0o600)
+
+    def test_modeled_windows_external_mode_change_is_not_overwritten_on_abort(
+        self,
+    ) -> None:
+        target = self.artifact_directory / "report.json"
+        target.write_bytes(b"old\n")
+        target.chmod(0o444)
+        externally_changed = False
+
+        try:
+            with ByteArtifactTransaction.open(
+                str(self.root),
+                "gm2godot",
+                create=False,
+                description="test artifact directory",
+            ) as transaction:
+                real_prepare = cast(
+                    Callable[[str, Any], None],
+                    getattr(transaction, "_prepare_replace_target_mode"),
+                )
+
+                def change_mode_after_target_preparation(
+                    name: str,
+                    prepared: Any,
+                ) -> None:
+                    nonlocal externally_changed
+                    real_prepare(name, prepared)
+                    if name == "report.json" and not externally_changed:
+                        target.chmod(0o400)
+                        externally_changed = True
+
+                with (
+                    patch(
+                        "src.conversion.anchored_artifacts._is_windows_platform",
+                        return_value=True,
+                    ),
+                    patch.object(
+                        transaction,
+                        "_prepare_replace_target_mode",
+                        side_effect=change_mode_after_target_preparation,
+                    ),
+                    self.assertRaisesRegex(OSError, "Artifact changed"),
+                ):
+                    transaction.publish_specs((ArtifactSpec("report.json", b"new\n"),))
+
+            self.assertTrue(externally_changed)
+            self.assertEqual(target.read_bytes(), b"old\n")
+            self.assertArtifactModeEqual(stat.S_IMODE(target.stat().st_mode), 0o400)
+        finally:
+            target.chmod(0o600)
+
+    def test_writable_hardlink_change_at_replace_boundary_is_preserved(self) -> None:
+        target = self.artifact_directory / "report.json"
+        alias = self.root / "report-alias.json"
+        target.write_bytes(b"old\n")
+        os.link(target, alias)
+        original_identity = (target.stat().st_dev, target.stat().st_ino)
+        changed = False
+
+        def change_through_alias(
+            phase: str,
+            _directory_path: str,
+            name: str | None,
+        ) -> None:
+            nonlocal changed
+            if phase != "before_replace" or name != "report.json" or changed:
+                return
+            self._overwrite_same_inode(alias, b"EXT\n")
+            changed = True
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._file_fingerprint",
+                    side_effect=self._stable_ctime_fingerprint,
+                ),
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=change_through_alias,
+                ),
+                self.assertRaisesRegex(OSError, "Artifact content changed"),
+            ):
+                transaction.publish_specs((ArtifactSpec("report.json", b"new\n"),))
+
+        self.assertTrue(changed)
+        self.assertEqual(target.read_bytes(), b"EXT\n")
+        self.assertEqual(alias.read_bytes(), b"EXT\n")
+        self.assertEqual(
+            (target.stat().st_dev, target.stat().st_ino), original_identity
+        )
+        self.assertEqual((alias.stat().st_dev, alias.stat().st_ino), original_identity)
+        self.assertGreaterEqual(target.stat().st_nlink, 2)
+        self.assertEqual(
+            sorted(path.name for path in self.artifact_directory.iterdir()),
+            ["report.json"],
+        )
+
     def test_ordered_present_absent_publish_and_restore_share_one_core(self) -> None:
         first = self.artifact_directory / "first.json"
         second = self.artifact_directory / "second.json"
@@ -388,6 +1029,217 @@ class TestAnchoredArtifacts(unittest.TestCase):
             ["first.json", "second.json"],
         )
 
+    def test_publish_rejects_same_inode_change_at_replace_boundary(self) -> None:
+        target = self.artifact_directory / "report.json"
+        target.write_bytes(b"old\n")
+        original_identity = (target.stat().st_dev, target.stat().st_ino)
+        changed = False
+
+        def change_target_at_replace(
+            phase: str,
+            _directory_path: str,
+            name: str | None,
+        ) -> None:
+            nonlocal changed
+            if phase != "before_replace" or name != "report.json" or changed:
+                return
+            self._overwrite_same_inode(target, b"EXT\n")
+            changed = True
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._file_fingerprint",
+                    side_effect=self._stable_ctime_fingerprint,
+                ),
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=change_target_at_replace,
+                ),
+                self.assertRaisesRegex(OSError, "Artifact content changed"),
+            ):
+                transaction.publish_specs((ArtifactSpec("report.json", b"new\n"),))
+
+        self.assertTrue(changed)
+        self.assertEqual(target.read_bytes(), b"EXT\n")
+        self.assertEqual(
+            (target.stat().st_dev, target.stat().st_ino), original_identity
+        )
+        self.assertEqual(
+            sorted(path.name for path in self.artifact_directory.iterdir()),
+            ["report.json"],
+        )
+
+    def test_publish_rejects_same_inode_stage_change_at_replace_boundary(
+        self,
+    ) -> None:
+        target = self.artifact_directory / "report.json"
+        target.write_bytes(b"old\n")
+        changed_stage: Path | None = None
+
+        def change_stage_at_replace(
+            phase: str,
+            _directory_path: str,
+            name: str | None,
+        ) -> None:
+            nonlocal changed_stage
+            if phase != "before_replace" or name != "report.json":
+                return
+            candidates = tuple(self.artifact_directory.glob(".report.json.*.tmp"))
+            self.assertEqual(len(candidates), 1)
+            changed_stage = candidates[0]
+            self._overwrite_same_inode(changed_stage, b"BAD\n")
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._file_fingerprint",
+                    side_effect=self._stable_ctime_fingerprint,
+                ),
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=change_stage_at_replace,
+                ),
+                self.assertRaisesRegex(OSError, "Staged artifact content changed"),
+            ):
+                transaction.publish_specs((ArtifactSpec("report.json", b"new\n"),))
+
+        self.assertEqual(target.read_bytes(), b"old\n")
+        self.assertIsNotNone(changed_stage)
+        assert changed_stage is not None
+        self.assertTrue(changed_stage.is_file())
+        self.assertEqual(changed_stage.read_bytes(), b"BAD\n")
+        self.assertEqual(
+            sorted(path.name for path in self.artifact_directory.iterdir()),
+            sorted(("report.json", changed_stage.name)),
+        )
+
+    def test_absent_publish_rejects_same_inode_change_at_unlink_boundary(
+        self,
+    ) -> None:
+        target = self.artifact_directory / "report.json"
+        target.write_bytes(b"old\n")
+        original_identity = (target.stat().st_dev, target.stat().st_ino)
+        changed = False
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            windows_tombstone = transaction.strategy == "windows_handle"
+
+            def change_target_at_unlink(
+                phase: str,
+                _directory_path: str,
+                name: str | None,
+            ) -> None:
+                nonlocal changed
+                posix_boundary = phase == "before_unlink" and name == "report.json"
+                windows_boundary = (
+                    windows_tombstone
+                    and phase == "before_replace"
+                    and name is not None
+                    and name.endswith(".tombstone")
+                )
+                if changed or not (posix_boundary or windows_boundary):
+                    return
+                self._overwrite_same_inode(target, b"EXT\n")
+                changed = True
+
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._file_fingerprint",
+                    side_effect=self._stable_ctime_fingerprint,
+                ),
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=change_target_at_unlink,
+                ),
+                self.assertRaisesRegex(OSError, "content changed"),
+            ):
+                transaction.publish_specs((ArtifactSpec("report.json", None),))
+
+        self.assertTrue(changed)
+        self.assertEqual(target.read_bytes(), b"EXT\n")
+        self.assertEqual(
+            (target.stat().st_dev, target.stat().st_ino), original_identity
+        )
+        self.assertEqual(
+            sorted(path.name for path in self.artifact_directory.iterdir()),
+            ["report.json"],
+        )
+
+    def test_restore_rejects_same_inode_receipt_change_at_replace_boundary(
+        self,
+    ) -> None:
+        target = self.artifact_directory / "report.json"
+        target.write_bytes(b"old\n")
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            snapshot = transaction.capture_snapshot("report.json")
+            receipt = transaction.publish_specs(
+                (ArtifactSpec("report.json", b"new\n"),)
+            )[0]
+            assert receipt is not None
+            published_identity = (target.stat().st_dev, target.stat().st_ino)
+            changed = False
+
+            def change_receipt_at_displacement(
+                phase: str,
+                _directory_path: str,
+                name: str | None,
+            ) -> None:
+                nonlocal changed
+                if (
+                    phase != "before_replace"
+                    or name is None
+                    or not name.endswith(".restore.backup")
+                    or changed
+                ):
+                    return
+                self._overwrite_same_inode(target, b"EXT\n")
+                changed = True
+
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._file_fingerprint",
+                    side_effect=self._stable_ctime_fingerprint,
+                ),
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=change_receipt_at_displacement,
+                ),
+                self.assertRaisesRegex(OSError, "content changed"),
+            ):
+                transaction.restore_snapshots((snapshot,), (receipt,))
+
+        self.assertTrue(changed)
+        self.assertEqual(target.read_bytes(), b"EXT\n")
+        self.assertEqual(
+            (target.stat().st_dev, target.stat().st_ino), published_identity
+        )
+        self.assertEqual(
+            sorted(path.name for path in self.artifact_directory.iterdir()),
+            ["report.json"],
+        )
+
     def test_publish_rollback_continues_after_one_target_fails(self) -> None:
         first = self.artifact_directory / "first.json"
         second = self.artifact_directory / "second.json"
@@ -454,6 +1306,77 @@ class TestAnchoredArtifacts(unittest.TestCase):
         self.assertTrue(
             any("injected second rollback failure" in note for note in notes)
         )
+        self.assertTrue(
+            any("verified recovery artifact preserved" in note for note in notes)
+        )
+
+    def test_publish_rollback_preserves_same_inode_external_change(self) -> None:
+        target = self.artifact_directory / "report.json"
+        target.write_bytes(b"old\n")
+        original_mode = stat.S_IMODE(target.stat().st_mode)
+        rolling_back = False
+        changed = False
+
+        def fail_then_change_rollback_target(
+            phase: str,
+            _directory_path: str,
+            name: str | None,
+        ) -> None:
+            nonlocal changed, rolling_back
+            if phase == "before_commit_report.json_durability":
+                rolling_back = True
+                raise OSError("injected publication durability failure")
+            if (
+                rolling_back
+                and phase == "before_replace"
+                and name == "report.json"
+                and not changed
+            ):
+                self._overwrite_same_inode(target, b"EXT\n")
+                changed = True
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._file_fingerprint",
+                    side_effect=self._stable_ctime_fingerprint,
+                ),
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=fail_then_change_rollback_target,
+                ),
+                self.assertRaisesRegex(
+                    OSError,
+                    "publication durability failure",
+                ) as raised,
+            ):
+                transaction.publish_specs((ArtifactSpec("report.json", b"new\n"),))
+
+        self.assertTrue(changed)
+        self.assertEqual(target.read_bytes(), b"EXT\n")
+        retained = [
+            path
+            for path in self.artifact_directory.iterdir()
+            if path.name != "report.json"
+        ]
+        self.assertEqual(len(retained), 1)
+        self.assertEqual(retained[0].read_bytes(), b"old\n")
+        retained_stat = retained[0].stat()
+        self.assertEqual(retained_stat.st_nlink, 1)
+        self.assertNotEqual(
+            (retained_stat.st_dev, retained_stat.st_ino),
+            (target.stat().st_dev, target.stat().st_ino),
+        )
+        self.assertArtifactModeEqual(
+            stat.S_IMODE(retained_stat.st_mode),
+            original_mode,
+        )
+        notes = getattr(raised.exception, "__notes__", ())
         self.assertTrue(
             any("verified recovery artifact preserved" in note for note in notes)
         )
@@ -754,6 +1677,82 @@ class TestAnchoredArtifacts(unittest.TestCase):
         self.assertTrue(
             any("injected receipt rollback failure" in note for note in notes)
         )
+        self.assertTrue(
+            any("verified recovery artifact preserved" in note for note in notes)
+        )
+
+    def test_restore_rollback_preserves_same_inode_external_change(self) -> None:
+        target = self.artifact_directory / "report.json"
+        target.write_bytes(b"old\n")
+
+        with ByteArtifactTransaction.open(
+            str(self.root),
+            "gm2godot",
+            create=False,
+            description="test artifact directory",
+        ) as transaction:
+            snapshot = transaction.capture_snapshot("report.json")
+            receipt = transaction.publish_specs(
+                (ArtifactSpec("report.json", b"new\n"),)
+            )[0]
+            assert receipt is not None
+            rolling_back = False
+            changed = False
+
+            def fail_then_change_rollback_target(
+                phase: str,
+                _directory_path: str,
+                name: str | None,
+            ) -> None:
+                nonlocal changed, rolling_back
+                if phase == "before_restore_report.json_durability":
+                    rolling_back = True
+                    raise OSError("injected restore durability failure")
+                if (
+                    rolling_back
+                    and phase == "before_replace"
+                    and name == "report.json"
+                    and not changed
+                ):
+                    self._overwrite_same_inode(target, b"EXT\n")
+                    changed = True
+
+            with (
+                patch(
+                    "src.conversion.anchored_artifacts._file_fingerprint",
+                    side_effect=self._stable_ctime_fingerprint,
+                ),
+                patch(
+                    "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                    side_effect=fail_then_change_rollback_target,
+                ),
+                self.assertRaisesRegex(
+                    OSError,
+                    "restore durability failure",
+                ) as raised,
+            ):
+                transaction.restore_snapshots((snapshot,), (receipt,))
+
+        self.assertTrue(changed)
+        self.assertEqual(target.read_bytes(), b"EXT\n")
+        retained = [
+            path
+            for path in self.artifact_directory.iterdir()
+            if path.name != "report.json"
+        ]
+        self.assertEqual(len(retained), 1)
+        self.assertEqual(retained[0].read_bytes(), receipt.content)
+        retained_stat = retained[0].stat()
+        self.assertEqual(retained_stat.st_nlink, 1)
+        self.assertNotEqual(
+            (retained_stat.st_dev, retained_stat.st_ino),
+            (target.stat().st_dev, target.stat().st_ino),
+        )
+        self.assertArtifactModeEqual(
+            stat.S_IMODE(retained_stat.st_mode),
+            receipt.mode,
+        )
+        notes = getattr(raised.exception, "__notes__", ())
         self.assertTrue(
             any("verified recovery artifact preserved" in note for note in notes)
         )
@@ -1106,6 +2105,35 @@ class TestAnchoredArtifacts(unittest.TestCase):
                 child.read_bytes(),
             )
         return snapshot
+
+    def _overwrite_same_inode(self, path: Path, content: bytes) -> None:
+        before = path.stat()
+        self.assertEqual(len(content), before.st_size)
+        with path.open("r+b", buffering=0) as artifact_file:
+            artifact_file.write(content)
+            artifact_file.truncate()
+            os.fsync(artifact_file.fileno())
+        os.utime(
+            path,
+            ns=(before.st_atime_ns, before.st_mtime_ns),
+        )
+        after = path.stat()
+        self.assertEqual(
+            (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns),
+            (before.st_dev, before.st_ino, before.st_size, before.st_mtime_ns),
+        )
+
+    @staticmethod
+    def _stable_ctime_fingerprint(
+        path_stat: os.stat_result,
+    ) -> tuple[int, int, int, int, int]:
+        return (
+            path_stat.st_dev,
+            path_stat.st_ino,
+            path_stat.st_size,
+            path_stat.st_mtime_ns,
+            0,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_architecture_policy.py
+++ b/tests/test_architecture_policy.py
@@ -445,6 +445,7 @@ class TestArchitecturePolicy(unittest.TestCase):
                     ):
                         verify_receipt(receipt, transaction)
 
+    @unittest.skipIf(os.name == "nt", "POSIX-modeled Windows semantics required")
     def test_mocked_windows_readonly_report_publishes_restores_and_cleans(
         self,
     ) -> None:
@@ -499,6 +500,10 @@ class TestArchitecturePolicy(unittest.TestCase):
                 return_value=True,
             ),
             patch(
+                "src.conversion.anchored_artifacts._descriptor_relative_supported",
+                return_value=True,
+            ),
+            patch(
                 "src.conversion.anchored_artifacts.os.rename",
                 side_effect=windows_replace,
             ),
@@ -528,6 +533,7 @@ class TestArchitecturePolicy(unittest.TestCase):
         self.assertEqual(list(report_path.parent.iterdir()), [report_path])
         report_path.chmod(0o600)
 
+    @unittest.skipIf(os.name == "nt", "POSIX-modeled Windows semantics required")
     def test_mocked_windows_failed_replace_restores_readonly_and_cleans(
         self,
     ) -> None:
@@ -537,24 +543,31 @@ class TestArchitecturePolicy(unittest.TestCase):
         report_path.parent.mkdir(parents=True)
         report_path.write_bytes(previous_content)
         report_path.chmod(0o444)
+        real_rename = os.rename
         real_unlink = os.unlink
 
         def fail_report_replace(
-            phase: str,
-            directory_path: str,
-            name: str | None,
+            source: str,
+            destination: str,
+            *,
+            src_dir_fd: int | None = None,
+            dst_dir_fd: int | None = None,
         ) -> None:
-            if phase == "before_replace" and name == report_path.name:
-                assert name is not None
-                destination = os.path.join(directory_path, name)
+            if destination == report_path.name:
                 destination_mode = stat.S_IMODE(
-                    os.lstat(destination).st_mode
+                    _lstat_at(destination, dir_fd=dst_dir_fd).st_mode
                 )
                 if not destination_mode & stat.S_IWUSR:
                     raise PermissionError(
                         "mock Windows refuses to replace a read-only destination"
                     )
                 raise OSError("injected Windows replacement failure")
+            real_rename(
+                source,
+                destination,
+                src_dir_fd=src_dir_fd,
+                dst_dir_fd=dst_dir_fd,
+            )
 
         def windows_unlink(
             path: str | bytes,
@@ -575,7 +588,11 @@ class TestArchitecturePolicy(unittest.TestCase):
                 return_value=True,
             ),
             patch(
-                "src.conversion.anchored_artifacts._before_anchored_artifact_phase",
+                "src.conversion.anchored_artifacts._descriptor_relative_supported",
+                return_value=True,
+            ),
+            patch(
+                "src.conversion.anchored_artifacts.os.rename",
                 side_effect=fail_report_replace,
             ),
             patch(
@@ -596,6 +613,7 @@ class TestArchitecturePolicy(unittest.TestCase):
         self.assertEqual(list(report_path.parent.iterdir()), [report_path])
         report_path.chmod(0o600)
 
+    @unittest.skipIf(os.name == "nt", "POSIX-modeled Windows semantics required")
     def test_mocked_windows_readonly_rollback_restores_replaceable_backup(
         self,
     ) -> None:
@@ -659,6 +677,10 @@ class TestArchitecturePolicy(unittest.TestCase):
         with (
             patch(
                 "src.conversion.anchored_artifacts._is_windows_platform",
+                return_value=True,
+            ),
+            patch(
+                "src.conversion.anchored_artifacts._descriptor_relative_supported",
                 return_value=True,
             ),
             patch(

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -5027,6 +5027,7 @@ class TestCIWorkflows(unittest.TestCase):
             "tests.test_conversion_outcome",
             "tests.test_conversion_manifest",
             "tests.test_diagnostics",
+            "tests.test_anchored_artifacts",
             "tests.test_architecture_policy",
             "tests.test_converter",
             "tests.test_cli",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_54(self) -> None:
-        self.assertEqual(get_version(), "0.7.54")
+    def test_release_version_is_0_7_55(self) -> None:
+        self.assertEqual(get_version(), "0.7.55")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #823.

Revalidates immutable staged sources and expected destinations after the observable replace/unlink hooks and Windows writable-mode preparation, immediately before namespace mutation. Publish, absent publish, restore displacement, and both rollback directions now fail closed on same-inode byte changes while retaining verified recovery material. Hard-link races restore only the exact temporary mode set by the transaction, preserving unrelated external mode changes.

Adds deterministic equal-size/restored-mtime/constant-ctime race coverage, locks the core anchored-artifact suite into native Windows CI, and bumps the project to 0.7.55 for GameMaker LTS 2026 and exact Godot 4.7.1.

Local evidence on exact head 08c3bb405ec9cc7a009b100169586d65fe61babb:
- 2,445 unit tests passed; 76 platform-specific skips
- Python 3.12 and project-venv focused suites: 73 passed; 7 native-Windows skips each
- exact Godot 4.7.1 discovery: 83 passed
- exact Godot validation/golden/settings: 60 passed
- Ruff clean; Pyright 0 errors and 0 warnings

Exact-head pull-request CI:
- 20/20 check records completed: 17 success, 3 expected pull-request release skips, zero failures
- Linux: 2,445 passed in 698.716s, 151 skips, 81.43% coverage; privileged bind-mount gate passed 1/1
- native Windows artifact transactions: 635 passed in 486.850s, 57 expected skips; Python 3.12 path-chmod race variants passed
- native Windows 10,000-entry scale: 1 passed in 653.520s with no skip
- native Windows crash recovery: 19 passed in 1,154.303s, 2 skips; this is close to the 20-minute job cap and is recorded for infrastructure follow-up
- macOS managed-output transactions: 159 passed in 266.686s, 9 skips
- exact Godot 4.7.1: 83 discovery plus 60 validation/golden/settings tests passed
- current GameMaker LTS 2026 fixtures and TCC conversion gates passed