### PR TITLE
Document all converter-managed output roots

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.63, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.64, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.64 - 2026-09-03
+
+- Documented `particles/` and `particlesystems/` in the complete generated-project tree and converter-managed output-root list.
+- Bound the marked canonical Wiki list to the production `MANAGED_OUTPUT_DIRECTORIES` order with an executable documentation-health check so future ownership changes cannot silently drift from user guidance.
+- Kept GameMaker LTS 2026 conversion behavior and exact Godot 4.7.1 output unchanged while preparing the reviewed Wiki source for publication.
+
 ## 0.7.63 - 2026-09-03
 
 - Normalized only CRLF and lone-CR line endings when the privileged dependency-submission validator compares native lock artifacts with canonical Git blob bytes.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Version 0.7.62 makes `requirements-bootstrap.txt` the only reviewed source for t
 
 Version 0.7.63 makes the privileged dependency-submission validator compare native lock artifacts with canonical Git blob bytes after normalizing only CRLF and lone-CR line endings. Exact native bytes remain bound to their receipt hashes, while every non-newline content, provenance, pin, or ordering difference still fails closed. This restores verified Linux, macOS, and Windows dependency-graph submission without changing GameMaker LTS 2026 conversion behavior or exact Godot 4.7.1 output.
 
+Version 0.7.64 makes the canonical generated-project documentation enumerate every converter-managed output root in exact production order, including `particles/` and `particlesystems/`. An executable documentation-health check binds the marked list to `MANAGED_OUTPUT_DIRECTORIES`, so future ownership changes cannot silently drift from Wiki guidance. This documentation-only release leaves GameMaker LTS 2026 conversion behavior and exact Godot 4.7.1 output unchanged.
+
 ## What GM2Godot Is and Isn't
 
 **GM2Godot is:**
@@ -104,7 +106,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.63`.
+Current source version: `0.7.64`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.63 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.64 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.63 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.64 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.63 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.64 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.63 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.64 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -32,6 +32,8 @@ GodotProject/
 ├── included_files/
 ├── notes/
 ├── objects/
+├── particles/
+├── particlesystems/
 ├── paths/
 ├── rooms/
 ├── scripts/
@@ -44,8 +46,24 @@ GodotProject/
 
 GM2Godot treats these directories as managed output roots:
 
+<!-- managed-output-directories:start -->
 - `addons/gm2godot_extensions/`
-- `fonts/`, `gm2godot/`, `included_files/`, `notes/`, `objects/`, `paths/`, `rooms/`, `scripts/`, `sequences/`, `shaders/`, `sounds/`, `sprites/`, and `tilesets/`
+- `fonts/`
+- `gm2godot/`
+- `included_files/`
+- `notes/`
+- `objects/`
+- `particles/`
+- `particlesystems/`
+- `paths/`
+- `rooms/`
+- `scripts/`
+- `sequences/`
+- `shaders/`
+- `sounds/`
+- `sprites/`
+- `tilesets/`
+<!-- managed-output-directories:end -->
 
 The top-level `default_bus_layout.tres`, `icon.ico`, and `icon.png` are managed files. `project.godot` is jointly managed: GM2Godot can update the generated `GM*` autoload entries and, when a room is generated, set `run/main_scene` from the first GameMaker `RoomOrderNodes` entry. Existing unrelated project settings and unrelated autoloads are preserved.
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.63 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.64 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.63;
+- GM2Godot 0.7.64;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.63 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.64 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 
@@ -46,7 +46,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.63`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.64`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
 
 ## Run from source
 
@@ -148,6 +148,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.63`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.64`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.63 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.64 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.63 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.64 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.63"
+VERSION = "0.7.64"
 
 
 def get_version():

--- a/tests/test_documentation_health.py
+++ b/tests/test_documentation_health.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import re
 import unittest
 
+from src.conversion.project_godot import MANAGED_OUTPUT_DIRECTORIES
 from src.version import get_version
 
 
@@ -137,6 +138,25 @@ class TestDocumentationHealth(unittest.TestCase):
                 with self.subTest(source=source.name, target=target):
                     self.assertIn(target_filename, WIKI_PAGES | {"_Sidebar.md"})
                     self.assertTrue((WIKI_SOURCE_DIR / target_filename).is_file())
+
+    def test_wiki_managed_output_roots_match_production(self) -> None:
+        generated_project = (
+            WIKI_SOURCE_DIR / "Generated-Project-and-Runtime.md"
+        ).read_text(encoding="utf-8")
+        start_marker = "<!-- managed-output-directories:start -->"
+        end_marker = "<!-- managed-output-directories:end -->"
+        before, separator, remainder = generated_project.partition(start_marker)
+        self.assertTrue(separator, "Managed-output directory start marker is missing")
+        managed_roots, separator, after = remainder.partition(end_marker)
+        self.assertTrue(separator, "Managed-output directory end marker is missing")
+        self.assertNotIn(start_marker, before + after)
+        self.assertNotIn(end_marker, before + after)
+
+        expected_roots = "\n" + "\n".join(
+            f"- `{Path(directory).as_posix()}/`"
+            for directory in MANAGED_OUTPUT_DIRECTORIES
+        ) + "\n"
+        self.assertEqual(managed_roots, expected_roots)
 
     def test_user_documentation_links_and_guidance_are_current(self) -> None:
         readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_63(self) -> None:
-        self.assertEqual(get_version(), "0.7.63")
+    def test_release_version_is_0_7_64(self) -> None:
+        self.assertEqual(get_version(), "0.7.64")
 
     def test_release_surfaces_match_source_version(self) -> None:
         version_source = (PROJECT_ROOT / "src" / "version.py").read_text(


### PR DESCRIPTION
Prepares #712 by correcting the canonical Wiki source before live publication.

The generated-project page now lists `particles/` and `particlesystems/` in both the project tree and converter-managed output-root inventory. A documentation-health test binds the marked list exactly to production `MANAGED_OUTPUT_DIRECTORIES`, including order, so ownership guidance cannot silently drift.

This bumps the release to 0.7.64. GameMaker LTS 2026 conversion behavior and exact Godot 4.7.1 output are unchanged.

Validated with 13 focused documentation/version tests, Ruff, Pyright with zero errors or warnings, issue-form YAML parsing, and `git diff --check`.

The live Wiki is intentionally not published by this PR and #712 must remain open. After this exact source revision is merged and released, the separate Wiki repository will be initialized, populated from the merged `docs/wiki/` bytes, fresh-cloned, byte-compared, and live-navigation checked before closure.
