### PR TITLE
Fix Godot output reader shutdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.58, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.59, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -235,6 +235,15 @@ jobs:
           tests.test_included_files.TestIncludedFilesManagedRootTransaction
           tests.test_included_files.TestIncludedFilesConverterOutputContainment
 
+      - name: Run native Windows Godot output-reader scheduling tests
+        run: >-
+          python -m unittest -v
+          tests.test_godot_validation.TestGodotValidation.test_timeout_reader_deferred_until_after_stop_retains_buffered_diagnostic
+          tests.test_godot_validation.TestGodotValidation.test_reader_retries_after_output_arrives_during_stop_wait
+          tests.test_godot_validation.TestGodotValidation.test_normal_completion_reader_oserror_is_capture_failure
+          tests.test_godot_validation.TestGodotValidation.test_timeout_reader_oserror_is_capture_failure
+          tests.test_godot_validation.TestGodotValidation.test_stop_deadline_leaves_stdout_owned_by_live_reader
+
   windows-included-files-scale:
     runs-on: windows-2025
     timeout-minutes: 20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.59 - 2026-09-02
+
+- Performed one final nonblocking Godot-output read attempt when validation shutdown begins, so buffered warning/error diagnostics cannot be mistaken for clean import-only timeouts.
+- Kept shutdown bounded for inherited or continuously writing stdout descendants, and surfaced timeout-path reader errors as capture failures with their original cause.
+- Added deterministic deferred-reader, error-injection, timeout-diagnostic, and continuous-writer coverage while preserving GameMaker LTS 2026 conversion behavior and exact Godot 4.7.1 output.
+
 ## 0.7.58 - 2026-09-02
 
 - Revalidated every staged artifact backup after its observable hook, across the complete set before the first public mutation, and again at each commit boundary so in-place or identity-replacement tampering fails closed without changing public output.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Version 0.7.57 upgrades the dependency bootstrap and lock generator as the revie
 
 Version 0.7.58 makes staged artifact backups and successful cleanup fail closed. Each backup is revalidated after its observable hook, across the full set before public mutation, and again at its commit boundary; changed or replaced paths are preserved instead of trusted or deleted. Backup-hook failures durably remove only the exact owned stage, while publication, restoration, and stale conversion-artifact cleanup now report incomplete cleanup rather than returning success. Earlier operation and control-flow failures retain their established precedence with later cleanup context attached. GameMaker LTS 2026 conversion behavior and the exact Godot 4.7.1 target are unchanged.
 
+Version 0.7.59 performs one final nonblocking Godot-output read attempt when validation shutdown begins, so buffered warning/error diagnostics cannot be mistaken for clean import-only timeouts. Shutdown remains bounded for inherited or continuously writing stdout descendants, and timeout-path reader errors surface as capture failures with their original cause. GameMaker LTS 2026 conversion behavior and the exact Godot 4.7.1 target are unchanged.
+
 ## What GM2Godot Is and Isn't
 
 **GM2Godot is:**
@@ -94,7 +96,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.58`.
+Current source version: `0.7.59`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.58 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.59 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-02
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.58 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.59 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-02
 
@@ -95,6 +95,8 @@ Fix every Pyright error and warning in changed code. Run the relevant focused te
 GODOT_BIN=/path/to/Godot-4.7.1 \
   ./venv/bin/python -m unittest discover -s tests -p 'test_*_godot.py'
 ```
+
+Godot validation gives the output reader a bounded drain window, then requests shutdown and permits exactly one deliberate final nonblocking read attempt. Reader I/O failures fail validation capture, and inherited or continuously writing stdout descendants cannot extend the stop deadline.
 
 ### Preserve the GML phase-boundary baseline
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.58 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.59 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-02
 
@@ -131,6 +131,8 @@ An explicit or environment path that is not a file is skipped and discovery cont
 If no Godot binary is found, validation records `status: "skipped"` and an informational diagnostic. It does **not** prove the project is valid and is not a hard failure by itself. Set `GODOT_BIN` or pass `--godot-bin` to get real parser/resource validation.
 
 With a binary available, validation asks Godot to import supported asset types and loads every `.gd`, `.gdshader`, `.tscn`, and `.tres` resource under the destination project (excluding `.godot/`), not only GM2Godot-managed files. It records Godot warning/error output as validation issues. `--godot-boot-frames N` additionally boots the configured main scene headlessly for `N` frames after resource validation; it is disabled by default. Use `--skip-godot-validation` only when intentionally limiting `validate` to existing reports and project-presence checks.
+
+An import-only timeout is treated as clean only when output capture succeeded and contains no Godot warning/error. Shutdown performs one final nonblocking read attempt for already-buffered diagnostics; an output-reader error is reported as a capture failure instead of empty output.
 
 ## Common failures
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.58 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.59 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-02
 
@@ -400,6 +400,8 @@ python main.py validate \
 ```
 
 Validation imports supported asset types, loads every `.gd`, `.tscn`, `.tres`, and `.gdshader` resource under the destination project except `.godot/`, and can boot the configured main scene for the requested frame count. Read the first warning/error in `gm2godot/godot_validation_report.json`, then correlate it with conversion diagnostics and any `.gmlmap.json` source map.
+
+Headless import, resource, and boot validation captures bounded combined stdout/stderr. At reader shutdown it makes one final nonblocking read attempt, preserving buffered diagnostics without waiting indefinitely for inherited stdout descriptors.
 
 For report interpretation and failure recovery, continue to [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting). For implementation changes, use [Contributing and Testing](Contributing-and-Testing) and preserve the runtime/architecture contracts covered by the Godot-backed tests.
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.58 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.59 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-02
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.58;
+- GM2Godot 0.7.59;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.58 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.59 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-02
 
@@ -46,7 +46,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.58`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.59`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
 
 ## Run from source
 
@@ -133,6 +133,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.58`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.59`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.58 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.59 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-02
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.58 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.59 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-02
 

--- a/src/conversion/godot_validation.py
+++ b/src/conversion/godot_validation.py
@@ -610,18 +610,34 @@ def _run_godot_command(
     os.set_blocking(output_fd, False)
 
     def read_output() -> None:
-        while not reader_stop.is_set():
+        try:
+            while True:
+                # Once shutdown is observed, make one last nonblocking read.
+                # This retains bytes that arrived during the preceding poll
+                # without draining a continuously writable pipe indefinitely.
+                final_attempt = reader_stop.is_set()
+                try:
+                    chunk = os.read(output_fd, _GODOT_OUTPUT_READ_CHUNK_BYTES)
+                except BlockingIOError:
+                    if final_attempt:
+                        return
+                    reader_stop.wait(_GODOT_OUTPUT_READER_POLL_SECONDS)
+                    continue
+                except OSError as exc:
+                    reader_errors.append(exc)
+                    return
+                if not chunk:
+                    return
+                output.append(chunk)
+                if final_attempt:
+                    return
+        finally:
+            # Keep the descriptor owned by the reader until no later read can
+            # run, including when the caller reports a missed stop deadline.
             try:
-                chunk = os.read(output_fd, _GODOT_OUTPUT_READ_CHUNK_BYTES)
-            except BlockingIOError:
-                reader_stop.wait(_GODOT_OUTPUT_READER_POLL_SECONDS)
-                continue
+                output_stream.close()
             except OSError as exc:
                 reader_errors.append(exc)
-                return
-            if not chunk:
-                return
-            output.append(chunk)
 
     output_reader = threading.Thread(
         target=read_output,
@@ -635,23 +651,19 @@ def _run_godot_command(
     except subprocess.TimeoutExpired:
         _kill_godot_process(process)
         process.wait()
-        _finish_godot_output_reader(output_reader, reader_stop)
-        output_stream.close()
+        _finish_godot_output_reader(output_reader, reader_stop, reader_errors)
         raise subprocess.TimeoutExpired(
             command,
             timeout,
             output=output.text(),
         ) from None
 
-    if output_reader.is_alive():
+    if output_reader.is_alive() or reader_errors:
         # The direct process has exited, so an open pipe now belongs to a
-        # descendant. Clean up the validation process group instead of waiting
-        # indefinitely for that inherited descriptor to close.
+        # descendant, or output capture failed before proving otherwise. Clean
+        # up the validation process group instead of leaving either case alive.
         _kill_godot_process(process)
-    _finish_godot_output_reader(output_reader, reader_stop)
-    output_stream.close()
-    if reader_errors:
-        raise RuntimeError("Failed while capturing Godot output.") from reader_errors[0]
+    _finish_godot_output_reader(output_reader, reader_stop, reader_errors)
     return subprocess.CompletedProcess(
         command,
         returncode,
@@ -663,14 +675,16 @@ def _run_godot_command(
 def _finish_godot_output_reader(
     output_reader: threading.Thread,
     reader_stop: threading.Event,
+    reader_errors: list[OSError],
 ) -> None:
     output_reader.join(timeout=_GODOT_OUTPUT_READER_DRAIN_GRACE_SECONDS)
-    if not output_reader.is_alive():
-        return
-    reader_stop.set()
-    output_reader.join(timeout=_GODOT_OUTPUT_READER_STOP_GRACE_SECONDS)
     if output_reader.is_alive():
-        raise RuntimeError("Godot output reader did not stop after pipe cleanup.")
+        reader_stop.set()
+        output_reader.join(timeout=_GODOT_OUTPUT_READER_STOP_GRACE_SECONDS)
+        if output_reader.is_alive():
+            raise RuntimeError("Godot output reader did not stop after pipe cleanup.")
+    if reader_errors:
+        raise RuntimeError("Failed while capturing Godot output.") from reader_errors[0]
 
 
 def _kill_godot_process(process: subprocess.Popen[bytes]) -> None:

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.58"
+VERSION = "0.7.59"
 
 
 def get_version():

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -34,6 +34,18 @@ LIVE_GODOT_MODULES_OUTSIDE_DISCOVERY = (
     "tests.test_golden_conversion",
     "tests.test_project_settings",
 )
+WINDOWS_GODOT_OUTPUT_READER_TESTS = (
+    "tests.test_godot_validation.TestGodotValidation."
+    "test_timeout_reader_deferred_until_after_stop_retains_buffered_diagnostic",
+    "tests.test_godot_validation.TestGodotValidation."
+    "test_reader_retries_after_output_arrives_during_stop_wait",
+    "tests.test_godot_validation.TestGodotValidation."
+    "test_normal_completion_reader_oserror_is_capture_failure",
+    "tests.test_godot_validation.TestGodotValidation."
+    "test_timeout_reader_oserror_is_capture_failure",
+    "tests.test_godot_validation.TestGodotValidation."
+    "test_stop_deadline_leaves_stdout_owned_by_live_reader",
+)
 EXTERNAL_CONVERSION_MODULES = (
     "tests.test_simple_topdown_conversion",
     "tests.test_tcc_conversion",
@@ -5037,6 +5049,33 @@ class TestCIWorkflows(unittest.TestCase):
         ):
             with self.subTest(module=module):
                 self.assertIn(module, windows_job)
+
+        output_reader_step_name = (
+            "- name: Run native Windows Godot output-reader scheduling tests"
+        )
+        self.assertEqual(windows_job.count(output_reader_step_name), 1)
+        output_reader_step_index = windows_job.index(output_reader_step_name)
+        artifact_step = windows_job[
+            windows_job.index(
+                "- name: Run Windows outcome and artifact transaction tests"
+            ):output_reader_step_index
+        ]
+        output_reader_step = windows_job[output_reader_step_index:]
+        self.assertNotIn("tests.test_godot_validation", artifact_step)
+        self.assertEqual(output_reader_step.count("python -m unittest -v"), 1)
+        self.assertEqual(
+            tuple(
+                re.findall(
+                    r"(?m)^          (tests\.test_godot_validation\."
+                    r"TestGodotValidation\.test_[a-z0-9_]+)$",
+                    output_reader_step,
+                )
+            ),
+            WINDOWS_GODOT_OUTPUT_READER_TESTS,
+        )
+        for selector in WINDOWS_GODOT_OUTPUT_READER_TESTS:
+            with self.subTest(output_reader_selector=selector):
+                self.assertEqual(windows_job.count(selector), 1)
 
     def test_unit_workflow_shards_native_windows_included_files_scale_gate(
         self,

--- a/tests/test_godot_validation.py
+++ b/tests/test_godot_validation.py
@@ -7,15 +7,20 @@ import json
 import os
 import signal
 import shutil
+import subprocess
 import sys
 import tempfile
 import threading
 import time
 import unittest
+from collections.abc import Callable
 from pathlib import Path
+from types import ModuleType
+from typing import Any
 from unittest.mock import patch
 
 from src import cli
+from src.conversion import godot_validation as godot_validation_module
 from src.conversion.godot_validation import (
     GODOT_VALIDATION_REPORT_RELATIVE_PATH,
     detect_godot_output_issues,
@@ -31,6 +36,246 @@ _PNG_1X1_WHITE = (
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4"
     "////fwAJ+wP9KobjigAAAABJRU5ErkJggg=="
 )
+
+
+class _ModuleBindingProxy:
+    def __init__(self, original: ModuleType, **overrides: object) -> None:
+        self._original = original
+        self._overrides = overrides
+
+    def __getattr__(self, name: str) -> Any:
+        if name in self._overrides:
+            return self._overrides[name]
+        return getattr(self._original, name)
+
+
+class _PipeBackedProcess:
+    def __init__(
+        self,
+        output: bytes,
+        *,
+        timeout_on_first_wait: bool = False,
+        keep_writer_open: bool = False,
+    ) -> None:
+        read_fd, write_fd = os.pipe()
+        try:
+            self._write_all(write_fd, output)
+        except BaseException:
+            os.close(read_fd)
+            os.close(write_fd)
+            raise
+
+        self._write_fd = write_fd if keep_writer_open else None
+        if not keep_writer_open:
+            os.close(write_fd)
+
+        self.stdout = os.fdopen(read_fd, "rb", buffering=0)
+        self.pid = 1
+        self.returncode: int | None = None
+        self._timeout_on_first_wait = timeout_on_first_wait
+        self._wait_calls = 0
+        self.kill_calls = 0
+
+    def wait(self, timeout: float | None = None) -> int:
+        self._wait_calls += 1
+        if self._timeout_on_first_wait and self._wait_calls == 1:
+            if timeout is None:
+                raise AssertionError("the first fake wait must be bounded")
+            raise subprocess.TimeoutExpired(["fake-godot"], timeout)
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        if self.returncode is None:
+            self.returncode = -9
+
+    @staticmethod
+    def _write_all(write_fd: int, output: bytes) -> None:
+        remaining = memoryview(output)
+        while remaining:
+            written = os.write(write_fd, remaining)
+            remaining = remaining[written:]
+
+    def write_output(self, output: bytes) -> None:
+        if self._write_fd is None:
+            raise AssertionError("the fake output writer is closed")
+        self._write_all(self._write_fd, output)
+
+    def close_stdout(self) -> None:
+        if self._write_fd is not None:
+            os.close(self._write_fd)
+            self._write_fd = None
+        if not self.stdout.closed:
+            self.stdout.close()
+
+
+def _ignore_killpg(_pid: int, _signal: int) -> None:
+    pass
+
+
+def _popen_returning(
+    process: _PipeBackedProcess,
+) -> Callable[..., _PipeBackedProcess]:
+    def fake_popen(*_args: object, **_kwargs: object) -> _PipeBackedProcess:
+        return process
+
+    return fake_popen
+
+
+class _DeferredTargetThread:
+    def __init__(
+        self,
+        *,
+        target: Callable[[], None],
+        name: str,
+        daemon: bool,
+    ) -> None:
+        self._target = target
+        self._gate = threading.Event()
+        self._join_calls = 0
+        self._thread = threading.Thread(
+            target=self._run_after_release,
+            name=name,
+            daemon=daemon,
+        )
+
+    def _run_after_release(self) -> None:
+        self._gate.wait()
+        self._target()
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def join(self, timeout: float | None = None) -> None:
+        self._join_calls += 1
+        if self._join_calls == 1:
+            return
+        self._gate.set()
+        self._thread.join(timeout)
+
+    def is_alive(self) -> bool:
+        return self._thread.is_alive()
+
+    def release(self) -> None:
+        self._gate.set()
+        self._thread.join(timeout=1.0)
+
+
+class _SynchronousTargetThread:
+    def __init__(
+        self,
+        *,
+        target: Callable[[], None],
+        name: str,
+        daemon: bool,
+    ) -> None:
+        del name, daemon
+        self._target = target
+
+    def start(self) -> None:
+        self._target()
+
+    def join(self, timeout: float | None = None) -> None:
+        del timeout
+
+    def is_alive(self) -> bool:
+        return False
+
+
+class _DeadlineBlockedTargetThread:
+    def __init__(
+        self,
+        *,
+        target: Callable[[], None],
+        name: str,
+        daemon: bool,
+    ) -> None:
+        self._target = target
+        self._gate = threading.Event()
+        self._join_calls = 0
+        self._thread = threading.Thread(
+            target=self._run_after_release,
+            name=name,
+            daemon=daemon,
+        )
+
+    def _run_after_release(self) -> None:
+        self._gate.wait()
+        self._target()
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def join(self, timeout: float | None = None) -> None:
+        del timeout
+        self._join_calls += 1
+
+    def is_alive(self) -> bool:
+        return self._thread.is_alive()
+
+    @property
+    def join_calls(self) -> int:
+        return self._join_calls
+
+    def release(self) -> None:
+        self._gate.set()
+        self._thread.join(timeout=1.0)
+
+
+class _WaitArrivalStopEvent:
+    def __init__(self) -> None:
+        self.wait_entered = threading.Event()
+        self._event = threading.Event()
+
+    def is_set(self) -> bool:
+        return self._event.is_set()
+
+    def wait(self, _timeout: float | None = None) -> bool:
+        self.wait_entered.set()
+        return self._event.wait(timeout=1.0)
+
+    def set(self) -> None:
+        self._event.set()
+
+
+class _WriteDuringWaitThread:
+    def __init__(
+        self,
+        *,
+        target: Callable[[], None],
+        name: str,
+        daemon: bool,
+        stop_event: _WaitArrivalStopEvent,
+        buffer_output: Callable[[], None],
+    ) -> None:
+        self._stop_event = stop_event
+        self._buffer_output = buffer_output
+        self._join_calls = 0
+        self._thread = threading.Thread(target=target, name=name, daemon=daemon)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def join(self, timeout: float | None = None) -> None:
+        self._join_calls += 1
+        if self._join_calls == 1:
+            if not self._stop_event.wait_entered.wait(timeout=1.0):
+                raise AssertionError("the output reader did not enter its poll wait")
+            self._buffer_output()
+            return
+        self._thread.join(timeout)
+
+    def is_alive(self) -> bool:
+        return self._thread.is_alive()
+
+    def release(self) -> None:
+        self._stop_event.set()
+        self._thread.join(timeout=1.0)
 
 
 class TestGodotValidation(unittest.TestCase):
@@ -138,6 +383,258 @@ class TestGodotValidation(unittest.TestCase):
         self.assertEqual(resolved_binary, macos_app_binary)
         is_file.assert_called_once_with(macos_app_binary)
 
+    def test_timeout_reader_deferred_until_after_stop_retains_buffered_diagnostic(
+        self,
+    ) -> None:
+        diagnostic = b"SCRIPT ERROR: buffered before timeout shutdown\n"
+        process = _PipeBackedProcess(diagnostic, timeout_on_first_wait=True)
+        self.addCleanup(process.close_stdout)
+        deferred_threads: list[_DeferredTargetThread] = []
+        read_calls = 0
+
+        def make_deferred_thread(
+            *,
+            target: Callable[[], None],
+            name: str,
+            daemon: bool,
+        ) -> _DeferredTargetThread:
+            output_reader = _DeferredTargetThread(
+                target=target,
+                name=name,
+                daemon=daemon,
+            )
+            deferred_threads.append(output_reader)
+            return output_reader
+
+        def counted_read(fd: int, size: int) -> bytes:
+            nonlocal read_calls
+            read_calls += 1
+            return os.read(fd, size)
+
+        os_proxy = _ModuleBindingProxy(
+            os,
+            killpg=_ignore_killpg,
+            read=counted_read,
+        )
+        subprocess_proxy = _ModuleBindingProxy(
+            subprocess,
+            Popen=_popen_returning(process),
+        )
+        threading_proxy = _ModuleBindingProxy(
+            threading,
+            Thread=make_deferred_thread,
+        )
+
+        try:
+            with (
+                patch.object(godot_validation_module, "os", os_proxy),
+                patch.object(godot_validation_module, "subprocess", subprocess_proxy),
+                patch.object(godot_validation_module, "threading", threading_proxy),
+                self.assertRaises(subprocess.TimeoutExpired) as raised,
+            ):
+                _run_godot_command(["fake-godot"], timeout=1)
+        finally:
+            for output_reader in deferred_threads:
+                output_reader.release()
+
+        self.assertEqual(read_calls, 1)
+        self.assertIn(diagnostic.decode("utf-8").strip(), raised.exception.output)
+
+    def test_reader_retries_after_output_arrives_during_stop_wait(self) -> None:
+        diagnostic = b"WARNING: buffered while the reader waited for shutdown\n"
+        process = _PipeBackedProcess(b"", keep_writer_open=True)
+        self.addCleanup(process.close_stdout)
+        stop_event = _WaitArrivalStopEvent()
+        race_threads: list[_WriteDuringWaitThread] = []
+        read_calls = 0
+
+        def make_stop_event() -> _WaitArrivalStopEvent:
+            return stop_event
+
+        def make_race_thread(
+            *,
+            target: Callable[[], None],
+            name: str,
+            daemon: bool,
+        ) -> _WriteDuringWaitThread:
+            output_reader = _WriteDuringWaitThread(
+                target=target,
+                name=name,
+                daemon=daemon,
+                stop_event=stop_event,
+                buffer_output=lambda: process.write_output(diagnostic),
+            )
+            race_threads.append(output_reader)
+            return output_reader
+
+        def counted_read(fd: int, size: int) -> bytes:
+            nonlocal read_calls
+            read_calls += 1
+            return os.read(fd, size)
+
+        os_proxy = _ModuleBindingProxy(
+            os,
+            killpg=_ignore_killpg,
+            read=counted_read,
+        )
+        subprocess_proxy = _ModuleBindingProxy(
+            subprocess,
+            Popen=_popen_returning(process),
+        )
+        threading_proxy = _ModuleBindingProxy(
+            threading,
+            Event=make_stop_event,
+            Thread=make_race_thread,
+        )
+
+        try:
+            with (
+                patch.object(godot_validation_module, "os", os_proxy),
+                patch.object(godot_validation_module, "subprocess", subprocess_proxy),
+                patch.object(godot_validation_module, "threading", threading_proxy),
+            ):
+                result = _run_godot_command(["fake-godot"], timeout=1)
+        finally:
+            for output_reader in race_threads:
+                output_reader.release()
+
+        self.assertEqual(read_calls, 2)
+        self.assertIn(diagnostic.decode("utf-8").strip(), result.stdout)
+
+    def test_normal_completion_reader_oserror_is_capture_failure(self) -> None:
+        process = _PipeBackedProcess(b"")
+        self.addCleanup(process.close_stdout)
+        capture_error = OSError("injected normal read failure")
+
+        def fail_read(_fd: int, _size: int) -> bytes:
+            raise capture_error
+
+        os_proxy = _ModuleBindingProxy(
+            os,
+            name="not-posix",
+            read=fail_read,
+        )
+        subprocess_proxy = _ModuleBindingProxy(
+            subprocess,
+            Popen=_popen_returning(process),
+        )
+        threading_proxy = _ModuleBindingProxy(
+            threading,
+            Thread=_SynchronousTargetThread,
+        )
+
+        with (
+            patch.object(godot_validation_module, "os", os_proxy),
+            patch.object(godot_validation_module, "subprocess", subprocess_proxy),
+            patch.object(godot_validation_module, "threading", threading_proxy),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "Failed while capturing Godot output",
+            ) as raised,
+        ):
+            _run_godot_command(["fake-godot"], timeout=1)
+
+        self.assertEqual(process.kill_calls, 1)
+        self.assertIs(raised.exception.__cause__, capture_error)
+
+    def test_timeout_reader_oserror_is_capture_failure(self) -> None:
+        process = _PipeBackedProcess(b"", timeout_on_first_wait=True)
+        self.addCleanup(process.close_stdout)
+        capture_error = OSError("injected timeout read failure")
+
+        def fail_read(_fd: int, _size: int) -> bytes:
+            raise capture_error
+
+        os_proxy = _ModuleBindingProxy(
+            os,
+            killpg=_ignore_killpg,
+            read=fail_read,
+        )
+        subprocess_proxy = _ModuleBindingProxy(
+            subprocess,
+            Popen=_popen_returning(process),
+        )
+
+        with (
+            patch.object(godot_validation_module, "os", os_proxy),
+            patch.object(godot_validation_module, "subprocess", subprocess_proxy),
+            self.assertRaisesRegex(
+                RuntimeError,
+                "Failed while capturing Godot output",
+            ) as raised,
+        ):
+            _run_godot_command(["fake-godot"], timeout=1)
+
+        self.assertIs(raised.exception.__cause__, capture_error)
+
+    def test_stop_deadline_leaves_stdout_owned_by_live_reader(self) -> None:
+        process = _PipeBackedProcess(b"")
+        self.addCleanup(process.close_stdout)
+        blocked_readers: list[_DeadlineBlockedTargetThread] = []
+        existing_readers = {
+            thread.ident
+            for thread in threading.enumerate()
+            if thread.name == "gm2godot-godot-output-reader"
+        }
+
+        def make_blocked_reader(
+            *,
+            target: Callable[[], None],
+            name: str,
+            daemon: bool,
+        ) -> _DeadlineBlockedTargetThread:
+            output_reader = _DeadlineBlockedTargetThread(
+                target=target,
+                name=name,
+                daemon=daemon,
+            )
+            blocked_readers.append(output_reader)
+            return output_reader
+
+        os_proxy = _ModuleBindingProxy(
+            os,
+            killpg=_ignore_killpg,
+            name="posix",
+        )
+        subprocess_proxy = _ModuleBindingProxy(
+            subprocess,
+            Popen=_popen_returning(process),
+        )
+        threading_proxy = _ModuleBindingProxy(
+            threading,
+            Thread=make_blocked_reader,
+        )
+
+        try:
+            with (
+                patch.object(godot_validation_module, "os", os_proxy),
+                patch.object(godot_validation_module, "subprocess", subprocess_proxy),
+                patch.object(godot_validation_module, "threading", threading_proxy),
+                self.assertRaisesRegex(
+                    RuntimeError,
+                    "Godot output reader did not stop after pipe cleanup",
+                ),
+            ):
+                _run_godot_command(["fake-godot"], timeout=1)
+
+            self.assertEqual(len(blocked_readers), 1)
+            self.assertEqual(blocked_readers[0].join_calls, 2)
+            self.assertTrue(blocked_readers[0].is_alive())
+            self.assertFalse(process.stdout.closed)
+        finally:
+            for output_reader in blocked_readers:
+                output_reader.release()
+
+        lingering_readers = [
+            thread
+            for thread in threading.enumerate()
+            if thread.name == "gm2godot-godot-output-reader"
+            and thread.ident not in existing_readers
+        ]
+        self.assertTrue(process.stdout.closed)
+        self.assertFalse(blocked_readers[0].is_alive())
+        self.assertEqual(lingering_readers, [])
+
     @unittest.skipUnless(os.name == "posix", "requires POSIX process groups")
     def test_command_exit_with_inherited_stdout_remains_bounded(self) -> None:
         project_dir = self._write_project()
@@ -224,6 +721,75 @@ class TestGodotValidation(unittest.TestCase):
         ]
         self.assertEqual(result.returncode, 0)
         self.assertLess(elapsed, 1.5)
+        self.assertIsNotNone(child_pid)
+        self.assertEqual(lingering_readers, [])
+
+    @unittest.skipUnless(os.name == "posix", "requires fork and POSIX sessions")
+    def test_continuously_writing_detached_stdout_stops_at_reader_deadline(
+        self,
+    ) -> None:
+        child_pid_path = self.temp_dir / "continuous-detached-child.pid"
+        fake_godot = self.temp_dir / "continuous-detached-stdout.py"
+        fake_godot.write_text(
+            "\n".join(
+                (
+                    "import os",
+                    "import time",
+                    "from pathlib import Path",
+                    "",
+                    f"child_pid_path = Path({os.fspath(child_pid_path)!r})",
+                    "child_pid_temporary_path = child_pid_path.with_suffix('.tmp')",
+                    "child_pid = os.fork()",
+                    "if child_pid == 0:",
+                    "    os.setsid()",
+                    "    child_pid_temporary_path.write_text(str(os.getpid()))",
+                    "    os.replace(child_pid_temporary_path, child_pid_path)",
+                    "    payload = b'continuous-detached-output\\n' * 128",
+                    "    while True:",
+                    "        try:",
+                    "            os.write(1, payload)",
+                    "        except OSError:",
+                    "            os._exit(0)",
+                    "while not child_pid_path.is_file():",
+                    "    time.sleep(0.001)",
+                    "os._exit(0)",
+                    "",
+                )
+            ),
+            encoding="utf-8",
+        )
+        existing_readers = {
+            thread.ident
+            for thread in threading.enumerate()
+            if thread.name == "gm2godot-godot-output-reader"
+        }
+        child_pid: int | None = None
+        started = time.monotonic()
+
+        try:
+            result = _run_godot_command(
+                [sys.executable, os.fspath(fake_godot)],
+                timeout=3,
+            )
+            elapsed = time.monotonic() - started
+            child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+        finally:
+            if child_pid is None and child_pid_path.is_file():
+                child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+            if child_pid is not None:
+                try:
+                    os.kill(child_pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
+        lingering_readers = [
+            thread
+            for thread in threading.enumerate()
+            if thread.name == "gm2godot-godot-output-reader"
+            and thread.ident not in existing_readers
+        ]
+        self.assertEqual(result.returncode, 0)
+        self.assertLess(elapsed, 2.0)
         self.assertIsNotNone(child_pid)
         self.assertEqual(lingering_readers, [])
 

--- a/tests/test_godot_validation.py
+++ b/tests/test_godot_validation.py
@@ -594,7 +594,6 @@ class TestGodotValidation(unittest.TestCase):
         os_proxy = _ModuleBindingProxy(
             os,
             killpg=_ignore_killpg,
-            name="posix",
         )
         subprocess_proxy = _ModuleBindingProxy(
             subprocess,

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_58(self) -> None:
-        self.assertEqual(get_version(), "0.7.58")
+    def test_release_version_is_0_7_59(self) -> None:
+        self.assertEqual(get_version(), "0.7.59")
 
     def test_release_surfaces_match_source_version(self) -> None:
         changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #827.

Ensures the Godot output reader performs one final nonblocking attempt after shutdown is observed, including data that arrives while it is waiting. Reader capture errors now fail both timeout and normal completion paths, and the reader retains pipe ownership until it exits to avoid descriptor reuse.

Adds deterministic race, error, deadline, and continuous-writer coverage plus a native Windows selector, while preserving bounded inherited/detached writer shutdown, GameMaker LTS 2026 conversion behavior, and the exact Godot 4.7.1 target.