### PR TITLE
Enable complete Pyflakes Ruff coverage

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.65, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.66, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -118,3 +118,9 @@ jobs:
 
       - name: Run Ruff
         run: python -m ruff check .
+
+      - name: Run Ruff on every tracked lint input
+        run: |
+          git ls-files -z -- '*.py' '*.pyi' '*.pyw' '*.ipynb' '*.md' |
+            xargs -0 -- python -m ruff check --isolated --target-version py312 \
+              --select E9,F --ignore-noqa --no-respect-gitignore --no-force-exclude --

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.66 - 2026-09-03
+
+- Enabled Ruff's complete Pyflakes (`F`) rule family while retaining the existing fatal-error checks, and added executable policy coverage that rejects whole-family, individual-rule, per-file, and `ALL` escapes.
+- Removed one duplicate identical manifest key and nine redundant constant f-string prefixes without changing generated sprite scenes, project settings, manifest output, or GUI presentation.
+- Documented the enforced lint policy and kept GameMaker LTS 2026 conversion behavior plus exact Godot 4.7.1 output unchanged.
+
 ## 0.7.65 - 2026-09-03
 
 - Reused retained, verified Windows cleanup-parent bindings across present Included Files trees instead of recapturing and reverifying the same ancestor chain for every child.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Compatibility work continues to target GameMaker LTS 2026 source projects and ex
 - Keep functions focused and concise
 - Use type hints where appropriate
 - Keep linting and type checking clean for code changes. Run `./venv/bin/pyright --warnings` before submitting Python or generated-code logic changes and fix every reported error or warning.
-- Run `ruff check .` before submitting Python code. The project currently enables fatal/static Ruff checks in CI; broader style rules should be introduced separately from feature work.
+- Run `ruff check .` before submitting Python code. CI enforces Ruff's `E9` fatal-error checks and the complete Pyflakes (`F`) rule family. Do not disable `F` or individual `F`-numbered rules globally or per file. Broader style rules should be introduced separately from feature work.
 
 ### UI Development
 - Maintain consistency with the existing dark theme

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Version 0.7.64 makes the canonical generated-project documentation enumerate eve
 
 Version 0.7.65 reuses retained, verified Windows cleanup-parent bindings across present Included Files trees, removing repeated ancestor capture and re-verification for every child. Nested cleanup now uses iterative full-tree preflight and bottom-up removal with live native handles bounded by directory depth while retaining exact identity, no-follow, reparse/junction, mount, hard-link, digest, read-only, relocation/replacement, tombstone, and rollback defenses. Deterministic flat, nested, and deep-tree operation-count and adversarial tests cover the optimized fallback. GameMaker LTS 2026 conversion behavior and exact Godot 4.7.1 output remain unchanged.
 
+Version 0.7.66 enables Ruff's complete Pyflakes rule family while retaining the existing fatal-error checks. Executable policy coverage prevents whole-family, individual-rule, per-file, and `ALL` escapes; the ten newly enforced findings were corrected without changing generated sprite scenes, project settings, manifest output, or GUI presentation. GameMaker LTS 2026 conversion behavior and exact Godot 4.7.1 output remain unchanged.
+
 ## What GM2Godot Is and Isn't
 
 **GM2Godot is:**
@@ -108,7 +110,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.65`.
+Current source version: `0.7.66`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.65 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.66 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -95,7 +95,7 @@ For Python or generated-code logic changes:
 ./venv/bin/python -m unittest
 ```
 
-Fix every Pyright error and warning in changed code. Run the relevant focused test while iterating; use the full suite for broad behavior changes. For Godot-dependent changes, run with the exact binary:
+CI enforces Ruff's `E9` fatal-error checks and the complete Pyflakes (`F`) rule family. Do not disable `F` or individual `F`-numbered rules globally or per file. Fix every Pyright error and warning in changed code. Run the relevant focused test while iterating; use the full suite for broad behavior changes. For Godot-dependent changes, run with the exact binary:
 
 ```bash
 GODOT_BIN=/path/to/Godot-4.7.1 \

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.65 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.66 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.65 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.66 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.65 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.66 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.65 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.66 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.65;
+- GM2Godot 0.7.66;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.65 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.66 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 
@@ -46,7 +46,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.65`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.66`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
 
 ## Run from source
 
@@ -148,6 +148,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.65`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.66`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.65 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.66 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.65 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.66 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,5 @@ extend-exclude = [
 [tool.ruff.lint]
 select = [
   "E9",
-  "F63",
-  "F7",
-  "F82",
+  "F",
 ]

--- a/src/conversion/gml_transpiler_parts/gml_api_manifest.py
+++ b/src/conversion/gml_transpiler_parts/gml_api_manifest.py
@@ -73,7 +73,6 @@ _CATEGORY_ISSUE_NUMBERS = {
     "Sequences and Timelines": 567,
     "Time": 497,
     "Data Structures Sequential": 498,
-    "Data Structures Sequential": 498,
     "Data Structures Maps": 499,
     "Data Structures Grids": 500,
     "Accessors": 501,

--- a/src/conversion/project_settings.py
+++ b/src/conversion/project_settings.py
@@ -52,7 +52,7 @@ class ProjectSettingsConverter(BaseConverter):
             target_platform=gm_platform,
         )
         self.options_platform_path = os.path.join(self.gm_project_path, 'options', self.gm_platform, f'options_{self.gm_platform}.yy')
-        self.options_windows_path = os.path.join(self.gm_project_path, 'options', 'windows', f'options_windows.yy')
+        self.options_windows_path = os.path.join(self.gm_project_path, 'options', 'windows', 'options_windows.yy')
         self.options_main_path = os.path.join(self.gm_project_path, 'options', 'main', 'options_main.yy')
 
     def convert_icon(self) -> ProjectOperationResult:

--- a/src/conversion/sprites.py
+++ b/src/conversion/sprites.py
@@ -1114,8 +1114,8 @@ class SpriteConverter(BaseConverter):
 
         parts.append(f'\n[node name="{sprite_name}" type="Area2D"]\n')
         parts.extend(self._sprite_metadata_lines(collision_data))
-        parts.append(f'\n[node name="Sprite2D" type="Sprite2D" parent="."]\n')
-        parts.append(f'texture = ExtResource("1")\n')
+        parts.append('\n[node name="Sprite2D" type="Sprite2D" parent="."]\n')
+        parts.append('texture = ExtResource("1")\n')
         parts.append(self._sprite_visual_position_line(collision_data))
 
         if has_collision:
@@ -1172,7 +1172,7 @@ class SpriteConverter(BaseConverter):
         godot_fps = self._compute_godot_fps(animation_data)
         loop_str = "true" if animation_data["loop"] else "false"
 
-        parts.append(f'\n[sub_resource type="SpriteFrames" id="SpriteFrames_1"]\n')
+        parts.append('\n[sub_resource type="SpriteFrames" id="SpriteFrames_1"]\n')
         parts.append(f'animations = [{{\n"frames": [{frames_str}],\n"loop": {loop_str},\n"name": &"default",\n"speed": {godot_fps}\n}}]\n')
 
         if has_collision:
@@ -1186,10 +1186,10 @@ class SpriteConverter(BaseConverter):
             parts.append(f"metadata/gamemaker_mask_frame_count = {frame_count}\n")
             parts.append("metadata/gamemaker_active_mask_frame = 0\n")
 
-        parts.append(f'\n[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]\n')
-        parts.append(f'sprite_frames = SubResource("SpriteFrames_1")\n')
-        parts.append(f'animation = &"default"\n')
-        parts.append(f'autoplay = "default"\n')
+        parts.append('\n[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]\n')
+        parts.append('sprite_frames = SubResource("SpriteFrames_1")\n')
+        parts.append('animation = &"default"\n')
+        parts.append('autoplay = "default"\n')
         parts.append(self._sprite_visual_position_line(collision_data))
 
         if has_collision:

--- a/src/gui/panels/info_bar.py
+++ b/src/gui/panels/info_bar.py
@@ -73,7 +73,7 @@ class InfoBar(QWidget):
         lang_button.setIcon(language_icon)
         lang_button.setFixedSize(32, 32)
         lang_button.setStyleSheet(
-            f"background-color: transparent; border: none;"
+            "background-color: transparent; border: none;"
         )
         lang_button.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
         lang_button.clicked.connect(on_language_click)

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.65"
+VERSION = "0.7.66"
 
 
 def get_version():

--- a/tests/test_documentation_health.py
+++ b/tests/test_documentation_health.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 import re
 import tomllib
 import unittest
+from typing import cast
 
 from src.conversion.project_godot import MANAGED_OUTPUT_DIRECTORIES
 from src.version import get_version
@@ -54,6 +56,41 @@ APPROVED_NODE24_ACTION_MAJORS = {
     "actions/download-artifact": 8,
     "softprops/action-gh-release": 3,
 }
+PYFLAKES_SELECTOR_PATTERN = re.compile(r"^F(?:\d+)?$")
+
+
+def _ruff_selectors(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    selectors = cast(list[object], value)
+    return tuple(selector for selector in selectors if isinstance(selector, str))
+
+
+def _ruff_pyflakes_policy_errors(lint_config: Mapping[str, object]) -> tuple[str, ...]:
+    errors: list[str] = []
+    if "F" not in _ruff_selectors(lint_config.get("select")):
+        errors.append("select must include the exact F selector")
+
+    for setting in ("ignore", "extend-ignore"):
+        for selector in _ruff_selectors(lint_config.get(setting)):
+            if PYFLAKES_SELECTOR_PATTERN.fullmatch(selector):
+                errors.append(f"{setting} disables Pyflakes selector {selector}")
+
+    for setting in ("per-file-ignores", "extend-per-file-ignores"):
+        per_file_ignores = lint_config.get(setting)
+        if not isinstance(per_file_ignores, dict):
+            continue
+        for file_pattern, configured_selectors in cast(
+            dict[object, object],
+            per_file_ignores,
+        ).items():
+            for selector in _ruff_selectors(configured_selectors):
+                if PYFLAKES_SELECTOR_PATTERN.fullmatch(selector):
+                    errors.append(
+                        f"{setting}[{file_pattern}] disables Pyflakes selector {selector}"
+                    )
+
+    return tuple(errors)
 
 
 class TestDocumentationHealth(unittest.TestCase):
@@ -261,17 +298,88 @@ class TestDocumentationHealth(unittest.TestCase):
                 for phrase in phrases:
                     self.assertIn(phrase, content)
 
-    def test_code_health_workflow_runs_ruff(self) -> None:
+    def test_code_health_workflow_runs_complete_pyflakes_suite(self) -> None:
         workflow = (PROJECT_ROOT / ".github" / "workflows" / "code-health.yml").read_text(encoding="utf-8")
         with (PROJECT_ROOT / "pyproject.toml").open("rb") as pyproject_file:
-            ruff_select = tomllib.load(pyproject_file)["tool"]["ruff"]["lint"]["select"]
+            lint_config = cast(
+                dict[str, object],
+                tomllib.load(pyproject_file)["tool"]["ruff"]["lint"],
+            )
 
         self.assertIn("ruff check .", workflow)
-        self.assertIn("E9", ruff_select)
+        self.assertIn("E9", _ruff_selectors(lint_config.get("select")))
+        self.assertEqual(_ruff_pyflakes_policy_errors(lint_config), ())
+
+    def test_ruff_pyflakes_policy_uses_exact_selector_boundaries(self) -> None:
+        unrelated_families = ["FBT", "FIX", "FA", "FLY", "FURB"]
         self.assertEqual(
-            [selector for selector in ruff_select if selector.startswith("F")],
-            ["F"],
+            _ruff_pyflakes_policy_errors(
+                {
+                    "select": ["E9", "F", *unrelated_families],
+                    "ignore": unrelated_families,
+                    "extend-ignore": unrelated_families,
+                    "per-file-ignores": {"tests/*.py": unrelated_families},
+                    "extend-per-file-ignores": {"src/*.py": unrelated_families},
+                }
+            ),
+            (),
         )
+
+    def test_ruff_pyflakes_policy_rejects_missing_or_disabled_rules(self) -> None:
+        invalid_configs = {
+            "missing exact F": (
+                {"select": ["E9", "FBT", "F82"]},
+                (
+                    "select must include the exact F selector",
+                ),
+            ),
+            "ignored family": (
+                {"select": ["E9", "F"], "ignore": ["F"]},
+                ("ignore disables Pyflakes selector F",),
+            ),
+            "extended ignored rule": (
+                {"select": ["E9", "F"], "extend-ignore": ["F601"]},
+                ("extend-ignore disables Pyflakes selector F601",),
+            ),
+            "per-file ignored rule": (
+                {
+                    "select": ["E9", "F"],
+                    "per-file-ignores": {"tests/*.py": ["F541"]},
+                },
+                (
+                    "per-file-ignores[tests/*.py] disables Pyflakes selector F541",
+                ),
+            ),
+            "extended per-file ignored family": (
+                {
+                    "select": ["E9", "F"],
+                    "extend-per-file-ignores": {"src/*.py": ["F"]},
+                },
+                (
+                    "extend-per-file-ignores[src/*.py] disables Pyflakes selector F",
+                ),
+            ),
+        }
+
+        for label, (lint_config, expected_errors) in invalid_configs.items():
+            with self.subTest(label=label):
+                self.assertEqual(
+                    _ruff_pyflakes_policy_errors(lint_config),
+                    expected_errors,
+                )
+
+    def test_contributor_docs_describe_complete_pyflakes_gate(self) -> None:
+        required_guidance = (
+            "CI enforces Ruff's `E9` fatal-error checks and the complete "
+            "Pyflakes (`F`) rule family. Do not disable `F` or individual "
+            "`F`-numbered rules globally or per file."
+        )
+        for path in (
+            PROJECT_ROOT / "CONTRIBUTING.md",
+            WIKI_SOURCE_DIR / "Contributing-and-Testing.md",
+        ):
+            with self.subTest(path=path.relative_to(PROJECT_ROOT)):
+                self.assertIn(required_guidance, path.read_text(encoding="utf-8"))
 
     def test_dependabot_updates_actions_weekly_and_pip_security_only(self) -> None:
         dependabot = (

--- a/tests/test_documentation_health.py
+++ b/tests/test_documentation_health.py
@@ -66,6 +66,10 @@ def _ruff_selectors(value: object) -> tuple[str, ...]:
     return tuple(selector for selector in selectors if isinstance(selector, str))
 
 
+def _ruff_selector_disables_pyflakes(selector: str) -> bool:
+    return selector == "ALL" or PYFLAKES_SELECTOR_PATTERN.fullmatch(selector) is not None
+
+
 def _ruff_pyflakes_policy_errors(lint_config: Mapping[str, object]) -> tuple[str, ...]:
     errors: list[str] = []
     if "F" not in _ruff_selectors(lint_config.get("select")):
@@ -73,7 +77,7 @@ def _ruff_pyflakes_policy_errors(lint_config: Mapping[str, object]) -> tuple[str
 
     for setting in ("ignore", "extend-ignore"):
         for selector in _ruff_selectors(lint_config.get(setting)):
-            if PYFLAKES_SELECTOR_PATTERN.fullmatch(selector):
+            if _ruff_selector_disables_pyflakes(selector):
                 errors.append(f"{setting} disables Pyflakes selector {selector}")
 
     for setting in ("per-file-ignores", "extend-per-file-ignores"):
@@ -85,7 +89,7 @@ def _ruff_pyflakes_policy_errors(lint_config: Mapping[str, object]) -> tuple[str
             per_file_ignores,
         ).items():
             for selector in _ruff_selectors(configured_selectors):
-                if PYFLAKES_SELECTOR_PATTERN.fullmatch(selector):
+                if _ruff_selector_disables_pyflakes(selector):
                     errors.append(
                         f"{setting}[{file_pattern}] disables Pyflakes selector {selector}"
                     )
@@ -337,6 +341,10 @@ class TestDocumentationHealth(unittest.TestCase):
                 {"select": ["E9", "F"], "ignore": ["F"]},
                 ("ignore disables Pyflakes selector F",),
             ),
+            "ignored all rules": (
+                {"select": ["E9", "F"], "ignore": ["ALL"]},
+                ("ignore disables Pyflakes selector ALL",),
+            ),
             "extended ignored rule": (
                 {"select": ["E9", "F"], "extend-ignore": ["F601"]},
                 ("extend-ignore disables Pyflakes selector F601",),
@@ -348,6 +356,15 @@ class TestDocumentationHealth(unittest.TestCase):
                 },
                 (
                     "per-file-ignores[tests/*.py] disables Pyflakes selector F541",
+                ),
+            ),
+            "per-file ignored all rules": (
+                {
+                    "select": ["E9", "F"],
+                    "per-file-ignores": {"tests/*.py": ["ALL"]},
+                },
+                (
+                    "per-file-ignores[tests/*.py] disables Pyflakes selector ALL",
                 ),
             ),
             "extended per-file ignored family": (

--- a/tests/test_documentation_health.py
+++ b/tests/test_documentation_health.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
 from pathlib import Path
 import re
 import tomllib
@@ -56,45 +55,22 @@ APPROVED_NODE24_ACTION_MAJORS = {
     "actions/download-artifact": 8,
     "softprops/action-gh-release": 3,
 }
-PYFLAKES_SELECTOR_PATTERN = re.compile(r"^F(?:\d+)?$")
+EXPECTED_RUFF_CONFIG: dict[str, object] = {
+    "target-version": "py312",
+    "line-length": 120,
+    "extend-exclude": ["build", "dist", "release", "venv"],
+    "lint": {"select": ["E9", "F"]},
+}
+EXPECTED_RUFF_LINT_STEPS = """\
+      - name: Run Ruff
+        run: python -m ruff check .
 
-
-def _ruff_selectors(value: object) -> tuple[str, ...]:
-    if not isinstance(value, list):
-        return ()
-    selectors = cast(list[object], value)
-    return tuple(selector for selector in selectors if isinstance(selector, str))
-
-
-def _ruff_selector_disables_pyflakes(selector: str) -> bool:
-    return selector == "ALL" or PYFLAKES_SELECTOR_PATTERN.fullmatch(selector) is not None
-
-
-def _ruff_pyflakes_policy_errors(lint_config: Mapping[str, object]) -> tuple[str, ...]:
-    errors: list[str] = []
-    if "F" not in _ruff_selectors(lint_config.get("select")):
-        errors.append("select must include the exact F selector")
-
-    for setting in ("ignore", "extend-ignore"):
-        for selector in _ruff_selectors(lint_config.get(setting)):
-            if _ruff_selector_disables_pyflakes(selector):
-                errors.append(f"{setting} disables Pyflakes selector {selector}")
-
-    for setting in ("per-file-ignores", "extend-per-file-ignores"):
-        per_file_ignores = lint_config.get(setting)
-        if not isinstance(per_file_ignores, dict):
-            continue
-        for file_pattern, configured_selectors in cast(
-            dict[object, object],
-            per_file_ignores,
-        ).items():
-            for selector in _ruff_selectors(configured_selectors):
-                if _ruff_selector_disables_pyflakes(selector):
-                    errors.append(
-                        f"{setting}[{file_pattern}] disables Pyflakes selector {selector}"
-                    )
-
-    return tuple(errors)
+      - name: Run Ruff on every tracked lint input
+        run: |
+          git ls-files -z -- '*.py' '*.pyi' '*.pyw' '*.ipynb' '*.md' |
+            xargs -0 -- python -m ruff check --isolated --target-version py312 \\
+              --select E9,F --ignore-noqa --no-respect-gitignore --no-force-exclude --
+"""
 
 
 class TestDocumentationHealth(unittest.TestCase):
@@ -305,85 +281,13 @@ class TestDocumentationHealth(unittest.TestCase):
     def test_code_health_workflow_runs_complete_pyflakes_suite(self) -> None:
         workflow = (PROJECT_ROOT / ".github" / "workflows" / "code-health.yml").read_text(encoding="utf-8")
         with (PROJECT_ROOT / "pyproject.toml").open("rb") as pyproject_file:
-            lint_config = cast(
+            ruff_config = cast(
                 dict[str, object],
-                tomllib.load(pyproject_file)["tool"]["ruff"]["lint"],
+                tomllib.load(pyproject_file)["tool"]["ruff"],
             )
 
-        self.assertIn("ruff check .", workflow)
-        self.assertIn("E9", _ruff_selectors(lint_config.get("select")))
-        self.assertEqual(_ruff_pyflakes_policy_errors(lint_config), ())
-
-    def test_ruff_pyflakes_policy_uses_exact_selector_boundaries(self) -> None:
-        unrelated_families = ["FBT", "FIX", "FA", "FLY", "FURB"]
-        self.assertEqual(
-            _ruff_pyflakes_policy_errors(
-                {
-                    "select": ["E9", "F", *unrelated_families],
-                    "ignore": unrelated_families,
-                    "extend-ignore": unrelated_families,
-                    "per-file-ignores": {"tests/*.py": unrelated_families},
-                    "extend-per-file-ignores": {"src/*.py": unrelated_families},
-                }
-            ),
-            (),
-        )
-
-    def test_ruff_pyflakes_policy_rejects_missing_or_disabled_rules(self) -> None:
-        invalid_configs = {
-            "missing exact F": (
-                {"select": ["E9", "FBT", "F82"]},
-                (
-                    "select must include the exact F selector",
-                ),
-            ),
-            "ignored family": (
-                {"select": ["E9", "F"], "ignore": ["F"]},
-                ("ignore disables Pyflakes selector F",),
-            ),
-            "ignored all rules": (
-                {"select": ["E9", "F"], "ignore": ["ALL"]},
-                ("ignore disables Pyflakes selector ALL",),
-            ),
-            "extended ignored rule": (
-                {"select": ["E9", "F"], "extend-ignore": ["F601"]},
-                ("extend-ignore disables Pyflakes selector F601",),
-            ),
-            "per-file ignored rule": (
-                {
-                    "select": ["E9", "F"],
-                    "per-file-ignores": {"tests/*.py": ["F541"]},
-                },
-                (
-                    "per-file-ignores[tests/*.py] disables Pyflakes selector F541",
-                ),
-            ),
-            "per-file ignored all rules": (
-                {
-                    "select": ["E9", "F"],
-                    "per-file-ignores": {"tests/*.py": ["ALL"]},
-                },
-                (
-                    "per-file-ignores[tests/*.py] disables Pyflakes selector ALL",
-                ),
-            ),
-            "extended per-file ignored family": (
-                {
-                    "select": ["E9", "F"],
-                    "extend-per-file-ignores": {"src/*.py": ["F"]},
-                },
-                (
-                    "extend-per-file-ignores[src/*.py] disables Pyflakes selector F",
-                ),
-            ),
-        }
-
-        for label, (lint_config, expected_errors) in invalid_configs.items():
-            with self.subTest(label=label):
-                self.assertEqual(
-                    _ruff_pyflakes_policy_errors(lint_config),
-                    expected_errors,
-                )
+        self.assertEqual(ruff_config, EXPECTED_RUFF_CONFIG)
+        self.assertTrue(workflow.endswith(EXPECTED_RUFF_LINT_STEPS))
 
     def test_contributor_docs_describe_complete_pyflakes_gate(self) -> None:
         required_guidance = (

--- a/tests/test_documentation_health.py
+++ b/tests/test_documentation_health.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import re
+import tomllib
 import unittest
 
 from src.conversion.project_godot import MANAGED_OUTPUT_DIRECTORIES
@@ -262,11 +263,15 @@ class TestDocumentationHealth(unittest.TestCase):
 
     def test_code_health_workflow_runs_ruff(self) -> None:
         workflow = (PROJECT_ROOT / ".github" / "workflows" / "code-health.yml").read_text(encoding="utf-8")
-        pyproject = (PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        with (PROJECT_ROOT / "pyproject.toml").open("rb") as pyproject_file:
+            ruff_select = tomllib.load(pyproject_file)["tool"]["ruff"]["lint"]["select"]
 
         self.assertIn("ruff check .", workflow)
-        self.assertIn("[tool.ruff.lint]", pyproject)
-        self.assertIn('"F82"', pyproject)
+        self.assertIn("E9", ruff_select)
+        self.assertEqual(
+            [selector for selector in ruff_select if selector.startswith("F")],
+            ["F"],
+        )
 
     def test_dependabot_updates_actions_weekly_and_pip_security_only(self) -> None:
         dependabot = (

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_65(self) -> None:
-        self.assertEqual(get_version(), "0.7.65")
+    def test_release_version_is_0_7_66(self) -> None:
+        self.assertEqual(get_version(), "0.7.66")
 
     def test_release_surfaces_match_source_version(self) -> None:
         version_source = (PROJECT_ROOT / "src" / "version.py").read_text(


### PR DESCRIPTION
Fixes #850.

Enables the complete Ruff Pyflakes rule family, hardens CI against configuration and per-file bypasses, fixes the newly exposed findings mechanically, and advances the project to 0.7.66 without changing conversion behavior.

Validated with Ruff, Pyright with zero warnings, focused policy tests, and the full 2,591-test suite using Godot 4.7.1 (78 platform skips). External fixture jobs remain covered by pull-request CI.