### PR TITLE
Extract shared anchored byte publisher

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.66, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.67, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.67 - 2026-09-03
+
+- Extracted dependency snapshot publication into one private, stdlib-only anchored byte publisher loaded directly from its sibling path in isolated mode.
+- Preserved snapshot JSON bytes, containment rules, no-overwrite behavior, stable error codes, and POSIX and Windows anchoring while expanding direct and isolated-loader coverage.
+- Kept GameMaker LTS 2026 conversion behavior and exact Godot 4.7.1 output unchanged.
+
 ## 0.7.66 - 2026-09-03
 
 - Enabled Ruff's complete Pyflakes (`F`) rule family while retaining the existing fatal-error checks, and added executable policy coverage that rejects whole-family, individual-rule, per-file, and `ALL` escapes.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Version 0.7.65 reuses retained, verified Windows cleanup-parent bindings across 
 
 Version 0.7.66 enables Ruff's complete Pyflakes rule family while retaining the existing fatal-error checks. Executable policy coverage prevents whole-family, individual-rule, per-file, and `ALL` escapes; the ten newly enforced findings were corrected without changing generated sprite scenes, project settings, manifest output, or GUI presentation. GameMaker LTS 2026 conversion behavior and exact Godot 4.7.1 output remain unchanged.
 
+Version 0.7.67 extracts dependency snapshot publication into one private, stdlib-only anchored byte publisher loaded directly from its sibling path in isolated mode. Snapshot JSON bytes, containment rules, no-overwrite behavior, stable error codes, and POSIX and Windows anchoring remain unchanged, with direct and isolated-loader coverage guarding the shared primitive. GameMaker LTS 2026 conversion behavior and exact Godot 4.7.1 output remain unchanged.
+
 ## What GM2Godot Is and Isn't
 
 **GM2Godot is:**
@@ -110,7 +112,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.66`.
+Current source version: `0.7.67`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.66 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.67 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.66 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.67 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.66 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.67 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.66 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.67 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.66 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.67 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.66;
+- GM2Godot 0.7.67;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.66 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.67 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 
@@ -46,7 +46,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.66`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.67`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
 
 ## Run from source
 
@@ -148,6 +148,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.66`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.67`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.66 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.67 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.66 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.67 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/scripts/_anchored_output.py
+++ b/scripts/_anchored_output.py
@@ -1,0 +1,696 @@
+"""Anchored, no-overwrite byte publication for isolated repository scripts.
+
+This private module is deliberately stdlib-only. Callers retain responsibility
+for serialization, size limits, and translating stable publication error codes
+into their own CLI error taxonomy.
+"""
+
+from __future__ import annotations
+
+import ctypes
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import secrets
+import stat
+from typing import Any, Callable, Literal, cast
+
+
+class AnchoredOutputError(ValueError):
+    """An anchored output path or publication violated the output contract."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+_WINDOWS_FILE_READ_ATTRIBUTES = 0x00000080
+_WINDOWS_FILE_TRAVERSE = 0x00000020
+_WINDOWS_FILE_SHARE_READ = 0x00000001
+_WINDOWS_FILE_SHARE_WRITE = 0x00000002
+_WINDOWS_OPEN_EXISTING = 3
+_WINDOWS_FILE_FLAG_BACKUP_SEMANTICS = 0x02000000
+_WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000
+_WINDOWS_FILE_ATTRIBUTE_DIRECTORY = 0x00000010
+_WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
+_WINDOWS_FILE_TYPE_DISK = 1
+_WINDOWS_FILE_BASIC_INFO_CLASS = 0
+_WINDOWS_FILE_ID_INFO_CLASS = 18
+
+
+class _WindowsFileId128(ctypes.Structure):
+    _fields_ = (("Identifier", ctypes.c_uint8 * 16),)
+
+
+class _WindowsFileIdInfo(ctypes.Structure):
+    _fields_ = (
+        ("VolumeSerialNumber", ctypes.c_uint64),
+        ("FileId", _WindowsFileId128),
+    )
+
+
+class _WindowsFileBasicInfo(ctypes.Structure):
+    _fields_ = (
+        ("CreationTime", ctypes.c_int64),
+        ("LastAccessTime", ctypes.c_int64),
+        ("LastWriteTime", ctypes.c_int64),
+        ("ChangeTime", ctypes.c_int64),
+        ("FileAttributes", ctypes.c_uint32),
+    )
+
+
+def descriptor_relative_output_supported() -> bool:
+    return (
+        os.name != "nt"
+        and bool(getattr(os, "O_DIRECTORY", 0))
+        and bool(getattr(os, "O_NOFOLLOW", 0))
+        and os.stat in os.supports_follow_symlinks
+        and all(
+            operation in os.supports_dir_fd
+            for operation in (os.open, os.stat, os.link, os.unlink)
+        )
+    )
+
+
+def _path_is_redirected(path: Path, path_stat: os.stat_result) -> bool:
+    if stat.S_ISLNK(path_stat.st_mode):
+        return True
+    junction_candidate: object = getattr(os.path, "isjunction", None)
+    if not callable(junction_candidate):
+        return False
+    junction_checker = cast(Callable[[str], bool], junction_candidate)
+    return junction_checker(os.fspath(path))
+
+
+def _windows_extended_path(path: Path) -> str:
+    absolute_path = os.path.abspath(path)
+    if absolute_path.startswith(("\\\\?\\", "\\\\.\\")):
+        return absolute_path
+    if absolute_path.startswith("\\\\"):
+        return "\\\\?\\UNC\\" + absolute_path[2:]
+    return "\\\\?\\" + absolute_path
+
+
+def _windows_file_api() -> Any:
+    if os.name != "nt":
+        raise AnchoredOutputError(
+            "output-anchor-unavailable",
+            "Win32 output-directory handles are unavailable on this platform.",
+        )
+    win_dll = cast(Callable[..., Any], getattr(ctypes, "WinDLL"))
+    kernel32 = win_dll("kernel32", use_last_error=True)
+    kernel32.CreateFileW.argtypes = (
+        ctypes.c_wchar_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+    )
+    kernel32.CreateFileW.restype = ctypes.c_void_p
+    kernel32.GetFileInformationByHandleEx.argtypes = (
+        ctypes.c_void_p,
+        ctypes.c_int,
+        ctypes.c_void_p,
+        ctypes.c_uint32,
+    )
+    kernel32.GetFileInformationByHandleEx.restype = ctypes.c_int
+    kernel32.GetFileType.argtypes = (ctypes.c_void_p,)
+    kernel32.GetFileType.restype = ctypes.c_uint32
+    kernel32.CloseHandle.argtypes = (ctypes.c_void_p,)
+    kernel32.CloseHandle.restype = ctypes.c_int
+    return kernel32
+
+
+def _windows_handle_identity(kernel32: Any, handle: int) -> tuple[int, int]:
+    identity_info = _WindowsFileIdInfo()
+    if not kernel32.GetFileInformationByHandleEx(
+        handle,
+        _WINDOWS_FILE_ID_INFO_CLASS,
+        ctypes.byref(identity_info),
+        ctypes.sizeof(identity_info),
+    ):
+        raise OSError("Could not identify the snapshot output directory handle.")
+    return (
+        int(identity_info.VolumeSerialNumber),
+        int.from_bytes(bytes(identity_info.FileId.Identifier), "little"),
+    )
+
+
+def _windows_directory_attributes(kernel32: Any, handle: int) -> int:
+    basic_info = _WindowsFileBasicInfo()
+    if not kernel32.GetFileInformationByHandleEx(
+        handle,
+        _WINDOWS_FILE_BASIC_INFO_CLASS,
+        ctypes.byref(basic_info),
+        ctypes.sizeof(basic_info),
+    ):
+        raise OSError("Could not inspect the snapshot output directory handle.")
+    return int(basic_info.FileAttributes)
+
+
+def _open_windows_directory_handle(
+    kernel32: Any,
+    path: Path,
+    expected_identity: tuple[int, int],
+) -> int:
+    handle = kernel32.CreateFileW(
+        _windows_extended_path(path),
+        _WINDOWS_FILE_TRAVERSE | _WINDOWS_FILE_READ_ATTRIBUTES,
+        _WINDOWS_FILE_SHARE_READ | _WINDOWS_FILE_SHARE_WRITE,
+        None,
+        _WINDOWS_OPEN_EXISTING,
+        _WINDOWS_FILE_FLAG_BACKUP_SEMANTICS | _WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT,
+        None,
+    )
+    invalid_handle = ctypes.c_void_p(-1).value
+    if handle is None or handle == invalid_handle:
+        raise OSError(f"Could not bind snapshot output directory: {path}.")
+    handle_value = cast(int, handle)
+    try:
+        path_stat = path.lstat()
+        attributes = _windows_directory_attributes(kernel32, handle_value)
+        if (
+            kernel32.GetFileType(handle_value) != _WINDOWS_FILE_TYPE_DISK
+            or _path_is_redirected(path, path_stat)
+            or not stat.S_ISDIR(path_stat.st_mode)
+            or (path_stat.st_dev, path_stat.st_ino) != expected_identity
+            or _windows_handle_identity(kernel32, handle_value) != expected_identity
+            or not attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY
+            or attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT
+        ):
+            raise OSError(f"Snapshot output directory changed: {path}.")
+    except BaseException as error:
+        try:
+            if not kernel32.CloseHandle(handle_value):
+                error.add_note(
+                    "Could not close the rejected snapshot output directory handle."
+                )
+        except BaseException as cleanup_error:
+            error.add_note(
+                "Could not close the rejected snapshot output directory handle: "
+                f"{cleanup_error}"
+            )
+        raise
+    return handle_value
+
+
+@dataclass
+class OutputParentBinding:
+    checkout: Path
+    parent: Path
+    leaf: str
+    strategy: Literal["posix-dir-fd", "windows-handle"]
+    descriptors: tuple[int, ...] = ()
+    links: tuple[tuple[int, str, int], ...] = ()
+    windows_api: Any | None = None
+    windows_entries: tuple[tuple[Path, tuple[int, int], int], ...] = ()
+
+    def close(self) -> tuple[BaseException, ...]:
+        failures: list[BaseException] = []
+        for descriptor in reversed(self.descriptors):
+            try:
+                os.close(descriptor)
+            except BaseException as error:
+                failures.append(error)
+        if self.windows_api is not None:
+            for _path, _identity, handle in reversed(self.windows_entries):
+                try:
+                    if not self.windows_api.CloseHandle(handle):
+                        failures.append(
+                            OSError(
+                                "Could not close a snapshot output directory handle."
+                            )
+                        )
+                except BaseException as error:
+                    failures.append(error)
+        return tuple(failures)
+
+    def verify(self) -> None:
+        if self.strategy == "posix-dir-fd":
+            root_stat = self.checkout.lstat()
+            opened_root = os.fstat(self.descriptors[0])
+            if (
+                _path_is_redirected(self.checkout, root_stat)
+                or not stat.S_ISDIR(root_stat.st_mode)
+                or (root_stat.st_dev, root_stat.st_ino)
+                != (opened_root.st_dev, opened_root.st_ino)
+            ):
+                raise AnchoredOutputError(
+                    "output-parent-changed",
+                    f"Snapshot output checkout changed while bound: {self.checkout}.",
+                )
+            for parent_descriptor, component, child_descriptor in self.links:
+                entry = os.stat(
+                    component,
+                    dir_fd=parent_descriptor,
+                    follow_symlinks=False,
+                )
+                opened = os.fstat(child_descriptor)
+                if (
+                    stat.S_ISLNK(entry.st_mode)
+                    or not stat.S_ISDIR(entry.st_mode)
+                    or (entry.st_dev, entry.st_ino) != (opened.st_dev, opened.st_ino)
+                ):
+                    raise AnchoredOutputError(
+                        "output-parent-changed",
+                        f"Snapshot output ancestor changed while bound: {self.parent}.",
+                    )
+            return
+
+        assert self.windows_api is not None
+        for path, identity, handle in self.windows_entries:
+            path_stat = path.lstat()
+            attributes = _windows_directory_attributes(self.windows_api, handle)
+            if (
+                _path_is_redirected(path, path_stat)
+                or not stat.S_ISDIR(path_stat.st_mode)
+                or (path_stat.st_dev, path_stat.st_ino) != identity
+                or _windows_handle_identity(self.windows_api, handle) != identity
+                or not attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY
+                or attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT
+            ):
+                raise AnchoredOutputError(
+                    "output-parent-changed",
+                    f"Snapshot output ancestor changed while bound: {path}.",
+                )
+
+    def stat(self, name: str) -> os.stat_result:
+        if self.strategy == "posix-dir-fd":
+            return os.stat(
+                name,
+                dir_fd=self.descriptors[-1],
+                follow_symlinks=False,
+            )
+        self.verify()
+        result = (self.parent / name).lstat()
+        self.verify()
+        return result
+
+    def open_new(self, name: str) -> int:
+        flags = (
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_BINARY", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
+        if self.strategy == "posix-dir-fd":
+            return os.open(name, flags, 0o600, dir_fd=self.descriptors[-1])
+        self.verify()
+        return os.open(self.parent / name, flags, 0o600)
+
+    def link(self, source: str, destination: str) -> None:
+        if self.strategy == "posix-dir-fd":
+            os.link(
+                source,
+                destination,
+                src_dir_fd=self.descriptors[-1],
+                dst_dir_fd=self.descriptors[-1],
+                follow_symlinks=False,
+            )
+            return
+        self.verify()
+        os.link(
+            self.parent / source,
+            self.parent / destination,
+            follow_symlinks=False,
+        )
+
+    def unlink(self, name: str) -> None:
+        if self.strategy == "posix-dir-fd":
+            os.unlink(name, dir_fd=self.descriptors[-1])
+            return
+        self.verify()
+        os.unlink(self.parent / name)
+        self.verify()
+
+    def sync(self) -> None:
+        if self.strategy != "posix-dir-fd":
+            # The hard-link operation still publishes one name atomically on
+            # Windows, but Python exposes no portable directory-entry flush
+            # for the retained Win32 directory handles used here.
+            return
+        os.fsync(self.descriptors[-1])
+
+
+def _checkout_output_parts(path: Path) -> tuple[Path, Path, tuple[str, ...]]:
+    leaf = path.name
+    if leaf in {"", ".", ".."}:
+        raise AnchoredOutputError(
+            "path-outside-checkout",
+            f"Snapshot output must name a file below the physical checkout: {path}.",
+        )
+    try:
+        checkout = Path.cwd().resolve(strict=True)
+        # Normalize dot components without following any caller-controlled
+        # output ancestor. Absolute spellings may still use an OS-level alias
+        # for the physical cwd (for example macOS /var -> /private/var), so map
+        # the outermost lexical ancestor that identifies the checkout and keep
+        # every component below it for no-follow traversal from the anchor.
+        lexical_parent = Path(os.path.abspath(os.path.normpath(os.fspath(path.parent))))
+        try:
+            relative_parent_parts = lexical_parent.relative_to(checkout).parts
+        except ValueError:
+            reversed_suffix: list[str] = []
+            current = lexical_parent
+            matched_parts: tuple[str, ...] | None = None
+            while True:
+                try:
+                    matches_checkout = current.samefile(checkout)
+                except OSError:
+                    matches_checkout = False
+                if matches_checkout:
+                    # Continue toward the filesystem root so a symlink below
+                    # the checkout that points back to it cannot become the
+                    # trusted prefix.
+                    matched_parts = tuple(reversed(reversed_suffix))
+                parent = current.parent
+                if parent == current:
+                    break
+                reversed_suffix.append(current.name)
+                current = parent
+            if matched_parts is None:
+                raise ValueError("Output parent is not lexically below the checkout.")
+            relative_parent_parts = matched_parts
+    except (OSError, ValueError) as error:
+        raise AnchoredOutputError(
+            "path-outside-checkout",
+            f"Snapshot output must resolve below the physical checkout: {path}.",
+        ) from error
+    absolute = checkout.joinpath(*relative_parent_parts, leaf)
+    return checkout, absolute, (*relative_parent_parts, leaf)
+
+
+def open_output_parent(path: Path) -> OutputParentBinding:
+    checkout, absolute, parts = _checkout_output_parts(path)
+    parent = absolute.parent
+    leaf = parts[-1]
+    if descriptor_relative_output_supported():
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        descriptors: list[int] = []
+        links: list[tuple[int, str, int]] = []
+        try:
+            root_descriptor = os.open(".", flags)
+            descriptors.append(root_descriptor)
+            root_path_stat = checkout.lstat()
+            opened_root = os.fstat(root_descriptor)
+            if (
+                _path_is_redirected(checkout, root_path_stat)
+                or not stat.S_ISDIR(opened_root.st_mode)
+                or (root_path_stat.st_dev, root_path_stat.st_ino)
+                != (opened_root.st_dev, opened_root.st_ino)
+            ):
+                raise OSError("The physical checkout changed while it was opened.")
+            for component in parts[:-1]:
+                parent_descriptor = descriptors[-1]
+                entry = os.stat(
+                    component,
+                    dir_fd=parent_descriptor,
+                    follow_symlinks=False,
+                )
+                if stat.S_ISLNK(entry.st_mode) or not stat.S_ISDIR(entry.st_mode):
+                    raise OSError(f"Redirected output ancestor: {component}.")
+                child_descriptor = os.open(
+                    component,
+                    flags,
+                    dir_fd=parent_descriptor,
+                )
+                descriptors.append(child_descriptor)
+                opened = os.fstat(child_descriptor)
+                if (
+                    not stat.S_ISDIR(opened.st_mode)
+                    or (entry.st_dev, entry.st_ino) != (opened.st_dev, opened.st_ino)
+                ):
+                    raise OSError(f"Output ancestor changed: {component}.")
+                links.append((parent_descriptor, component, child_descriptor))
+            binding = OutputParentBinding(
+                checkout=checkout,
+                parent=parent,
+                leaf=leaf,
+                strategy="posix-dir-fd",
+                descriptors=tuple(descriptors),
+                links=tuple(links),
+            )
+            binding.verify()
+            return binding
+        except BaseException as error:
+            cleanup_binding = OutputParentBinding(
+                checkout=checkout,
+                parent=parent,
+                leaf=leaf,
+                strategy="posix-dir-fd",
+                descriptors=tuple(descriptors),
+            )
+            for cleanup_error in cleanup_binding.close():
+                error.add_note(
+                    f"Could not close a snapshot output directory descriptor: "
+                    f"{cleanup_error}"
+                )
+            if isinstance(error, AnchoredOutputError) or not isinstance(error, Exception):
+                raise
+            raise AnchoredOutputError(
+                "output-parent-invalid",
+                f"Cannot bind snapshot output parent inside the checkout: {parent}.",
+            ) from error
+
+    if os.name == "nt":
+        kernel32 = _windows_file_api()
+        entries: list[tuple[Path, tuple[int, int], int]] = []
+        try:
+            current = checkout
+            for component in (None, *parts[:-1]):
+                if component is not None:
+                    current /= component
+                path_stat = current.lstat()
+                if _path_is_redirected(current, path_stat) or not stat.S_ISDIR(
+                    path_stat.st_mode
+                ):
+                    raise OSError(f"Redirected output ancestor: {current}.")
+                identity = (path_stat.st_dev, path_stat.st_ino)
+                handle = _open_windows_directory_handle(kernel32, current, identity)
+                entries.append((current, identity, handle))
+            binding = OutputParentBinding(
+                checkout=checkout,
+                parent=parent,
+                leaf=leaf,
+                strategy="windows-handle",
+                windows_api=kernel32,
+                windows_entries=tuple(entries),
+            )
+            binding.verify()
+            return binding
+        except BaseException as error:
+            cleanup_binding = OutputParentBinding(
+                checkout=checkout,
+                parent=parent,
+                leaf=leaf,
+                strategy="windows-handle",
+                windows_api=kernel32,
+                windows_entries=tuple(entries),
+            )
+            for cleanup_error in cleanup_binding.close():
+                error.add_note(
+                    f"Could not close a snapshot output directory handle: "
+                    f"{cleanup_error}"
+                )
+            if isinstance(error, AnchoredOutputError) or not isinstance(error, Exception):
+                raise
+            raise AnchoredOutputError(
+                "output-parent-invalid",
+                f"Cannot bind snapshot output parent inside the checkout: {parent}.",
+            ) from error
+
+    raise AnchoredOutputError(
+        "output-anchor-unavailable",
+        "This platform cannot bind snapshot output operations to the physical checkout.",
+    )
+
+
+def _same_identity(path_stat: os.stat_result, identity: tuple[int, int]) -> bool:
+    return (path_stat.st_dev, path_stat.st_ino) == identity
+
+
+def _unlink_output_if_identity(
+    binding: OutputParentBinding,
+    name: str,
+    identity: tuple[int, int],
+) -> None:
+    try:
+        current = binding.stat(name)
+    except FileNotFoundError:
+        return
+    if not stat.S_ISREG(current.st_mode) or not _same_identity(current, identity):
+        raise AnchoredOutputError(
+            "output-cleanup-changed",
+            f"Refusing to remove a changed snapshot output artifact: {binding.parent / name}.",
+        )
+    binding.unlink(name)
+
+
+def publish_new_bytes(path: Path, payload: bytes) -> None:
+    """Publish bytes below the physical cwd without replacing an existing name."""
+
+    binding = open_output_parent(path)
+    temporary_name = ""
+    temporary_identity: tuple[int, int] | None = None
+    output_identity: tuple[int, int] | None = None
+    published = False
+    descriptor = -1
+    primary_error: BaseException | None = None
+    try:
+        try:
+            binding.stat(binding.leaf)
+        except FileNotFoundError:
+            pass
+        else:
+            raise AnchoredOutputError("output-exists", f"Refusing to overwrite existing snapshot output: {path}.")
+
+        for _attempt in range(100):
+            temporary_name = f".{binding.leaf}.{secrets.token_hex(8)}.tmp"
+            try:
+                descriptor = binding.open_new(temporary_name)
+            except FileExistsError:
+                continue
+            binding.verify()
+            break
+        if descriptor < 0:
+            raise AnchoredOutputError(
+                "output-temporary-unavailable",
+                f"Could not create a private temporary snapshot beside {path}.",
+            )
+        opened = os.fstat(descriptor)
+        temporary_identity = (opened.st_dev, opened.st_ino)
+        if not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1:
+            raise AnchoredOutputError(
+                "output-temporary-invalid",
+                f"Snapshot temporary file is not one private regular file: {path}.",
+            )
+        file_handle = os.fdopen(descriptor, "wb")
+        descriptor = -1
+        with file_handle as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+        binding.verify()
+        try:
+            binding.link(temporary_name, binding.leaf)
+        except FileExistsError as error:
+            raise AnchoredOutputError("output-exists", f"Refusing to overwrite existing snapshot output: {path}.") from error
+        published = True
+        output_identity = temporary_identity
+        output_stat = binding.stat(binding.leaf)
+        if (
+            not stat.S_ISREG(output_stat.st_mode)
+            or not _same_identity(output_stat, temporary_identity)
+        ):
+            raise AnchoredOutputError(
+                "output-changed",
+                f"Snapshot output changed while it was published: {path}.",
+            )
+        binding.verify()
+        binding.sync()
+        _unlink_output_if_identity(binding, temporary_name, temporary_identity)
+        temporary_identity = None
+        binding.sync()
+        binding.verify()
+        output_stat = binding.stat(binding.leaf)
+        if (
+            not stat.S_ISREG(output_stat.st_mode)
+            or output_stat.st_nlink != 1
+            or not _same_identity(output_stat, output_identity)
+        ):
+            raise AnchoredOutputError(
+                "output-changed",
+                f"Snapshot output changed before publication completed: {path}.",
+            )
+    except BaseException as error:
+        primary_error = error
+        if descriptor >= 0:
+            if temporary_identity is None:
+                try:
+                    opened_for_cleanup = os.fstat(descriptor)
+                    if stat.S_ISREG(opened_for_cleanup.st_mode):
+                        temporary_identity = (
+                            opened_for_cleanup.st_dev,
+                            opened_for_cleanup.st_ino,
+                        )
+                    else:
+                        error.add_note(
+                            "Could not bind the snapshot temporary file for cleanup: "
+                            "the opened descriptor is not a regular file."
+                        )
+                except BaseException as cleanup_error:
+                    # Do not unlink by name without proving that the entry is
+                    # still the file represented by this descriptor. A writer
+                    # with directory access could have replaced it. At this
+                    # point publication has not begun, so the fail-closed cost
+                    # is at most one unpredictable, newly created empty temp.
+                    error.add_note(
+                        f"Could not identify the snapshot temporary file for cleanup: "
+                        f"{cleanup_error}. The unverified temporary name was "
+                        "intentionally left in place rather than risk deleting "
+                        "a replaced entry."
+                    )
+            try:
+                os.close(descriptor)
+            except BaseException as cleanup_error:
+                error.add_note(
+                    f"Could not close the snapshot temporary descriptor: "
+                    f"{cleanup_error}"
+                )
+            descriptor = -1
+        if published and output_identity is not None:
+            try:
+                _unlink_output_if_identity(binding, binding.leaf, output_identity)
+            except BaseException as cleanup_error:
+                error.add_note(f"Could not remove rejected snapshot output: {cleanup_error}")
+        if temporary_identity is not None:
+            try:
+                _unlink_output_if_identity(binding, temporary_name, temporary_identity)
+            except BaseException as cleanup_error:
+                error.add_note(f"Could not remove snapshot temporary file: {cleanup_error}")
+        raise
+    finally:
+        close_failures = binding.close()
+        if close_failures:
+            if primary_error is not None:
+                for close_error in close_failures:
+                    primary_error.add_note(
+                        f"Could not close a snapshot output anchor: {close_error}"
+                    )
+            else:
+                control_flow_failure = next(
+                    (
+                        failure
+                        for failure in close_failures
+                        if not isinstance(failure, Exception)
+                    ),
+                    None,
+                )
+                if control_flow_failure is not None:
+                    for failure in close_failures:
+                        if failure is not control_flow_failure:
+                            control_flow_failure.add_note(
+                                f"Output anchor close failure: {failure}"
+                            )
+                    raise control_flow_failure
+                close_error = AnchoredOutputError(
+                    "output-anchor-close-failed",
+                    "Snapshot publication completed, but one or more output "
+                    "directory anchors could not be closed.",
+                )
+                for failure in close_failures:
+                    close_error.add_note(f"Output anchor close failure: {failure}")
+                raise close_error from close_failures[0]
+
+
+__all__ = [
+    "AnchoredOutputError",
+    "OutputParentBinding",
+    "descriptor_relative_output_supported",
+    "open_output_parent",
+    "publish_new_bytes",
+]

--- a/scripts/build_dependency_snapshot.py
+++ b/scripts/build_dependency_snapshot.py
@@ -6,22 +6,22 @@ from __future__ import annotations
 import argparse
 from collections import deque
 from collections.abc import Callable, Iterator, Mapping, Sequence
-import ctypes
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import hashlib
 import importlib
+import importlib.util
 import json
 import os
 from pathlib import Path
 import re
-import secrets
 import stat
 import subprocess
 import sys
 import tempfile
 import time
-from typing import IO, Any, Literal, Protocol, cast
+from types import ModuleType
+from typing import IO, Literal, Protocol, cast
 from urllib.parse import quote
 
 SNAPSHOT_VERSION = 0
@@ -130,6 +130,49 @@ class SnapshotError(ValueError):
     def __init__(self, code: str, message: str) -> None:
         super().__init__(message)
         self.code = code
+
+
+def _load_anchored_output_module() -> ModuleType:
+    """Load the exact stdlib-only sibling without changing ``sys.path``."""
+
+    # This caller is isolated-mode safe. The separate bootstrap wrapper retains
+    # its pre-existing sibling-name import and is intentionally outside #858.
+    module_path = Path(__file__).resolve(strict=True).with_name("_anchored_output.py")
+    module_name = "_gm2godot_anchored_output"
+    existing = sys.modules.get(module_name)
+    if existing is not None:
+        existing_path = getattr(existing, "__file__", None)
+        if (
+            isinstance(existing_path, str)
+            and Path(existing_path).resolve(strict=True) == module_path
+        ):
+            return existing
+        raise ImportError(
+            f"Refusing conflicting anchored output module {module_name!r}."
+        )
+
+    specification = importlib.util.spec_from_file_location(module_name, module_path)
+    if specification is None or specification.loader is None:
+        raise ImportError(f"Cannot load anchored output helper: {module_path}")
+    module = importlib.util.module_from_spec(specification)
+    sys.modules[module_name] = module
+    try:
+        specification.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+_ANCHORED_OUTPUT = _load_anchored_output_module()
+_ANCHORED_OUTPUT_ERROR = cast(
+    type[ValueError],
+    getattr(_ANCHORED_OUTPUT, "AnchoredOutputError"),
+)
+_PUBLISH_NEW_BYTES = cast(
+    Callable[[Path, bytes], None],
+    getattr(_ANCHORED_OUTPUT, "publish_new_bytes"),
+)
 
 
 class DuplicateJsonKeyError(ValueError):
@@ -1390,654 +1433,32 @@ def validate_output_path(output: Path, inputs: Sequence[Path]) -> None:
         raise SnapshotError("output-parent-invalid", f"Snapshot output parent is not a regular directory: {parent}.")
 
 
-_WINDOWS_FILE_READ_ATTRIBUTES = 0x00000080
-_WINDOWS_FILE_TRAVERSE = 0x00000020
-_WINDOWS_FILE_SHARE_READ = 0x00000001
-_WINDOWS_FILE_SHARE_WRITE = 0x00000002
-_WINDOWS_OPEN_EXISTING = 3
-_WINDOWS_FILE_FLAG_BACKUP_SEMANTICS = 0x02000000
-_WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000
-_WINDOWS_FILE_ATTRIBUTE_DIRECTORY = 0x00000010
-_WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
-_WINDOWS_FILE_TYPE_DISK = 1
-_WINDOWS_FILE_BASIC_INFO_CLASS = 0
-_WINDOWS_FILE_ID_INFO_CLASS = 18
-
-
-class _WindowsFileId128(ctypes.Structure):
-    _fields_ = (("Identifier", ctypes.c_uint8 * 16),)
-
-
-class _WindowsFileIdInfo(ctypes.Structure):
-    _fields_ = (
-        ("VolumeSerialNumber", ctypes.c_uint64),
-        ("FileId", _WindowsFileId128),
-    )
-
-
-class _WindowsFileBasicInfo(ctypes.Structure):
-    _fields_ = (
-        ("CreationTime", ctypes.c_int64),
-        ("LastAccessTime", ctypes.c_int64),
-        ("LastWriteTime", ctypes.c_int64),
-        ("ChangeTime", ctypes.c_int64),
-        ("FileAttributes", ctypes.c_uint32),
-    )
-
-
-def descriptor_relative_output_supported() -> bool:
-    return (
-        os.name != "nt"
-        and bool(getattr(os, "O_DIRECTORY", 0))
-        and bool(getattr(os, "O_NOFOLLOW", 0))
-        and os.stat in os.supports_follow_symlinks
-        and all(
-            operation in os.supports_dir_fd
-            for operation in (os.open, os.stat, os.link, os.unlink)
-        )
-    )
-
-
-def _path_is_redirected(path: Path, path_stat: os.stat_result) -> bool:
-    if stat.S_ISLNK(path_stat.st_mode):
-        return True
-    junction_candidate: object = getattr(os.path, "isjunction", None)
-    if not callable(junction_candidate):
-        return False
-    junction_checker = cast(Callable[[str], bool], junction_candidate)
-    return junction_checker(os.fspath(path))
-
-
-def _windows_extended_path(path: Path) -> str:
-    absolute_path = os.path.abspath(path)
-    if absolute_path.startswith(("\\\\?\\", "\\\\.\\")):
-        return absolute_path
-    if absolute_path.startswith("\\\\"):
-        return "\\\\?\\UNC\\" + absolute_path[2:]
-    return "\\\\?\\" + absolute_path
-
-
-def _windows_file_api() -> Any:
-    if os.name != "nt":
-        raise SnapshotError(
-            "output-anchor-unavailable",
-            "Win32 output-directory handles are unavailable on this platform.",
-        )
-    win_dll = cast(Callable[..., Any], getattr(ctypes, "WinDLL"))
-    kernel32 = win_dll("kernel32", use_last_error=True)
-    kernel32.CreateFileW.argtypes = (
-        ctypes.c_wchar_p,
-        ctypes.c_uint32,
-        ctypes.c_uint32,
-        ctypes.c_void_p,
-        ctypes.c_uint32,
-        ctypes.c_uint32,
-        ctypes.c_void_p,
-    )
-    kernel32.CreateFileW.restype = ctypes.c_void_p
-    kernel32.GetFileInformationByHandleEx.argtypes = (
-        ctypes.c_void_p,
-        ctypes.c_int,
-        ctypes.c_void_p,
-        ctypes.c_uint32,
-    )
-    kernel32.GetFileInformationByHandleEx.restype = ctypes.c_int
-    kernel32.GetFileType.argtypes = (ctypes.c_void_p,)
-    kernel32.GetFileType.restype = ctypes.c_uint32
-    kernel32.CloseHandle.argtypes = (ctypes.c_void_p,)
-    kernel32.CloseHandle.restype = ctypes.c_int
-    return kernel32
-
-
-def _windows_handle_identity(kernel32: Any, handle: int) -> tuple[int, int]:
-    identity_info = _WindowsFileIdInfo()
-    if not kernel32.GetFileInformationByHandleEx(
-        handle,
-        _WINDOWS_FILE_ID_INFO_CLASS,
-        ctypes.byref(identity_info),
-        ctypes.sizeof(identity_info),
-    ):
-        raise OSError("Could not identify the snapshot output directory handle.")
-    return (
-        int(identity_info.VolumeSerialNumber),
-        int.from_bytes(bytes(identity_info.FileId.Identifier), "little"),
-    )
-
-
-def _windows_directory_attributes(kernel32: Any, handle: int) -> int:
-    basic_info = _WindowsFileBasicInfo()
-    if not kernel32.GetFileInformationByHandleEx(
-        handle,
-        _WINDOWS_FILE_BASIC_INFO_CLASS,
-        ctypes.byref(basic_info),
-        ctypes.sizeof(basic_info),
-    ):
-        raise OSError("Could not inspect the snapshot output directory handle.")
-    return int(basic_info.FileAttributes)
-
-
-def _open_windows_directory_handle(
-    kernel32: Any,
-    path: Path,
-    expected_identity: tuple[int, int],
-) -> int:
-    handle = kernel32.CreateFileW(
-        _windows_extended_path(path),
-        _WINDOWS_FILE_TRAVERSE | _WINDOWS_FILE_READ_ATTRIBUTES,
-        _WINDOWS_FILE_SHARE_READ | _WINDOWS_FILE_SHARE_WRITE,
-        None,
-        _WINDOWS_OPEN_EXISTING,
-        _WINDOWS_FILE_FLAG_BACKUP_SEMANTICS | _WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT,
-        None,
-    )
-    invalid_handle = ctypes.c_void_p(-1).value
-    if handle is None or handle == invalid_handle:
-        raise OSError(f"Could not bind snapshot output directory: {path}.")
-    handle_value = cast(int, handle)
-    try:
-        path_stat = path.lstat()
-        attributes = _windows_directory_attributes(kernel32, handle_value)
-        if (
-            kernel32.GetFileType(handle_value) != _WINDOWS_FILE_TYPE_DISK
-            or _path_is_redirected(path, path_stat)
-            or not stat.S_ISDIR(path_stat.st_mode)
-            or (path_stat.st_dev, path_stat.st_ino) != expected_identity
-            or _windows_handle_identity(kernel32, handle_value) != expected_identity
-            or not attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY
-            or attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT
-        ):
-            raise OSError(f"Snapshot output directory changed: {path}.")
-    except BaseException as error:
-        try:
-            if not kernel32.CloseHandle(handle_value):
-                error.add_note(
-                    "Could not close the rejected snapshot output directory handle."
-                )
-        except BaseException as cleanup_error:
-            error.add_note(
-                "Could not close the rejected snapshot output directory handle: "
-                f"{cleanup_error}"
-            )
-        raise
-    return handle_value
-
-
-@dataclass
-class _OutputParentBinding:
-    checkout: Path
-    parent: Path
-    leaf: str
-    strategy: Literal["posix-dir-fd", "windows-handle"]
-    descriptors: tuple[int, ...] = ()
-    links: tuple[tuple[int, str, int], ...] = ()
-    windows_api: Any | None = None
-    windows_entries: tuple[tuple[Path, tuple[int, int], int], ...] = ()
-
-    def close(self) -> tuple[Exception, ...]:
-        failures: list[Exception] = []
-        for descriptor in reversed(self.descriptors):
-            try:
-                os.close(descriptor)
-            except Exception as error:
-                failures.append(error)
-        if self.windows_api is not None:
-            for _path, _identity, handle in reversed(self.windows_entries):
-                try:
-                    if not self.windows_api.CloseHandle(handle):
-                        failures.append(
-                            OSError(
-                                "Could not close a snapshot output directory handle."
-                            )
-                        )
-                except Exception as error:
-                    failures.append(error)
-        return tuple(failures)
-
-    def verify(self) -> None:
-        if self.strategy == "posix-dir-fd":
-            root_stat = self.checkout.lstat()
-            opened_root = os.fstat(self.descriptors[0])
-            if (
-                _path_is_redirected(self.checkout, root_stat)
-                or not stat.S_ISDIR(root_stat.st_mode)
-                or (root_stat.st_dev, root_stat.st_ino)
-                != (opened_root.st_dev, opened_root.st_ino)
-            ):
-                raise SnapshotError(
-                    "output-parent-changed",
-                    f"Snapshot output checkout changed while bound: {self.checkout}.",
-                )
-            for parent_descriptor, component, child_descriptor in self.links:
-                entry = os.stat(
-                    component,
-                    dir_fd=parent_descriptor,
-                    follow_symlinks=False,
-                )
-                opened = os.fstat(child_descriptor)
-                if (
-                    stat.S_ISLNK(entry.st_mode)
-                    or not stat.S_ISDIR(entry.st_mode)
-                    or (entry.st_dev, entry.st_ino) != (opened.st_dev, opened.st_ino)
-                ):
-                    raise SnapshotError(
-                        "output-parent-changed",
-                        f"Snapshot output ancestor changed while bound: {self.parent}.",
-                    )
-            return
-
-        assert self.windows_api is not None
-        for path, identity, handle in self.windows_entries:
-            path_stat = path.lstat()
-            attributes = _windows_directory_attributes(self.windows_api, handle)
-            if (
-                _path_is_redirected(path, path_stat)
-                or not stat.S_ISDIR(path_stat.st_mode)
-                or (path_stat.st_dev, path_stat.st_ino) != identity
-                or _windows_handle_identity(self.windows_api, handle) != identity
-                or not attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY
-                or attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT
-            ):
-                raise SnapshotError(
-                    "output-parent-changed",
-                    f"Snapshot output ancestor changed while bound: {path}.",
-                )
-
-    def stat(self, name: str) -> os.stat_result:
-        if self.strategy == "posix-dir-fd":
-            return os.stat(
-                name,
-                dir_fd=self.descriptors[-1],
-                follow_symlinks=False,
-            )
-        self.verify()
-        result = (self.parent / name).lstat()
-        self.verify()
-        return result
-
-    def open_new(self, name: str) -> int:
-        flags = (
-            os.O_WRONLY
-            | os.O_CREAT
-            | os.O_EXCL
-            | getattr(os, "O_BINARY", 0)
-            | getattr(os, "O_NOFOLLOW", 0)
-        )
-        if self.strategy == "posix-dir-fd":
-            return os.open(name, flags, 0o600, dir_fd=self.descriptors[-1])
-        self.verify()
-        return os.open(self.parent / name, flags, 0o600)
-
-    def link(self, source: str, destination: str) -> None:
-        if self.strategy == "posix-dir-fd":
-            os.link(
-                source,
-                destination,
-                src_dir_fd=self.descriptors[-1],
-                dst_dir_fd=self.descriptors[-1],
-                follow_symlinks=False,
-            )
-            return
-        self.verify()
-        os.link(
-            self.parent / source,
-            self.parent / destination,
-            follow_symlinks=False,
-        )
-
-    def unlink(self, name: str) -> None:
-        if self.strategy == "posix-dir-fd":
-            os.unlink(name, dir_fd=self.descriptors[-1])
-            return
-        self.verify()
-        os.unlink(self.parent / name)
-        self.verify()
-
-    def sync(self) -> None:
-        if self.strategy != "posix-dir-fd":
-            # The hard-link operation still publishes one name atomically on
-            # Windows, but Python exposes no portable directory-entry flush
-            # for the retained Win32 directory handles used here.
-            return
-        os.fsync(self.descriptors[-1])
-
-
-def _checkout_output_parts(path: Path) -> tuple[Path, Path, tuple[str, ...]]:
-    leaf = path.name
-    if leaf in {"", ".", ".."}:
-        raise SnapshotError(
-            "path-outside-checkout",
-            f"Snapshot output must name a file below the physical checkout: {path}.",
-        )
-    try:
-        checkout = Path.cwd().resolve(strict=True)
-        # Normalize dot components without following any caller-controlled
-        # output ancestor. Absolute spellings may still use an OS-level alias
-        # for the physical cwd (for example macOS /var -> /private/var), so map
-        # the outermost lexical ancestor that identifies the checkout and keep
-        # every component below it for no-follow traversal from the anchor.
-        lexical_parent = Path(os.path.abspath(os.path.normpath(os.fspath(path.parent))))
-        try:
-            relative_parent_parts = lexical_parent.relative_to(checkout).parts
-        except ValueError:
-            reversed_suffix: list[str] = []
-            current = lexical_parent
-            matched_parts: tuple[str, ...] | None = None
-            while True:
-                try:
-                    matches_checkout = current.samefile(checkout)
-                except OSError:
-                    matches_checkout = False
-                if matches_checkout:
-                    # Continue toward the filesystem root so a symlink below
-                    # the checkout that points back to it cannot become the
-                    # trusted prefix.
-                    matched_parts = tuple(reversed(reversed_suffix))
-                parent = current.parent
-                if parent == current:
-                    break
-                reversed_suffix.append(current.name)
-                current = parent
-            if matched_parts is None:
-                raise ValueError("Output parent is not lexically below the checkout.")
-            relative_parent_parts = matched_parts
-    except (OSError, ValueError) as error:
-        raise SnapshotError(
-            "path-outside-checkout",
-            f"Snapshot output must resolve below the physical checkout: {path}.",
-        ) from error
-    absolute = checkout.joinpath(*relative_parent_parts, leaf)
-    return checkout, absolute, (*relative_parent_parts, leaf)
-
-
-def _open_output_parent(path: Path) -> _OutputParentBinding:
-    checkout, absolute, parts = _checkout_output_parts(path)
-    parent = absolute.parent
-    leaf = parts[-1]
-    if descriptor_relative_output_supported():
-        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-        descriptors: list[int] = []
-        links: list[tuple[int, str, int]] = []
-        try:
-            root_descriptor = os.open(".", flags)
-            descriptors.append(root_descriptor)
-            root_path_stat = checkout.lstat()
-            opened_root = os.fstat(root_descriptor)
-            if (
-                _path_is_redirected(checkout, root_path_stat)
-                or not stat.S_ISDIR(opened_root.st_mode)
-                or (root_path_stat.st_dev, root_path_stat.st_ino)
-                != (opened_root.st_dev, opened_root.st_ino)
-            ):
-                raise OSError("The physical checkout changed while it was opened.")
-            for component in parts[:-1]:
-                parent_descriptor = descriptors[-1]
-                entry = os.stat(
-                    component,
-                    dir_fd=parent_descriptor,
-                    follow_symlinks=False,
-                )
-                if stat.S_ISLNK(entry.st_mode) or not stat.S_ISDIR(entry.st_mode):
-                    raise OSError(f"Redirected output ancestor: {component}.")
-                child_descriptor = os.open(
-                    component,
-                    flags,
-                    dir_fd=parent_descriptor,
-                )
-                descriptors.append(child_descriptor)
-                opened = os.fstat(child_descriptor)
-                if (
-                    not stat.S_ISDIR(opened.st_mode)
-                    or (entry.st_dev, entry.st_ino) != (opened.st_dev, opened.st_ino)
-                ):
-                    raise OSError(f"Output ancestor changed: {component}.")
-                links.append((parent_descriptor, component, child_descriptor))
-            binding = _OutputParentBinding(
-                checkout=checkout,
-                parent=parent,
-                leaf=leaf,
-                strategy="posix-dir-fd",
-                descriptors=tuple(descriptors),
-                links=tuple(links),
-            )
-            binding.verify()
-            return binding
-        except BaseException as error:
-            cleanup_binding = _OutputParentBinding(
-                checkout=checkout,
-                parent=parent,
-                leaf=leaf,
-                strategy="posix-dir-fd",
-                descriptors=tuple(descriptors),
-            )
-            for cleanup_error in cleanup_binding.close():
-                error.add_note(
-                    f"Could not close a snapshot output directory descriptor: "
-                    f"{cleanup_error}"
-                )
-            if isinstance(error, SnapshotError) or not isinstance(error, Exception):
-                raise
-            raise SnapshotError(
-                "output-parent-invalid",
-                f"Cannot bind snapshot output parent inside the checkout: {parent}.",
-            ) from error
-
-    if os.name == "nt":
-        kernel32 = _windows_file_api()
-        entries: list[tuple[Path, tuple[int, int], int]] = []
-        try:
-            current = checkout
-            for component in (None, *parts[:-1]):
-                if component is not None:
-                    current /= component
-                path_stat = current.lstat()
-                if _path_is_redirected(current, path_stat) or not stat.S_ISDIR(
-                    path_stat.st_mode
-                ):
-                    raise OSError(f"Redirected output ancestor: {current}.")
-                identity = (path_stat.st_dev, path_stat.st_ino)
-                handle = _open_windows_directory_handle(kernel32, current, identity)
-                entries.append((current, identity, handle))
-            binding = _OutputParentBinding(
-                checkout=checkout,
-                parent=parent,
-                leaf=leaf,
-                strategy="windows-handle",
-                windows_api=kernel32,
-                windows_entries=tuple(entries),
-            )
-            binding.verify()
-            return binding
-        except BaseException as error:
-            cleanup_binding = _OutputParentBinding(
-                checkout=checkout,
-                parent=parent,
-                leaf=leaf,
-                strategy="windows-handle",
-                windows_api=kernel32,
-                windows_entries=tuple(entries),
-            )
-            for cleanup_error in cleanup_binding.close():
-                error.add_note(
-                    f"Could not close a snapshot output directory handle: "
-                    f"{cleanup_error}"
-                )
-            if isinstance(error, SnapshotError) or not isinstance(error, Exception):
-                raise
-            raise SnapshotError(
-                "output-parent-invalid",
-                f"Cannot bind snapshot output parent inside the checkout: {parent}.",
-            ) from error
-
-    raise SnapshotError(
-        "output-anchor-unavailable",
-        "This platform cannot bind snapshot output operations to the physical checkout.",
-    )
-
-
-def _same_identity(path_stat: os.stat_result, identity: tuple[int, int]) -> bool:
-    return (path_stat.st_dev, path_stat.st_ino) == identity
-
-
-def _unlink_output_if_identity(
-    binding: _OutputParentBinding,
-    name: str,
-    identity: tuple[int, int],
-) -> None:
-    try:
-        current = binding.stat(name)
-    except FileNotFoundError:
-        return
-    if not stat.S_ISREG(current.st_mode) or not _same_identity(current, identity):
-        raise SnapshotError(
-            "output-cleanup-changed",
-            f"Refusing to remove a changed snapshot output artifact: {binding.parent / name}.",
-        )
-    binding.unlink(name)
-
-
 def atomic_write_new_json(path: Path, value: Mapping[str, object]) -> None:
-    payload = (json.dumps(value, ensure_ascii=True, allow_nan=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    payload = (
+        json.dumps(
+            value,
+            ensure_ascii=True,
+            allow_nan=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
     if len(payload) > MAX_SNAPSHOT_BYTES:
-        raise SnapshotError("snapshot-too-large", f"Snapshot exceeds the {MAX_SNAPSHOT_BYTES}-byte limit.")
-
-    binding = _open_output_parent(path)
-    temporary_name = ""
-    temporary_identity: tuple[int, int] | None = None
-    output_identity: tuple[int, int] | None = None
-    published = False
-    descriptor = -1
-    primary_error: BaseException | None = None
+        raise SnapshotError(
+            "snapshot-too-large",
+            f"Snapshot exceeds the {MAX_SNAPSHOT_BYTES}-byte limit.",
+        )
     try:
-        try:
-            binding.stat(binding.leaf)
-        except FileNotFoundError:
-            pass
-        else:
-            raise SnapshotError("output-exists", f"Refusing to overwrite existing snapshot output: {path}.")
-
-        for _attempt in range(100):
-            temporary_name = f".{binding.leaf}.{secrets.token_hex(8)}.tmp"
-            try:
-                descriptor = binding.open_new(temporary_name)
-            except FileExistsError:
-                continue
-            binding.verify()
-            break
-        if descriptor < 0:
-            raise SnapshotError(
-                "output-temporary-unavailable",
-                f"Could not create a private temporary snapshot beside {path}.",
-            )
-        opened = os.fstat(descriptor)
-        temporary_identity = (opened.st_dev, opened.st_ino)
-        if not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1:
-            raise SnapshotError(
-                "output-temporary-invalid",
-                f"Snapshot temporary file is not one private regular file: {path}.",
-            )
-        file_handle = os.fdopen(descriptor, "wb")
-        descriptor = -1
-        with file_handle as handle:
-            handle.write(payload)
-            handle.flush()
-            os.fsync(handle.fileno())
-
-        binding.verify()
-        try:
-            binding.link(temporary_name, binding.leaf)
-        except FileExistsError as error:
-            raise SnapshotError("output-exists", f"Refusing to overwrite existing snapshot output: {path}.") from error
-        published = True
-        output_identity = temporary_identity
-        output_stat = binding.stat(binding.leaf)
-        if (
-            not stat.S_ISREG(output_stat.st_mode)
-            or not _same_identity(output_stat, temporary_identity)
-        ):
-            raise SnapshotError(
-                "output-changed",
-                f"Snapshot output changed while it was published: {path}.",
-            )
-        binding.verify()
-        binding.sync()
-        _unlink_output_if_identity(binding, temporary_name, temporary_identity)
-        temporary_identity = None
-        binding.sync()
-        binding.verify()
-        output_stat = binding.stat(binding.leaf)
-        if (
-            not stat.S_ISREG(output_stat.st_mode)
-            or output_stat.st_nlink != 1
-            or not _same_identity(output_stat, output_identity)
-        ):
-            raise SnapshotError(
-                "output-changed",
-                f"Snapshot output changed before publication completed: {path}.",
-            )
-    except BaseException as error:
-        primary_error = error
-        if descriptor >= 0:
-            if temporary_identity is None:
-                try:
-                    opened_for_cleanup = os.fstat(descriptor)
-                    if stat.S_ISREG(opened_for_cleanup.st_mode):
-                        temporary_identity = (
-                            opened_for_cleanup.st_dev,
-                            opened_for_cleanup.st_ino,
-                        )
-                    else:
-                        error.add_note(
-                            "Could not bind the snapshot temporary file for cleanup: "
-                            "the opened descriptor is not a regular file."
-                        )
-                except BaseException as cleanup_error:
-                    # Do not unlink by name without proving that the entry is
-                    # still the file represented by this descriptor. A writer
-                    # with directory access could have replaced it. At this
-                    # point publication has not begun, so the fail-closed cost
-                    # is at most one unpredictable, newly created empty temp.
-                    error.add_note(
-                        f"Could not identify the snapshot temporary file for cleanup: "
-                        f"{cleanup_error}. The unverified temporary name was "
-                        "intentionally left in place rather than risk deleting "
-                        "a replaced entry."
-                    )
-            try:
-                os.close(descriptor)
-            except BaseException as cleanup_error:
-                error.add_note(
-                    f"Could not close the snapshot temporary descriptor: "
-                    f"{cleanup_error}"
-                )
-            descriptor = -1
-        if published and output_identity is not None:
-            try:
-                _unlink_output_if_identity(binding, binding.leaf, output_identity)
-            except BaseException as cleanup_error:
-                error.add_note(f"Could not remove rejected snapshot output: {cleanup_error}")
-        if temporary_identity is not None:
-            try:
-                _unlink_output_if_identity(binding, temporary_name, temporary_identity)
-            except BaseException as cleanup_error:
-                error.add_note(f"Could not remove snapshot temporary file: {cleanup_error}")
-        raise
-    finally:
-        close_failures = binding.close()
-        if close_failures:
-            if primary_error is not None:
-                for close_error in close_failures:
-                    primary_error.add_note(
-                        f"Could not close a snapshot output anchor: {close_error}"
-                    )
-            else:
-                close_error = SnapshotError(
-                    "output-anchor-close-failed",
-                    "Snapshot publication completed, but one or more output "
-                    "directory anchors could not be closed.",
-                )
-                for failure in close_failures:
-                    close_error.add_note(f"Output anchor close failure: {failure}")
-                raise close_error from close_failures[0]
+        _PUBLISH_NEW_BYTES(path, payload)
+    except _ANCHORED_OUTPUT_ERROR as error:
+        translated = SnapshotError(
+            cast(str, getattr(error, "code")),
+            str(error),
+        )
+        for note in cast(list[str], getattr(error, "__notes__", [])):
+            translated.add_note(note)
+        raise translated from error
 
 
 def _positive_decimal(value: str, *, label: str) -> str:

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.66"
+VERSION = "0.7.67"
 
 
 def get_version():

--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from contextlib import contextmanager, nullcontext, redirect_stderr, redirect_stdout
 import copy
 import errno
 from io import StringIO
@@ -8,8 +8,11 @@ import json
 import os
 from pathlib import Path
 import stat
+import subprocess
+import sys
 import tempfile
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Mapping
+from types import ModuleType
 from typing import Any, cast
 import unittest
 from unittest import mock
@@ -19,18 +22,20 @@ from scripts import build_dependency_snapshot as snapshotter
 
 SHA = "0123456789abcdef0123456789abcdef01234567"
 SCANNED = "2026-09-02T12:34:56Z"
-OUTPUT_PARENT_BINDING_TYPE: Any = getattr(snapshotter, "_OutputParentBinding")
-OPEN_OUTPUT_PARENT: Any = getattr(snapshotter, "_open_output_parent")
+ANCHORED_OUTPUT: ModuleType = getattr(snapshotter, "_ANCHORED_OUTPUT")
+ANCHORED_OUTPUT_ERROR: Any = getattr(ANCHORED_OUTPUT, "AnchoredOutputError")
+OUTPUT_PARENT_BINDING_TYPE: Any = getattr(ANCHORED_OUTPUT, "OutputParentBinding")
+OPEN_OUTPUT_PARENT: Any = getattr(ANCHORED_OUTPUT, "open_output_parent")
 WINDOWS_FILE_ATTRIBUTE_DIRECTORY = cast(
     int,
-    getattr(snapshotter, "_WINDOWS_FILE_ATTRIBUTE_DIRECTORY"),
+    getattr(ANCHORED_OUTPUT, "_WINDOWS_FILE_ATTRIBUTE_DIRECTORY"),
 )
 WINDOWS_FILE_TYPE_DISK = cast(
     int,
-    getattr(snapshotter, "_WINDOWS_FILE_TYPE_DISK"),
+    getattr(ANCHORED_OUTPUT, "_WINDOWS_FILE_TYPE_DISK"),
 )
 OPEN_WINDOWS_DIRECTORY_HANDLE: Any = getattr(
-    snapshotter,
+    ANCHORED_OUTPUT,
     "_open_windows_directory_handle",
 )
 ENVIRONMENT = {
@@ -55,6 +60,20 @@ PINS = {
     "pip-tools": "7.6.1",
     "tool": "4.0",
 }
+
+
+def _publish_new_json(path: Path, value: Mapping[str, object]) -> None:
+    payload = (
+        json.dumps(
+            value,
+            ensure_ascii=True,
+            allow_nan=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+    ANCHORED_OUTPUT.publish_new_bytes(path, payload)
 
 
 def _installed_item(
@@ -925,15 +944,91 @@ class DependencySnapshotTests(unittest.TestCase):
                 with self.assertRaises(snapshotter.SnapshotError):
                     snapshotter.parse_inspect_report(value)
 
+    def test_anchored_output_exact_loader_supports_isolated_script_execution(
+        self,
+    ) -> None:
+        loader = cast(
+            Callable[[], object],
+            getattr(snapshotter, "_load_anchored_output_module"),
+        )
+        before_path = tuple(sys.path)
+        self.assertIs(loader(), ANCHORED_OUTPUT)
+        self.assertEqual(tuple(sys.path), before_path)
+        anchored_output_path = ANCHORED_OUTPUT.__file__
+        self.assertIsNotNone(anchored_output_path)
+        assert anchored_output_path is not None
+        self.assertEqual(
+            Path(anchored_output_path).resolve(strict=True),
+            Path(snapshotter.__file__)
+            .resolve(strict=True)
+            .with_name("_anchored_output.py"),
+        )
+
+        with tempfile.TemporaryDirectory() as raw_directory:
+            shadow = Path(raw_directory) / "_anchored_output.py"
+            shadow.write_text(
+                'raise RuntimeError("loaded shadow anchored output")\n',
+                encoding="utf-8",
+            )
+            environment = dict(os.environ)
+            environment["PYTHONPATH"] = raw_directory
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    "-I",
+                    os.fspath(Path(snapshotter.__file__).resolve(strict=True)),
+                    "--help",
+                ],
+                cwd=raw_directory,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertNotIn("loaded shadow anchored output", completed.stderr)
+
+    def test_snapshot_json_adapter_preserves_publication_error_and_cleanup_note(
+        self,
+    ) -> None:
+        real_close = OUTPUT_PARENT_BINDING_TYPE.close
+
+        def close_then_report_failure(binding: Any) -> tuple[BaseException, ...]:
+            self.assertEqual(real_close(binding), ())
+            return (OSError("injected adapter close failure"),)
+
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory)
+            output = root / "snapshot.json"
+            output.write_bytes(b"existing\n")
+            with (
+                _working_directory(root),
+                mock.patch.object(
+                    OUTPUT_PARENT_BINDING_TYPE,
+                    "close",
+                    close_then_report_failure,
+                ),
+                self.assertRaises(snapshotter.SnapshotError) as raised,
+            ):
+                snapshotter.atomic_write_new_json(output, {"version": 0})
+
+            self.assertEqual(raised.exception.code, "output-exists")
+            self.assertIn(
+                "injected adapter close failure",
+                "\n".join(getattr(raised.exception, "__notes__", ())),
+            )
+            self.assertEqual(output.read_bytes(), b"existing\n")
+
     def test_atomic_output_never_overwrites_and_rejects_symlink_parent(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:
             root = Path(raw_directory)
             output = root / "snapshot.json"
             with _working_directory(root):
-                snapshotter.atomic_write_new_json(output, {"version": 0})
+                _publish_new_json(output, {"version": 0})
                 original = output.read_bytes()
-                with self.assertRaisesRegex(snapshotter.SnapshotError, "overwrite"):
-                    snapshotter.atomic_write_new_json(output, {"version": 1})
+                with self.assertRaisesRegex(ANCHORED_OUTPUT_ERROR, "overwrite"):
+                    _publish_new_json(output, {"version": 1})
             self.assertEqual(output.read_bytes(), original)
             self.assertEqual(list(root.glob(".snapshot.json.*.tmp")), [])
 
@@ -961,9 +1056,9 @@ class DependencySnapshotTests(unittest.TestCase):
 
             with (
                 _working_directory(root),
-                self.assertRaisesRegex(snapshotter.SnapshotError, "overwrite"),
+                self.assertRaisesRegex(ANCHORED_OUTPUT_ERROR, "overwrite"),
             ):
-                snapshotter.atomic_write_new_json(output, {"version": 0})
+                _publish_new_json(output, {"version": 0})
 
             self.assertTrue(output.is_symlink())
             self.assertFalse(redirected.exists())
@@ -990,10 +1085,10 @@ class DependencySnapshotTests(unittest.TestCase):
                     self.skipTest("This platform cannot create directory symlinks.")
 
                 with self.assertRaisesRegex(
-                    snapshotter.SnapshotError,
+                    ANCHORED_OUTPUT_ERROR,
                     "Cannot bind snapshot output parent",
                 ):
-                    snapshotter.atomic_write_new_json(output, {"version": 0})
+                    _publish_new_json(output, {"version": 0})
 
             self.assertFalse((redirected_safe / "out" / output.name).exists())
             self.assertFalse((original_safe / "out" / output.name).exists())
@@ -1007,7 +1102,7 @@ class DependencySnapshotTests(unittest.TestCase):
             )
 
     @unittest.skipUnless(
-        snapshotter.descriptor_relative_output_supported(),
+        ANCHORED_OUTPUT.descriptor_relative_output_supported(),
         "Descriptor-relative output binding is unavailable on this platform.",
     )
     def test_atomic_output_recovers_when_initial_fstat_fails_once(
@@ -1044,13 +1139,13 @@ class DependencySnapshotTests(unittest.TestCase):
                     recording_open_new,
                 ),
                 mock.patch.object(
-                    snapshotter.os,
+                    ANCHORED_OUTPUT.os,
                     "fstat",
                     side_effect=fail_created_descriptor_once,
                 ),
                 self.assertRaisesRegex(OSError, "injected post-open fstat failure"),
             ):
-                snapshotter.atomic_write_new_json(output, {"version": 0})
+                _publish_new_json(output, {"version": 0})
 
             self.assertTrue(injected)
             self.assertFalse(output.exists())
@@ -1059,7 +1154,7 @@ class DependencySnapshotTests(unittest.TestCase):
                 real_fstat(created_descriptor)
 
     @unittest.skipUnless(
-        snapshotter.descriptor_relative_output_supported(),
+        ANCHORED_OUTPUT.descriptor_relative_output_supported(),
         "Descriptor-relative output binding is unavailable on this platform.",
     )
     def test_atomic_output_persistent_initial_fstat_failure_is_bounded(
@@ -1090,13 +1185,13 @@ class DependencySnapshotTests(unittest.TestCase):
                     recording_open_new,
                 ),
                 mock.patch.object(
-                    snapshotter.os,
+                    ANCHORED_OUTPUT.os,
                     "fstat",
                     side_effect=fail_created_descriptor,
                 ),
                 self.assertRaisesRegex(OSError, "persistent post-open fstat failure") as raised,
             ):
-                snapshotter.atomic_write_new_json(output, {"version": 0})
+                _publish_new_json(output, {"version": 0})
 
             self.assertFalse(output.exists())
             temporary_files = list(root.glob(".snapshot.json.*.tmp"))
@@ -1110,7 +1205,7 @@ class DependencySnapshotTests(unittest.TestCase):
                 real_fstat(created_descriptor)
 
     @unittest.skipUnless(
-        snapshotter.descriptor_relative_output_supported(),
+        ANCHORED_OUTPUT.descriptor_relative_output_supported(),
         "Descriptor-relative output binding is unavailable on this platform.",
     )
     def test_atomic_output_propagates_directory_sync_failure_and_cleans_up(
@@ -1129,13 +1224,13 @@ class DependencySnapshotTests(unittest.TestCase):
             with (
                 _working_directory(root),
                 mock.patch.object(
-                    snapshotter.os,
+                    ANCHORED_OUTPUT.os,
                     "fsync",
                     side_effect=reject_directory_sync,
                 ),
                 self.assertRaises(OSError) as raised,
             ):
-                snapshotter.atomic_write_new_json(output, {"version": 0})
+                _publish_new_json(output, {"version": 0})
 
             self.assertEqual(raised.exception.errno, errno.EIO)
             self.assertFalse(output.exists())
@@ -1156,7 +1251,7 @@ class DependencySnapshotTests(unittest.TestCase):
             strategy="posix-dir-fd",
             descriptors=(1, 2, 3),
         )
-        with mock.patch.object(snapshotter.os, "close", side_effect=close_descriptor):
+        with mock.patch.object(ANCHORED_OUTPUT.os, "close", side_effect=close_descriptor):
             posix_failures = posix_binding.close()
         self.assertEqual(closed_descriptors, [3, 2, 1])
         self.assertEqual(len(posix_failures), 2)
@@ -1186,6 +1281,58 @@ class DependencySnapshotTests(unittest.TestCase):
         self.assertEqual(windows_api.closed, [30, 20, 10])
         self.assertEqual(len(windows_failures), 2)
 
+    def test_output_binding_close_collects_control_flow_and_keeps_closing(self) -> None:
+        for strategy in ("posix-dir-fd", "windows-handle"):
+            for failure_type in (KeyboardInterrupt, SystemExit):
+                with self.subTest(strategy=strategy, failure=failure_type.__name__):
+                    failure = failure_type("injected close control flow")
+                    attempted: list[int] = []
+                    if strategy == "posix-dir-fd":
+                        binding = OUTPUT_PARENT_BINDING_TYPE(
+                            checkout=Path("checkout"),
+                            parent=Path("parent"),
+                            leaf="snapshot.json",
+                            strategy=strategy,
+                            descriptors=(1, 2),
+                        )
+
+                        def close_descriptor(descriptor: int) -> None:
+                            attempted.append(descriptor)
+                            if descriptor == 2:
+                                raise failure
+
+                        context = mock.patch.object(
+                            ANCHORED_OUTPUT.os,
+                            "close",
+                            side_effect=close_descriptor,
+                        )
+                    else:
+                        class FakeWindowsApi:
+                            def CloseHandle(self, handle: int) -> int:
+                                attempted.append(handle)
+                                if handle == 2:
+                                    raise failure
+                                return 1
+
+                        binding = OUTPUT_PARENT_BINDING_TYPE(
+                            checkout=Path("checkout"),
+                            parent=Path("parent"),
+                            leaf="snapshot.json",
+                            strategy=strategy,
+                            windows_api=FakeWindowsApi(),
+                            windows_entries=(
+                                (Path("one"), (1, 1), 1),
+                                (Path("two"), (2, 2), 2),
+                            ),
+                        )
+                        context = nullcontext()
+
+                    with context:
+                        failures = binding.close()
+
+                    self.assertEqual(attempted, [2, 1])
+                    self.assertEqual(failures, (failure,))
+
     def test_anchor_close_failure_preserves_primary_or_reports_published_output(
         self,
     ) -> None:
@@ -1193,7 +1340,7 @@ class DependencySnapshotTests(unittest.TestCase):
 
         def close_then_report_failure(
             binding: Any,
-        ) -> tuple[Exception, ...]:
+        ) -> tuple[BaseException, ...]:
             self.assertEqual(real_close(binding), ())
             return (OSError("injected anchor close failure"),)
 
@@ -1208,9 +1355,9 @@ class DependencySnapshotTests(unittest.TestCase):
                     "close",
                     close_then_report_failure,
                 ),
-                self.assertRaises(snapshotter.SnapshotError) as raised,
+                self.assertRaises(ANCHORED_OUTPUT_ERROR) as raised,
             ):
-                snapshotter.atomic_write_new_json(output, {"version": 0})
+                _publish_new_json(output, {"version": 0})
             self.assertEqual(raised.exception.code, "output-exists")
             self.assertIn(
                 "injected anchor close failure",
@@ -1227,14 +1374,95 @@ class DependencySnapshotTests(unittest.TestCase):
                     "close",
                     close_then_report_failure,
                 ),
-                self.assertRaises(snapshotter.SnapshotError) as raised,
+                self.assertRaises(ANCHORED_OUTPUT_ERROR) as raised,
             ):
-                snapshotter.atomic_write_new_json(output, {"version": 0})
+                _publish_new_json(output, {"version": 0})
             self.assertEqual(raised.exception.code, "output-anchor-close-failed")
             self.assertEqual(json.loads(output.read_bytes()), {"version": 0})
 
+    def test_anchor_close_control_flow_respects_active_primary_cross_product(
+        self,
+    ) -> None:
+        real_close = OUTPUT_PARENT_BINDING_TYPE.close
+        primary_types = (OSError, KeyboardInterrupt, SystemExit)
+        cleanup_types = (OSError, KeyboardInterrupt, SystemExit)
+
+        for primary_type in primary_types:
+            for cleanup_type in cleanup_types:
+                with (
+                    self.subTest(
+                        primary=primary_type.__name__,
+                        cleanup=cleanup_type.__name__,
+                    ),
+                    tempfile.TemporaryDirectory() as raw_directory,
+                ):
+                    root = Path(raw_directory)
+                    output = root / "snapshot.json"
+                    primary = primary_type("injected primary")
+                    cleanup = cleanup_type("injected cleanup")
+
+                    def close_then_report_failure(
+                        binding: Any,
+                    ) -> tuple[BaseException, ...]:
+                        self.assertEqual(real_close(binding), ())
+                        return (cleanup,)
+
+                    with (
+                        _working_directory(root),
+                        mock.patch.object(
+                            OUTPUT_PARENT_BINDING_TYPE,
+                            "open_new",
+                            side_effect=primary,
+                        ),
+                        mock.patch.object(
+                            OUTPUT_PARENT_BINDING_TYPE,
+                            "close",
+                            close_then_report_failure,
+                        ),
+                        self.assertRaises(primary_type) as raised,
+                    ):
+                        ANCHORED_OUTPUT.publish_new_bytes(output, b"payload\n")
+
+                    self.assertIs(raised.exception, primary)
+                    self.assertIn(
+                        "injected cleanup",
+                        "\n".join(getattr(raised.exception, "__notes__", ())),
+                    )
+                    self.assertFalse(output.exists())
+
+    def test_anchor_close_control_flow_without_primary_is_propagated(self) -> None:
+        real_close = OUTPUT_PARENT_BINDING_TYPE.close
+        for cleanup_type in (KeyboardInterrupt, SystemExit):
+            with (
+                self.subTest(cleanup=cleanup_type.__name__),
+                tempfile.TemporaryDirectory() as raw_directory,
+            ):
+                root = Path(raw_directory)
+                output = root / "snapshot.json"
+                cleanup = cleanup_type("injected cleanup")
+
+                def close_then_report_failure(
+                    binding: Any,
+                ) -> tuple[BaseException, ...]:
+                    self.assertEqual(real_close(binding), ())
+                    return (cleanup,)
+
+                with (
+                    _working_directory(root),
+                    mock.patch.object(
+                        OUTPUT_PARENT_BINDING_TYPE,
+                        "close",
+                        close_then_report_failure,
+                    ),
+                    self.assertRaises(cleanup_type) as raised,
+                ):
+                    ANCHORED_OUTPUT.publish_new_bytes(output, b"payload\n")
+
+                self.assertIs(raised.exception, cleanup)
+                self.assertEqual(output.read_bytes(), b"payload\n")
+
     @unittest.skipUnless(
-        snapshotter.descriptor_relative_output_supported(),
+        ANCHORED_OUTPUT.descriptor_relative_output_supported(),
         "Descriptor-relative output binding is unavailable on this platform.",
     )
     def test_cli_rejects_output_ancestor_replaced_during_snapshot_build(self) -> None:
@@ -1272,8 +1500,8 @@ class DependencySnapshotTests(unittest.TestCase):
                     return_value=fixture.inspect_value,
                 ),
                 mock.patch.object(
-                    snapshotter,
-                    "_open_output_parent",
+                    ANCHORED_OUTPUT,
+                    "open_output_parent",
                     side_effect=bind_then_replace_output_ancestor,
                 ),
                 redirect_stderr(stderr),
@@ -1339,12 +1567,12 @@ class DependencySnapshotTests(unittest.TestCase):
             )
             with (
                 mock.patch.object(
-                    snapshotter,
+                    ANCHORED_OUTPUT,
                     "_windows_directory_attributes",
                     return_value=WINDOWS_FILE_ATTRIBUTE_DIRECTORY,
                 ),
                 mock.patch.object(
-                    snapshotter,
+                    ANCHORED_OUTPUT,
                     "_windows_handle_identity",
                     return_value=identity,
                 ),
@@ -1353,7 +1581,7 @@ class DependencySnapshotTests(unittest.TestCase):
                 parent.rename(original_parent)
                 parent.mkdir()
                 with self.assertRaisesRegex(
-                    snapshotter.SnapshotError,
+                    ANCHORED_OUTPUT_ERROR,
                     "ancestor changed",
                 ):
                     binding.verify()
@@ -1389,12 +1617,12 @@ class DependencySnapshotTests(unittest.TestCase):
                     windows_api = FakeWindowsApi(close_failure)
                     with (
                         mock.patch.object(
-                            snapshotter,
+                            ANCHORED_OUTPUT,
                             "_windows_directory_attributes",
                             return_value=0,
                         ),
                         mock.patch.object(
-                            snapshotter,
+                            ANCHORED_OUTPUT,
                             "_windows_handle_identity",
                             return_value=identity,
                         ),
@@ -1416,7 +1644,7 @@ class DependencySnapshotTests(unittest.TestCase):
                         self.assertIn("injected CloseHandle failure", notes)
 
     @unittest.skipUnless(
-        snapshotter.descriptor_relative_output_supported(),
+        ANCHORED_OUTPUT.descriptor_relative_output_supported(),
         "Descriptor-relative output binding is unavailable on this platform.",
     )
     def test_output_parent_binding_preserves_control_flow_exceptions(self) -> None:
@@ -1433,7 +1661,7 @@ class DependencySnapshotTests(unittest.TestCase):
                 with (
                     _working_directory(root),
                     mock.patch.object(
-                        snapshotter.os,
+                        ANCHORED_OUTPUT.os,
                         "close",
                         side_effect=recording_close,
                     ),

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_66(self) -> None:
-        self.assertEqual(get_version(), "0.7.66")
+    def test_release_version_is_0_7_67(self) -> None:
+        self.assertEqual(get_version(), "0.7.67")
 
     def test_release_surfaces_match_source_version(self) -> None:
         version_source = (PROJECT_ROOT / "src" / "version.py").read_text(


### PR DESCRIPTION
Extracts dependency snapshot output publication into one private, stdlib-only sibling module loaded by exact path. Snapshot JSON bytes, containment checks, no-overwrite behavior, stable errors, cleanup semantics, and POSIX/modeled-Windows anchoring remain intact, with focused direct and isolated-loader coverage.

Bumps the source version to 0.7.67. GameMaker LTS 2026 conversion behavior and exact Godot 4.7.1 output are unchanged.

Validated with Ruff, Pyright with zero diagnostics, 71 focused tests, and the full 2,596-test suite under Godot 4.7.1 (78 expected skips).

Fixes #858.