### PR TITLE
Publish dependency receipts with identical-only anchored semantics

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.67, GameMaker LTS 2026, Godot 4.7.1, Windows"
+      placeholder: "GM2Godot 0.7.68, GameMaker LTS 2026, Godot 4.7.1, Windows"
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.68 - 2026-09-03
+
+- Bound dependency-receipt publication to the physical filesystem root and every output ancestor, creating missing parents only through retained descriptors or handles.
+- Added identical-only publication with private staging, no-replace installation, exact byte/mode/link/identity verification, and fail-closed cleanup across POSIX, macOS ACLs, and modeled Windows mutation boundaries.
+- Preserved receipt schemas, dependency resolution, GameMaker LTS 2026 conversion behavior, and generated Godot output; native Windows proof remains isolated in its dedicated follow-up gate.
+
 ## 0.7.67 - 2026-09-03
 
 - Extracted dependency snapshot publication into one private, stdlib-only anchored byte publisher loaded directly from its sibling path in isolated mode.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Version 0.7.66 enables Ruff's complete Pyflakes rule family while retaining the 
 
 Version 0.7.67 extracts dependency snapshot publication into one private, stdlib-only anchored byte publisher loaded directly from its sibling path in isolated mode. Snapshot JSON bytes, containment rules, no-overwrite behavior, stable error codes, and POSIX and Windows anchoring remain unchanged, with direct and isolated-loader coverage guarding the shared primitive. GameMaker LTS 2026 conversion behavior and exact Godot 4.7.1 output remain unchanged.
 
+Version 0.7.68 binds dependency-receipt publication to the physical filesystem root and every output ancestor for the whole operation. Missing parents are created only through retained descriptors or handles; existing identical receipts preserve their bytes and inode, while different, redirected, multiply linked, non-regular, wrong-mode, or non-canonical targets fail untouched. Private staging, no-replace publication, exact post-publication verification, and reverse-order cleanup remain bounded across POSIX, macOS ACL, and modeled Windows mutation boundaries. Receipt schemas, dependency resolution, GameMaker LTS 2026 conversion behavior, and generated Godot output are unchanged; native Windows proof remains isolated in its dedicated follow-up gate.
+
 ## What GM2Godot Is and Isn't
 
 **GM2Godot is:**
@@ -112,7 +114,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.67`.
+Current source version: `0.7.68`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.67 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.68 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.67 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.68 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.67 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.68 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.67 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.68 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.67 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.68 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.67;
+- GM2Godot 0.7.68;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.1 output and validation, pinned in CI as `4.7.1.stable.official.a13da4feb`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.67 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.68 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 
@@ -46,7 +46,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.67`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.68`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
 
 ## Run from source
 
@@ -148,6 +148,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.67`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.68`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.67 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.68 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.67 · GameMaker LTS 2026 · Godot 4.7.1
+> **Applies to:** GM2Godot 0.7.68 · GameMaker LTS 2026 · Godot 4.7.1
 >
 > **Last reviewed:** 2026-09-03
 

--- a/scripts/_anchored_output.py
+++ b/scripts/_anchored_output.py
@@ -8,12 +8,16 @@ into their own CLI error taxonomy.
 from __future__ import annotations
 
 import ctypes
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+import errno
+import functools
 import os
 from pathlib import Path
 import secrets
 import stat
-from typing import Any, Callable, Literal, cast
+import sys
+from typing import Any, Callable, Literal, Protocol, cast
+import weakref
 
 
 class AnchoredOutputError(ValueError):
@@ -22,6 +26,33 @@ class AnchoredOutputError(ValueError):
     def __init__(self, code: str, message: str) -> None:
         super().__init__(message)
         self.code = code
+
+
+def _translated_anchored_output_error(
+    error: BaseException,
+    code: str,
+    message: str,
+) -> AnchoredOutputError:
+    """Translate a contract-boundary failure without losing cleanup notes."""
+
+    translated = AnchoredOutputError(code, message)
+    for note in getattr(error, "__notes__", ()):
+        translated.add_note(note)
+    return translated
+
+
+class _PublicationResourceLease(Protocol):
+    @property
+    def is_closed(self) -> bool: ...
+
+    def close(self) -> tuple[BaseException, ...]: ...
+
+
+class _LeaseFinalizer(Protocol):
+    @property
+    def alive(self) -> bool: ...
+
+    def detach(self) -> object | None: ...
 
 
 _WINDOWS_FILE_READ_ATTRIBUTES = 0x00000080
@@ -36,6 +67,513 @@ _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
 _WINDOWS_FILE_TYPE_DISK = 1
 _WINDOWS_FILE_BASIC_INFO_CLASS = 0
 _WINDOWS_FILE_ID_INFO_CLASS = 18
+
+_POSIX_NATIVE_RESULT_PENDING = object()
+_POSIX_RECEIPT_NAMESPACE_CHANGED_ERRNOS = frozenset({errno.ENOENT, errno.ELOOP})
+_DARWIN_ACL_TYPE_EXTENDED = 0x00000100
+_DARWIN_ACL_EXTENDED_ALLOW = 1
+_DARWIN_ACL_EXTENDED_DENY = 2
+_DARWIN_ACL_FIRST_ENTRY = 0
+_DARWIN_ACL_NEXT_ENTRY = -1
+_DARWIN_ACL_MAX_ENTRIES = 128
+_DARWIN_ACL_UNAVAILABLE_ERRNOS = frozenset(
+    {
+        errno.ENOSYS,
+        getattr(errno, "ENOTSUP", errno.ENOSYS),
+        getattr(errno, "EOPNOTSUPP", errno.ENOSYS),
+    }
+)
+_posix_libc_cache: Any | None = None
+
+
+def _posix_libc() -> Any:
+    global _posix_libc_cache
+    if _posix_libc_cache is None:
+        _posix_libc_cache = ctypes.CDLL(None, use_errno=True)
+    return _posix_libc_cache
+
+
+def _native_int_result(value: object) -> int:
+    raw = getattr(value, "value", value)
+    if not isinstance(raw, int):
+        raise OSError("Native descriptor operation returned a non-integer result.")
+    return raw
+
+
+@dataclass(slots=True)
+class _DarwinAclQueryState:
+    """Record ACL ownership independently of the frame performing the query."""
+
+    free_acl: Any
+    acl_result: object = _POSIX_NATIVE_RESULT_PENDING
+    acl_errno: int = 0
+    free_result: object = _POSIX_NATIVE_RESULT_PENDING
+    free_errno: int = 0
+
+    @property
+    def pointer(self) -> int | None:
+        if self.acl_result is _POSIX_NATIVE_RESULT_PENDING:
+            return None
+        value = getattr(self.acl_result, "value", self.acl_result)
+        if value is None:
+            return None
+        if not isinstance(value, int):
+            raise OSError("Native ACL query returned a non-pointer result.")
+        return value
+
+
+def _close_darwin_acl_query_state(
+    state: _DarwinAclQueryState,
+) -> BaseException | None:
+    """Release one ACL allocation without replaying a recorded native free."""
+
+    pointer = state.pointer
+    if pointer is None:
+        return None
+
+    free_call_failures: list[BaseException] = []
+    for _attempt in range(2):
+        if state.free_result is not _POSIX_NATIVE_RESULT_PENDING:
+            break
+        try:
+
+            class _AclFreeResult(ctypes.c_int):
+                pass
+
+            setattr(
+                _AclFreeResult,
+                "_check_retval_",
+                functools.partial(setattr, state, "free_result"),
+            )
+            free_acl = state.free_acl
+            free_acl.argtypes = (ctypes.c_void_p,)
+            free_acl.restype = _AclFreeResult
+            ctypes.set_errno(0)
+            free_acl(ctypes.c_void_p(pointer))
+            state.free_errno = ctypes.get_errno()
+        except BaseException as free_call_error:
+            free_call_failures.append(free_call_error)
+            continue
+
+    if state.free_result is _POSIX_NATIVE_RESULT_PENDING:
+        if free_call_failures:
+            free_error = free_call_failures[0]
+            for later_error in free_call_failures[1:]:
+                free_error.add_note(f"ACL release retry failure: {later_error}")
+            return free_error
+        return AnchoredOutputError(
+            "output-anchor-unavailable",
+            "Native macOS ACL release returned without recording its result.",
+        )
+
+    raw_free_result = state.free_result
+    free_errno = state.free_errno
+    # The native call has completed. Retire the pointer before interpreting or
+    # reporting the result so neither an explicit retry nor the finalizer can
+    # release the same allocation twice after a return-boundary interruption.
+    state.acl_result = _POSIX_NATIVE_RESULT_PENDING
+    state.free_result = _POSIX_NATIVE_RESULT_PENDING
+    free_status = _native_int_result(raw_free_result)
+    native_free_error: BaseException | None = None
+    if free_status != 0:
+        error_number = free_errno or errno.EIO
+        native_free_error = AnchoredOutputError(
+            "output-anchor-unavailable",
+            "The macOS descriptor ACL query could not be released safely.",
+        )
+        native_free_error.__cause__ = OSError(error_number, os.strerror(error_number))
+    if free_call_failures:
+        free_error = free_call_failures[0]
+        for later_error in free_call_failures[1:]:
+            free_error.add_note(f"ACL release retry failure: {later_error}")
+        if native_free_error is not None:
+            free_error.add_note(f"Native ACL release failure: {native_free_error}")
+        return free_error
+    return native_free_error
+
+
+def _finalize_darwin_acl_query(state: _DarwinAclQueryState) -> None:
+    """Best-effort fallback when ACL-query frame cleanup is interrupted."""
+
+    try:
+        _close_darwin_acl_query_state(state)
+    except BaseException:
+        # A finalizer cannot safely replace the exception that abandoned the
+        # owning query frame. The cleanup attempt itself remains bounded.
+        pass
+
+
+@dataclass(slots=True, weakref_slot=True, init=False)
+class _DarwinAclQueryLease:
+    """Weak-referenceable owner for separately retained ACL query state."""
+
+    _state: _DarwinAclQueryState
+    _finalizer: _LeaseFinalizer
+
+    def __init__(self, free_acl: Any) -> None:
+        state = _DarwinAclQueryState(free_acl=free_acl)
+        self._state = state
+        # The callback retains only the separate state, never this owner.
+        self._finalizer = cast(
+            _LeaseFinalizer,
+            weakref.finalize(self, _finalize_darwin_acl_query, state),
+        )
+
+    @property
+    def state(self) -> _DarwinAclQueryState:
+        return self._state
+
+    def close(self) -> BaseException | None:
+        free_error = _close_darwin_acl_query_state(self._state)
+        if self._state.pointer is None:
+            self._finalizer.detach()
+        return free_error
+
+
+def _darwin_descriptor_has_extended_acl(
+    descriptor: int,
+    *,
+    error_code: str = "output-anchor-unavailable",
+    context: str = "retained macOS descriptor",
+    allow_deny_only: bool = False,
+) -> bool:
+    """Return whether a Darwin descriptor has a disallowed extended ACL."""
+
+    if sys.platform != "darwin":
+        return False
+    libc = _posix_libc()
+    try:
+        get_acl: Any = libc["acl_get_fd_np"]
+        free_acl: Any = libc["acl_free"]
+        valid_acl: Any | None = libc["acl_valid_fd_np"] if allow_deny_only else None
+        get_entry: Any | None = libc["acl_get_entry"] if allow_deny_only else None
+        get_tag_type: Any | None = libc["acl_get_tag_type"] if allow_deny_only else None
+    except (AttributeError, KeyError) as error:
+        raise AnchoredOutputError(
+            "output-anchor-unavailable",
+            "macOS descriptor ACL inspection is unavailable.",
+        ) from error
+
+    lease = _DarwinAclQueryLease(free_acl)
+    state = lease.state
+
+    class _AclResult(ctypes.c_void_p):
+        pass
+
+    setattr(
+        _AclResult,
+        "_check_retval_",
+        functools.partial(setattr, state, "acl_result"),
+    )
+    get_acl.argtypes = (ctypes.c_int, ctypes.c_int)
+    get_acl.restype = _AclResult
+    ctypes.set_errno(0)
+    primary_error: BaseException | None = None
+    try:
+        get_acl(descriptor, _DARWIN_ACL_TYPE_EXTENDED)
+        state.acl_errno = ctypes.get_errno()
+        pointer = state.pointer
+        if pointer is None:
+            if state.acl_result is _POSIX_NATIVE_RESULT_PENDING:
+                raise OSError("Native ACL query returned without recording its result.")
+            if state.acl_errno == errno.ENOENT:
+                return False
+            error_number = state.acl_errno or errno.EIO
+            if error_number in _DARWIN_ACL_UNAVAILABLE_ERRNOS:
+                raise AnchoredOutputError(
+                    "output-anchor-unavailable",
+                    f"The filesystem does not support extended-ACL inspection for the {context}.",
+                ) from OSError(error_number, os.strerror(error_number))
+            raise AnchoredOutputError(
+                error_code,
+                f"Could not inspect the {context} for extended ACLs: "
+                f"[Errno {error_number}] {os.strerror(error_number)}.",
+            ) from OSError(error_number, os.strerror(error_number))
+        if not allow_deny_only:
+            return True
+
+        assert valid_acl is not None
+        assert get_entry is not None
+        assert get_tag_type is not None
+        acl_pointer = ctypes.c_void_p(pointer)
+        valid_acl.argtypes = (ctypes.c_int, ctypes.c_int, ctypes.c_void_p)
+        valid_acl.restype = ctypes.c_int
+        ctypes.set_errno(0)
+        validity_status = _native_int_result(
+            valid_acl(descriptor, _DARWIN_ACL_TYPE_EXTENDED, acl_pointer)
+        )
+        validity_errno = ctypes.get_errno()
+        if validity_status != 0:
+            error_number = validity_errno or errno.EINVAL
+            if error_number not in _DARWIN_ACL_UNAVAILABLE_ERRNOS:
+                raise AnchoredOutputError(
+                    error_code,
+                    f"Could not validate the extended ACL for the {context}: "
+                    f"[Errno {error_number}] {os.strerror(error_number)}.",
+                ) from OSError(error_number, os.strerror(error_number))
+            try:
+                structurally_valid_acl: Any = libc["acl_valid"]
+            except (AttributeError, KeyError) as error:
+                raise AnchoredOutputError(
+                    "output-anchor-unavailable",
+                    "macOS structural ACL validation is unavailable.",
+                ) from error
+            structurally_valid_acl.argtypes = (ctypes.c_void_p,)
+            structurally_valid_acl.restype = ctypes.c_int
+            ctypes.set_errno(0)
+            structural_status = _native_int_result(
+                structurally_valid_acl(acl_pointer)
+            )
+            structural_errno = ctypes.get_errno()
+            if structural_status != 0:
+                structural_error_number = structural_errno or errno.EINVAL
+                raise AnchoredOutputError(
+                    error_code,
+                    f"Could not structurally validate the extended ACL for the {context}: "
+                    f"[Errno {structural_error_number}] "
+                    f"{os.strerror(structural_error_number)}.",
+                ) from OSError(
+                    structural_error_number,
+                    os.strerror(structural_error_number),
+                )
+
+        get_entry.argtypes = (
+            ctypes.c_void_p,
+            ctypes.c_int,
+            ctypes.POINTER(ctypes.c_void_p),
+        )
+        get_entry.restype = ctypes.c_int
+        get_tag_type.argtypes = (
+            ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_int),
+        )
+        get_tag_type.restype = ctypes.c_int
+        selector = _DARWIN_ACL_FIRST_ENTRY
+        entries_seen = 0
+        while True:
+            entry = ctypes.c_void_p()
+            ctypes.set_errno(0)
+            entry_status = _native_int_result(
+                get_entry(
+                    acl_pointer,
+                    selector,
+                    ctypes.byref(entry),
+                )
+            )
+            entry_errno = ctypes.get_errno()
+            if entry_status == -1 and entry_errno == errno.EINVAL:
+                # acl_get_entry(3) reports end-of-list as -1/EINVAL. A
+                # non-null extended ACL that cannot produce even one entry is
+                # malformed for this allow-deny classification and is unsafe.
+                return entries_seen == 0
+            if entry_status != 0 or entry.value is None:
+                error_number = entry_errno or errno.EIO
+                raise AnchoredOutputError(
+                    error_code,
+                    f"Could not enumerate the extended ACL for the {context}: "
+                    f"[Errno {error_number}] {os.strerror(error_number)}.",
+                ) from OSError(error_number, os.strerror(error_number))
+            if entries_seen >= _DARWIN_ACL_MAX_ENTRIES:
+                raise AnchoredOutputError(
+                    error_code,
+                    f"The extended ACL for the {context} exceeds the supported entry limit.",
+                )
+            entries_seen += 1
+
+            tag_type = ctypes.c_int()
+            ctypes.set_errno(0)
+            tag_status = _native_int_result(
+                get_tag_type(entry, ctypes.byref(tag_type))
+            )
+            tag_errno = ctypes.get_errno()
+            if tag_status != 0:
+                error_number = tag_errno or errno.EIO
+                raise AnchoredOutputError(
+                    error_code,
+                    f"Could not inspect an extended ACL entry for the {context}: "
+                    f"[Errno {error_number}] {os.strerror(error_number)}.",
+                ) from OSError(error_number, os.strerror(error_number))
+            if tag_type.value == _DARWIN_ACL_EXTENDED_ALLOW:
+                return True
+            if tag_type.value != _DARWIN_ACL_EXTENDED_DENY:
+                return True
+            selector = _DARWIN_ACL_NEXT_ENTRY
+    except BaseException as error:
+        primary_error = error
+        raise
+    finally:
+        try:
+            free_error = lease.close()
+        except BaseException as close_error:
+            free_error = close_error
+        if free_error is not None:
+            if primary_error is not None:
+                primary_error.add_note(f"Could not release a macOS descriptor ACL query: {free_error}")
+            else:
+                raise free_error
+
+
+def _validate_safe_posix_directory_descriptor(
+    descriptor: int,
+    *,
+    code: str,
+    context: str,
+    require_private: bool = False,
+    allow_darwin_deny_only_acl: bool = False,
+) -> os.stat_result:
+    """Validate a retained directory before using its mutable namespace.
+
+    Same-UID processes and root remain outside the enforceable threat model.
+    """
+
+    value = os.fstat(descriptor)
+    mode = stat.S_IMODE(value.st_mode)
+    owner_is_trusted = value.st_uid in {0, os.geteuid()}
+    safe_permissions = not bool(mode & 0o022) or (
+        bool(mode & stat.S_ISVTX) and owner_is_trusted
+    )
+    if require_private:
+        owner_is_trusted = value.st_uid == os.geteuid()
+        safe_permissions = mode == 0o700
+    if (
+        not stat.S_ISDIR(value.st_mode)
+        or not owner_is_trusted
+        or not safe_permissions
+        or _darwin_descriptor_has_extended_acl(
+            descriptor,
+            error_code=code,
+            context=context,
+            allow_deny_only=allow_darwin_deny_only_acl,
+        )
+    ):
+        raise AnchoredOutputError(
+            code,
+            f"The {context} is not a safely owned directory without unsafe permissions or extended ACLs.",
+        )
+    return value
+
+
+@dataclass(slots=True)
+class _PosixDescriptorLease:
+    """Preallocated ownership slot populated before a native call returns."""
+
+    descriptor_result: object | None = None
+    close_result: object = _POSIX_NATIVE_RESULT_PENDING
+
+    @property
+    def descriptor(self) -> int | None:
+        if self.descriptor_result is None:
+            return None
+        value = _native_int_result(self.descriptor_result)
+        return value if value >= 0 else None
+
+    def close(self) -> None:
+        raw_descriptor = self.descriptor_result
+        if raw_descriptor is None:
+            return
+        descriptor = _native_int_result(raw_descriptor)
+        if descriptor < 0:
+            self.descriptor_result = None
+            self.close_result = _POSIX_NATIVE_RESULT_PENDING
+            return
+
+        if self.close_result is _POSIX_NATIVE_RESULT_PENDING:
+
+            class _CloseResult(ctypes.c_int):
+                pass
+
+            setattr(
+                _CloseResult,
+                "_check_retval_",
+                functools.partial(setattr, self, "close_result"),
+            )
+            operation: Any = _posix_libc()["close"]
+            operation.argtypes = (ctypes.c_int,)
+            operation.restype = _CloseResult
+            operation(descriptor)
+
+        status = _native_int_result(self.close_result)
+        # The native call has completed. Retire the descriptor number before
+        # reporting its result so an interrupted caller can never close a
+        # subsequently reused descriptor on retry.
+        self.descriptor_result = None
+        self.close_result = _POSIX_NATIVE_RESULT_PENDING
+        if status != 0:
+            error_number = ctypes.get_errno() or errno.EIO
+            raise OSError(error_number, os.strerror(error_number))
+
+
+def _open_posix_descriptor(
+    lease: _PosixDescriptorLease,
+    path: os.PathLike[str] | str,
+    flags: int,
+    mode: int = 0o777,
+    *,
+    dir_fd: int | None = None,
+) -> int:
+    """Open through ``openat`` while transferring the result into ``lease``."""
+
+    if lease.descriptor_result is not None:
+        raise ValueError("POSIX descriptor lease is already occupied.")
+    # A completed close retires the descriptor before clearing its native
+    # result marker. If control flow interrupted between those two stores, the
+    # marker is stale but there is no live resource. Normalize it before this
+    # lease is reused so the next close cannot mistake the old result for the
+    # new descriptor's close result.
+    if lease.close_result is not _POSIX_NATIVE_RESULT_PENDING:
+        lease.close_result = _POSIX_NATIVE_RESULT_PENDING
+    encoded = os.fsencode(path)
+    if b"\x00" in encoded:
+        raise ValueError("POSIX descriptor path must not contain NUL.")
+    directory_descriptor = (-2 if sys.platform == "darwin" else -100) if dir_fd is None else dir_fd
+    while True:
+
+        class _OpenResult(ctypes.c_int):
+            pass
+
+        setattr(
+            _OpenResult,
+            "_check_retval_",
+            functools.partial(setattr, lease, "descriptor_result"),
+        )
+        operation: Any = _posix_libc()["openat"]
+        # ``mode`` is variadic. Declaring only the three fixed arguments is
+        # required by ctypes on Apple arm64; Linux expects an unsigned mode.
+        operation.argtypes = (ctypes.c_int, ctypes.c_char_p, ctypes.c_int)
+        operation.restype = _OpenResult
+        mode_argument = ctypes.c_uint(mode) if sys.platform.startswith("linux") else ctypes.c_int(mode)
+        operation(directory_descriptor, encoded, flags, mode_argument)
+        raw_result = lease.descriptor_result
+        if raw_result is None:
+            raise OSError("Native openat returned without recording descriptor ownership.")
+        descriptor = _native_int_result(raw_result)
+        if descriptor >= 0:
+            return descriptor
+        error_number = ctypes.get_errno() or errno.EIO
+        lease.descriptor_result = None
+        if error_number == errno.EINTR:
+            continue
+        raise OSError(error_number, os.strerror(error_number), os.fsdecode(encoded))
+
+
+def _close_posix_descriptor_lease(
+    lease: _PosixDescriptorLease,
+    primary: BaseException | None,
+    context: str,
+) -> BaseException | None:
+    """Close once, retrying only a pre-call control-flow interruption."""
+
+    for _attempt in range(2):
+        try:
+            if lease.descriptor is None:
+                break
+            lease.close()
+        except BaseException as close_error:
+            if primary is None:
+                primary = close_error
+            else:
+                primary.add_note(f"Could not close {context}: {close_error}")
+    return primary
 
 
 class _WindowsFileId128(ctypes.Structure):
@@ -65,10 +603,7 @@ def descriptor_relative_output_supported() -> bool:
         and bool(getattr(os, "O_DIRECTORY", 0))
         and bool(getattr(os, "O_NOFOLLOW", 0))
         and os.stat in os.supports_follow_symlinks
-        and all(
-            operation in os.supports_dir_fd
-            for operation in (os.open, os.stat, os.link, os.unlink)
-        )
+        and all(operation in os.supports_dir_fd for operation in (os.open, os.stat, os.link, os.unlink))
     )
 
 
@@ -184,14 +719,9 @@ def _open_windows_directory_handle(
     except BaseException as error:
         try:
             if not kernel32.CloseHandle(handle_value):
-                error.add_note(
-                    "Could not close the rejected snapshot output directory handle."
-                )
+                error.add_note("Could not close the rejected snapshot output directory handle.")
         except BaseException as cleanup_error:
-            error.add_note(
-                "Could not close the rejected snapshot output directory handle: "
-                f"{cleanup_error}"
-            )
+            error.add_note(f"Could not close the rejected snapshot output directory handle: {cleanup_error}")
         raise
     return handle_value
 
@@ -202,79 +732,254 @@ class OutputParentBinding:
     parent: Path
     leaf: str
     strategy: Literal["posix-dir-fd", "windows-handle"]
-    descriptors: tuple[int, ...] = ()
-    links: tuple[tuple[int, str, int], ...] = ()
+    descriptors: list[int] | tuple[int, ...] = ()
+    links: list[tuple[int, str, int]] | tuple[tuple[int, str, int], ...] = ()
     windows_api: Any | None = None
-    windows_entries: tuple[tuple[Path, tuple[int, int], int], ...] = ()
+    windows_entries: list[tuple[Path, tuple[int, int], int]] | tuple[tuple[Path, tuple[int, int], int], ...] = ()
+    descriptor_leases: list[_PosixDescriptorLease] | tuple[_PosixDescriptorLease, ...] = field(
+        default=(),
+        kw_only=True,
+    )
+    windows_handle_leases: list[Any] | tuple[Any, ...] = field(
+        default=(),
+        kw_only=True,
+    )
+    receipt_parent_policy: bool = field(default=False, kw_only=True)
+    private_posix_descriptor_indexes: list[int] | tuple[int, ...] = field(
+        default=(),
+        kw_only=True,
+    )
+    _closed: bool = field(default=False, init=False)
+
+    @property
+    def is_closed(self) -> bool:
+        """Return whether every retained descriptor or handle is retired."""
+
+        return self._closed
 
     def close(self) -> tuple[BaseException, ...]:
+        if self._closed:
+            return ()
         failures: list[BaseException] = []
-        for descriptor in reversed(self.descriptors):
+        if self.descriptor_leases:
+            for descriptor_lease in reversed(self.descriptor_leases):
+                close_call_failures: list[BaseException] = []
+                close_error: BaseException | None = None
+                for _attempt in range(2):
+                    try:
+                        close_error = _close_posix_descriptor_lease(
+                            descriptor_lease,
+                            None,
+                            "receipt output directory descriptor",
+                        )
+                    except BaseException as error:
+                        close_call_failures.append(error)
+                        if descriptor_lease.descriptor is not None:
+                            continue
+                    break
+                failures.extend(close_call_failures)
+                if close_error is not None:
+                    failures.append(close_error)
+                try:
+                    descriptor_closed = descriptor_lease.descriptor is None
+                except BaseException as status_error:
+                    failures.append(status_error)
+                    descriptor_closed = False
+                if not descriptor_closed:
+                    if not close_call_failures and close_error is None:
+                        failures.append(
+                            AnchoredOutputError(
+                                "output-cleanup-retained",
+                                "A receipt output directory descriptor remained open after bounded cleanup attempts.",
+                            )
+                        )
+                    # Preserve strict lifetime order: an ancestor must remain
+                    # retained while its newer child descriptor is still live.
+                    return tuple(failures)
+        else:
+            for descriptor in reversed(self.descriptors):
+                try:
+                    os.close(descriptor)
+                except BaseException as error:
+                    failures.append(error)
+        if self.windows_api is not None and self.windows_handle_leases:
             try:
-                os.close(descriptor)
+                windows_receipt = _windows_receipt_module()
             except BaseException as error:
                 failures.append(error)
-        if self.windows_api is not None:
+            else:
+                for handle_lease in reversed(self.windows_handle_leases):
+                    close_call_failures: list[BaseException] = []
+                    close_error: BaseException | None = None
+                    for _attempt in range(2):
+                        try:
+                            close_error = windows_receipt.close_windows_handle_lease(
+                                self.windows_api,
+                                handle_lease,
+                                None,
+                                "receipt output directory handle",
+                            )
+                        except BaseException as error:
+                            close_call_failures.append(error)
+                            if handle_lease.handle is not None:
+                                continue
+                        break
+                    failures.extend(close_call_failures)
+                    if close_error is not None:
+                        failures.append(close_error)
+                    if handle_lease.handle is not None:
+                        if not close_call_failures and close_error is None:
+                            failures.append(
+                                AnchoredOutputError(
+                                    "output-cleanup-retained",
+                                    "A receipt output directory handle remained open after bounded cleanup attempts.",
+                                )
+                            )
+                        # Preserve strict lifetime order: an ancestor must remain
+                        # retained while its newer child handle is still live.
+                        return tuple(failures)
+        elif self.windows_api is not None:
             for _path, _identity, handle in reversed(self.windows_entries):
                 try:
                     if not self.windows_api.CloseHandle(handle):
-                        failures.append(
-                            OSError(
-                                "Could not close a snapshot output directory handle."
-                            )
-                        )
+                        failures.append(OSError("Could not close a snapshot output directory handle."))
                 except BaseException as error:
                     failures.append(error)
+        if self.receipt_parent_policy or self.descriptor_leases or self.windows_handle_leases:
+            self._closed = not any(
+                descriptor_lease.descriptor is not None for descriptor_lease in self.descriptor_leases
+            ) and not any(handle_lease.handle is not None for handle_lease in self.windows_handle_leases)
         return tuple(failures)
 
     def verify(self) -> None:
         if self.strategy == "posix-dir-fd":
-            root_stat = self.checkout.lstat()
-            opened_root = os.fstat(self.descriptors[0])
-            if (
-                _path_is_redirected(self.checkout, root_stat)
-                or not stat.S_ISDIR(root_stat.st_mode)
-                or (root_stat.st_dev, root_stat.st_ino)
-                != (opened_root.st_dev, opened_root.st_ino)
-            ):
-                raise AnchoredOutputError(
-                    "output-parent-changed",
-                    f"Snapshot output checkout changed while bound: {self.checkout}.",
-                )
-            for parent_descriptor, component, child_descriptor in self.links:
-                entry = os.stat(
-                    component,
-                    dir_fd=parent_descriptor,
-                    follow_symlinks=False,
-                )
-                opened = os.fstat(child_descriptor)
+            if not self.receipt_parent_policy:
+                root_stat = self.checkout.lstat()
+                opened_root = os.fstat(self.descriptors[0])
                 if (
-                    stat.S_ISLNK(entry.st_mode)
-                    or not stat.S_ISDIR(entry.st_mode)
-                    or (entry.st_dev, entry.st_ino) != (opened.st_dev, opened.st_ino)
+                    _path_is_redirected(self.checkout, root_stat)
+                    or not stat.S_ISDIR(root_stat.st_mode)
+                    or (root_stat.st_dev, root_stat.st_ino)
+                    != (opened_root.st_dev, opened_root.st_ino)
                 ):
                     raise AnchoredOutputError(
                         "output-parent-changed",
-                        f"Snapshot output ancestor changed while bound: {self.parent}.",
+                        f"Snapshot output checkout changed while bound: {self.checkout}.",
                     )
+                for parent_descriptor, component, child_descriptor in self.links:
+                    entry = os.stat(
+                        component,
+                        dir_fd=parent_descriptor,
+                        follow_symlinks=False,
+                    )
+                    opened = os.fstat(child_descriptor)
+                    if (
+                        stat.S_ISLNK(entry.st_mode)
+                        or not stat.S_ISDIR(entry.st_mode)
+                        or (entry.st_dev, entry.st_ino) != (opened.st_dev, opened.st_ino)
+                    ):
+                        raise AnchoredOutputError(
+                            "output-parent-changed",
+                            f"Snapshot output ancestor changed while bound: {self.parent}.",
+                        )
+                return
+            try:
+                root_stat = self.checkout.lstat()
+                opened_root = os.fstat(self.descriptors[0])
+                if (
+                    _path_is_redirected(self.checkout, root_stat)
+                    or not stat.S_ISDIR(root_stat.st_mode)
+                    or (root_stat.st_dev, root_stat.st_ino) != (opened_root.st_dev, opened_root.st_ino)
+                ):
+                    raise AnchoredOutputError(
+                        "output-parent-changed",
+                        f"Snapshot output checkout changed while bound: {self.checkout}.",
+                    )
+                private_indexes = frozenset(self.private_posix_descriptor_indexes)
+                for descriptor_index, (
+                    parent_descriptor,
+                    component,
+                    child_descriptor,
+                ) in enumerate(self.links):
+                    parent_is_private = descriptor_index in private_indexes
+                    _validate_safe_posix_directory_descriptor(
+                        parent_descriptor,
+                        code="output-parent-changed",
+                        context="bound receipt output intermediate ancestor",
+                        require_private=parent_is_private,
+                        allow_darwin_deny_only_acl=not parent_is_private,
+                    )
+                    entry = os.stat(
+                        component,
+                        dir_fd=parent_descriptor,
+                        follow_symlinks=False,
+                    )
+                    opened = os.fstat(child_descriptor)
+                    if (
+                        stat.S_ISLNK(entry.st_mode)
+                        or not stat.S_ISDIR(entry.st_mode)
+                        or (entry.st_dev, entry.st_ino) != (opened.st_dev, opened.st_ino)
+                    ):
+                        raise AnchoredOutputError(
+                            "output-parent-changed",
+                            f"Snapshot output ancestor changed while bound: {self.parent}.",
+                        )
+                _validate_safe_posix_directory_descriptor(
+                    self.descriptors[-1],
+                    code="output-parent-changed",
+                    context="bound final receipt output parent",
+                    require_private=len(self.descriptors) - 1 in private_indexes,
+                )
+            except OSError as error:
+                translated = _translated_anchored_output_error(
+                    error,
+                    "output-parent-changed",
+                    f"Snapshot output ancestor could not be verified while bound: {self.parent}.",
+                )
+                raise translated from error
             return
 
         assert self.windows_api is not None
-        for path, identity, handle in self.windows_entries:
-            path_stat = path.lstat()
-            attributes = _windows_directory_attributes(self.windows_api, handle)
-            if (
-                _path_is_redirected(path, path_stat)
-                or not stat.S_ISDIR(path_stat.st_mode)
-                or (path_stat.st_dev, path_stat.st_ino) != identity
-                or _windows_handle_identity(self.windows_api, handle) != identity
-                or not attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY
-                or attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT
-            ):
-                raise AnchoredOutputError(
-                    "output-parent-changed",
-                    f"Snapshot output ancestor changed while bound: {path}.",
-                )
+        if not self.receipt_parent_policy:
+            for path, identity, handle in self.windows_entries:
+                path_stat = path.lstat()
+                attributes = _windows_directory_attributes(self.windows_api, handle)
+                if (
+                    _path_is_redirected(path, path_stat)
+                    or not stat.S_ISDIR(path_stat.st_mode)
+                    or (path_stat.st_dev, path_stat.st_ino) != identity
+                    or _windows_handle_identity(self.windows_api, handle) != identity
+                    or not attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY
+                    or attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT
+                ):
+                    raise AnchoredOutputError(
+                        "output-parent-changed",
+                        f"Snapshot output ancestor changed while bound: {path}.",
+                    )
+            return
+        try:
+            for path, identity, handle in self.windows_entries:
+                path_stat = path.lstat()
+                attributes = _windows_directory_attributes(self.windows_api, handle)
+                if (
+                    _path_is_redirected(path, path_stat)
+                    or not stat.S_ISDIR(path_stat.st_mode)
+                    or (path_stat.st_dev, path_stat.st_ino) != identity
+                    or _windows_handle_identity(self.windows_api, handle) != identity
+                    or not attributes & _WINDOWS_FILE_ATTRIBUTE_DIRECTORY
+                    or attributes & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT
+                ):
+                    raise AnchoredOutputError(
+                        "output-parent-changed",
+                        f"Snapshot output ancestor changed while bound: {path}.",
+                    )
+        except OSError as error:
+            translated = _translated_anchored_output_error(
+                error,
+                "output-parent-changed",
+                f"Snapshot output ancestor could not be verified while bound: {self.parent}.",
+            )
+            raise translated from error
 
     def stat(self, name: str) -> os.stat_result:
         if self.strategy == "posix-dir-fd":
@@ -289,17 +994,31 @@ class OutputParentBinding:
         return result
 
     def open_new(self, name: str) -> int:
-        flags = (
-            os.O_WRONLY
-            | os.O_CREAT
-            | os.O_EXCL
-            | getattr(os, "O_BINARY", 0)
-            | getattr(os, "O_NOFOLLOW", 0)
-        )
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
         if self.strategy == "posix-dir-fd":
             return os.open(name, flags, 0o600, dir_fd=self.descriptors[-1])
         self.verify()
         return os.open(self.parent / name, flags, 0o600)
+
+    def open_read(self, name: str, lease: _PosixDescriptorLease) -> int:
+        flags = (
+            os.O_RDONLY
+            | getattr(os, "O_BINARY", 0)
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0)
+        )
+        if self.strategy != "posix-dir-fd":
+            raise AnchoredOutputError(
+                "output-anchor-unavailable",
+                "Windows receipt reads require the retained-handle native helper.",
+            )
+        return _open_posix_descriptor(
+            lease,
+            name,
+            flags,
+            dir_fd=self.descriptors[-1],
+        )
 
     def link(self, source: str, destination: str) -> None:
         if self.strategy == "posix-dir-fd":
@@ -333,6 +1052,138 @@ class OutputParentBinding:
             # for the retained Win32 directory handles used here.
             return
         os.fsync(self.descriptors[-1])
+
+
+@dataclass(slots=True)
+class _OutputParentBindingLeaseState:
+    """Mutable ownership state kept alive independently of its public lease."""
+
+    binding: OutputParentBinding | None = None
+    publication_resources: list[_PublicationResourceLease] = field(
+        default_factory=lambda: list[_PublicationResourceLease]()
+    )
+    fully_closed: bool = False
+
+    def close(self) -> tuple[BaseException, ...]:
+        if self.fully_closed:
+            return ()
+        binding = self.binding
+        failures: list[BaseException] = []
+        for resource in reversed(self.publication_resources):
+            resource_failure_count = len(failures)
+            resource_closed = False
+            for _attempt in range(2):
+                try:
+                    failures.extend(resource.close())
+                except BaseException as error:
+                    failures.append(error)
+                try:
+                    resource_closed = resource.is_closed
+                except BaseException as status_error:
+                    failures.append(status_error)
+                    resource_closed = False
+                if resource_closed:
+                    break
+            if not resource_closed:
+                if len(failures) == resource_failure_count:
+                    failures.append(
+                        AnchoredOutputError(
+                            "output-cleanup-retained",
+                            "A receipt publication resource remained open after bounded cleanup attempts.",
+                        )
+                    )
+                # Do not close an older resource or the parent binding while a
+                # newer child still owns a descriptor that may depend on it.
+                return tuple(failures)
+        if binding is None:
+            self.fully_closed = True
+            return tuple(failures)
+        for _attempt in range(2):
+            try:
+                failures.extend(binding.close())
+            except BaseException as error:
+                failures.append(error)
+                if binding.is_closed:
+                    break
+                continue
+            if binding.is_closed:
+                break
+        if binding.is_closed:
+            self.fully_closed = True
+        elif not failures:
+            failures.append(
+                AnchoredOutputError(
+                    "output-cleanup-retained",
+                    "A receipt output parent binding remained open after bounded cleanup attempts.",
+                )
+            )
+        return tuple(failures)
+
+
+def _finalize_output_parent_binding_lease(state: _OutputParentBindingLeaseState) -> None:
+    """Best-effort, bounded fallback when explicit outer cleanup is interrupted.
+
+    CPython normally invokes this when the owning frame releases its final
+    lease reference. Other Python implementations may defer it until a later
+    garbage collection or interpreter shutdown, so explicit cleanup remains
+    the primary path.
+    """
+
+    try:
+        state.close()
+    except BaseException:
+        # Finalizers cannot report cleanup failures without replacing or
+        # obscuring the exception that caused the owning frame to unwind.
+        pass
+
+
+@dataclass(slots=True, weakref_slot=True, init=False)
+class _OutputParentBindingLease:
+    """Keep a binding reachable across nested Python call-return boundaries."""
+
+    _state: _OutputParentBindingLeaseState
+    _finalizer: _LeaseFinalizer
+
+    def __init__(self, binding: OutputParentBinding | None = None) -> None:
+        state = _OutputParentBindingLeaseState(binding=binding)
+        self._state = state
+        # The callback retains only the separate state, never this lease, so
+        # registration does not create a cycle that would delay collection.
+        self._finalizer = cast(
+            _LeaseFinalizer,
+            weakref.finalize(
+                self,
+                _finalize_output_parent_binding_lease,
+                state,
+            ),
+        )
+
+    @property
+    def binding(self) -> OutputParentBinding | None:
+        return self._state.binding
+
+    @binding.setter
+    def binding(self, binding: OutputParentBinding | None) -> None:
+        if self._state.fully_closed:
+            raise ValueError("Receipt output binding lease is already closed.")
+        self._state.binding = binding
+
+    @property
+    def publication_resources(self) -> list[_PublicationResourceLease]:
+        return self._state.publication_resources
+
+    def retain_publication_resource(self, resource: _PublicationResourceLease) -> None:
+        """Transfer a transient resource owner to the outermost public lease."""
+
+        if self._state.fully_closed:
+            raise ValueError("Receipt output binding lease is already closed.")
+        self._state.publication_resources.append(resource)
+
+    def close(self) -> tuple[BaseException, ...]:
+        failures = self._state.close()
+        if self._state.fully_closed:
+            self._finalizer.detach()
+        return failures
 
 
 def _checkout_output_parts(path: Path) -> tuple[Path, Path, tuple[str, ...]]:
@@ -399,8 +1250,7 @@ def open_output_parent(path: Path) -> OutputParentBinding:
             if (
                 _path_is_redirected(checkout, root_path_stat)
                 or not stat.S_ISDIR(opened_root.st_mode)
-                or (root_path_stat.st_dev, root_path_stat.st_ino)
-                != (opened_root.st_dev, opened_root.st_ino)
+                or (root_path_stat.st_dev, root_path_stat.st_ino) != (opened_root.st_dev, opened_root.st_ino)
             ):
                 raise OSError("The physical checkout changed while it was opened.")
             for component in parts[:-1]:
@@ -419,10 +1269,7 @@ def open_output_parent(path: Path) -> OutputParentBinding:
                 )
                 descriptors.append(child_descriptor)
                 opened = os.fstat(child_descriptor)
-                if (
-                    not stat.S_ISDIR(opened.st_mode)
-                    or (entry.st_dev, entry.st_ino) != (opened.st_dev, opened.st_ino)
-                ):
+                if not stat.S_ISDIR(opened.st_mode) or (entry.st_dev, entry.st_ino) != (opened.st_dev, opened.st_ino):
                     raise OSError(f"Output ancestor changed: {component}.")
                 links.append((parent_descriptor, component, child_descriptor))
             binding = OutputParentBinding(
@@ -444,10 +1291,7 @@ def open_output_parent(path: Path) -> OutputParentBinding:
                 descriptors=tuple(descriptors),
             )
             for cleanup_error in cleanup_binding.close():
-                error.add_note(
-                    f"Could not close a snapshot output directory descriptor: "
-                    f"{cleanup_error}"
-                )
+                error.add_note(f"Could not close a snapshot output directory descriptor: {cleanup_error}")
             if isinstance(error, AnchoredOutputError) or not isinstance(error, Exception):
                 raise
             raise AnchoredOutputError(
@@ -464,9 +1308,7 @@ def open_output_parent(path: Path) -> OutputParentBinding:
                 if component is not None:
                     current /= component
                 path_stat = current.lstat()
-                if _path_is_redirected(current, path_stat) or not stat.S_ISDIR(
-                    path_stat.st_mode
-                ):
+                if _path_is_redirected(current, path_stat) or not stat.S_ISDIR(path_stat.st_mode):
                     raise OSError(f"Redirected output ancestor: {current}.")
                 identity = (path_stat.st_dev, path_stat.st_ino)
                 handle = _open_windows_directory_handle(kernel32, current, identity)
@@ -491,10 +1333,7 @@ def open_output_parent(path: Path) -> OutputParentBinding:
                 windows_entries=tuple(entries),
             )
             for cleanup_error in cleanup_binding.close():
-                error.add_note(
-                    f"Could not close a snapshot output directory handle: "
-                    f"{cleanup_error}"
-                )
+                error.add_note(f"Could not close a snapshot output directory handle: {cleanup_error}")
             if isinstance(error, AnchoredOutputError) or not isinstance(error, Exception):
                 raise
             raise AnchoredOutputError(
@@ -505,6 +1344,355 @@ def open_output_parent(path: Path) -> OutputParentBinding:
     raise AnchoredOutputError(
         "output-anchor-unavailable",
         "This platform cannot bind snapshot output operations to the physical checkout.",
+    )
+
+
+def _rooted_output_parts(path: Path) -> tuple[Path, Path, tuple[str, ...]]:
+    leaf = path.name
+    invalid_leaf: ValueError | None = None
+    windows_receipt: Any | None = None
+    if os.name == "nt":
+        windows_receipt = _windows_receipt_module()
+        try:
+            windows_receipt._validate_windows_relative_leaf(leaf)
+        except ValueError as error:
+            invalid_leaf = error
+    elif leaf in {"", ".", ".."} or "\x00" in leaf:
+        invalid_leaf = ValueError("Receipt output must name one file")
+    if invalid_leaf is not None:
+        raise AnchoredOutputError(
+            "path-invalid",
+            f"Receipt output must name one file: {path}.",
+        ) from invalid_leaf
+    try:
+        absolute = Path(os.path.abspath(os.path.normpath(os.fspath(path))))
+        anchor_text = absolute.anchor
+        if not anchor_text:
+            raise ValueError("The output path has no filesystem anchor.")
+        anchor = Path(anchor_text)
+        relative_parts = absolute.relative_to(anchor).parts
+        if sys.platform == "darwin" and relative_parts and relative_parts[0] in {"tmp", "var"}:
+            # macOS exposes trusted root-level aliases such as /var and /tmp.
+            # Resolve only that root-owned prefix; every component beneath it
+            # remains lexical and is traversed without following redirects.
+            first_component = anchor / relative_parts[0]
+            try:
+                first_stat = first_component.lstat()
+            except FileNotFoundError:
+                pass
+            else:
+                if _path_is_redirected(first_component, first_stat):
+                    physical_prefix = first_component.resolve(strict=True)
+                    expected_prefix = Path("/private") / relative_parts[0]
+                    if physical_prefix != expected_prefix:
+                        raise ValueError("The trusted macOS root alias does not name its physical prefix.")
+                    absolute = physical_prefix.joinpath(*relative_parts[1:])
+                    anchor_text = absolute.anchor
+                    if not anchor_text:
+                        raise ValueError("The physical output path has no filesystem anchor.")
+                    anchor = Path(anchor_text)
+                    relative_parts = absolute.relative_to(anchor).parts
+        if windows_receipt is not None:
+            # Reject device namespaces and unsupported Windows roots before the
+            # retained-parent opener can acquire or create anything below them.
+            windows_receipt._nt_anchor_path(anchor)
+    except (OSError, RuntimeError, ValueError) as error:
+        translated = AnchoredOutputError(
+            "path-invalid",
+            f"Cannot anchor receipt output at one physical filesystem root: {path}.",
+        )
+        for note in getattr(error, "__notes__", ()):
+            translated.add_note(note)
+        raise translated from error
+    if not relative_parts or relative_parts[-1] != leaf:
+        raise AnchoredOutputError(
+            "path-invalid",
+            f"Receipt output must name one canonical file path: {path}.",
+        )
+    if windows_receipt is not None:
+        try:
+            for component in relative_parts:
+                windows_receipt._validate_windows_relative_leaf(component)
+        except ValueError as error:
+            raise AnchoredOutputError(
+                "path-invalid",
+                f"Receipt output must use valid Windows path components: {path}.",
+            ) from error
+    return anchor, absolute, relative_parts
+
+
+def _open_rooted_posix_parent(
+    anchor: Path,
+    absolute: Path,
+    parts: tuple[str, ...],
+    lease: _OutputParentBindingLease,
+) -> OutputParentBinding:
+    if lease.binding is not None:
+        raise ValueError("Receipt output binding lease is already occupied.")
+    if os.mkdir not in os.supports_dir_fd:
+        raise AnchoredOutputError(
+            "output-anchor-unavailable",
+            "Descriptor-relative receipt parent creation is unavailable on this platform.",
+        )
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+    descriptors: list[int] = []
+    descriptor_leases: list[_PosixDescriptorLease] = []
+    links: list[tuple[int, str, int]] = []
+    private_descriptor_indexes: list[int] = []
+    binding = OutputParentBinding(
+        checkout=anchor,
+        parent=absolute.parent,
+        leaf=parts[-1],
+        strategy="posix-dir-fd",
+        receipt_parent_policy=True,
+        descriptors=descriptors,
+        descriptor_leases=descriptor_leases,
+        links=links,
+        private_posix_descriptor_indexes=private_descriptor_indexes,
+    )
+    # Install the mutable owner before any openat call can populate one of its
+    # pre-registered descriptor slots. The outer finalizer can then recover a
+    # descriptor even if control flow is interrupted at a call-return boundary.
+    lease.binding = binding
+    try:
+        root_lease = _PosixDescriptorLease()
+        descriptor_leases.append(root_lease)
+        root_descriptor = _open_posix_descriptor(root_lease, anchor, flags)
+        descriptors.append(root_descriptor)
+        root_path_stat = anchor.lstat()
+        opened_root = os.fstat(root_descriptor)
+        if (
+            _path_is_redirected(anchor, root_path_stat)
+            or not stat.S_ISDIR(opened_root.st_mode)
+            or (root_path_stat.st_dev, root_path_stat.st_ino) != (opened_root.st_dev, opened_root.st_ino)
+        ):
+            raise OSError("The physical filesystem root changed while it was opened.")
+        for component in parts[:-1]:
+            parent_descriptor = descriptors[-1]
+            parent_index = len(descriptors) - 1
+            parent_is_private = parent_index in private_descriptor_indexes
+            _validate_safe_posix_directory_descriptor(
+                parent_descriptor,
+                code="output-parent-invalid",
+                context="receipt output intermediate ancestor",
+                require_private=parent_is_private,
+                allow_darwin_deny_only_acl=not parent_is_private,
+            )
+            created_component = False
+            try:
+                entry = os.stat(
+                    component,
+                    dir_fd=parent_descriptor,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                _validate_safe_posix_directory_descriptor(
+                    parent_descriptor,
+                    code="output-parent-invalid",
+                    context="receipt ancestor creation parent",
+                    require_private=parent_is_private,
+                    allow_darwin_deny_only_acl=not parent_is_private,
+                )
+                try:
+                    os.mkdir(component, 0o700, dir_fd=parent_descriptor)
+                except FileExistsError as error:
+                    raise AnchoredOutputError(
+                        "output-parent-changed",
+                        f"Receipt output ancestor appeared after it was observed missing: {component}.",
+                    ) from error
+                created_component = True
+                entry = os.stat(
+                    component,
+                    dir_fd=parent_descriptor,
+                    follow_symlinks=False,
+                )
+                # A restrictive umask may remove owner access. The retained
+                # parent was just proven safe against other-UID replacement;
+                # same-UID/root interference remains explicitly out of scope.
+                created_identity = (entry.st_dev, entry.st_ino)
+                os.chmod(
+                    component,
+                    0o700,
+                    dir_fd=parent_descriptor,
+                    follow_symlinks=False,
+                )
+                entry = os.stat(
+                    component,
+                    dir_fd=parent_descriptor,
+                    follow_symlinks=False,
+                )
+                if (entry.st_dev, entry.st_ino) != created_identity:
+                    raise AnchoredOutputError(
+                        "output-parent-changed",
+                        f"New receipt output ancestor changed while its mode was sealed: {component}.",
+                    )
+            if stat.S_ISLNK(entry.st_mode) or not stat.S_ISDIR(entry.st_mode):
+                raise OSError(f"Redirected receipt output ancestor: {component}.")
+            child_lease = _PosixDescriptorLease()
+            descriptor_leases.append(child_lease)
+            child_descriptor = _open_posix_descriptor(
+                child_lease,
+                component,
+                flags,
+                dir_fd=parent_descriptor,
+            )
+            descriptors.append(child_descriptor)
+            opened = os.fstat(child_descriptor)
+            if not stat.S_ISDIR(opened.st_mode) or (entry.st_dev, entry.st_ino) != (
+                opened.st_dev,
+                opened.st_ino,
+            ):
+                raise OSError(f"Receipt output ancestor changed: {component}.")
+            if created_component:
+                private_descriptor_indexes.append(len(descriptors) - 1)
+                os.fchmod(child_descriptor, 0o700)
+                _validate_safe_posix_directory_descriptor(
+                    child_descriptor,
+                    code="output-parent-invalid",
+                    context="newly created receipt output ancestor",
+                    require_private=True,
+                )
+            # Repeat the containing-directory barrier for existing components:
+            # a prior invocation may have created the entry and failed here.
+            os.fsync(parent_descriptor)
+            links.append((parent_descriptor, component, child_descriptor))
+        _validate_safe_posix_directory_descriptor(
+            descriptors[-1],
+            code="output-parent-invalid",
+            context="final receipt output parent",
+            require_private=len(descriptors) - 1 in private_descriptor_indexes,
+        )
+        binding.verify()
+        return binding
+    except BaseException as error:
+        try:
+            cleanup_failures = lease.close()
+        except BaseException as cleanup_error:
+            cleanup_failures = (cleanup_error,)
+        for cleanup_error in cleanup_failures:
+            error.add_note(f"Could not close a receipt output directory descriptor: {cleanup_error}")
+        if isinstance(error, AnchoredOutputError) or not isinstance(error, Exception):
+            raise
+        translated = AnchoredOutputError(
+            "output-parent-invalid",
+            f"Cannot bind or create receipt output parent: {absolute.parent}.",
+        )
+        for note in getattr(error, "__notes__", ()):
+            translated.add_note(note)
+        raise translated from error
+
+
+def _open_rooted_windows_parent(
+    anchor: Path,
+    absolute: Path,
+    parts: tuple[str, ...],
+    lease: _OutputParentBindingLease,
+) -> OutputParentBinding:
+    if lease.binding is not None:
+        raise ValueError("Receipt output binding lease is already occupied.")
+    kernel32 = _windows_file_api()
+    entries: list[tuple[Path, tuple[int, int], int]] = []
+    handle_leases: list[Any] = []
+    loaded_windows_receipt: Any | None = None
+    try:
+        loaded = _windows_receipt_module()
+        loaded_windows_receipt = loaded
+        kernel32, nt_api = loaded._select_apis(kernel32, None)
+        kernel32 = loaded._configure_api(kernel32)
+        nt_api = loaded._configure_nt_api(nt_api)
+
+        binding = OutputParentBinding(
+            checkout=anchor,
+            parent=absolute.parent,
+            leaf=parts[-1],
+            strategy="windows-handle",
+            receipt_parent_policy=True,
+            windows_api=kernel32,
+            windows_entries=entries,
+            windows_handle_leases=handle_leases,
+        )
+        # NtCreateFile writes into each WindowsHandleLease. Retain the mutable
+        # binding first, then register every empty slot in native-open order so
+        # interrupted acquisition is still closed child-to-root by the owner.
+        lease.binding = binding
+
+        current = anchor
+        root_lease = loaded.WindowsHandleLease()
+        handle_leases.append(root_lease)
+        root = loaded.open_windows_directory_anchor(
+            current,
+            root_lease,
+            api=kernel32,
+            nt_api=nt_api,
+        )
+        if root_lease.handle != root.handle:
+            raise OSError("Windows directory anchor helper returned an unowned handle.")
+        root_identity = (
+            root.volume_serial_number,
+            int.from_bytes(root.file_id, "little"),
+        )
+        entries.append((current, root_identity, root.handle))
+
+        for component in parts[:-1]:
+            current /= component
+            child_lease = loaded.WindowsHandleLease()
+            handle_leases.append(child_lease)
+            directory = loaded.open_or_create_windows_directory(
+                entries[-1][2],
+                component,
+                child_lease,
+                api=kernel32,
+                nt_api=nt_api,
+            )
+            if child_lease.handle != directory.handle:
+                raise OSError("Relative directory helper returned an unowned handle.")
+            identity = (
+                directory.volume_serial_number,
+                int.from_bytes(directory.file_id, "little"),
+            )
+            entries.append((current, identity, directory.handle))
+        binding.verify()
+        return binding
+    except BaseException as error:
+        try:
+            cleanup_failures = lease.close()
+        except BaseException as cleanup_error:
+            cleanup_failures = (cleanup_error,)
+        for cleanup_error in cleanup_failures:
+            error.add_note(f"Could not close a receipt output directory handle: {cleanup_error}")
+        if isinstance(error, AnchoredOutputError) or not isinstance(error, Exception):
+            raise
+        if loaded_windows_receipt is not None and isinstance(
+            error,
+            loaded_windows_receipt.WindowsReceiptValidationError,
+        ):
+            translated = _translated_anchored_output_error(
+                error,
+                cast(str, getattr(error, "code")),
+                str(error),
+            )
+            raise translated from error
+        translated = AnchoredOutputError(
+            "output-parent-invalid",
+            f"Cannot bind or create receipt output parent: {absolute.parent}.",
+        )
+        for note in getattr(error, "__notes__", ()):
+            translated.add_note(note)
+        raise translated from error
+
+
+def open_rooted_output_parent(
+    path: Path,
+    lease: _OutputParentBindingLease,
+) -> OutputParentBinding:
+    anchor, absolute, parts = _rooted_output_parts(path)
+    if descriptor_relative_output_supported():
+        return _open_rooted_posix_parent(anchor, absolute, parts, lease)
+    if os.name == "nt":
+        return _open_rooted_windows_parent(anchor, absolute, parts, lease)
+    raise AnchoredOutputError(
+        "output-anchor-unavailable",
+        "This platform cannot bind receipt output operations to the filesystem root.",
     )
 
 
@@ -527,6 +1715,185 @@ def _unlink_output_if_identity(
             f"Refusing to remove a changed snapshot output artifact: {binding.parent / name}.",
         )
     binding.unlink(name)
+
+
+def _stable_file_metadata(
+    value: os.stat_result,
+) -> tuple[int, int, int, int, int, int, int]:
+    return (
+        value.st_dev,
+        value.st_ino,
+        value.st_mode,
+        value.st_nlink,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+
+
+def _receipt_mode_is_canonical(value: os.stat_result) -> bool:
+    return stat.S_IMODE(value.st_mode) == 0o600 and value.st_uid == os.geteuid()
+
+
+def _receipt_namespace_changed(error: OSError) -> bool:
+    return isinstance(error, FileNotFoundError) or error.errno in _POSIX_RECEIPT_NAMESPACE_CHANGED_ERRNOS
+
+
+def _validate_receipt_file(
+    binding: OutputParentBinding,
+    name: str,
+    value: os.stat_result,
+    *,
+    code: str,
+) -> None:
+    if (
+        _path_is_redirected(binding.parent / name, value)
+        or not stat.S_ISREG(value.st_mode)
+        or value.st_nlink != 1
+        or not _receipt_mode_is_canonical(value)
+    ):
+        raise AnchoredOutputError(
+            code,
+            f"Receipt output is not one canonical private regular file: {binding.parent / name}.",
+        )
+
+
+def _read_exact_receipt(
+    binding: OutputParentBinding,
+    name: str,
+    payload: bytes,
+    *,
+    descriptor_lease: _PosixDescriptorLease,
+    expected_identity: tuple[int, int] | None = None,
+) -> tuple[int, int]:
+    try:
+        before = binding.stat(name)
+    except OSError as error:
+        if not _receipt_namespace_changed(error):
+            raise
+        translated = _translated_anchored_output_error(
+            error,
+            "output-changed",
+            f"Receipt output changed while it was being located: {binding.parent / name}.",
+        )
+        raise translated from error
+    validation_code = "output-changed" if expected_identity is not None else "output-existing-invalid"
+    _validate_receipt_file(binding, name, before, code=validation_code)
+    identity = (before.st_dev, before.st_ino)
+    if expected_identity is not None and identity != expected_identity:
+        raise AnchoredOutputError(
+            "output-changed",
+            f"Receipt output changed while it was being verified: {binding.parent / name}.",
+        )
+
+    descriptor: int | None = None
+    primary_error: BaseException | None = None
+    try:
+        descriptor = binding.open_read(name, descriptor_lease)
+        opened = os.fstat(descriptor)
+        if _darwin_descriptor_has_extended_acl(
+            descriptor,
+            error_code=validation_code,
+            context="receipt output descriptor",
+        ):
+            raise AnchoredOutputError(
+                validation_code,
+                f"Receipt output has an extended ACL while it is being opened: {binding.parent / name}.",
+            )
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_nlink != 1
+            or not _receipt_mode_is_canonical(opened)
+            or (opened.st_dev, opened.st_ino) != identity
+            or opened.st_size != before.st_size
+        ):
+            raise AnchoredOutputError(
+                "output-changed",
+                f"Receipt output changed while it was being opened: {binding.parent / name}.",
+            )
+        chunks: list[bytes] = []
+        remaining = len(payload) + 1
+        while remaining > 0:
+            chunk = os.read(descriptor, min(64 * 1024, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        observed = b"".join(chunks)
+        opened_after = os.fstat(descriptor)
+        if _darwin_descriptor_has_extended_acl(
+            descriptor,
+            error_code="output-changed",
+            context="receipt output descriptor after reading",
+        ):
+            raise AnchoredOutputError(
+                "output-changed",
+                f"Receipt output gained an extended ACL while it was being read: {binding.parent / name}.",
+            )
+        after = binding.stat(name)
+        binding.verify()
+        _validate_receipt_file(binding, name, after, code="output-changed")
+        if (
+            _stable_file_metadata(opened) != _stable_file_metadata(opened_after)
+            or _stable_file_metadata(before) != _stable_file_metadata(after)
+            or (opened_after.st_dev, opened_after.st_ino) != (after.st_dev, after.st_ino)
+            or opened_after.st_size != after.st_size
+        ):
+            raise AnchoredOutputError(
+                "output-changed",
+                f"Receipt output changed while it was being read: {binding.parent / name}.",
+            )
+        if observed != payload:
+            raise AnchoredOutputError(
+                "output-changed" if expected_identity is not None else "output-different",
+                (
+                    f"Receipt output changed while it was being verified: {binding.parent / name}."
+                    if expected_identity is not None
+                    else f"Refusing to replace different existing receipt output: {binding.parent / name}."
+                ),
+            )
+        return identity
+    except OSError as error:
+        if not _receipt_namespace_changed(error):
+            primary_error = error
+            raise
+        translated = _translated_anchored_output_error(
+            error,
+            "output-changed",
+            f"Receipt output changed while it was being verified: {binding.parent / name}.",
+        )
+        primary_error = translated
+        raise translated from error
+    except BaseException as error:
+        primary_error = error
+        raise
+    finally:
+        close_call_failures: list[BaseException] = []
+        close_error: BaseException | None = None
+        for _attempt in range(2):
+            try:
+                close_error = _close_posix_descriptor_lease(
+                    descriptor_lease,
+                    primary_error,
+                    "receipt verification descriptor",
+                )
+            except BaseException as cleanup_error:
+                close_call_failures.append(cleanup_error)
+                if descriptor_lease.descriptor is not None:
+                    continue
+            break
+        if primary_error is not None:
+            for cleanup_error in close_call_failures:
+                primary_error.add_note(f"Could not close receipt verification descriptor: {cleanup_error}")
+        elif close_call_failures:
+            first_cleanup_error = close_call_failures[0]
+            for later_error in close_call_failures[1:]:
+                first_cleanup_error.add_note(f"Receipt verification close failure: {later_error}")
+            if close_error is not None:
+                first_cleanup_error.add_note(f"Receipt verification close failure: {close_error}")
+            raise first_cleanup_error
+        elif close_error is not None:
+            raise close_error
 
 
 def publish_new_bytes(path: Path, payload: bytes) -> None:
@@ -578,14 +1945,13 @@ def publish_new_bytes(path: Path, payload: bytes) -> None:
         try:
             binding.link(temporary_name, binding.leaf)
         except FileExistsError as error:
-            raise AnchoredOutputError("output-exists", f"Refusing to overwrite existing snapshot output: {path}.") from error
+            raise AnchoredOutputError(
+                "output-exists", f"Refusing to overwrite existing snapshot output: {path}."
+            ) from error
         published = True
         output_identity = temporary_identity
         output_stat = binding.stat(binding.leaf)
-        if (
-            not stat.S_ISREG(output_stat.st_mode)
-            or not _same_identity(output_stat, temporary_identity)
-        ):
+        if not stat.S_ISREG(output_stat.st_mode) or not _same_identity(output_stat, temporary_identity):
             raise AnchoredOutputError(
                 "output-changed",
                 f"Snapshot output changed while it was published: {path}.",
@@ -637,10 +2003,7 @@ def publish_new_bytes(path: Path, payload: bytes) -> None:
             try:
                 os.close(descriptor)
             except BaseException as cleanup_error:
-                error.add_note(
-                    f"Could not close the snapshot temporary descriptor: "
-                    f"{cleanup_error}"
-                )
+                error.add_note(f"Could not close the snapshot temporary descriptor: {cleanup_error}")
             descriptor = -1
         if published and output_identity is not None:
             try:
@@ -658,33 +2021,378 @@ def publish_new_bytes(path: Path, payload: bytes) -> None:
         if close_failures:
             if primary_error is not None:
                 for close_error in close_failures:
-                    primary_error.add_note(
-                        f"Could not close a snapshot output anchor: {close_error}"
-                    )
+                    primary_error.add_note(f"Could not close a snapshot output anchor: {close_error}")
             else:
                 control_flow_failure = next(
-                    (
-                        failure
-                        for failure in close_failures
-                        if not isinstance(failure, Exception)
-                    ),
+                    (failure for failure in close_failures if not isinstance(failure, Exception)),
                     None,
                 )
                 if control_flow_failure is not None:
                     for failure in close_failures:
                         if failure is not control_flow_failure:
-                            control_flow_failure.add_note(
-                                f"Output anchor close failure: {failure}"
-                            )
+                            control_flow_failure.add_note(f"Output anchor close failure: {failure}")
                     raise control_flow_failure
                 close_error = AnchoredOutputError(
                     "output-anchor-close-failed",
-                    "Snapshot publication completed, but one or more output "
-                    "directory anchors could not be closed.",
+                    "Snapshot publication completed, but one or more output directory anchors could not be closed.",
                 )
                 for failure in close_failures:
                     close_error.add_note(f"Output anchor close failure: {failure}")
                 raise close_error from close_failures[0]
+
+
+def _load_exact_sibling(module_name: str, filename: str, injected: dict[str, object] | None = None) -> Any:
+    """Load one private sibling by its resolved path, never by import search."""
+
+    import importlib.util
+
+    module_path = Path(__file__).resolve(strict=True).with_name(filename)
+    existing = sys.modules.get(module_name)
+    if existing is not None:
+        existing_path = getattr(existing, "__file__", None)
+        if isinstance(existing_path, str) and Path(existing_path).resolve(strict=True) == module_path:
+            return existing
+        raise ImportError(f"Refusing conflicting anchored receipt module {module_name!r}.")
+    specification = importlib.util.spec_from_file_location(module_name, module_path)
+    if specification is None or specification.loader is None:
+        raise ImportError(f"Cannot load anchored receipt helper: {module_path}")
+    module = importlib.util.module_from_spec(specification)
+    if injected is not None:
+        module.__dict__.update(injected)
+    sys.modules[module_name] = module
+    try:
+        specification.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+_posix_receipt_cache: Any | None = None
+_windows_receipt_cache: Any | None = None
+
+
+def _posix_receipt_module() -> Any:
+    global _posix_receipt_cache
+    if _posix_receipt_cache is None:
+        _posix_receipt_cache = _load_exact_sibling(
+            f"{__name__}__anchored_receipt_posix",
+            "_anchored_receipt_posix.py",
+            {
+                "AnchoredOutputError": AnchoredOutputError,
+                "OutputParentBinding": OutputParentBinding,
+                "_PosixDescriptorLease": _PosixDescriptorLease,
+                "_close_posix_descriptor_lease": _close_posix_descriptor_lease,
+                "_darwin_descriptor_has_extended_acl": _darwin_descriptor_has_extended_acl,
+                "_open_posix_descriptor": _open_posix_descriptor,
+                "_read_exact_receipt": _read_exact_receipt,
+                "_receipt_mode_is_canonical": _receipt_mode_is_canonical,
+                "_same_identity": _same_identity,
+                "_stable_file_metadata": _stable_file_metadata,
+                "_validate_safe_posix_directory_descriptor": _validate_safe_posix_directory_descriptor,
+            },
+        )
+    return _posix_receipt_cache
+
+
+def _windows_receipt_module() -> Any:
+    global _windows_receipt_cache
+    if _windows_receipt_cache is None:
+        _windows_receipt_cache = _load_exact_sibling(
+            f"{__name__}__anchored_receipt_windows",
+            "_anchored_receipt_windows.py",
+        )
+    return _windows_receipt_cache
+
+
+def _publish_posix_receipt_bytes(
+    path: Path,
+    payload: bytes,
+    binding: OutputParentBinding,
+    outer_lease: _OutputParentBindingLease,
+) -> None:
+    if outer_lease.binding is not binding:
+        raise ValueError("POSIX receipt output binding is not retained by its outer owner.")
+    try:
+        loaded_posix_receipt = _posix_receipt_module()
+    except BaseException as error:
+        try:
+            close_failures = binding.close()
+        except BaseException as close_error:
+            close_failures = (close_error,)
+        for close_error in close_failures:
+            error.add_note(f"Could not close a receipt publication resource: {close_error}")
+        raise
+    publication_lease = loaded_posix_receipt._PosixReceiptPublicationLease(binding)
+    outer_lease.retain_publication_resource(publication_lease)
+    loaded_posix_receipt._publish_posix_receipt_bytes(
+        path,
+        payload,
+        binding,
+        publication_lease,
+    )
+
+
+def _publish_windows_receipt_bytes(
+    path: Path,
+    payload: bytes,
+    binding: OutputParentBinding,
+    outer_lease: _OutputParentBindingLease,
+) -> None:
+    """Publish with the retained-handle helper without rolling back uncertain outcomes."""
+
+    if outer_lease.binding is not binding:
+        raise ValueError("Windows receipt output binding is not retained by its outer owner.")
+    primary_error: BaseException | None = None
+    windows_receipt: Any | None = None
+    publication_lease: Any | None = None
+    try:
+        loaded_windows_receipt = _windows_receipt_module()
+        windows_receipt = loaded_windows_receipt
+        windows_api, nt_api = loaded_windows_receipt._select_apis(binding.windows_api, None)
+        windows_api = loaded_windows_receipt._configure_api(windows_api)
+        nt_api = loaded_windows_receipt._configure_nt_api(nt_api)
+        publication_lease = loaded_windows_receipt._WindowsReceiptPublicationLease(windows_api)
+        outer_lease.retain_publication_resource(cast(_PublicationResourceLease, publication_lease))
+        parent_handle = binding.windows_entries[-1][2]
+
+        def observe_exact(expected: Any | None = None, *, missing_ok: bool = False) -> Any | None:
+            binding.verify()
+            try:
+                observed = loaded_windows_receipt.read_windows_receipt(
+                    parent_handle,
+                    binding.leaf,
+                    payload,
+                    api=windows_api,
+                    nt_api=nt_api,
+                    publication_lease=publication_lease,
+                )
+            except FileNotFoundError as error:
+                if missing_ok:
+                    binding.verify()
+                    return None
+                translated = AnchoredOutputError(
+                    "output-changed",
+                    f"Receipt output disappeared while it was being verified: {path}.",
+                )
+                for note in getattr(error, "__notes__", ()):
+                    translated.add_note(note)
+                raise translated from error
+            except loaded_windows_receipt.WindowsReceiptValidationError as error:
+                code = error.code
+                if expected is not None and code in {"output-existing-invalid", "output-different"}:
+                    code = "output-changed"
+                translated = _translated_anchored_output_error(error, code, str(error))
+                raise translated from error
+            except ValueError as error:
+                translated = AnchoredOutputError(
+                    "path-invalid",
+                    f"Receipt output must name one valid Windows file: {path}.",
+                )
+                for note in getattr(error, "__notes__", ()):
+                    translated.add_note(note)
+                raise translated from error
+            if expected is not None and (
+                observed.leaf != expected.leaf
+                or observed.volume_serial_number != expected.volume_serial_number
+                or observed.file_id != expected.file_id
+                or observed.size != expected.size
+            ):
+                raise AnchoredOutputError(
+                    "output-changed",
+                    f"Receipt output changed before publication completed: {path}.",
+                )
+            binding.verify()
+            return observed
+
+        binding.verify()
+        existing = observe_exact(missing_ok=True)
+        if existing is not None:
+            binding.verify()
+            return
+        try:
+            published_result: Any | None = None
+            for _attempt in range(100):
+                try:
+                    published_result = loaded_windows_receipt.publish_windows_receipt(
+                        parent_handle,
+                        binding.leaf,
+                        payload,
+                        api=windows_api,
+                        nt_api=nt_api,
+                        publication_lease=publication_lease,
+                    )
+                except loaded_windows_receipt._StageNameCollision as stage_error:
+                    if not loaded_windows_receipt.is_internal_stage_name_collision(stage_error):
+                        raise
+                    continue
+                except loaded_windows_receipt._DefiniteRenameCollision as collision_error:
+                    if not loaded_windows_receipt.is_internal_definite_rename_collision(collision_error):
+                        raise
+                    try:
+                        observe_exact()
+                    except BaseException as observation_error:
+                        for note in getattr(collision_error, "__notes__", ()):
+                            observation_error.add_note(note)
+                        raise
+                    cleanup_failures = loaded_windows_receipt.cleanup_failures_from_error(collision_error)
+                    if cleanup_failures:
+                        control_flow_failure = next(
+                            (failure for failure in cleanup_failures if not isinstance(failure, Exception)),
+                            None,
+                        )
+                        if control_flow_failure is not None:
+                            for note in getattr(collision_error, "__notes__", ()):
+                                control_flow_failure.add_note(note)
+                            raise control_flow_failure from collision_error
+                        cleanup_error = AnchoredOutputError(
+                            "output-cleanup-retained",
+                            "An identical Windows receipt already exists, but its private staging resource "
+                            f"could not be cleaned up or closed: {path}.",
+                        )
+                        for note in getattr(collision_error, "__notes__", ()):
+                            cleanup_error.add_note(note)
+                        raise cleanup_error from collision_error
+                    return
+                break
+            else:
+                raise AnchoredOutputError(
+                    "output-temporary-unavailable",
+                    f"Could not create a private temporary receipt beside {path}.",
+                )
+        except BaseException as error:
+            outcome = None if windows_receipt is None else windows_receipt.outcome_from_error(error)
+            if outcome is None and publication_lease is not None:
+                outcome = publication_lease.outcome
+            if outcome is not None and outcome.state in {"unknown", "published"}:
+                try:
+                    binding.verify()
+                    observe_exact(outcome.receipt)
+                    binding.verify()
+                except BaseException as observation_error:
+                    error.add_note(
+                        "Retained-handle receipt publication may have taken effect; the public name was "
+                        f"intentionally left untouched because it could not be verified: {observation_error}"
+                    )
+                else:
+                    error.add_note(
+                        "Retained-handle receipt publication took effect before the failure; "
+                        "the valid public receipt was left untouched."
+                    )
+            if outcome is None and loaded_windows_receipt.is_windows_publication_unavailable(error):
+                translated = _translated_anchored_output_error(
+                    error,
+                    "output-anchor-unavailable",
+                    f"Windows cannot publish a retained-handle receipt on this filesystem: {path}.",
+                )
+                raise translated from error
+            raise
+        binding.verify()
+        assert published_result is not None
+        observe_exact(published_result)
+        binding.verify()
+    except BaseException as error:
+        primary_error = error
+        raise
+    finally:
+        close_failures: tuple[BaseException, ...] = ()
+        publication_closed = publication_lease is None
+        if publication_lease is not None:
+            resource_failures: list[BaseException] = []
+            for _attempt in range(2):
+                try:
+                    resource_failures.extend(publication_lease.close())
+                except BaseException as close_error:
+                    resource_failures.append(close_error)
+                try:
+                    publication_closed = publication_lease.is_closed
+                except BaseException as status_error:
+                    resource_failures.append(status_error)
+                    publication_closed = False
+                if publication_closed:
+                    break
+            close_failures = tuple(resource_failures)
+        if publication_closed:
+            try:
+                binding_close_failures = binding.close()
+            except BaseException as close_error:
+                binding_close_failures = (close_error,)
+            close_failures = (*close_failures, *binding_close_failures)
+        elif not close_failures:
+            close_failures = (
+                AnchoredOutputError(
+                    "output-cleanup-retained",
+                    "A Windows receipt handle remained open after bounded cleanup attempts.",
+                ),
+            )
+        if close_failures:
+            if primary_error is not None:
+                for close_error in close_failures:
+                    primary_error.add_note(f"Could not close a receipt publication resource: {close_error}")
+            else:
+                control_flow_failure = next(
+                    (failure for failure in close_failures if not isinstance(failure, Exception)),
+                    None,
+                )
+                if control_flow_failure is not None:
+                    for failure in close_failures:
+                        if failure is not control_flow_failure:
+                            control_flow_failure.add_note(f"Receipt publication close failure: {failure}")
+                    raise control_flow_failure
+                first_close_error = close_failures[0]
+                for later_error in close_failures[1:]:
+                    first_close_error.add_note(f"Receipt publication close failure: {later_error}")
+                raise first_close_error
+
+
+def publish_identical_receipt_bytes(path: Path, payload: bytes) -> None:
+    """Publish or verify one canonical receipt without replacing an existing name."""
+
+    lease = _OutputParentBindingLease()
+    primary_error: BaseException | None = None
+    try:
+        binding = open_rooted_output_parent(path, lease)
+        if lease.binding is not binding:
+            raise AnchoredOutputError(
+                "output-anchor-unavailable",
+                "Receipt output binding ownership was not retained across acquisition.",
+            )
+        if binding.strategy == "posix-dir-fd":
+            _publish_posix_receipt_bytes(path, payload, binding, lease)
+            return
+        if binding.strategy == "windows-handle":
+            _publish_windows_receipt_bytes(path, payload, binding, lease)
+            return
+        raise AnchoredOutputError(
+            "output-anchor-unavailable",
+            "This platform cannot publish a descriptor-bound canonical receipt.",
+        )
+    except BaseException as error:
+        primary_error = error
+        raise
+    finally:
+        try:
+            close_failures = lease.close()
+        except BaseException as close_error:
+            close_failures = (close_error,)
+        if close_failures:
+            if primary_error is not None:
+                for close_error in close_failures:
+                    primary_error.add_note(f"Could not close a receipt publication resource: {close_error}")
+            else:
+                control_flow_failure = next(
+                    (failure for failure in close_failures if not isinstance(failure, Exception)),
+                    None,
+                )
+                if control_flow_failure is not None:
+                    for failure in close_failures:
+                        if failure is not control_flow_failure:
+                            control_flow_failure.add_note(f"Receipt publication close failure: {failure}")
+                    raise control_flow_failure
+                first_close_error = close_failures[0]
+                for later_error in close_failures[1:]:
+                    first_close_error.add_note(f"Receipt publication close failure: {later_error}")
+                raise first_close_error
 
 
 __all__ = [
@@ -692,5 +2400,7 @@ __all__ = [
     "OutputParentBinding",
     "descriptor_relative_output_supported",
     "open_output_parent",
+    "open_rooted_output_parent",
+    "publish_identical_receipt_bytes",
     "publish_new_bytes",
 ]

--- a/scripts/_anchored_output.py
+++ b/scripts/_anchored_output.py
@@ -2280,6 +2280,30 @@ def _publish_windows_receipt_bytes(
                         "the valid public receipt was left untouched."
                     )
             if outcome is None and loaded_windows_receipt.is_windows_publication_unavailable(error):
+                diagnostic_parts = [
+                    f"type={type(error).__name__}",
+                    f"errno={getattr(error, 'errno', None)}",
+                    f"message={error}",
+                ]
+                nt_operation = getattr(error, "_windows_receipt_nt_operation", None)
+                nt_status = getattr(error, "_windows_receipt_nt_status", None)
+                if nt_operation is not None:
+                    diagnostic_parts.append(f"nt_operation={nt_operation}")
+                if nt_status is not None:
+                    diagnostic_parts.append(f"nt_status=0x{int(nt_status):08X}")
+                native_cause = error.__cause__
+                if isinstance(native_cause, OSError):
+                    diagnostic_parts.extend(
+                        (
+                            f"cause_type={type(native_cause).__name__}",
+                            f"cause_errno={native_cause.errno}",
+                            f"cause_message={native_cause}",
+                        )
+                    )
+                error.add_note(
+                    "Windows retained-handle publication diagnostic: "
+                    + "; ".join(diagnostic_parts)
+                )
                 translated = _translated_anchored_output_error(
                     error,
                     "output-anchor-unavailable",

--- a/scripts/_anchored_receipt_posix.py
+++ b/scripts/_anchored_receipt_posix.py
@@ -1,0 +1,1347 @@
+"""Descriptor-retained POSIX publication for small immutable receipts.
+
+The private staging protections assume adversaries cannot access or mutate the
+retained descriptor. They do not claim protection from same-UID processes or
+root once those actors can inspect this process or its open descriptors.
+"""
+
+from __future__ import annotations
+
+import ctypes
+from dataclasses import dataclass, field
+import errno
+import functools
+import os
+from pathlib import Path
+import secrets
+import stat
+import sys
+from typing import Callable, NoReturn, Protocol, TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+
+    class AnchoredOutputError(ValueError):
+        code: str
+
+        def __init__(self, code: str, message: str) -> None: ...
+
+    class OutputParentBinding(Protocol):
+        parent: Path
+        leaf: str
+        strategy: str
+        descriptors: tuple[int, ...]
+
+        def stat(self, name: str) -> os.stat_result: ...
+        def open_read(self, name: str, lease: _PosixDescriptorLease) -> int: ...
+        def verify(self) -> None: ...
+        def sync(self) -> None: ...
+        def close(self) -> list[BaseException]: ...
+
+    class _PosixDescriptorLease:
+        descriptor: int | None
+
+        def close(self) -> None: ...
+
+    def _close_posix_descriptor_lease(
+        lease: _PosixDescriptorLease,
+        primary: BaseException | None,
+        context: str,
+    ) -> BaseException | None: ...
+
+    def _darwin_descriptor_has_extended_acl(
+        descriptor: int,
+        *,
+        error_code: str = "output-anchor-unavailable",
+        context: str = "retained macOS descriptor",
+    ) -> bool: ...
+
+    def _open_posix_descriptor(
+        lease: _PosixDescriptorLease,
+        path: os.PathLike[str] | str,
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int: ...
+
+    def _read_exact_receipt(
+        binding: OutputParentBinding,
+        name: str,
+        expected_payload: bytes,
+        *,
+        descriptor_lease: _PosixDescriptorLease,
+        expected_identity: tuple[int, int] | None = None,
+    ) -> tuple[int, int]: ...
+
+    def _receipt_mode_is_canonical(value: os.stat_result) -> bool: ...
+    def _same_identity(value: os.stat_result, identity: tuple[int, int]) -> bool: ...
+    def _stable_file_metadata(value: os.stat_result) -> tuple[int, int, int, int, int, int, int]: ...
+    def _validate_safe_posix_directory_descriptor(
+        descriptor: int,
+        *,
+        code: str,
+        context: str,
+        require_private: bool = False,
+    ) -> os.stat_result: ...
+
+
+_LINUX_AT_FDCWD = -100
+_LINUX_AT_SYMLINK_FOLLOW = 0x400
+_DARWIN_RECEIPT_STAGING_ROOT = ".gm2godot-receipt-staging"
+_DARWIN_RECEIPT_STAGING_ROOT_ALTERNATE = ".gm2godot-receipt-staging.private"
+_DARWIN_RENAME_EXCL = 0x00000004
+_NATIVE_RESULT_PENDING = object()
+_POSIX_PUBLICATION_UNAVAILABLE_ERRNOS = frozenset(
+    {
+        errno.EINVAL,
+        errno.ENOSYS,
+        getattr(errno, "ENOTSUP", errno.EINVAL),
+        getattr(errno, "EOPNOTSUPP", errno.EINVAL),
+    }
+)
+
+
+@dataclass(frozen=True)
+class _PosixReceiptStage:
+    descriptor: int
+    private_directory_descriptor: int = -1
+    private_directory_name: str = ""
+    private_directory_identity: tuple[int, int] | None = None
+    named_stage_name: str = ""
+
+
+@dataclass
+class _PosixReceiptStageLease:
+    descriptor: _PosixDescriptorLease
+    private_directory: _PosixDescriptorLease
+    stage: _PosixReceiptStage | None = None
+    named_stage_name: str | None = None
+    named_cleanup_attempts: int = 0
+    named_stage_retained: bool = False
+    private_directory_sync_pending: bool = False
+    private_directory_sync_attempts: int = 0
+    private_directory_sync_retained: bool = False
+    rename_result: object = _NATIVE_RESULT_PENDING
+    rename_errno: int = 0
+
+
+@dataclass
+class _PosixReceiptPublicationLease:
+    """Own every transient descriptor outside the publisher's exception table."""
+
+    binding: OutputParentBinding
+    stage: _PosixReceiptStageLease = field(
+        default_factory=lambda: _PosixReceiptStageLease(
+            _PosixDescriptorLease(),
+            _PosixDescriptorLease(),
+        )
+    )
+    transient_descriptors: list[_PosixDescriptorLease] = field(default_factory=lambda: list[_PosixDescriptorLease]())
+    _private_verification_complete: bool = False
+    _closed: bool = False
+
+    def new_transient_descriptor(self) -> _PosixDescriptorLease:
+        lease = _PosixDescriptorLease()
+        self.transient_descriptors.append(lease)
+        return lease
+
+    @property
+    def is_closed(self) -> bool:
+        return self._closed or (
+            self.stage.descriptor.descriptor is None
+            and self.stage.private_directory.descriptor is None
+            and all(lease.descriptor is None for lease in self.transient_descriptors)
+            and (self.stage.named_stage_name is None or self.stage.named_stage_retained)
+            and (
+                not self.stage.private_directory_sync_pending
+                or self.stage.private_directory_sync_retained
+            )
+        )
+
+    def close(self) -> tuple[BaseException, ...]:
+        if self._closed:
+            return ()
+        failures: list[BaseException] = []
+
+        def close_descriptor(lease: _PosixDescriptorLease, context: str) -> bool:
+            failure_count = len(failures)
+            close_error: BaseException | None = None
+            for _attempt in range(2):
+                try:
+                    close_error = _close_posix_descriptor_lease(
+                        lease,
+                        None,
+                        context,
+                    )
+                except BaseException as close_call_error:
+                    failures.append(close_call_error)
+                    if lease.descriptor is not None:
+                        continue
+                else:
+                    if close_error is not None:
+                        failures.append(close_error)
+                break
+            try:
+                descriptor_closed = lease.descriptor is None
+            except BaseException as status_error:
+                failures.append(status_error)
+                descriptor_closed = False
+            if not descriptor_closed and len(failures) == failure_count:
+                failures.append(
+                    AnchoredOutputError(
+                        "output-cleanup-retained",
+                        f"The {context} remained open after bounded cleanup attempts.",
+                    )
+                )
+            return descriptor_closed
+
+        for transient in reversed(self.transient_descriptors):
+            if not close_descriptor(transient, "receipt verification descriptor"):
+                return tuple(failures)
+        if (
+            sys.platform == "darwin"
+            and self.stage.named_stage_name is not None
+            and not self.stage.named_stage_retained
+        ):
+            for _attempt in range(2):
+                if self.stage.named_cleanup_attempts >= 4:
+                    break
+                self.stage.named_cleanup_attempts += 1
+                try:
+                    _cleanup_darwin_named_stage(self.stage)
+                except BaseException as cleanup_error:
+                    failures.append(cleanup_error)
+                    continue
+                break
+        if (
+            self.stage.named_stage_name is not None
+            and not self.stage.named_stage_retained
+            and self.stage.named_cleanup_attempts < 4
+        ):
+            # Keep both identity descriptors alive for the outer owner to make
+            # one more bounded cleanup pass before giving up safely.
+            return tuple(failures)
+        if self.stage.named_stage_name is not None and not self.stage.named_stage_retained:
+            self.stage.named_stage_retained = True
+            failures.append(
+                AnchoredOutputError(
+                    "output-cleanup-retained",
+                    "The private macOS receipt staging name could not be removed after bounded identity checks; "
+                    "the entry was left untouched.",
+                )
+            )
+        if (
+            self.stage.private_directory_sync_pending
+            and not self.stage.private_directory_sync_retained
+            and self.stage.private_directory_sync_attempts < 4
+        ):
+            for _attempt in range(2):
+                if self.stage.private_directory_sync_attempts >= 4:
+                    break
+                try:
+                    _sync_darwin_private_directory_if_pending(self.stage)
+                except BaseException as sync_error:
+                    failures.append(sync_error)
+                    continue
+                break
+        if (
+            self.stage.private_directory_sync_pending
+            and not self.stage.private_directory_sync_retained
+            and self.stage.private_directory_sync_attempts < 4
+        ):
+            # The private directory must outlive its retryable durability
+            # barrier just as it outlives a retryable named-stage cleanup.
+            return tuple(failures)
+        if self.stage.private_directory_sync_pending and not self.stage.private_directory_sync_retained:
+            self.stage.private_directory_sync_retained = True
+            failures.append(
+                AnchoredOutputError(
+                    "output-cleanup-retained",
+                    "The private macOS receipt directory could not be durably flushed after bounded retries.",
+                )
+            )
+        if not close_descriptor(self.stage.descriptor, "receipt staging descriptor"):
+            return tuple(failures)
+        retained_stage = self.stage.stage
+        if (
+            retained_stage is not None
+            and retained_stage.private_directory_descriptor >= 0
+            and not self._private_verification_complete
+        ):
+            try:
+                _verify_darwin_private_directory(self.binding, retained_stage)
+            except BaseException as verification_error:
+                failures.append(verification_error)
+            finally:
+                self._private_verification_complete = True
+        if not close_descriptor(
+            self.stage.private_directory,
+            "private receipt directory descriptor",
+        ):
+            return tuple(failures)
+        self._closed = self.is_closed
+        return tuple(failures)
+
+
+def _raise_posix_publication_error(
+    error_number: int,
+    destination: str,
+    *,
+    operation: str,
+    additional_unavailable: frozenset[int] = frozenset(),
+) -> NoReturn:
+    if error_number == errno.EEXIST:
+        raise FileExistsError(error_number, os.strerror(error_number), destination)
+    if error_number in _POSIX_PUBLICATION_UNAVAILABLE_ERRNOS | additional_unavailable:
+        raise AnchoredOutputError(
+            "output-anchor-unavailable",
+            f"The filesystem does not support descriptor-bound receipt {operation}.",
+        )
+    raise OSError(error_number, os.strerror(error_number), destination)
+
+
+def _linux_link_receipt_descriptor(
+    descriptor: int,
+    directory_descriptor: int,
+    destination: str,
+) -> None:
+    """Link one unnamed Linux file descriptor without replacing a name."""
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    operation = getattr(libc, "linkat", None)
+    if operation is None:
+        raise AnchoredOutputError(
+            "output-anchor-unavailable",
+            "Linux linkat is unavailable for descriptor-bound receipt publication.",
+        )
+    operation.argtypes = (
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+    )
+    operation.restype = ctypes.c_int
+    source = os.fsencode(f"/proc/self/fd/{descriptor}")
+    if (
+        operation(
+            _LINUX_AT_FDCWD,
+            source,
+            directory_descriptor,
+            os.fsencode(destination),
+            _LINUX_AT_SYMLINK_FOLLOW,
+        )
+        == 0
+    ):
+        return
+    _raise_posix_publication_error(
+        ctypes.get_errno(),
+        destination,
+        operation="linking",
+        additional_unavailable=frozenset(
+            {
+                errno.EACCES,
+                errno.ENOENT,
+                errno.ENOTDIR,
+                errno.EPERM,
+                errno.EXDEV,
+            }
+        ),
+    )
+
+
+def _darwin_rename_receipt_stage(
+    stage: _PosixReceiptStage,
+    lease: _PosixReceiptStageLease,
+    directory_descriptor: int,
+    destination: str,
+) -> None:
+    """Move one private retained inode into place without replacement."""
+
+    source_name = lease.named_stage_name
+    if not source_name or source_name != stage.named_stage_name:
+        raise AnchoredOutputError(
+            "output-temporary-invalid",
+            "The private macOS receipt stage has no retained source name.",
+        )
+    source_entry = os.stat(
+        source_name,
+        dir_fd=stage.private_directory_descriptor,
+        follow_symlinks=False,
+    )
+    source_descriptor = os.fstat(stage.descriptor)
+    if (
+        not stat.S_ISREG(source_entry.st_mode)
+        or source_entry.st_nlink != 1
+        or _stable_file_metadata(source_entry) != _stable_file_metadata(source_descriptor)
+    ):
+        raise AnchoredOutputError(
+            "output-temporary-invalid",
+            "The private macOS receipt staging name changed before publication.",
+        )
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    operation = getattr(libc, "renameatx_np", None)
+    if operation is None:
+        raise AnchoredOutputError(
+            "output-anchor-unavailable",
+            "macOS renameatx_np is unavailable for descriptor-bound receipt publication.",
+        )
+    operation.argtypes = (
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    )
+
+    class _RenameResult(ctypes.c_int):
+        pass
+
+    setattr(
+        _RenameResult,
+        "_check_retval_",
+        functools.partial(setattr, lease, "rename_result"),
+    )
+    operation.restype = _RenameResult
+    lease.private_directory_sync_pending = True
+    ctypes.set_errno(0)
+    operation(
+        stage.private_directory_descriptor,
+        os.fsencode(source_name),
+        directory_descriptor,
+        os.fsencode(destination),
+        _DARWIN_RENAME_EXCL,
+    )
+    lease.rename_errno = ctypes.get_errno()
+    result = getattr(lease.rename_result, "value", lease.rename_result)
+    if not isinstance(result, int):
+        raise OSError("Native macOS receipt rename returned without recording its result.")
+    if result == 0:
+        return
+    _raise_posix_publication_error(
+        lease.rename_errno or errno.EIO,
+        destination,
+        operation="renaming",
+    )
+
+
+def _validate_exact_receipt_descriptor(
+    descriptor: int,
+    payload: bytes,
+    expected_identity: tuple[int, int],
+    *,
+    expected_link_count: int,
+    code: str,
+) -> None:
+    """Read and validate the exact retained inode used for publication."""
+
+    before = os.fstat(descriptor)
+    if (
+        not stat.S_ISREG(before.st_mode)
+        or before.st_nlink != expected_link_count
+        or not _same_identity(before, expected_identity)
+        or not _receipt_mode_is_canonical(before)
+        or _darwin_descriptor_has_extended_acl(
+            descriptor,
+            error_code=code,
+            context="retained receipt descriptor",
+        )
+    ):
+        raise AnchoredOutputError(
+            code,
+            "The retained receipt descriptor is not one canonical private regular file.",
+        )
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    chunks: list[bytes] = []
+    remaining = len(payload) + 1
+    while remaining > 0:
+        chunk = os.read(descriptor, min(64 * 1024, remaining))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    after = os.fstat(descriptor)
+    if (
+        _stable_file_metadata(before) != _stable_file_metadata(after)
+        or not _receipt_mode_is_canonical(after)
+        or _darwin_descriptor_has_extended_acl(
+            descriptor,
+            error_code=code,
+            context="retained receipt descriptor after reading",
+        )
+        or b"".join(chunks) != payload
+    ):
+        raise AnchoredOutputError(
+            code,
+            "The retained receipt descriptor changed during exact verification.",
+        )
+
+
+def _write_and_sync_retained_descriptor(descriptor: int, payload: bytes) -> None:
+    """Write and sync a new staging inode while retaining its descriptor."""
+
+    os.ftruncate(descriptor, 0)
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    written = 0
+    while written < len(payload):
+        count = os.write(descriptor, payload[written:])
+        if count <= 0:
+            raise OSError(errno.EIO, "Could not write the complete receipt staging payload.")
+        written += count
+    os.fsync(descriptor)
+
+
+def _sync_posix_public_descriptor(
+    binding: OutputParentBinding,
+    payload: bytes,
+    expected_identity: tuple[int, int],
+    descriptor_lease: _PosixDescriptorLease,
+) -> None:
+    """Bind, validate, and durably flush one exact public receipt inode."""
+    descriptor: int | None = None
+    primary: BaseException | None = None
+    try:
+        try:
+            descriptor = binding.open_read(binding.leaf, descriptor_lease)
+        except OSError as error:
+            if not isinstance(error, FileNotFoundError) and error.errno not in {errno.ENOENT, errno.ELOOP}:
+                raise
+            translated = AnchoredOutputError(
+                "output-changed",
+                f"Published receipt changed while it was being opened: {binding.parent / binding.leaf}.",
+            )
+            for note in getattr(error, "__notes__", ()):
+                translated.add_note(note)
+            raise translated from error
+        _validate_exact_receipt_descriptor(
+            descriptor,
+            payload,
+            expected_identity,
+            expected_link_count=1,
+            code="output-changed",
+        )
+        os.fsync(descriptor)
+    except BaseException as error:
+        primary = error
+        raise
+    finally:
+        close_call_failures: list[BaseException] = []
+        close_error: BaseException | None = None
+        for _attempt in range(2):
+            try:
+                close_error = _close_posix_descriptor_lease(
+                    descriptor_lease,
+                    primary,
+                    "published receipt descriptor",
+                )
+            except BaseException as close_call_error:
+                # Catch both a pre-call interruption and one delivered after
+                # the helper returned but before Python stored its result.
+                close_call_failures.append(close_call_error)
+                if descriptor_lease.descriptor is not None:
+                    continue
+            break
+        if primary is not None:
+            for close_call_error in close_call_failures:
+                primary.add_note(f"Could not close published receipt descriptor: {close_call_error}")
+        elif close_call_failures:
+            first_close_failure = close_call_failures[0]
+            for later_failure in close_call_failures[1:]:
+                first_close_failure.add_note(f"Published receipt close failure: {later_failure}")
+            raise first_close_failure
+        elif close_error is not None:
+            raise close_error
+
+
+def _darwin_private_directory_is_canonical(
+    value: os.stat_result,
+    identity: tuple[int, int],
+) -> bool:
+    return (
+        stat.S_ISDIR(value.st_mode)
+        and _same_identity(value, identity)
+        and stat.S_IMODE(value.st_mode) == 0o700
+        and value.st_uid == os.geteuid()
+    )
+
+
+def _verify_darwin_private_directory(
+    binding: OutputParentBinding,
+    stage: _PosixReceiptStage,
+) -> None:
+    """Report outer-name changes without removing any directory by name.
+
+    macOS has no public descriptor-bound directory-removal primitive. The
+    stable 0700 staging root is therefore intentionally retained: a final
+    ``rmdir`` through the writable parent would reintroduce a last-component
+    swap race after an otherwise descriptor-bound publication.
+    """
+
+    identity = stage.private_directory_identity
+    if stage.private_directory_descriptor < 0 or identity is None:
+        raise AnchoredOutputError(
+            "output-cleanup-retained",
+            "The macOS receipt staging directory was not bound for safe cleanup.",
+        )
+    try:
+        entry = binding.stat(stage.private_directory_name)
+        opened = os.fstat(stage.private_directory_descriptor)
+    except BaseException as error:
+        raise AnchoredOutputError(
+            "output-cleanup-retained",
+            "The stable macOS receipt staging root is missing or cannot be verified; no outer directory was removed.",
+        ) from error
+    if not (
+        _darwin_private_directory_is_canonical(entry, identity)
+        and _darwin_private_directory_is_canonical(opened, identity)
+        and not _darwin_descriptor_has_extended_acl(
+            stage.private_directory_descriptor,
+            error_code="output-cleanup-retained",
+            context="private macOS receipt directory",
+        )
+    ):
+        raise AnchoredOutputError(
+            "output-cleanup-retained",
+            "The stable macOS receipt staging root changed; no outer directory was removed.",
+        )
+
+
+def _unlink_darwin_stage_if_identity(
+    directory_descriptor: int,
+    stage_name: str,
+    identity: tuple[int, int],
+    *,
+    before_unlink: Callable[[], None] | None = None,
+) -> None:
+    entry: os.stat_result | None = None
+    for _attempt in range(2):
+        try:
+            entry = os.stat(
+                stage_name,
+                dir_fd=directory_descriptor,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            # A control-flow exception can replace a successful stat return
+            # before Python stores it. Re-observe once before concluding that
+            # the leased stage name is absent.
+            continue
+        break
+    if entry is None:
+        return
+    if not stat.S_ISREG(entry.st_mode) or not _same_identity(entry, identity):
+        raise AnchoredOutputError(
+            "output-cleanup-retained",
+            "The private macOS receipt staging entry changed and was left untouched.",
+        )
+    if before_unlink is not None:
+        before_unlink()
+    os.unlink(stage_name, dir_fd=directory_descriptor)
+
+
+def _cleanup_darwin_named_stage(lease: _PosixReceiptStageLease) -> None:
+    """Remove only the still-named inode owned by a Darwin stage lease."""
+
+    stage_name = lease.named_stage_name
+    if stage_name is None:
+        _sync_darwin_private_directory_if_pending(lease)
+        return
+    stage_descriptor = lease.descriptor.descriptor
+    if stage_descriptor is None:
+        # The candidate name is recorded before openat. Without a leased
+        # descriptor there is no identity that authorizes removing anything.
+        lease.named_stage_name = None
+        return
+    private_descriptor = lease.private_directory.descriptor
+    if private_descriptor is None:
+        raise AnchoredOutputError(
+            "output-cleanup-retained",
+            "The failed private receipt stage is still named, but its directory descriptor is unavailable.",
+        )
+    leased_stage = os.fstat(stage_descriptor)
+    if (
+        not stat.S_ISREG(leased_stage.st_mode)
+        or _darwin_descriptor_has_extended_acl(
+            stage_descriptor,
+            error_code="output-cleanup-retained",
+            context="private macOS receipt stage during cleanup",
+        )
+    ):
+        raise AnchoredOutputError(
+            "output-cleanup-retained",
+            "The failed private receipt staging descriptor is not a regular file; no named entry was removed.",
+        )
+    _unlink_darwin_stage_if_identity(
+        private_descriptor,
+        stage_name,
+        (leased_stage.st_dev, leased_stage.st_ino),
+        before_unlink=lambda: setattr(
+            lease,
+            "private_directory_sync_pending",
+            True,
+        ),
+    )
+    lease.named_stage_name = None
+    _sync_darwin_private_directory_if_pending(lease)
+
+
+def _sync_darwin_private_directory_if_pending(lease: _PosixReceiptStageLease) -> None:
+    """Retry the source-directory barrier after unlink or rename removal."""
+
+    if not lease.private_directory_sync_pending:
+        return
+    private_descriptor = lease.private_directory.descriptor
+    if private_descriptor is None:
+        raise AnchoredOutputError(
+            "output-cleanup-retained",
+            "The private macOS receipt directory needs a durability retry but its descriptor is unavailable.",
+        )
+    lease.private_directory_sync_attempts += 1
+    os.fsync(private_descriptor)
+    lease.private_directory_sync_pending = False
+
+
+def _open_darwin_receipt_stage(
+    binding: OutputParentBinding,
+    private_directory_name: str,
+    lease: _PosixReceiptStageLease,
+) -> _PosixReceiptStage:
+    """Create a named source inside one stable retained ACL-free 0700 root.
+
+    A writer with access only to the shared parent may rename or replace the
+    stable outer entry, but cannot redirect inner operations away from the
+    retained directory descriptor. Darwin cannot prevent a hostile same-UID
+    process from opening or mutating another process's staging inode.
+    """
+
+    parent_descriptor = binding.descriptors[-1]
+    private_created = False
+    private_descriptor = -1
+    private_identity: tuple[int, int] | None = None
+    stage_descriptor = -1
+    stage_name = ""
+    try:
+        created: os.stat_result | None = None
+        for _attempt in range(2):
+            try:
+                created = binding.stat(private_directory_name)
+            except FileNotFoundError:
+                # Re-observe once so a return-boundary exception cannot make
+                # an existing wrong-mode root look absent and eligible for
+                # sealing as a directory created by this call.
+                continue
+            break
+        if created is None:
+            _validate_safe_posix_directory_descriptor(
+                parent_descriptor,
+                code="output-temporary-invalid",
+                context="macOS receipt staging-root creation parent",
+            )
+            try:
+                os.mkdir(private_directory_name, 0o700, dir_fd=parent_descriptor)
+            except FileExistsError as create_error:
+                raise AnchoredOutputError(
+                    "output-temporary-invalid",
+                    "The macOS receipt staging root appeared after it was observed missing.",
+                ) from create_error
+            private_created = True
+            created = binding.stat(private_directory_name)
+        if (
+            not stat.S_ISDIR(created.st_mode)
+            or created.st_uid != os.geteuid()
+            or (
+                not private_created
+                and stat.S_IMODE(created.st_mode) != 0o700
+            )
+            or (
+                private_created
+                and stat.S_IMODE(created.st_mode) & ~0o700
+            )
+        ):
+            raise AnchoredOutputError(
+                "output-temporary-invalid",
+                "The stable macOS receipt staging root is not a current-user-owned 0700 directory.",
+            )
+        private_identity = (created.st_dev, created.st_ino)
+        if private_created:
+            # The public parent was proven safe before mkdir, so another UID
+            # cannot swap this entry while a restrictive umask is repaired.
+            # Same-UID/root interference remains outside the threat model.
+            os.chmod(
+                private_directory_name,
+                0o700,
+                dir_fd=parent_descriptor,
+                follow_symlinks=False,
+            )
+            created = binding.stat(private_directory_name)
+            if not _darwin_private_directory_is_canonical(created, private_identity):
+                raise AnchoredOutputError(
+                    "output-temporary-invalid",
+                    "The new macOS receipt staging root changed while its mode was sealed.",
+                )
+        private_descriptor = _open_posix_descriptor(
+            lease.private_directory,
+            private_directory_name,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0),
+            dir_fd=parent_descriptor,
+        )
+        opened_directory = os.fstat(private_descriptor)
+        if (
+            not stat.S_ISDIR(opened_directory.st_mode)
+            or opened_directory.st_uid != os.geteuid()
+            or not _same_identity(opened_directory, private_identity)
+        ):
+            raise AnchoredOutputError(
+                "output-temporary-invalid",
+                "The stable macOS receipt staging root changed while it was opened.",
+            )
+        if not _darwin_private_directory_is_canonical(
+            opened_directory,
+            private_identity,
+        ) and private_created:
+            os.fchmod(private_descriptor, 0o700)
+            opened_directory = os.fstat(private_descriptor)
+        if not _darwin_private_directory_is_canonical(
+            opened_directory,
+            private_identity,
+        ):
+            raise AnchoredOutputError(
+                "output-temporary-invalid",
+                "The stable macOS receipt staging root could not be sealed to mode 0700.",
+            )
+        _validate_safe_posix_directory_descriptor(
+            private_descriptor,
+            code="output-temporary-invalid",
+            context="private macOS receipt staging root",
+            require_private=True,
+        )
+
+        for _attempt in range(100):
+            stage_name = f"{secrets.token_hex(16)}.tmp"
+            # Record the candidate name before entering the native open. If
+            # control flow is interrupted after openat has populated the
+            # descriptor lease but before its return value reaches a Python
+            # local, exception cleanup can still bind that name to the leased
+            # descriptor's identity. A failed open owns no descriptor, so this
+            # intent alone never authorizes unlinking an existing entry.
+            lease.named_stage_name = stage_name
+            try:
+                stage_descriptor = _open_posix_descriptor(
+                    lease.descriptor,
+                    stage_name,
+                    os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+                    0o600,
+                    dir_fd=private_descriptor,
+                )
+            except FileExistsError:
+                # A FileExistsError raised at the Python call/return seam can
+                # arrive after openat created the file and transferred its
+                # descriptor into the lease. That is not a collision: keep
+                # the original candidate name so outer cleanup can bind and
+                # remove exactly the acquired inode.
+                if lease.descriptor.descriptor is not None:
+                    raise
+                lease.named_stage_name = None
+                continue
+            break
+        if stage_descriptor < 0:
+            raise AnchoredOutputError(
+                "output-temporary-unavailable",
+                "Could not create a unique private macOS receipt staging inode.",
+            )
+        os.fchmod(stage_descriptor, 0o600)
+        opened_stage = os.fstat(stage_descriptor)
+        stage_entry = os.stat(
+            stage_name,
+            dir_fd=private_descriptor,
+            follow_symlinks=False,
+        )
+        if (
+            not stat.S_ISREG(opened_stage.st_mode)
+            or opened_stage.st_nlink != 1
+            or not _receipt_mode_is_canonical(opened_stage)
+            or _darwin_descriptor_has_extended_acl(
+                stage_descriptor,
+                error_code="output-temporary-invalid",
+                context="private macOS receipt staging descriptor",
+            )
+            or _stable_file_metadata(opened_stage) != _stable_file_metadata(stage_entry)
+        ):
+            raise AnchoredOutputError(
+                "output-temporary-invalid",
+                "The private macOS receipt staging inode changed before publication.",
+            )
+        stage = _PosixReceiptStage(
+            descriptor=stage_descriptor,
+            private_directory_descriptor=private_descriptor,
+            private_directory_name=private_directory_name,
+            private_directory_identity=private_identity,
+            named_stage_name=stage_name,
+        )
+        lease.stage = stage
+        return stage
+    except BaseException as error:
+        if lease.named_stage_name is not None and not lease.named_stage_retained:
+            while lease.named_cleanup_attempts < 4:
+                lease.named_cleanup_attempts += 1
+                try:
+                    _cleanup_darwin_named_stage(lease)
+                except BaseException as cleanup_error:
+                    error.add_note(f"Could not remove failed private receipt staging: {cleanup_error}")
+                    continue
+                break
+        if lease.named_stage_name is not None and not lease.named_stage_retained:
+            lease.named_stage_retained = True
+            error.add_note("The failed private receipt staging name was left untouched after bounded identity checks.")
+        if (
+            lease.private_directory_sync_pending
+            and not lease.private_directory_sync_retained
+        ):
+            while lease.private_directory_sync_attempts < 4:
+                try:
+                    _sync_darwin_private_directory_if_pending(lease)
+                except BaseException as sync_error:
+                    error.add_note(
+                        "Could not durably flush the failed private receipt staging directory: "
+                        f"{sync_error}"
+                    )
+                    continue
+                break
+        if (
+            lease.private_directory_sync_pending
+            and not lease.private_directory_sync_retained
+        ):
+            # Record the exhausted durability obligation before either owned
+            # descriptor can be closed. The outer publication lease may then
+            # finish bounded cleanup without replaying an ambiguous barrier.
+            lease.private_directory_sync_retained = True
+            error.add_note(
+                "The failed private receipt staging directory could not be durably flushed "
+                "after bounded retries."
+            )
+        for descriptor_lease, context in (
+            (lease.descriptor, "failed receipt staging descriptor"),
+            (lease.private_directory, "failed private receipt directory"),
+        ):
+            for _attempt in range(2):
+                try:
+                    close_error = _close_posix_descriptor_lease(
+                        descriptor_lease,
+                        error,
+                        context,
+                    )
+                except BaseException as close_call_error:
+                    error.add_note(f"Could not close {context}: {close_call_error}")
+                    if descriptor_lease.descriptor is not None:
+                        continue
+                else:
+                    if close_error is not error and close_error is not None:
+                        error.add_note(f"Could not close {context}: {close_error}")
+                break
+            try:
+                descriptor_closed = descriptor_lease.descriptor is None
+            except BaseException as status_error:
+                error.add_note(f"Could not confirm closure of {context}: {status_error}")
+                descriptor_closed = False
+            if not descriptor_closed:
+                error.add_note(f"The {context} remained open after bounded cleanup attempts.")
+                # The private directory is the staging descriptor's retained
+                # parent and must outlive it when cleanup cannot finish.
+                break
+        if private_descriptor < 0 and private_created:
+            error.add_note(
+                "The stable macOS receipt staging root was intentionally left in place because macOS has no "
+                "descriptor-bound directory-removal primitive."
+            )
+        raise
+
+
+def _open_posix_receipt_stage(
+    binding: OutputParentBinding,
+    temporary_name: str,
+    lease: _PosixReceiptStageLease,
+) -> _PosixReceiptStage:
+    """Open Linux unnamed staging or a private named macOS stage."""
+
+    if binding.strategy != "posix-dir-fd":
+        raise AnchoredOutputError(
+            "output-anchor-unavailable",
+            "Descriptor-bound POSIX receipt staging requires a retained directory descriptor.",
+        )
+    if sys.platform.startswith("linux"):
+        temporary_flag = int(getattr(os, "O_TMPFILE", 0))
+        if not temporary_flag:
+            raise AnchoredOutputError(
+                "output-anchor-unavailable",
+                "Linux O_TMPFILE is unavailable for descriptor-bound receipt staging.",
+            )
+        flags = os.O_RDWR | temporary_flag | getattr(os, "O_CLOEXEC", 0)
+        try:
+            try:
+                descriptor = _open_posix_descriptor(
+                    lease.descriptor,
+                    ".",
+                    flags,
+                    0o600,
+                    dir_fd=binding.descriptors[-1],
+                )
+            except OSError as error:
+                if error.errno in _POSIX_PUBLICATION_UNAVAILABLE_ERRNOS | {
+                    errno.EISDIR,
+                    errno.ENOENT,
+                }:
+                    raise AnchoredOutputError(
+                        "output-anchor-unavailable",
+                        "The filesystem does not support Linux O_TMPFILE receipt staging.",
+                    ) from error
+                raise
+            os.fchmod(descriptor, 0o600)
+            opened = os.fstat(descriptor)
+            if not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 0 or not _receipt_mode_is_canonical(opened):
+                raise AnchoredOutputError(
+                    "output-temporary-invalid",
+                    "Receipt staging is not one canonical private regular file.",
+                )
+            stage = _PosixReceiptStage(descriptor=descriptor)
+            lease.stage = stage
+            return stage
+        except BaseException as error:
+            for _attempt in range(2):
+                try:
+                    close_error = _close_posix_descriptor_lease(
+                        lease.descriptor,
+                        error,
+                        "failed receipt staging descriptor",
+                    )
+                except BaseException as close_call_error:
+                    error.add_note(f"Could not close failed receipt staging descriptor: {close_call_error}")
+                    if lease.descriptor.descriptor is not None:
+                        continue
+                else:
+                    if close_error is not error and close_error is not None:
+                        error.add_note(f"Could not close failed receipt staging descriptor: {close_error}")
+                break
+            raise
+    if sys.platform == "darwin":
+        return _open_darwin_receipt_stage(binding, temporary_name, lease)
+    raise AnchoredOutputError(
+        "output-anchor-unavailable",
+        "This POSIX platform has no supported descriptor-bound receipt publication primitive.",
+    )
+
+
+def _publish_posix_receipt_descriptor(
+    binding: OutputParentBinding,
+    stage: _PosixReceiptStage,
+    stage_lease: _PosixReceiptStageLease,
+    destination: str,
+    payload: bytes,
+    expected_identity: tuple[int, int],
+) -> None:
+    """Verify and publish exactly the inode held by ``descriptor``."""
+
+    binding.verify()
+    _validate_exact_receipt_descriptor(
+        stage.descriptor,
+        payload,
+        expected_identity,
+        expected_link_count=(0 if sys.platform.startswith("linux") else 1),
+        code="output-temporary-invalid",
+    )
+    if sys.platform.startswith("linux"):
+        _linux_link_receipt_descriptor(
+            stage.descriptor,
+            binding.descriptors[-1],
+            destination,
+        )
+        return
+    if sys.platform == "darwin":
+        _darwin_rename_receipt_stage(
+            stage,
+            stage_lease,
+            binding.descriptors[-1],
+            destination,
+        )
+        return
+    raise AnchoredOutputError(
+        "output-anchor-unavailable",
+        "This POSIX platform has no supported descriptor-bound receipt publication primitive.",
+    )
+
+
+def _darwin_private_root_for_destination(destination: str) -> str:
+    """Keep the implementation root distinct from every supported leaf."""
+
+    if destination == _DARWIN_RECEIPT_STAGING_ROOT:
+        return _DARWIN_RECEIPT_STAGING_ROOT_ALTERNATE
+    return _DARWIN_RECEIPT_STAGING_ROOT
+
+
+def _durably_verify_public_receipt(
+    binding: OutputParentBinding,
+    payload: bytes,
+    expected_identity: tuple[int, int],
+    publication_lease: _PosixReceiptPublicationLease,
+) -> None:
+    """Flush the exact public inode and parent, then verify the namespace."""
+
+    _sync_posix_public_descriptor(
+        binding,
+        payload,
+        expected_identity,
+        publication_lease.new_transient_descriptor(),
+    )
+    binding.sync()
+    _read_exact_receipt(
+        binding,
+        binding.leaf,
+        payload,
+        descriptor_lease=publication_lease.new_transient_descriptor(),
+        expected_identity=expected_identity,
+    )
+
+
+def _publish_posix_receipt_bytes(
+    path: Path,
+    payload: bytes,
+    binding: OutputParentBinding,
+    publication_lease: _PosixReceiptPublicationLease,
+) -> None:
+    """Publish one canonical receipt through caller-retained ownership."""
+
+    if publication_lease.binding is not binding:
+        raise ValueError("POSIX receipt publication lease belongs to another binding.")
+    stage_lease = publication_lease.stage
+    stage: _PosixReceiptStage | None = None
+    descriptor = -1
+    source_identity: tuple[int, int] | None = None
+    output_identity: tuple[int, int] | None = None
+    publication_attempted = False
+    primary_error: BaseException | None = None
+    try:
+        try:
+            binding.stat(binding.leaf)
+        except FileNotFoundError:
+            pass
+        else:
+            output_identity = _read_exact_receipt(
+                binding,
+                binding.leaf,
+                payload,
+                descriptor_lease=publication_lease.new_transient_descriptor(),
+            )
+            _durably_verify_public_receipt(
+                binding,
+                payload,
+                output_identity,
+                publication_lease,
+            )
+            return
+
+        if sys.platform == "darwin":
+            stage = _open_posix_receipt_stage(
+                binding,
+                _darwin_private_root_for_destination(binding.leaf),
+                stage_lease,
+            )
+            descriptor = stage.descriptor
+        else:
+            stage = _open_posix_receipt_stage(binding, "", stage_lease)
+            descriptor = stage.descriptor
+        opened = os.fstat(descriptor)
+        source_identity = (opened.st_dev, opened.st_ino)
+        _write_and_sync_retained_descriptor(descriptor, payload)
+        _validate_exact_receipt_descriptor(
+            descriptor,
+            payload,
+            source_identity,
+            expected_link_count=(0 if sys.platform.startswith("linux") else 1),
+            code="output-temporary-invalid",
+        )
+
+        source_link_count: int | None = None
+        try:
+            publication_attempted = True
+            _publish_posix_receipt_descriptor(
+                binding,
+                stage,
+                stage_lease,
+                binding.leaf,
+                payload,
+                source_identity,
+            )
+        except FileExistsError:
+            # FileExistsError may be a true collision or an exception delivered
+            # after the native no-replace operation took effect. Observe the
+            # public inode before deciding whether durability work is required.
+            output_identity = _read_exact_receipt(
+                binding,
+                binding.leaf,
+                payload,
+                descriptor_lease=publication_lease.new_transient_descriptor(),
+            )
+            if sys.platform == "darwin":
+                # A distinct exact collision winner leaves our source named;
+                # an effect-then-exception leaves it absent. The same identity-
+                # checked cleanup handles both and durably flushes the private
+                # directory removal before the public parent.
+                _cleanup_darwin_named_stage(stage_lease)
+            _durably_verify_public_receipt(
+                binding,
+                payload,
+                output_identity,
+                publication_lease,
+            )
+            return
+        if source_link_count is None:
+            output_identity = source_identity
+            _read_exact_receipt(
+                binding,
+                binding.leaf,
+                payload,
+                descriptor_lease=publication_lease.new_transient_descriptor(),
+                expected_identity=source_identity,
+            )
+            if sys.platform == "darwin":
+                _cleanup_darwin_named_stage(stage_lease)
+            source_link_count = 1
+
+        assert source_link_count is not None
+        _validate_exact_receipt_descriptor(
+            descriptor,
+            payload,
+            source_identity,
+            expected_link_count=source_link_count,
+            code="output-changed",
+        )
+        binding.verify()
+        assert output_identity is not None
+        _durably_verify_public_receipt(
+            binding,
+            payload,
+            output_identity,
+            publication_lease,
+        )
+    except BaseException as error:
+        primary_error = error
+        if publication_attempted:
+            if sys.platform == "darwin":
+                try:
+                    _cleanup_darwin_named_stage(stage_lease)
+                except BaseException as private_cleanup_error:
+                    error.add_note(
+                        "Could not remove and flush the private macOS receipt stage after a publication failure: "
+                        f"{private_cleanup_error}"
+                    )
+            recovered_identity: tuple[int, int] | None = None
+            try:
+                recovered_identity = _read_exact_receipt(
+                    binding,
+                    binding.leaf,
+                    payload,
+                    descriptor_lease=publication_lease.new_transient_descriptor(),
+                )
+            except BaseException as observation_error:
+                error.add_note(
+                    "Descriptor-bound receipt publication outcome could not be bound to one exact public inode: "
+                    f"{observation_error}."
+                )
+            else:
+                error.add_note(
+                    "Descriptor-bound receipt publication exposed an exact public receipt before the failure; "
+                    "the valid public inode was left untouched."
+                )
+            recovery_steps: list[tuple[str, Callable[[], object]]] = [
+                ("revalidate the receipt parent", lambda: binding.verify()),
+            ]
+            if recovered_identity is not None:
+                recovery_steps.append(
+                    (
+                        "flush the exact public receipt",
+                        lambda: _sync_posix_public_descriptor(
+                            binding,
+                            payload,
+                            recovered_identity,
+                            publication_lease.new_transient_descriptor(),
+                        ),
+                    )
+                )
+            recovery_steps.append(("flush the receipt parent", lambda: binding.sync()))
+            if recovered_identity is not None:
+                recovery_steps.append(
+                    (
+                        "perform final receipt verification",
+                        lambda: _read_exact_receipt(
+                            binding,
+                            binding.leaf,
+                            payload,
+                            descriptor_lease=publication_lease.new_transient_descriptor(),
+                            expected_identity=recovered_identity,
+                        ),
+                    )
+                )
+            for description, recovery_step in recovery_steps:
+                try:
+                    recovery_step()
+                except BaseException as recovery_error:
+                    error.add_note(
+                        f"Could not {description} while recovering an attempted receipt publication: {recovery_error}"
+                    )
+        raise
+    finally:
+        close_failures: list[BaseException] = []
+        publication_closed = False
+        for _attempt in range(2):
+            try:
+                close_failures.extend(publication_lease.close())
+            except BaseException as publication_close_error:
+                close_failures.append(publication_close_error)
+            try:
+                publication_closed = publication_lease.is_closed
+            except BaseException as status_error:
+                close_failures.append(status_error)
+                publication_closed = False
+            if publication_closed:
+                break
+        if not publication_closed:
+            if not close_failures:
+                close_failures.append(
+                    AnchoredOutputError(
+                        "output-cleanup-retained",
+                        "A POSIX receipt publication resource remained open after bounded cleanup attempts.",
+                    )
+                )
+        else:
+            try:
+                binding_close_failures = binding.close()
+            except BaseException as binding_close_error:
+                # The binding owns its resources until its close implementation
+                # confirms otherwise. Treat an interruption at the call/return
+                # boundary as another cleanup failure so it cannot replace an
+                # already-active publication error.
+                close_failures.append(binding_close_error)
+            else:
+                close_failures.extend(binding_close_failures)
+        if close_failures:
+            if primary_error is not None:
+                for close_error in close_failures:
+                    primary_error.add_note(f"Could not close a receipt publication resource: {close_error}")
+            else:
+                control_flow_failure = next(
+                    (failure for failure in close_failures if not isinstance(failure, Exception)),
+                    None,
+                )
+                if control_flow_failure is not None:
+                    for failure in close_failures:
+                        if failure is not control_flow_failure:
+                            control_flow_failure.add_note(f"Receipt publication close failure: {failure}")
+                    raise control_flow_failure
+                first_close_error = close_failures[0]
+                for later_error in close_failures[1:]:
+                    first_close_error.add_note(f"Receipt publication close failure: {later_error}")
+                raise first_close_error
+
+
+__all__ = ["_publish_posix_receipt_bytes"]

--- a/scripts/_anchored_receipt_windows.py
+++ b/scripts/_anchored_receipt_windows.py
@@ -1,0 +1,1539 @@
+"""Retained-handle Win32 publication for small immutable receipt bytes."""
+
+from __future__ import annotations
+
+import ctypes
+from dataclasses import dataclass, field
+import functools
+import os
+from pathlib import Path
+import secrets
+import sys
+from typing import Any, Callable, Literal, cast
+
+
+DWORD = ctypes.c_uint32
+BOOLEAN = ctypes.c_ubyte
+WCHAR = ctypes.c_uint16
+USHORT = ctypes.c_uint16
+ULONG = ctypes.c_uint32
+NTSTATUS = ctypes.c_int32
+ULONG_PTR = ctypes.c_size_t
+
+
+DELETE = 0x00010000
+SYNCHRONIZE = 0x00100000
+FILE_READ_DATA = 0x00000001
+FILE_WRITE_DATA = 0x00000002
+FILE_READ_ATTRIBUTES = 0x00000080
+FILE_SHARE_READ = 0x00000001
+FILE_SHARE_WRITE = 0x00000002
+FILE_ATTRIBUTE_NORMAL = 0x00000080
+FILE_ATTRIBUTE_READONLY = 0x00000001
+FILE_ATTRIBUTE_DIRECTORY = 0x00000010
+FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
+FILE_TYPE_UNKNOWN = 0
+FILE_TYPE_DISK = 1
+FILE_BEGIN = 0
+FILE_BASIC_INFO = 0
+FILE_STANDARD_INFO = 1
+FILE_RENAME_INFO = 3
+FILE_DISPOSITION_INFO = 4
+FILE_ID_INFO = 18
+ERROR_FILE_EXISTS = 80
+ERROR_ALREADY_EXISTS = 183
+ERROR_FILE_NOT_FOUND = 2
+ERROR_PATH_NOT_FOUND = 3
+ERROR_INVALID_FUNCTION = 1
+ERROR_NOT_SUPPORTED = 50
+ERROR_INVALID_PARAMETER = 87
+ERROR_CALL_NOT_IMPLEMENTED = 120
+
+OBJ_CASE_INSENSITIVE = 0x00000040
+FILE_OPEN = 0x00000001
+FILE_CREATE = 0x00000002
+FILE_OPEN_IF = 0x00000003
+FILE_OPENED = 0x00000001
+FILE_CREATED = 0x00000002
+FILE_DIRECTORY_FILE = 0x00000001
+FILE_SYNCHRONOUS_IO_NONALERT = 0x00000020
+FILE_NON_DIRECTORY_FILE = 0x00000040
+FILE_OPEN_REPARSE_POINT = 0x00200000
+STATUS_OBJECT_NAME_COLLISION = 0xC0000035
+STATUS_FILE_IS_A_DIRECTORY = 0xC00000BA
+
+_WINDOWS_CLOSE_RESULT_PENDING = object()
+_WINDOWS_CLOSE_ERROR_PENDING = object()
+_WINDOWS_PUBLICATION_UNAVAILABLE_ERRORS = frozenset(
+    {
+        ERROR_INVALID_FUNCTION,
+        ERROR_NOT_SUPPORTED,
+        ERROR_INVALID_PARAMETER,
+        ERROR_CALL_NOT_IMPLEMENTED,
+    }
+)
+_WINDOWS_NONREGULAR_OPEN_STATUSES = frozenset({STATUS_FILE_IS_A_DIRECTORY})
+
+_STAGE_ACCESS = FILE_READ_DATA | FILE_WRITE_DATA | FILE_READ_ATTRIBUTES | DELETE | SYNCHRONIZE
+_TARGET_READ_ACCESS = FILE_READ_DATA | FILE_READ_ATTRIBUTES | SYNCHRONIZE
+_DIRECTORY_ACCESS = 0x00000020 | FILE_READ_ATTRIBUTES | SYNCHRONIZE
+_FILE_OPEN_OPTIONS = FILE_SYNCHRONOUS_IO_NONALERT | FILE_NON_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT
+_DIRECTORY_OPEN_OPTIONS = FILE_SYNCHRONOUS_IO_NONALERT | FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT
+
+_WINDOWS_RESERVED_LEAF_CHARACTERS = frozenset('<>:"/\\|?*')
+_WINDOWS_RESERVED_DEVICE_BASENAMES = frozenset(
+    {
+        "con",
+        "prn",
+        "aux",
+        "nul",
+        *(f"com{suffix}" for suffix in "123456789¹²³"),
+        *(f"lpt{suffix}" for suffix in "123456789¹²³"),
+    }
+)
+
+
+class _FileId128(ctypes.Structure):
+    _fields_ = (("Identifier", ctypes.c_ubyte * 16),)
+
+
+class _FileIdInfo(ctypes.Structure):
+    _fields_ = (("VolumeSerialNumber", ctypes.c_ulonglong), ("FileId", _FileId128))
+
+
+class _FileBasicInfo(ctypes.Structure):
+    _fields_ = (
+        ("CreationTime", ctypes.c_longlong),
+        ("LastAccessTime", ctypes.c_longlong),
+        ("LastWriteTime", ctypes.c_longlong),
+        ("ChangeTime", ctypes.c_longlong),
+        ("FileAttributes", DWORD),
+    )
+
+
+class _FileStandardInfo(ctypes.Structure):
+    _fields_ = (
+        ("AllocationSize", ctypes.c_longlong),
+        ("EndOfFile", ctypes.c_longlong),
+        ("NumberOfLinks", DWORD),
+        ("DeletePending", BOOLEAN),
+        ("Directory", BOOLEAN),
+    )
+
+
+class _FileDispositionInfo(ctypes.Structure):
+    _fields_ = (("DeleteFile", BOOLEAN),)
+
+
+class _FileRenameInfo(ctypes.Structure):
+    _fields_ = (
+        ("ReplaceIfExists", BOOLEAN),
+        ("RootDirectory", ctypes.c_void_p),
+        ("FileNameLength", DWORD),
+        ("FileName", WCHAR * 1),
+    )
+
+
+class _UnicodeString(ctypes.Structure):
+    _fields_ = (
+        ("Length", USHORT),
+        ("MaximumLength", USHORT),
+        ("Buffer", ctypes.c_void_p),
+    )
+
+
+class _ObjectAttributes(ctypes.Structure):
+    _fields_ = (
+        ("Length", ULONG),
+        ("RootDirectory", ctypes.c_void_p),
+        ("ObjectName", ctypes.POINTER(_UnicodeString)),
+        ("Attributes", ULONG),
+        ("SecurityDescriptor", ctypes.c_void_p),
+        ("SecurityQualityOfService", ctypes.c_void_p),
+    )
+
+
+class _IoStatusValue(ctypes.Union):
+    _fields_ = (("Status", NTSTATUS), ("Pointer", ctypes.c_void_p))
+
+
+class _IoStatusBlock(ctypes.Structure):
+    _anonymous_ = ("value",)
+    _fields_ = (("value", _IoStatusValue), ("Information", ULONG_PTR))
+
+
+@dataclass(frozen=True)
+class WindowsReceiptResult:
+    leaf: str
+    volume_serial_number: int
+    file_id: bytes
+    size: int
+
+
+@dataclass(frozen=True)
+class WindowsReceiptOutcome:
+    state: Literal["published", "unknown"]
+    receipt: WindowsReceiptResult
+
+
+@dataclass(frozen=True)
+class WindowsDirectoryResult:
+    handle: int
+    volume_serial_number: int
+    file_id: bytes
+    created: bool
+
+
+@dataclass(slots=True)
+class _WindowsCloseObservation:
+    """One definitive CloseHandle result and its immediate error evidence."""
+
+    status: object
+    error: object = _WINDOWS_CLOSE_ERROR_PENDING
+
+
+@dataclass(slots=True, init=False)
+class WindowsHandleLease:
+    """Mutable ownership slot visible across Python call-return boundaries."""
+
+    _handle_output: ctypes.c_void_p = field(init=False, repr=False)
+    recorded_close_results: list[_WindowsCloseObservation] = field(init=False, repr=False)
+    close_retry_blocked: bool = field(init=False, repr=False)
+    pending_close_result_count: int | None = field(init=False, repr=False)
+
+    def __init__(
+        self,
+        handle: int | None = None,
+        close_result: object = _WINDOWS_CLOSE_RESULT_PENDING,
+    ) -> None:
+        # NtCreateFile writes directly into this lease-owned buffer. Every
+        # caller can therefore observe ownership through ``handle`` even when
+        # control flow is interrupted before the native call returns to its
+        # immediate Python frame.
+        self._handle_output = ctypes.c_void_p(handle)
+        self.recorded_close_results = []
+        self.close_retry_blocked = False
+        self.pending_close_result_count = None
+        if close_result is not _WINDOWS_CLOSE_RESULT_PENDING:
+            self.recorded_close_results.append(_WindowsCloseObservation(close_result))
+
+    @property
+    def handle(self) -> int | None:
+        return self._handle_output.value
+
+    @handle.setter
+    def handle(self, value: int | None) -> None:
+        self._handle_output.value = value
+
+    @property
+    def close_result(self) -> object:
+        if not self.recorded_close_results:
+            return _WINDOWS_CLOSE_RESULT_PENDING
+        return self.recorded_close_results[-1].status
+
+    @close_result.setter
+    def close_result(self, value: object) -> None:
+        if value is _WINDOWS_CLOSE_RESULT_PENDING:
+            self.recorded_close_results.clear()
+            self.close_retry_blocked = False
+            self.pending_close_result_count = None
+        else:
+            self.recorded_close_results.append(_WindowsCloseObservation(value))
+
+    def prepare_native_output(self) -> Any:
+        """Return an empty PHANDLE whose storage remains owned by this lease."""
+
+        if self.handle is not None:
+            raise ValueError("Windows handle lease is already occupied")
+        self._handle_output.value = None
+        self.recorded_close_results.clear()
+        self.close_retry_blocked = False
+        self.pending_close_result_count = None
+        return ctypes.byref(self._handle_output)
+
+
+@dataclass(slots=True)
+class _WindowsReceiptPublicationLease:
+    """Own transient receipt handles outside the helper exception tables."""
+
+    api: Any
+    stage: WindowsHandleLease = field(default_factory=WindowsHandleLease)
+    transient_handles: list[WindowsHandleLease] = field(default_factory=lambda: list[WindowsHandleLease]())
+    phase: Literal["staged", "unknown", "published"] = "staged"
+    candidate: WindowsReceiptResult | None = None
+    stage_disposition_attempted: bool = False
+    _retained_handles: set[int] = field(default_factory=lambda: set[int]())
+
+    def new_transient_handle(self) -> WindowsHandleLease:
+        lease = WindowsHandleLease()
+        self.transient_handles.append(lease)
+        return lease
+
+    @property
+    def is_closed(self) -> bool:
+        return self.stage.handle is None and all(lease.handle is None for lease in self.transient_handles)
+
+    @property
+    def outcome(self) -> WindowsReceiptOutcome | None:
+        if self.phase == "staged" or self.candidate is None:
+            return None
+        return WindowsReceiptOutcome(self.phase, self.candidate)
+
+    def prepare_stage(self) -> WindowsHandleLease:
+        if self.stage.handle is not None:
+            raise ValueError("Windows receipt staging lease is already occupied")
+        self.phase = "staged"
+        self.candidate = None
+        self.stage_disposition_attempted = False
+        return self.stage
+
+    def dispose_stage(self) -> BaseException | None:
+        handle = self.stage.handle
+        if handle is None or self.phase != "staged" or self.stage_disposition_attempted:
+            return None
+        cleanup_error = _dispose_staged(self.api, handle)
+        self.stage_disposition_attempted = True
+        return cleanup_error
+
+    def close(self) -> tuple[BaseException, ...]:
+        failures: list[BaseException] = []
+
+        def close_handle(lease: WindowsHandleLease, context: str) -> bool:
+            lease_identity = id(lease)
+            if lease_identity in self._retained_handles:
+                return False
+            failure_count = len(failures)
+            for _attempt in range(2):
+                try:
+                    close_error = close_windows_handle_lease(
+                        self.api,
+                        lease,
+                        None,
+                        context,
+                    )
+                except BaseException as close_call_error:
+                    failures.append(close_call_error)
+                    if lease.handle is not None:
+                        continue
+                else:
+                    if close_error is not None:
+                        failures.append(close_error)
+                        if lease.handle is not None:
+                            self._retained_handles.add(lease_identity)
+                    break
+                break
+            if lease.handle is not None and len(failures) == failure_count:
+                failures.append(OSError(f"The {context} remained open after bounded cleanup attempts."))
+            return lease.handle is None
+
+        for transient in reversed(self.transient_handles):
+            if not close_handle(transient, "receipt verification handle"):
+                return tuple(failures)
+        if self.stage.handle is not None and self.phase == "staged":
+            try:
+                cleanup_error = self.dispose_stage()
+            except BaseException as cleanup_interruption:
+                failures.append(cleanup_interruption)
+                return tuple(failures)
+            if cleanup_error is not None:
+                failures.append(cleanup_error)
+        close_handle(self.stage, "receipt staging handle")
+        return tuple(failures)
+
+
+class WindowsReceiptValidationError(ValueError):
+    """A retained-handle target violated the identical-receipt contract."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def _translated_windows_validation_error(
+    error: BaseException,
+    code: str,
+    message: str,
+) -> WindowsReceiptValidationError:
+    """Translate a native contract failure without losing cleanup notes."""
+
+    translated = WindowsReceiptValidationError(code, message)
+    for note in getattr(error, "__notes__", ()):
+        translated.add_note(note)
+    return translated
+
+
+class _DefiniteRenameError(OSError):
+    """A FileRenameInfo call returned FALSE without changing namespace state."""
+
+
+class _DefiniteRenameCollision(FileExistsError):
+    """A FileRenameInfo call returned FALSE with a destination collision."""
+
+
+class _StageNameCollision(FileExistsError):
+    """An unpredictable private staging name already existed."""
+
+
+_INTERNAL_FAILURE_PROVENANCE = object()
+
+
+def is_windows_publication_unavailable(error: BaseException) -> bool:
+    """Return whether Win32 rejected a required retained-handle primitive."""
+
+    return isinstance(error, OSError) and error.errno in _WINDOWS_PUBLICATION_UNAVAILABLE_ERRORS
+
+
+def _is_windows_nonregular_receipt_open_error(error: BaseException) -> bool:
+    return (
+        isinstance(error, OSError)
+        and getattr(error, "_windows_receipt_nt_status", None) in _WINDOWS_NONREGULAR_OPEN_STATUSES
+        and getattr(error, "_windows_receipt_nt_operation", None) == "open receipt"
+    )
+
+
+@dataclass(frozen=True)
+class _CleanupFailureRecord:
+    provenance: object
+    failures: tuple[BaseException, ...]
+
+
+def _native_api() -> Any:
+    if os.name != "nt":
+        raise OSError("Win32 retained-handle receipt publication is unavailable")
+    win_dll = cast(Callable[..., Any], getattr(ctypes, "WinDLL"))
+    api = win_dll("kernel32", use_last_error=True)
+    return _configure_api(api)
+
+
+def _native_nt_api() -> Any:
+    if os.name != "nt":
+        raise OSError("NT retained-handle relative opens are unavailable")
+    win_dll = cast(Callable[..., Any], getattr(ctypes, "WinDLL"))
+    return _configure_nt_api(win_dll("ntdll", use_last_error=True))
+
+
+def _configure_api(api: Any) -> Any:
+    """Declare the public Win32 ABI with fixed-width scalar types."""
+    api.WriteFile.argtypes = (
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        DWORD,
+        ctypes.POINTER(DWORD),
+        ctypes.c_void_p,
+    )
+    api.WriteFile.restype = ctypes.c_int
+    api.ReadFile.argtypes = api.WriteFile.argtypes
+    api.ReadFile.restype = ctypes.c_int
+    api.FlushFileBuffers.argtypes = (ctypes.c_void_p,)
+    api.FlushFileBuffers.restype = ctypes.c_int
+    api.SetFilePointerEx.argtypes = (
+        ctypes.c_void_p,
+        ctypes.c_longlong,
+        ctypes.POINTER(ctypes.c_longlong),
+        DWORD,
+    )
+    api.SetFilePointerEx.restype = ctypes.c_int
+    api.GetFileInformationByHandleEx.argtypes = (
+        ctypes.c_void_p,
+        ctypes.c_int,
+        ctypes.c_void_p,
+        DWORD,
+    )
+    api.GetFileInformationByHandleEx.restype = ctypes.c_int
+    api.SetFileInformationByHandle.argtypes = (
+        ctypes.c_void_p,
+        ctypes.c_int,
+        ctypes.c_void_p,
+        DWORD,
+    )
+    api.SetFileInformationByHandle.restype = ctypes.c_int
+    api.GetFileType.argtypes = (ctypes.c_void_p,)
+    api.GetFileType.restype = DWORD
+    api.CloseHandle.argtypes = (ctypes.c_void_p,)
+    api.CloseHandle.restype = ctypes.c_int
+    return api
+
+
+def _configure_nt_api(api: Any) -> Any:
+    """Declare the user-mode NT file ABI without host-C-width aliases."""
+    api.NtCreateFile.argtypes = (
+        ctypes.POINTER(ctypes.c_void_p),
+        ULONG,
+        ctypes.POINTER(_ObjectAttributes),
+        ctypes.POINTER(_IoStatusBlock),
+        ctypes.POINTER(ctypes.c_int64),
+        ULONG,
+        ULONG,
+        ULONG,
+        ULONG,
+        ctypes.c_void_p,
+        ULONG,
+    )
+    api.NtCreateFile.restype = NTSTATUS
+    api.RtlNtStatusToDosError.argtypes = (NTSTATUS,)
+    api.RtlNtStatusToDosError.restype = ULONG
+    return api
+
+
+def _nt_success(status: int) -> bool:
+    return ctypes.c_int32(status).value >= 0
+
+
+def _nt_status_bits(status: int) -> int:
+    return ctypes.c_uint32(status).value
+
+
+def _nt_failure(nt_api: Any, operation: str, status: int, leaf: str) -> OSError:
+    code = int(nt_api.RtlNtStatusToDosError(ctypes.c_int32(status).value))
+    message = f"NT {operation} failed with status 0x{_nt_status_bits(status):08X}"
+    error_type = FileNotFoundError if code in (ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND) else OSError
+    error = error_type(code, message, leaf)
+    setattr(error, "_windows_receipt_nt_operation", operation)
+    setattr(error, "_windows_receipt_nt_status", _nt_status_bits(status))
+    return error
+
+
+@dataclass(frozen=True)
+class _RelativeName:
+    buffer: ctypes.Array[WCHAR]
+    unicode: _UnicodeString
+    attributes: _ObjectAttributes
+
+
+def _validate_windows_relative_leaf(leaf: str) -> None:
+    """Reject names that Win32 would reinterpret instead of opening exactly."""
+
+    if not leaf or leaf in {".", ".."}:
+        raise ValueError("Windows relative leaf must name one file")
+    if leaf.endswith((" ", ".")):
+        raise ValueError("Windows relative leaf must not end in an ASCII space or period")
+    if any(character in _WINDOWS_RESERVED_LEAF_CHARACTERS or ord(character) < 0x20 for character in leaf):
+        raise ValueError("Windows relative leaf contains a reserved character")
+
+    # Win32 recognizes a DOS device before the first extension. It also
+    # ignores ASCII spaces immediately before that extension, so reject the
+    # cautious ``NUL .txt`` spelling without normalizing any Unicode text.
+    device_basename = leaf.partition(".")[0].rstrip(" ").casefold()
+    if device_basename in _WINDOWS_RESERVED_DEVICE_BASENAMES:
+        raise ValueError("Windows relative leaf uses a reserved DOS device name")
+
+    try:
+        encoded = leaf.encode("utf-16-le")
+    except UnicodeEncodeError as error:
+        raise ValueError("Windows relative leaf must be UTF-16 encodable") from error
+    if len(encoded) > 0xFFFC:
+        raise ValueError("Windows relative leaf is too long for UNICODE_STRING")
+
+
+def _native_name(root_handle: int | None, text: str) -> _RelativeName:
+    try:
+        encoded = text.encode("utf-16-le")
+    except UnicodeEncodeError as error:
+        raise ValueError("NT object name must be UTF-16 encodable") from error
+    if len(encoded) > 0xFFFC:
+        raise ValueError("NT object name is too long for UNICODE_STRING")
+
+    storage_type = WCHAR * (len(encoded) // ctypes.sizeof(WCHAR) + 1)
+    storage = storage_type()
+    if encoded:
+        ctypes.memmove(storage, encoded, len(encoded))
+    name = _UnicodeString(len(encoded), len(encoded) + ctypes.sizeof(WCHAR), ctypes.addressof(storage))
+    attributes = _ObjectAttributes(
+        ctypes.sizeof(_ObjectAttributes),
+        root_handle,
+        ctypes.pointer(name),
+        OBJ_CASE_INSENSITIVE,
+        None,
+        None,
+    )
+    return _RelativeName(storage, name, attributes)
+
+
+def _relative_name(parent_handle: int, leaf: str) -> _RelativeName:
+    _validate_windows_relative_leaf(leaf)
+    return _native_name(parent_handle, leaf)
+
+
+def _nt_anchor_path(path: Path) -> str:
+    text = os.fspath(path).replace("/", "\\")
+    folded = text.casefold()
+    if folded.startswith("\\\\?\\unc\\"):
+        suffix = text[8:]
+        prefix = "\\??\\UNC\\"
+        unc = True
+    elif text.startswith("\\\\?\\"):
+        suffix = text[4:]
+        prefix = "\\??\\"
+        unc = False
+    elif text.startswith("\\\\"):
+        suffix = text[2:]
+        prefix = "\\??\\UNC\\"
+        unc = True
+    elif len(text) >= 3 and text[1] == ":" and text[2] == "\\":
+        suffix = text
+        prefix = "\\??\\"
+        unc = False
+    else:
+        raise ValueError("Windows directory anchor must be an absolute drive or UNC path")
+    if "\x00" in suffix:
+        raise ValueError("Windows directory anchor is invalid")
+    if unc:
+        components = suffix.strip("\\").split("\\")
+        if (
+            len(components) != 2
+            or not all(components)
+            or any(component in {".", ".."} or ":" in component for component in components)
+        ):
+            raise ValueError("Windows UNC anchor must name exactly one server and share")
+        suffix = "\\".join(components) + "\\"
+    elif len(suffix) != 3 or suffix[1:] != ":\\" or not suffix[0].isascii() or not suffix[0].isalpha():
+        raise ValueError("Windows drive anchor must name exactly one drive root")
+    return prefix + suffix
+
+
+def _relative_handle(
+    kernel_api: Any,
+    nt_api: Any,
+    parent_handle: int | None,
+    leaf: str,
+    lease: WindowsHandleLease,
+    *,
+    desired_access: int,
+    share_access: int,
+    disposition: int,
+    options: int,
+    expected_information: tuple[int, ...],
+    operation: str,
+    stage_collision: bool = False,
+    absolute_name: bool = False,
+    retain_rejected_handle: bool = False,
+) -> int:
+    if not absolute_name:
+        _validate_windows_relative_leaf(leaf)
+    # A completed close deliberately retires the handle before resetting its
+    # result marker. If control flow interrupted that reset, preparing the
+    # empty lease normalizes the stale marker before the next native open.
+    handle_output = lease.prepare_native_output()
+    if not absolute_name and parent_handle is None:
+        raise ValueError("Relative NT opens require a retained parent directory handle")
+    relative = _native_name(None, leaf) if absolute_name else _relative_name(cast(int, parent_handle), leaf)
+    io_status = _IoStatusBlock()
+    invalid = ctypes.c_void_p(-1).value
+    primary: BaseException | None = None
+    result: int | None = None
+    try:
+        status = int(
+            nt_api.NtCreateFile(
+                handle_output,
+                desired_access,
+                ctypes.byref(relative.attributes),
+                ctypes.byref(io_status),
+                None,
+                FILE_ATTRIBUTE_NORMAL,
+                share_access,
+                disposition,
+                options,
+                None,
+                0,
+            )
+        )
+        if not _nt_success(status):
+            error = _nt_failure(nt_api, operation, status, leaf)
+            if stage_collision and _nt_status_bits(status) == STATUS_OBJECT_NAME_COLLISION:
+                collision = _StageNameCollision(error.errno, error.strerror, leaf)
+                setattr(collision, "_windows_receipt_stage_provenance", _INTERNAL_FAILURE_PROVENANCE)
+                raise collision from error
+            raise error
+
+        handle = lease.handle
+        if handle is None or handle == invalid:
+            raise OSError(f"NT {operation} returned no usable handle")
+        lease.handle = handle
+        completion_status = int(io_status.Status)
+        if not _nt_success(completion_status):
+            raise _nt_failure(nt_api, f"{operation} completion", completion_status, leaf)
+        information = int(io_status.Information)
+        if information not in expected_information:
+            raise OSError(f"NT {operation} returned unexpected IO_STATUS_BLOCK.Information {information}")
+        result = information
+    except BaseException as error:
+        primary = error
+    finally:
+        if primary is not None:
+            acquired = lease.handle
+            if acquired is not None and acquired != invalid:
+                lease.handle = acquired
+                # Cleanup retires the lease before the caller classifies the
+                # failure, so preserve authenticated acquisition provenance.
+                setattr(
+                    primary,
+                    "_windows_receipt_handle_acquired",
+                    _INTERNAL_FAILURE_PROVENANCE,
+                )
+                if not retain_rejected_handle:
+                    try:
+                        close_windows_handle_lease(
+                            kernel_api,
+                            lease,
+                            primary,
+                            "rejected NT file handle",
+                        )
+                    except BaseException as close_interruption:
+                        primary.add_note(f"Could not close rejected NT file handle: {close_interruption}")
+    if primary is not None:
+        raise primary
+    assert result is not None
+    return result
+
+
+def _last_error(api: Any) -> int:
+    getter: Any = getattr(api, "get_last_error", None)
+    if callable(getter):
+        return cast(int, getter())
+    ctypes_getter = cast(Callable[[], int], getattr(ctypes, "get_last_error"))
+    return ctypes_getter()
+
+
+def _set_last_error(api: Any, value: int) -> None:
+    """Set the calling thread's Win32 error slot for native or modeled APIs."""
+
+    setter: Any = getattr(api, "set_last_error", None)
+    if callable(setter):
+        setter(value)
+        return
+    ctypes_setter: Any = getattr(ctypes, "set_last_error", None)
+    if not callable(ctypes_setter):
+        raise OSError("Win32 SetLastError is unavailable")
+    ctypes_setter(value)
+
+
+def _failure(api: Any, operation: str) -> OSError:
+    code = _last_error(api)
+    return OSError(code, f"Win32 {operation} failed")
+
+
+def _checked_file_type(api: Any, handle: int) -> int:
+    """Return GetFileType while distinguishing valid UNKNOWN from failure."""
+
+    _set_last_error(api, 0)
+    file_type = int(api.GetFileType(handle))
+    if file_type == FILE_TYPE_UNKNOWN:
+        error_number = _last_error(api)
+        if error_number:
+            raise OSError(error_number, "Win32 GetFileType failed")
+    return file_type
+
+
+def _query_metadata(api: Any, handle: int) -> tuple[_FileBasicInfo, _FileStandardInfo, _FileIdInfo]:
+    values = (_FileBasicInfo(), _FileStandardInfo(), _FileIdInfo())
+    for info_class, value in zip((FILE_BASIC_INFO, FILE_STANDARD_INFO, FILE_ID_INFO), values, strict=True):
+        if not api.GetFileInformationByHandleEx(handle, info_class, ctypes.byref(value), ctypes.sizeof(value)):
+            raise _failure(api, "GetFileInformationByHandleEx")
+    return values
+
+
+def _regular_metadata_is_canonical(
+    api: Any,
+    handle: int,
+    values: tuple[_FileBasicInfo, _FileStandardInfo, _FileIdInfo],
+) -> bool:
+    basic, standard, _identity_info = values
+    return bool(
+        _checked_file_type(api, handle) == FILE_TYPE_DISK
+        and not basic.FileAttributes
+        & (FILE_ATTRIBUTE_READONLY | FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT)
+        and not standard.Directory
+        and not standard.DeletePending
+        and standard.NumberOfLinks == 1
+    )
+
+
+def _directory_metadata_is_canonical(
+    api: Any,
+    handle: int,
+    values: tuple[_FileBasicInfo, _FileStandardInfo, _FileIdInfo],
+) -> bool:
+    basic, standard, _identity_info = values
+    return bool(
+        _checked_file_type(api, handle) == FILE_TYPE_DISK
+        and basic.FileAttributes & FILE_ATTRIBUTE_DIRECTORY
+        and not basic.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT
+        and standard.Directory
+        and not standard.DeletePending
+    )
+
+
+def _metadata(api: Any, handle: int) -> tuple[_FileBasicInfo, _FileStandardInfo, _FileIdInfo]:
+    values = _query_metadata(api, handle)
+    if not _regular_metadata_is_canonical(api, handle, values):
+        raise OSError("Receipt handle is not one physical regular file")
+    return values
+
+
+def _identity(value: _FileIdInfo) -> tuple[int, bytes]:
+    return int(value.VolumeSerialNumber), bytes(value.FileId.Identifier)
+
+
+def _same_regular_metadata(
+    before: tuple[_FileBasicInfo, _FileStandardInfo, _FileIdInfo],
+    after: tuple[_FileBasicInfo, _FileStandardInfo, _FileIdInfo],
+) -> bool:
+    return bool(
+        _identity(before[2]) == _identity(after[2])
+        and before[0].FileAttributes == after[0].FileAttributes
+        and before[1].NumberOfLinks == after[1].NumberOfLinks
+        and before[1].EndOfFile == after[1].EndOfFile
+    )
+
+
+def _write_all(api: Any, handle: int, payload: bytes) -> None:
+    offset = 0
+    while offset < len(payload):
+        chunk = ctypes.create_string_buffer(payload[offset:])
+        written = DWORD()
+        if not api.WriteFile(handle, chunk, len(payload) - offset, ctypes.byref(written), None):
+            raise _failure(api, "WriteFile")
+        if written.value <= 0 or written.value > len(payload) - offset:
+            raise OSError("Win32 WriteFile made invalid progress")
+        offset += written.value
+
+
+def _read_exact(api: Any, handle: int, size: int) -> bytes:
+    if not api.SetFilePointerEx(handle, 0, None, FILE_BEGIN):
+        raise _failure(api, "SetFilePointerEx")
+    output = bytearray()
+    while len(output) < size:
+        buffer = ctypes.create_string_buffer(size - len(output))
+        read = DWORD()
+        if not api.ReadFile(handle, buffer, len(buffer), ctypes.byref(read), None):
+            raise _failure(api, "ReadFile")
+        if read.value > len(buffer):
+            raise OSError("Win32 ReadFile returned more bytes than requested")
+        if read.value == 0:
+            raise OSError("Receipt staging bytes ended early")
+        output.extend(buffer.raw[: read.value])
+    extra = ctypes.create_string_buffer(1)
+    read = DWORD()
+    if not api.ReadFile(handle, extra, 1, ctypes.byref(read), None):
+        raise _failure(api, "ReadFile EOF check")
+    if read.value > 1:
+        raise OSError("Win32 ReadFile EOF check returned an invalid byte count")
+    if read.value:
+        raise OSError("Receipt staging bytes exceed the expected payload")
+    return bytes(output)
+
+
+def _read_candidate(api: Any, handle: int, maximum: int) -> bytes:
+    """Read through EOF, bounded one byte beyond the canonical payload."""
+    if not api.SetFilePointerEx(handle, 0, None, FILE_BEGIN):
+        raise _failure(api, "SetFilePointerEx")
+    output = bytearray()
+    while len(output) < maximum:
+        buffer = ctypes.create_string_buffer(min(64 * 1024, maximum - len(output)))
+        read = DWORD()
+        if not api.ReadFile(handle, buffer, len(buffer), ctypes.byref(read), None):
+            raise _failure(api, "ReadFile")
+        if read.value > len(buffer):
+            raise OSError("Win32 ReadFile returned more bytes than requested")
+        if read.value == 0:
+            break
+        output.extend(buffer.raw[: read.value])
+    return bytes(output)
+
+
+def _prepare_rename(parent_handle: int, leaf: str) -> tuple[ctypes.Array[ctypes.c_char], int]:
+    _validate_windows_relative_leaf(leaf)
+    encoded = leaf.encode("utf-16-le")
+    logical_size = _FileRenameInfo.FileName.offset + len(encoded)
+    storage = ctypes.create_string_buffer(max(ctypes.sizeof(_FileRenameInfo), logical_size))
+    rename = _FileRenameInfo.from_buffer(storage)
+    rename.ReplaceIfExists = 0
+    rename.RootDirectory = parent_handle
+    rename.FileNameLength = len(encoded)
+    ctypes.memmove(ctypes.addressof(storage) + _FileRenameInfo.FileName.offset, encoded, len(encoded))
+
+    return storage, len(storage)
+
+
+def _rename(
+    api: Any,
+    handle: int,
+    storage: ctypes.Array[ctypes.c_char],
+    allocation_size: int,
+    leaf: str,
+) -> None:
+    """Make the single native rename call and classify only a FALSE return."""
+    if not api.SetFileInformationByHandle(handle, FILE_RENAME_INFO, storage, allocation_size):
+        error = _failure(api, "FileRenameInfo")
+        if error.errno in (ERROR_FILE_EXISTS, ERROR_ALREADY_EXISTS):
+            collision = _DefiniteRenameCollision(error.errno, error.strerror, leaf)
+            setattr(collision, "_windows_receipt_definite_provenance", _INTERNAL_FAILURE_PROVENANCE)
+            raise collision from error
+        failure = _DefiniteRenameError(error.errno, error.strerror, leaf)
+        setattr(failure, "_windows_receipt_definite_provenance", _INTERNAL_FAILURE_PROVENANCE)
+        raise failure from error
+
+
+def _is_internal_definite_rename_error(error: BaseException) -> bool:
+    return isinstance(error, (_DefiniteRenameCollision, _DefiniteRenameError)) and (
+        getattr(error, "_windows_receipt_definite_provenance", None) is _INTERNAL_FAILURE_PROVENANCE
+    )
+
+
+def is_internal_stage_name_collision(error: BaseException) -> bool:
+    return isinstance(error, _StageNameCollision) and (
+        getattr(error, "_windows_receipt_stage_provenance", None) is _INTERNAL_FAILURE_PROVENANCE
+    )
+
+
+def is_internal_definite_rename_collision(error: BaseException) -> bool:
+    return isinstance(error, _DefiniteRenameCollision) and _is_internal_definite_rename_error(error)
+
+
+def _add_cleanup_note(primary: BaseException, message: str, error: BaseException) -> None:
+    failures = cleanup_failures_from_error(primary)
+    record = _CleanupFailureRecord(_INTERNAL_FAILURE_PROVENANCE, (*failures, error))
+    setattr(primary, "_windows_receipt_cleanup_record", record)
+    primary.add_note(f"{message}: {error}")
+
+
+def cleanup_failures_from_error(error: BaseException) -> tuple[BaseException, ...]:
+    """Return explicit staging cleanup failures retained on a primary error."""
+
+    value: object = getattr(error, "_windows_receipt_cleanup_record", None)
+    if isinstance(value, _CleanupFailureRecord) and value.provenance is _INTERNAL_FAILURE_PROVENANCE:
+        return value.failures
+    return ()
+
+
+def _dispose_staged(api: Any, handle: int) -> BaseException | None:
+    """Attempt disposition inside a separate frame with an active handler."""
+    try:
+        disposition = _FileDispositionInfo(1)
+        if not api.SetFileInformationByHandle(
+            handle,
+            FILE_DISPOSITION_INFO,
+            ctypes.byref(disposition),
+            ctypes.sizeof(disposition),
+        ):
+            raise _failure(api, "FileDispositionInfo")
+    except BaseException as error:
+        return error
+    return None
+
+
+def outcome_from_error(error: BaseException) -> WindowsReceiptOutcome | None:
+    """Return retained namespace evidence attached to an uncertain failure."""
+    value: object = getattr(error, "_windows_receipt_outcome", None)
+    return value if isinstance(value, WindowsReceiptOutcome) else None
+
+
+def _select_apis(api: Any | None, nt_api: Any | None) -> tuple[Any, Any]:
+    selected_api = _native_api() if api is None else api
+    if nt_api is not None:
+        selected_nt_api = nt_api
+    elif hasattr(selected_api, "NtCreateFile") and hasattr(selected_api, "RtlNtStatusToDosError"):
+        # A combined injected API keeps modeled tests platform-independent.
+        selected_nt_api = selected_api
+    else:
+        selected_nt_api = _native_nt_api()
+    return selected_api, selected_nt_api
+
+
+def _native_close_handle_address(api: Any) -> int | None:
+    if getattr(ctypes, "WINFUNCTYPE", None) is None:
+        return None
+    try:
+        return ctypes.cast(api.CloseHandle, ctypes.c_void_p).value
+    except (TypeError, ValueError):
+        return None
+
+
+def _record_native_close_observation(
+    lease: WindowsHandleLease,
+    status: object,
+) -> None:
+    """Capture native result ownership before reading its saved last-error slot."""
+
+    observation = _WindowsCloseObservation(status)
+    lease.recorded_close_results.append(observation)
+    try:
+        getter: Any = getattr(ctypes, "get_last_error")
+        observation.error = int(getter())
+    except BaseException as error:
+        observation.error = error
+        raise
+
+
+def _record_close_handle_result(
+    api: Any,
+    lease: WindowsHandleLease,
+    handle: int,
+    native_address: int | None,
+) -> None:
+    """Record a native close result in ``lease`` before Python resumes."""
+
+    prototype_factory: Any | None = getattr(ctypes, "WINFUNCTYPE", None)
+    if native_address is not None and prototype_factory is not None:
+
+        class _CloseHandleResult(ctypes.c_int):
+            pass
+
+        setattr(
+            _CloseHandleResult,
+            "_check_retval_",
+            functools.partial(_record_native_close_observation, lease),
+        )
+        prototype = prototype_factory(
+            _CloseHandleResult,
+            ctypes.c_void_p,
+            use_last_error=True,
+        )
+        operation = prototype(native_address)
+        operation(handle)
+        return
+
+    # Modeled APIs are Python callables, so they cannot provide the native
+    # result-conversion hook. Ownership remains in the lease until this store.
+    status = int(bool(api.CloseHandle(handle)))
+    observation = _WindowsCloseObservation(status)
+    lease.recorded_close_results.append(observation)
+    if not status:
+        try:
+            observation.error = _last_error(api)
+        except BaseException as error:
+            observation.error = error
+            raise
+
+
+def close_windows_handle_lease(
+    api: Any,
+    lease: WindowsHandleLease,
+    primary: BaseException | None,
+    context: str,
+) -> BaseException | None:
+    handle = lease.handle
+    if handle is None:
+        return primary
+
+    def retain_failure(error: BaseException, action: str = "close") -> None:
+        nonlocal primary
+        if primary is None:
+            primary = error
+        else:
+            primary.add_note(f"Could not {action} {context}: {error}")
+
+    native_address: int | None = None
+    address_resolved = False
+    address_attempts = 0
+    native_call_attempts = 0
+    recorded_index = 0
+    while lease.handle is not None:
+        if recorded_index >= len(lease.recorded_close_results):
+            # Each retained handle accepts at most two definitive native
+            # results across every caller and finalizer re-entry. Recorded FALSE
+            # results remain in the lease so nested cleanup cannot reset that
+            # bound and then close an older ancestor while this child is live.
+            pending_result_was_recorded = (
+                lease.close_retry_blocked
+                and lease.pending_close_result_count is not None
+                and len(lease.recorded_close_results) > lease.pending_close_result_count
+            )
+            if (
+                (lease.close_retry_blocked and not pending_result_was_recorded)
+                or len(lease.recorded_close_results) >= 2
+                or native_call_attempts >= 2
+            ):
+                break
+            if not address_resolved:
+                while address_attempts < 2:
+                    address_attempts += 1
+                    try:
+                        native_address = _native_close_handle_address(api)
+                        address_resolved = True
+                        break
+                    except BaseException as close_error:
+                        retain_failure(close_error, "resolve CloseHandle for")
+                if not address_resolved:
+                    break
+
+            result_count = len(lease.recorded_close_results)
+            native_call_attempts += 1
+            # Arm the persistent no-retry state before entering CloseHandle.
+            # If the call's result is not recorded, even an interruption at
+            # the exception-handler boundary must leave every later owner and
+            # finalizer unable to re-enter an operation whose effect is unknown.
+            lease.close_retry_blocked = True
+            lease.pending_close_result_count = result_count
+            try:
+                _record_close_handle_result(api, lease, handle, native_address)
+            except BaseException as close_error:
+                retain_failure(close_error)
+                result_was_recorded = len(lease.recorded_close_results) > result_count
+                # Once a CloseHandle callable was entered, absence of a recorded
+                # result cannot prove whether control flow arrived before the OS
+                # call or between its return and the result hook. Retain the
+                # handle and prohibit all caller/finalizer re-entry.
+                if not result_was_recorded:
+                    break
+            if len(lease.recorded_close_results) == result_count:
+                retain_failure(
+                    OSError("CloseHandle returned without recording its result")
+                )
+                break
+            lease.close_retry_blocked = False
+            lease.pending_close_result_count = None
+
+        recorded = lease.recorded_close_results[recorded_index]
+        raw_status: object = _WINDOWS_CLOSE_RESULT_PENDING
+        for _attempt in range(2):
+            try:
+                candidate_status = getattr(recorded.status, "value", recorded.status)
+                if not isinstance(candidate_status, int):
+                    raise OSError("CloseHandle returned a non-integer result.")
+                raw_status = candidate_status
+                break
+            except BaseException as close_error:
+                retain_failure(close_error)
+
+        if raw_status is _WINDOWS_CLOSE_RESULT_PENDING:
+            # CloseHandle returned but its status cannot be interpreted. Keep
+            # owning this child and prohibit another native call: either
+            # retiring it or retrying could let an ancestor close while a live
+            # child remains, or close a recycled handle value twice.
+            lease.pending_close_result_count = None
+            lease.close_retry_blocked = True
+            break
+        elif raw_status:
+            # TRUE proves the handle is closed. Retire ownership before clearing
+            # the result history so a return-boundary interruption can consume
+            # the same proof without issuing CloseHandle again.
+            for _attempt in range(2):
+                try:
+                    lease.handle = None
+                except BaseException as close_error:
+                    retain_failure(close_error)
+                if lease.handle is None:
+                    break
+        else:
+            # FALSE proves CloseHandle failed: surface it, keep owning the child,
+            # and allow only the second result slot as a safe retry.
+            failure_evidence = recorded.error
+            if failure_evidence is _WINDOWS_CLOSE_ERROR_PENDING:
+                try:
+                    failure_evidence = _last_error(api)
+                    recorded.error = failure_evidence
+                except BaseException as close_error:
+                    recorded.error = close_error
+                    failure_evidence = close_error
+            if isinstance(failure_evidence, BaseException):
+                retain_failure(failure_evidence)
+            elif isinstance(failure_evidence, int):
+                retain_failure(OSError(failure_evidence, "Win32 CloseHandle failed"))
+            else:
+                retain_failure(OSError("CloseHandle failure evidence is invalid"))
+            recorded_index += 1
+            continue
+
+        if lease.handle is None:
+            for _attempt in range(2):
+                try:
+                    lease.recorded_close_results.clear()
+                except BaseException as close_error:
+                    retain_failure(close_error, "finalize")
+                if not lease.recorded_close_results:
+                    break
+        break
+    return primary
+
+
+def read_windows_receipt(
+    parent_handle: int,
+    leaf: str,
+    payload: bytes,
+    *,
+    api: Any | None = None,
+    nt_api: Any | None = None,
+    publication_lease: _WindowsReceiptPublicationLease,
+) -> WindowsReceiptResult:
+    """Read one child below a retained parent using caller-retained ownership."""
+    _validate_windows_relative_leaf(leaf)
+    if not payload:
+        raise ValueError("receipt payload must not be empty")
+    selected_api, selected_nt_api = _select_apis(api, nt_api)
+    if publication_lease.api is not selected_api:
+        raise ValueError("Windows receipt publication lease belongs to another API")
+    lease = publication_lease.new_transient_handle()
+    handle: int | None = None
+    handle_acquired = False
+    primary: BaseException | None = None
+    result: WindowsReceiptResult | None = None
+    try:
+        try:
+            _information = _relative_handle(
+                selected_api,
+                selected_nt_api,
+                parent_handle,
+                leaf,
+                lease,
+                desired_access=_TARGET_READ_ACCESS,
+                share_access=FILE_SHARE_READ,
+                disposition=FILE_OPEN,
+                options=_FILE_OPEN_OPTIONS,
+                expected_information=(FILE_OPENED,),
+                operation="open receipt",
+            )
+            handle = lease.handle
+            assert handle is not None
+            handle_acquired = True
+            before = _query_metadata(selected_api, handle)
+            if not _regular_metadata_is_canonical(selected_api, handle, before):
+                raise WindowsReceiptValidationError(
+                    "output-existing-invalid",
+                    f"Receipt output is not one canonical private regular file: {leaf}.",
+                )
+            observed = _read_candidate(selected_api, handle, len(payload) + 1)
+            after = _query_metadata(selected_api, handle)
+            if not _regular_metadata_is_canonical(selected_api, handle, after) or not _same_regular_metadata(
+                before, after
+            ):
+                raise WindowsReceiptValidationError(
+                    "output-changed",
+                    f"Receipt output changed while it was being read: {leaf}.",
+                )
+            if before[1].EndOfFile != len(payload) or observed != payload:
+                raise WindowsReceiptValidationError(
+                    "output-different",
+                    f"Refusing to replace different existing receipt output: {leaf}.",
+                )
+            result = WindowsReceiptResult(leaf, *_identity(after[2]), len(payload))
+        except OSError as error:
+            validation_started = handle_acquired or (
+                getattr(error, "_windows_receipt_handle_acquired", None) is _INTERNAL_FAILURE_PROVENANCE
+            )
+            if not validation_started and isinstance(error, FileNotFoundError):
+                raise
+            if validation_started and (
+                isinstance(error, FileNotFoundError) or error.errno in {ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND}
+            ):
+                code = "output-changed"
+                message = f"Receipt output changed while it was being verified: {leaf}."
+            elif is_windows_publication_unavailable(error):
+                code = "output-anchor-unavailable"
+                message = "Windows retained-handle receipt verification is unavailable."
+            elif _is_windows_nonregular_receipt_open_error(error):
+                code = "output-existing-invalid"
+                message = f"Receipt output is not one canonical private regular file: {leaf}."
+            else:
+                raise
+            translated = _translated_windows_validation_error(error, code, message)
+            raise translated from error
+    except BaseException as error:
+        primary = error
+    finally:
+        try:
+            close_failures = publication_lease.close()
+        except BaseException as close_interruption:
+            if primary is None:
+                primary = close_interruption
+            else:
+                primary.add_note(f"Could not close receipt verification handle: {close_interruption}")
+        else:
+            for close_error in close_failures:
+                if primary is None:
+                    primary = close_error
+                else:
+                    primary.add_note(f"Could not close receipt verification handle: {close_error}")
+    if primary is not None:
+        raise primary
+    assert result is not None
+    return result
+
+
+def open_windows_directory_anchor(
+    path: Path,
+    lease: WindowsHandleLease,
+    *,
+    api: Any | None = None,
+    nt_api: Any | None = None,
+) -> WindowsDirectoryResult:
+    """Open one trusted drive/UNC anchor while retaining async-safe ownership."""
+    selected_api, selected_nt_api = _select_apis(api, nt_api)
+    native_path = _nt_anchor_path(path)
+    handle: int | None = None
+    primary: BaseException | None = None
+    result: WindowsDirectoryResult | None = None
+    try:
+        information = _relative_handle(
+            selected_api,
+            selected_nt_api,
+            None,
+            native_path,
+            lease,
+            desired_access=_DIRECTORY_ACCESS,
+            share_access=FILE_SHARE_READ | FILE_SHARE_WRITE,
+            disposition=FILE_OPEN,
+            options=_DIRECTORY_OPEN_OPTIONS,
+            expected_information=(FILE_OPENED,),
+            operation="open directory anchor",
+            absolute_name=True,
+        )
+        handle = lease.handle
+        assert handle is not None
+        before = _query_metadata(selected_api, handle)
+        after = _query_metadata(selected_api, handle)
+        if (
+            not _directory_metadata_is_canonical(selected_api, handle, before)
+            or not _directory_metadata_is_canonical(selected_api, handle, after)
+            or _identity(before[2]) != _identity(after[2])
+            or before[0].FileAttributes != after[0].FileAttributes
+            or before[1].Directory != after[1].Directory
+            or before[1].DeletePending != after[1].DeletePending
+        ):
+            raise WindowsReceiptValidationError(
+                "output-parent-invalid",
+                f"Receipt output anchor is not one stable physical directory: {path}.",
+            )
+        result = WindowsDirectoryResult(handle, *_identity(after[2]), information == FILE_CREATED)
+    except BaseException as error:
+        primary = error
+    if primary is not None:
+        try:
+            close_windows_handle_lease(
+                selected_api,
+                lease,
+                primary,
+                "rejected directory anchor",
+            )
+        except BaseException as close_interruption:
+            primary.add_note(f"Could not close rejected directory anchor: {close_interruption}")
+        if is_windows_publication_unavailable(primary):
+            translated = _translated_windows_validation_error(
+                primary,
+                "output-anchor-unavailable",
+                "Windows retained-handle receipt directory binding is unavailable.",
+            )
+            raise translated from primary
+        raise primary
+    assert result is not None
+    return result
+
+
+def open_or_create_windows_directory(
+    parent_handle: int,
+    leaf: str,
+    lease: WindowsHandleLease,
+    *,
+    api: Any | None = None,
+    nt_api: Any | None = None,
+) -> WindowsDirectoryResult:
+    """Open or create one physical directory child relative to its retained parent."""
+    _validate_windows_relative_leaf(leaf)
+    selected_api, selected_nt_api = _select_apis(api, nt_api)
+    handle: int | None = None
+    primary: BaseException | None = None
+    result: WindowsDirectoryResult | None = None
+    try:
+        information = _relative_handle(
+            selected_api,
+            selected_nt_api,
+            parent_handle,
+            leaf,
+            lease,
+            desired_access=_DIRECTORY_ACCESS,
+            share_access=FILE_SHARE_READ | FILE_SHARE_WRITE,
+            disposition=FILE_OPEN_IF,
+            options=_DIRECTORY_OPEN_OPTIONS,
+            expected_information=(FILE_OPENED, FILE_CREATED),
+            operation="open or create directory",
+        )
+        handle = lease.handle
+        assert handle is not None
+        before = _query_metadata(selected_api, handle)
+        after = _query_metadata(selected_api, handle)
+        if (
+            not _directory_metadata_is_canonical(selected_api, handle, before)
+            or not _directory_metadata_is_canonical(selected_api, handle, after)
+            or _identity(before[2]) != _identity(after[2])
+            or before[0].FileAttributes != after[0].FileAttributes
+            or before[1].Directory != after[1].Directory
+            or before[1].DeletePending != after[1].DeletePending
+        ):
+            raise WindowsReceiptValidationError(
+                "output-parent-invalid",
+                f"Receipt output ancestor is not one stable physical directory: {leaf}.",
+            )
+        result = WindowsDirectoryResult(handle, *_identity(after[2]), information == FILE_CREATED)
+    except BaseException as error:
+        primary = error
+    if primary is not None:
+        try:
+            close_windows_handle_lease(
+                selected_api,
+                lease,
+                primary,
+                "rejected directory handle",
+            )
+        except BaseException as close_interruption:
+            primary.add_note(f"Could not close rejected directory handle: {close_interruption}")
+        if is_windows_publication_unavailable(primary):
+            translated = _translated_windows_validation_error(
+                primary,
+                "output-anchor-unavailable",
+                "Windows retained-handle receipt directory binding is unavailable.",
+            )
+            raise translated from primary
+        raise primary
+    assert result is not None
+    return result
+
+
+def publish_windows_receipt(
+    parent_handle: int,
+    leaf: str,
+    payload: bytes,
+    *,
+    api: Any | None = None,
+    nt_api: Any | None = None,
+    stage_token: str | None = None,
+    publication_lease: _WindowsReceiptPublicationLease,
+) -> WindowsReceiptResult:
+    """Create, verify and rename one receipt using caller-retained ownership."""
+    _validate_windows_relative_leaf(leaf)
+    if not payload:
+        raise ValueError("receipt payload must not be empty")
+    rename_storage, rename_size = _prepare_rename(parent_handle, leaf)
+    selected_api, selected_nt_api = _select_apis(api, nt_api)
+    if publication_lease.api is not selected_api:
+        raise ValueError("Windows receipt publication lease belongs to another API")
+    token = secrets.token_hex(16) if stage_token is None else stage_token
+    if not token or any(character not in "0123456789abcdef" for character in token):
+        raise ValueError("receipt staging token must be lowercase hexadecimal")
+    stage_leaf = f".{leaf}.{token}.tmp"
+    lease = publication_lease.prepare_stage()
+    handle: int | None = None
+    primary: BaseException | None = None
+    result: WindowsReceiptResult | None = None
+    candidate: WindowsReceiptResult | None = None
+    try:
+        try:
+            try:
+                _information = _relative_handle(
+                    selected_api,
+                    selected_nt_api,
+                    parent_handle,
+                    stage_leaf,
+                    lease,
+                    desired_access=_STAGE_ACCESS,
+                    share_access=FILE_SHARE_READ,
+                    disposition=FILE_CREATE,
+                    options=_FILE_OPEN_OPTIONS,
+                    expected_information=(FILE_CREATED,),
+                    operation="create receipt staging file",
+                    stage_collision=True,
+                    retain_rejected_handle=True,
+                )
+                handle = lease.handle
+                assert handle is not None
+                before = _metadata(selected_api, handle)
+                if before[1].EndOfFile != 0:
+                    raise OSError("New receipt staging file was not empty")
+                _write_all(selected_api, handle, payload)
+                if not selected_api.FlushFileBuffers(handle):
+                    raise _failure(selected_api, "FlushFileBuffers")
+                if _read_exact(selected_api, handle, len(payload)) != payload:
+                    raise OSError("Receipt staging bytes do not match the canonical payload")
+                after = _metadata(selected_api, handle)
+                if (
+                    _identity(before[2]) != _identity(after[2])
+                    or before[0].FileAttributes != after[0].FileAttributes
+                    or before[1].NumberOfLinks != after[1].NumberOfLinks
+                    or after[1].EndOfFile != len(payload)
+                ):
+                    raise OSError("Receipt staging identity, attributes, links, or size changed")
+                candidate = WindowsReceiptResult(leaf, *_identity(after[2]), len(payload))
+                publication_lease.candidate = candidate
+                # From this point until a definite FALSE return, namespace
+                # outcome is unknown and the handle must never be disposed.
+                publication_lease.phase = "unknown"
+                _rename(selected_api, handle, rename_storage, rename_size, leaf)
+                publication_lease.phase = "published"
+                if _read_exact(selected_api, handle, len(payload)) != payload:
+                    raise OSError("Published receipt bytes do not match the canonical payload")
+                published = _metadata(selected_api, handle)
+                if (
+                    _identity(published[2]) != (candidate.volume_serial_number, candidate.file_id)
+                    or published[0].FileAttributes != after[0].FileAttributes
+                    or published[1].NumberOfLinks != after[1].NumberOfLinks
+                    or published[1].EndOfFile != len(payload)
+                ):
+                    raise OSError("Published receipt identity, attributes, links, or size changed")
+                result = candidate
+            except BaseException as error:
+                primary = error
+                if _is_internal_definite_rename_error(error):
+                    publication_lease.phase = "staged"
+                if publication_lease.phase != "staged" and outcome_from_error(error) is None and candidate is not None:
+                    setattr(
+                        error,
+                        "_windows_receipt_outcome",
+                        WindowsReceiptOutcome(publication_lease.phase, candidate),
+                    )
+
+            staged_handle = lease.handle
+            if staged_handle is not None and publication_lease.phase == "staged":
+                cleanup_error = publication_lease.dispose_stage()
+                if cleanup_error is not None:
+                    if primary is None:
+                        primary = cleanup_error
+                    else:
+                        _add_cleanup_note(
+                            primary,
+                            "Could not mark receipt staging file for deletion",
+                            cleanup_error,
+                        )
+        except BaseException as error:
+            if primary is None:
+                primary = error
+            else:
+                _add_cleanup_note(primary, "Receipt staging cleanup was interrupted", error)
+            if publication_lease.phase != "staged" and outcome_from_error(error) is None and candidate is not None:
+                setattr(
+                    error,
+                    "_windows_receipt_outcome",
+                    WindowsReceiptOutcome(publication_lease.phase, candidate),
+                )
+    finally:
+        active_error = sys.exception()
+        if active_error is not None and primary is None:
+            primary = active_error
+        if (
+            active_error is not None
+            and publication_lease.phase != "staged"
+            and outcome_from_error(active_error) is None
+            and candidate is not None
+        ):
+            setattr(
+                active_error,
+                "_windows_receipt_outcome",
+                WindowsReceiptOutcome(publication_lease.phase, candidate),
+            )
+        try:
+            close_failures = publication_lease.close()
+        except BaseException as close_interruption:
+            if primary is None:
+                primary = close_interruption
+            else:
+                _add_cleanup_note(primary, "Could not close receipt staging handle", close_interruption)
+        else:
+            for close_error in close_failures:
+                if primary is None:
+                    primary = close_error
+                else:
+                    _add_cleanup_note(primary, "Could not close receipt staging handle", close_error)
+    if primary is not None:
+        if result is not None and outcome_from_error(primary) is None:
+            setattr(primary, "_windows_receipt_outcome", WindowsReceiptOutcome("published", result))
+        raise primary
+    assert result is not None
+    return result

--- a/scripts/_anchored_receipt_windows.py
+++ b/scripts/_anchored_receipt_windows.py
@@ -18,6 +18,7 @@ WCHAR = ctypes.c_uint16
 USHORT = ctypes.c_uint16
 ULONG = ctypes.c_uint32
 NTSTATUS = ctypes.c_int32
+FILE_INFORMATION_CLASS = ctypes.c_int32
 ULONG_PTR = ctypes.c_size_t
 
 
@@ -37,7 +38,6 @@ FILE_TYPE_DISK = 1
 FILE_BEGIN = 0
 FILE_BASIC_INFO = 0
 FILE_STANDARD_INFO = 1
-FILE_RENAME_INFO = 3
 FILE_DISPOSITION_INFO = 4
 FILE_ID_INFO = 18
 ERROR_FILE_EXISTS = 80
@@ -55,12 +55,14 @@ FILE_CREATE = 0x00000002
 FILE_OPEN_IF = 0x00000003
 FILE_OPENED = 0x00000001
 FILE_CREATED = 0x00000002
+FILE_RENAME_INFORMATION = 10
 FILE_DIRECTORY_FILE = 0x00000001
 FILE_SYNCHRONOUS_IO_NONALERT = 0x00000020
 FILE_NON_DIRECTORY_FILE = 0x00000040
 FILE_OPEN_REPARSE_POINT = 0x00200000
 STATUS_OBJECT_NAME_COLLISION = 0xC0000035
 STATUS_FILE_IS_A_DIRECTORY = 0xC00000BA
+STATUS_PENDING = 0x00000103
 
 _WINDOWS_CLOSE_RESULT_PENDING = object()
 _WINDOWS_CLOSE_ERROR_PENDING = object()
@@ -125,7 +127,7 @@ class _FileDispositionInfo(ctypes.Structure):
     _fields_ = (("DeleteFile", BOOLEAN),)
 
 
-class _FileRenameInfo(ctypes.Structure):
+class _FileRenameInformation(ctypes.Structure):
     _fields_ = (
         ("ReplaceIfExists", BOOLEAN),
         ("RootDirectory", ctypes.c_void_p),
@@ -363,11 +365,11 @@ def _translated_windows_validation_error(
 
 
 class _DefiniteRenameError(OSError):
-    """A FileRenameInfo call returned FALSE without changing namespace state."""
+    """NtSetInformationFile returned a definite failure before renaming."""
 
 
 class _DefiniteRenameCollision(FileExistsError):
-    """A FileRenameInfo call returned FALSE with a destination collision."""
+    """NtSetInformationFile returned a definite destination collision."""
 
 
 class _StageNameCollision(FileExistsError):
@@ -470,6 +472,14 @@ def _configure_nt_api(api: Any) -> Any:
         ULONG,
     )
     api.NtCreateFile.restype = NTSTATUS
+    api.NtSetInformationFile.argtypes = (
+        ctypes.c_void_p,
+        ctypes.POINTER(_IoStatusBlock),
+        ctypes.c_void_p,
+        ULONG,
+        FILE_INFORMATION_CLASS,
+    )
+    api.NtSetInformationFile.restype = NTSTATUS
     api.RtlNtStatusToDosError.argtypes = (NTSTATUS,)
     api.RtlNtStatusToDosError.restype = ULONG
     return api
@@ -841,37 +851,71 @@ def _read_candidate(api: Any, handle: int, maximum: int) -> bytes:
     return bytes(output)
 
 
-def _prepare_rename(parent_handle: int, leaf: str) -> tuple[ctypes.Array[ctypes.c_char], int]:
+def _prepare_rename(leaf: str) -> tuple[ctypes.Array[ctypes.c_char], int]:
     _validate_windows_relative_leaf(leaf)
     encoded = leaf.encode("utf-16-le")
-    logical_size = _FileRenameInfo.FileName.offset + len(encoded)
-    storage = ctypes.create_string_buffer(max(ctypes.sizeof(_FileRenameInfo), logical_size))
-    rename = _FileRenameInfo.from_buffer(storage)
+    # Microsoft requires at least sizeof(FILE_RENAME_INFORMATION) plus the
+    # byte length of FileName, even though FileName[1] is part of sizeof.
+    allocation_size = ctypes.sizeof(_FileRenameInformation) + len(encoded)
+    storage = ctypes.create_string_buffer(allocation_size)
+    rename = _FileRenameInformation.from_buffer(storage)
     rename.ReplaceIfExists = 0
-    rename.RootDirectory = parent_handle
+    # This is the native FILE_RENAME_INFORMATION contract, not the public
+    # FILE_RENAME_INFO wrapper contract. A simple name with a NULL root
+    # renames within the open source handle's existing directory, so no
+    # process-relative path is resolved during publication.
+    rename.RootDirectory = None
     rename.FileNameLength = len(encoded)
-    ctypes.memmove(ctypes.addressof(storage) + _FileRenameInfo.FileName.offset, encoded, len(encoded))
+    ctypes.memmove(
+        ctypes.addressof(storage) + _FileRenameInformation.FileName.offset,
+        encoded,
+        len(encoded),
+    )
 
     return storage, len(storage)
 
 
 def _rename(
-    api: Any,
+    nt_api: Any,
     handle: int,
     storage: ctypes.Array[ctypes.c_char],
     allocation_size: int,
     leaf: str,
 ) -> None:
-    """Make the single native rename call and classify only a FALSE return."""
-    if not api.SetFileInformationByHandle(handle, FILE_RENAME_INFO, storage, allocation_size):
-        error = _failure(api, "FileRenameInfo")
-        if error.errno in (ERROR_FILE_EXISTS, ERROR_ALREADY_EXISTS):
+    """Make one native rename call and authenticate only direct failures."""
+    io_status = _IoStatusBlock()
+    io_status.Status = ctypes.c_int32(STATUS_PENDING).value
+    status = int(
+        nt_api.NtSetInformationFile(
+            handle,
+            ctypes.byref(io_status),
+            storage,
+            allocation_size,
+            FILE_RENAME_INFORMATION,
+        )
+    )
+    if not _nt_success(status):
+        error = _nt_failure(nt_api, "FileRenameInformation", status, leaf)
+        if _nt_status_bits(status) == STATUS_OBJECT_NAME_COLLISION or error.errno in (
+            ERROR_FILE_EXISTS,
+            ERROR_ALREADY_EXISTS,
+        ):
             collision = _DefiniteRenameCollision(error.errno, error.strerror, leaf)
             setattr(collision, "_windows_receipt_definite_provenance", _INTERNAL_FAILURE_PROVENANCE)
             raise collision from error
         failure = _DefiniteRenameError(error.errno, error.strerror, leaf)
         setattr(failure, "_windows_receipt_definite_provenance", _INTERNAL_FAILURE_PROVENANCE)
         raise failure from error
+    if status != 0:
+        raise _nt_failure(nt_api, "FileRenameInformation nonfinal return", status, leaf)
+    completion_status = int(io_status.Status)
+    if completion_status != 0:
+        raise _nt_failure(
+            nt_api,
+            "FileRenameInformation completion",
+            completion_status,
+            leaf,
+        )
 
 
 def _is_internal_definite_rename_error(error: BaseException) -> bool:
@@ -1402,7 +1446,7 @@ def publish_windows_receipt(
     _validate_windows_relative_leaf(leaf)
     if not payload:
         raise ValueError("receipt payload must not be empty")
-    rename_storage, rename_size = _prepare_rename(parent_handle, leaf)
+    rename_storage, rename_size = _prepare_rename(leaf)
     selected_api, selected_nt_api = _select_apis(api, nt_api)
     if publication_lease.api is not selected_api:
         raise ValueError("Windows receipt publication lease belongs to another API")
@@ -1453,10 +1497,10 @@ def publish_windows_receipt(
                     raise OSError("Receipt staging identity, attributes, links, or size changed")
                 candidate = WindowsReceiptResult(leaf, *_identity(after[2]), len(payload))
                 publication_lease.candidate = candidate
-                # From this point until a definite FALSE return, namespace
-                # outcome is unknown and the handle must never be disposed.
+                # From this point until a directly returned failing NTSTATUS,
+                # namespace outcome is unknown and must never be disposed.
                 publication_lease.phase = "unknown"
-                _rename(selected_api, handle, rename_storage, rename_size, leaf)
+                _rename(selected_nt_api, handle, rename_storage, rename_size, leaf)
                 publication_lease.phase = "published"
                 if _read_exact(selected_api, handle, len(payload)) != payload:
                     raise OSError("Published receipt bytes do not match the canonical payload")

--- a/scripts/verify_dependency_environment.py
+++ b/scripts/verify_dependency_environment.py
@@ -8,6 +8,7 @@ from collections.abc import Generator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 import hashlib
+import importlib.util
 import json
 import os
 from pathlib import Path
@@ -17,7 +18,8 @@ import subprocess
 import sys
 import tempfile
 import time
-from typing import IO, Literal, Never, cast
+from types import ModuleType
+from typing import IO, Callable, Literal, Never, cast
 
 
 RECEIPT_SCHEMA_VERSION = 2
@@ -68,6 +70,44 @@ class PolicyError(ValueError):
     def __init__(self, code: str, message: str) -> None:
         super().__init__(message)
         self.code = code
+
+
+class ReceiptOutputError(OSError):
+    """A dependency receipt could not satisfy its publication contract."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def _load_anchored_output_module() -> ModuleType:
+    module_path = Path(__file__).resolve(strict=True).with_name("_anchored_output.py")
+    module_name = "_gm2godot_anchored_output"
+    existing = sys.modules.get(module_name)
+    if existing is not None:
+        existing_path = getattr(existing, "__file__", None)
+        if isinstance(existing_path, str) and Path(existing_path).resolve(strict=True) == module_path:
+            return existing
+        raise ImportError(f"Refusing conflicting anchored output module {module_name!r}.")
+    specification = importlib.util.spec_from_file_location(module_name, module_path)
+    if specification is None or specification.loader is None:
+        raise ImportError(f"Cannot load anchored output helper: {module_path}")
+    module = importlib.util.module_from_spec(specification)
+    sys.modules[module_name] = module
+    try:
+        specification.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+_ANCHORED_OUTPUT = _load_anchored_output_module()
+_ANCHORED_OUTPUT_ERROR = cast(type[ValueError], getattr(_ANCHORED_OUTPUT, "AnchoredOutputError"))
+_PUBLISH_IDENTICAL_RECEIPT_BYTES = cast(
+    Callable[[Path, bytes], None],
+    getattr(_ANCHORED_OUTPUT, "publish_identical_receipt_bytes"),
+)
 
 
 class DuplicateJsonKeyError(ValueError):
@@ -1558,43 +1598,41 @@ def atomic_write_receipt(path: Path, receipt: Mapping[str, object]) -> None:
         )
         + "\n"
     ).encode("utf-8")
-    path.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, temporary_name = tempfile.mkstemp(
-        prefix=f".{path.name}.",
-        suffix=".tmp",
-        dir=path.parent,
-    )
-    temporary_path = Path(temporary_name)
     try:
-        try:
-            handle = os.fdopen(descriptor, "wb")
-        except BaseException as error:
-            try:
-                os.close(descriptor)
-            except BaseException as cleanup_error:
-                error.add_note(
-                    f"Could not close receipt temporary descriptor: {cleanup_error}"
-                )
-            raise
-        try:
-            handle.write(payload)
-            handle.flush()
-            os.fsync(handle.fileno())
-        except BaseException as error:
-            try:
-                handle.close()
-            except BaseException as cleanup_error:
-                error.add_note(f"Could not close receipt temporary file: {cleanup_error}")
-            raise
-        else:
-            handle.close()
-        os.replace(temporary_path, path)
-    except BaseException as error:
-        try:
-            temporary_path.unlink(missing_ok=True)
-        except BaseException as cleanup_error:
-            error.add_note(f"Could not remove receipt temporary file: {cleanup_error}")
-        raise
+        _PUBLISH_IDENTICAL_RECEIPT_BYTES(path, payload)
+    except _ANCHORED_OUTPUT_ERROR as error:
+        translated = ReceiptOutputError(cast(str, getattr(error, "code")), str(error))
+        for note in cast(list[str], getattr(error, "__notes__", [])):
+            translated.add_note(note)
+        raise translated from error
+
+
+def _print_receipt_output_error(prefix: str, path: Path, error: OSError) -> None:
+    record: dict[str, object] = {
+        "message": str(error),
+        "path": os.fspath(path),
+    }
+    label = ""
+    if isinstance(error, ReceiptOutputError):
+        record["code"] = error.code
+        label = f" [{error.code}]"
+    else:
+        record["type"] = type(error).__name__
+    error_record = json.dumps(
+        record,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    print(f"{prefix}{label}: {error_record}", file=sys.stderr)
+    for note in cast(Sequence[str], getattr(error, "__notes__", ())):
+        note_record = json.dumps(
+            {"note": note},
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        print(f"Receipt output cleanup note: {note_record}", file=sys.stderr)
 
 
 def _parse_bootstrap_arguments(argv: Sequence[str] | None) -> argparse.Namespace:
@@ -1655,8 +1693,19 @@ def bootstrap_preflight_main(argv: Sequence[str] | None = None) -> int:
 
     try:
         atomic_write_receipt(output_path, receipt)
+    except ReceiptOutputError as error:
+        _print_receipt_output_error(
+            "Cannot write bootstrap verification receipt",
+            output_path,
+            error,
+        )
+        return 2
     except OSError as error:
-        print(f"Cannot write bootstrap verification receipt {output_path}: {error}", file=sys.stderr)
+        _print_receipt_output_error(
+            "Cannot write bootstrap verification receipt",
+            output_path,
+            error,
+        )
         return 2
 
     if receipt["status"] == "verified":
@@ -1825,8 +1874,19 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     try:
         atomic_write_receipt(output_path, receipt)
+    except ReceiptOutputError as error:
+        _print_receipt_output_error(
+            "Cannot write dependency verification receipt",
+            output_path,
+            error,
+        )
+        return 2
     except OSError as error:
-        print(f"Cannot write dependency verification receipt {output_path}: {error}", file=sys.stderr)
+        _print_receipt_output_error(
+            "Cannot write dependency verification receipt",
+            output_path,
+            error,
+        )
         return 2
 
     if receipt["status"] == "verified":

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.67"
+VERSION = "0.7.68"
 
 
 def get_version():

--- a/tests/test_anchored_receipt_ancestor.py
+++ b/tests/test_anchored_receipt_ancestor.py
@@ -1,0 +1,701 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+import errno
+import gc
+import inspect
+import os
+from pathlib import Path
+import stat
+import sys
+import tempfile
+from types import FrameType
+from typing import Any
+import unittest
+from unittest import mock
+
+from scripts import _anchored_output as anchored
+
+
+class AnchoredReceiptAncestorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if os.name == "nt" or not anchored.descriptor_relative_output_supported():
+            self.skipTest("descriptor-relative POSIX ancestry unavailable")
+
+    def test_substitution_after_created_ancestor_is_rejected_untouched(self) -> None:
+        for substitute in ("symlink", "file"):
+            with self.subTest(substitute=substitute), tempfile.TemporaryDirectory() as raw:
+                root = Path(raw).resolve()
+                attacker = root / "attacker"
+                attacker.mkdir()
+                real_mkdir = anchored.os.mkdir
+                retained_parent = -1
+                binding_lease = anchored._OutputParentBindingLease()
+
+                def mkdir_then_replace(name: str, mode: int, *, dir_fd: int) -> None:
+                    nonlocal retained_parent
+                    retained_parent = os.dup(dir_fd)
+                    real_mkdir(name, mode, dir_fd=dir_fd)
+                    os.rmdir(name, dir_fd=dir_fd)
+                    if substitute == "symlink":
+                        os.symlink(attacker, name, dir_fd=dir_fd, target_is_directory=True)
+                    else:
+                        descriptor = os.open(name, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600, dir_fd=dir_fd)
+                        os.write(descriptor, b"attacker")
+                        os.close(descriptor)
+
+                with mock.patch.object(anchored.os, "mkdir", side_effect=mkdir_then_replace) as patched_mkdir:
+                    anchored.os.supports_dir_fd.add(patched_mkdir)
+                    try:
+                        with self.assertRaises(anchored.AnchoredOutputError):
+                            anchored._open_rooted_posix_parent(
+                                root,
+                                root / "victim" / "receipt.json",
+                                ("victim", "receipt.json"),
+                                binding_lease,
+                            )
+                    finally:
+                        anchored.os.supports_dir_fd.discard(patched_mkdir)
+                binding = binding_lease.binding
+                self.assertIsNotNone(binding)
+                assert binding is not None
+                self.assertTrue(binding.is_closed)
+                self.assertGreaterEqual(retained_parent, 0)
+                entry = os.stat("victim", dir_fd=retained_parent, follow_symlinks=False)
+                self.assertEqual(stat.S_ISLNK(entry.st_mode), substitute == "symlink")
+                if substitute == "file":
+                    descriptor = os.open("victim", os.O_RDONLY, dir_fd=retained_parent)
+                    try:
+                        self.assertEqual(os.read(descriptor, 64), b"attacker")
+                    finally:
+                        os.close(descriptor)
+                os.close(retained_parent)
+
+    def test_mkdir_effect_then_file_exists_is_treated_as_changed(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw).resolve()
+            binding_lease = anchored._OutputParentBindingLease()
+            real_mkdir = anchored.os.mkdir
+
+            def mkdir_then_file_exists(name: str, mode: int, *, dir_fd: int) -> None:
+                real_mkdir(name, mode, dir_fd=dir_fd)
+                raise FileExistsError(errno.EEXIST, os.strerror(errno.EEXIST), name)
+
+            with (
+                mock.patch.object(anchored.os, "mkdir", side_effect=mkdir_then_file_exists) as patched_mkdir,
+                mock.patch.object(anchored.os, "fsync") as fsync,
+            ):
+                anchored.os.supports_dir_fd.add(patched_mkdir)
+                try:
+                    with self.assertRaises(anchored.AnchoredOutputError) as raised:
+                        anchored._open_rooted_posix_parent(
+                            root,
+                            root / "victim" / "receipt.json",
+                            ("victim", "receipt.json"),
+                            binding_lease,
+                        )
+                finally:
+                    anchored.os.supports_dir_fd.discard(patched_mkdir)
+
+            self.assertEqual(raised.exception.code, "output-parent-changed")
+            self.assertTrue((root / "victim").is_dir())
+            fsync.assert_not_called()
+            self.assertEqual(binding_lease.close(), ())
+            binding = binding_lease.binding
+            self.assertIsNotNone(binding)
+            assert binding is not None
+            self.assertTrue(binding.is_closed)
+
+    def test_replacement_between_stat_and_open_is_rejected_untouched(self) -> None:
+        for substitute in ("directory", "symlink"):
+            with self.subTest(substitute=substitute), tempfile.TemporaryDirectory() as raw:
+                root = Path(raw).resolve()
+                victim = root / "victim"
+                victim.mkdir()
+                displaced = root / "displaced"
+                attacker = root / "attacker"
+                attacker.mkdir()
+                real_open = anchored._open_posix_descriptor
+                replaced = False
+                binding_lease = anchored._OutputParentBindingLease()
+
+                def open_after_replace(
+                    descriptor_lease: anchored._PosixDescriptorLease,
+                    path: str | os.PathLike[str],
+                    flags: int,
+                    mode: int = 0o777,
+                    *,
+                    dir_fd: int | None = None,
+                ) -> int:
+                    nonlocal replaced
+                    if os.fspath(path) == "victim" and not replaced:
+                        replaced = True
+                        victim.rename(displaced)
+                        if substitute == "directory":
+                            victim.mkdir()
+                        else:
+                            victim.symlink_to(attacker, target_is_directory=True)
+                    return real_open(
+                        descriptor_lease,
+                        path,
+                        flags,
+                        mode,
+                        dir_fd=dir_fd,
+                    )
+
+                with (
+                    mock.patch.object(anchored, "_open_posix_descriptor", side_effect=open_after_replace),
+                    self.assertRaises(anchored.AnchoredOutputError),
+                ):
+                    anchored._open_rooted_posix_parent(
+                        root,
+                        root / "victim" / "receipt.json",
+                        ("victim", "receipt.json"),
+                        binding_lease,
+                    )
+                binding = binding_lease.binding
+                self.assertIsNotNone(binding)
+                assert binding is not None
+                self.assertTrue(binding.is_closed)
+                self.assertTrue(displaced.is_dir())
+                self.assertEqual(victim.is_symlink(), substitute == "symlink")
+
+    def test_bound_ancestor_disappearance_has_stable_changed_code(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw).resolve()
+            parent = root / "parent"
+            parent.mkdir()
+            relocated = root / "relocated"
+            binding_lease = anchored._OutputParentBindingLease()
+            binding = anchored._open_rooted_posix_parent(
+                root,
+                parent / "receipt.json",
+                ("parent", "receipt.json"),
+                binding_lease,
+            )
+            parent.rename(relocated)
+
+            try:
+                with self.assertRaises(anchored.AnchoredOutputError) as raised:
+                    binding.verify()
+            finally:
+                self.assertEqual(binding_lease.close(), ())
+
+            self.assertEqual(raised.exception.code, "output-parent-changed")
+            self.assertIsInstance(raised.exception.__cause__, FileNotFoundError)
+
+    def test_open_and_final_verification_failures_close_every_acquired_descriptor(self) -> None:
+        failures: tuple[tuple[str, BaseException], ...] = (
+            ("open", OSError("injected child open failure")),
+            ("verify", KeyboardInterrupt("injected verification interrupt")),
+        )
+        for seam, primary in failures:
+            with self.subTest(seam=seam), tempfile.TemporaryDirectory() as raw:
+                root = Path(raw).resolve()
+                (root / "victim").mkdir()
+                real_open = anchored._open_posix_descriptor
+                real_close = anchored._PosixDescriptorLease.close
+                opened: list[int] = []
+                closed: list[int] = []
+                binding_lease = anchored._OutputParentBindingLease()
+
+                def open_or_fail(
+                    descriptor_lease: anchored._PosixDescriptorLease,
+                    path: str | os.PathLike[str],
+                    flags: int,
+                    mode: int = 0o777,
+                    *,
+                    dir_fd: int | None = None,
+                ) -> int:
+                    if seam == "open" and os.fspath(path) == "victim":
+                        raise primary
+                    descriptor = real_open(
+                        descriptor_lease,
+                        path,
+                        flags,
+                        mode,
+                        dir_fd=dir_fd,
+                    )
+                    opened.append(descriptor)
+                    return descriptor
+
+                def record_close(descriptor_lease: anchored._PosixDescriptorLease) -> None:
+                    descriptor = descriptor_lease.descriptor
+                    if descriptor is not None:
+                        closed.append(descriptor)
+                    real_close(descriptor_lease)
+
+                verify_patch = (
+                    mock.patch.object(anchored.OutputParentBinding, "verify", side_effect=primary)
+                    if seam == "verify"
+                    else mock.patch.object(anchored.OutputParentBinding, "verify", autospec=True)
+                )
+                with (
+                    mock.patch.object(anchored, "_open_posix_descriptor", side_effect=open_or_fail),
+                    mock.patch.object(anchored._PosixDescriptorLease, "close", new=record_close),
+                    verify_patch,
+                    self.assertRaises(anchored.AnchoredOutputError if seam == "open" else type(primary)) as raised,
+                ):
+                    anchored._open_rooted_posix_parent(
+                        root,
+                        root / "victim" / "receipt.json",
+                        ("victim", "receipt.json"),
+                        binding_lease,
+                    )
+                if seam == "open":
+                    self.assertIs(raised.exception.__cause__, primary)
+                else:
+                    self.assertIs(raised.exception, primary)
+                binding = binding_lease.binding
+                self.assertIsNotNone(binding)
+                assert binding is not None
+                self.assertTrue(binding.is_closed)
+                self.assertEqual(closed, list(reversed(opened)))
+
+    def test_preinstalled_owner_recovers_root_child_and_verification_interrupts(self) -> None:
+        target = anchored._open_rooted_posix_parent
+        source, first_line = inspect.getsourcelines(target)
+        cleanup_lines = [
+            first_line + index
+            for index, line in enumerate(source)
+            if "cleanup_failures = lease.close()" in line
+        ]
+        self.assertEqual(len(cleanup_lines), 1)
+        cleanup_line = cleanup_lines[0]
+
+        for seam in ("root", "child", "verify"):
+            with self.subTest(seam=seam), tempfile.TemporaryDirectory() as raw:
+                root = Path(raw).resolve()
+                (root / "parent").mkdir()
+                output = root / "parent" / "receipt.json"
+                body_failure = RuntimeError(f"modeled {seam} acquisition failure")
+                cleanup_interruption = KeyboardInterrupt(
+                    f"interrupt {seam} exception-handler cleanup entry"
+                )
+                opened: list[int] = []
+                closed: list[int] = []
+                open_count = 0
+                cleanup_was_interrupted = False
+                real_open = anchored._open_posix_descriptor
+                real_close = anchored._PosixDescriptorLease.close
+                real_verify = anchored.OutputParentBinding.verify
+
+                def open_then_maybe_fail(
+                    descriptor_lease: anchored._PosixDescriptorLease,
+                    path: str | os.PathLike[str],
+                    flags: int,
+                    mode: int = 0o777,
+                    *,
+                    dir_fd: int | None = None,
+                ) -> int:
+                    nonlocal open_count
+                    descriptor = real_open(
+                        descriptor_lease,
+                        path,
+                        flags,
+                        mode,
+                        dir_fd=dir_fd,
+                    )
+                    opened.append(descriptor)
+                    current_open = open_count
+                    open_count += 1
+                    if (seam == "root" and current_open == 0) or (
+                        seam == "child" and current_open == 1
+                    ):
+                        raise body_failure
+                    return descriptor
+
+                def verify_then_maybe_fail(binding: anchored.OutputParentBinding) -> None:
+                    real_verify(binding)
+                    if seam == "verify":
+                        raise body_failure
+
+                def record_close(descriptor_lease: anchored._PosixDescriptorLease) -> None:
+                    descriptor = descriptor_lease.descriptor
+                    if descriptor is not None:
+                        closed.append(descriptor)
+                    real_close(descriptor_lease)
+
+                def trace(frame: FrameType, event: str, _argument: object) -> Any:
+                    nonlocal cleanup_was_interrupted
+                    if event == "call" and frame.f_code is target.__code__:
+                        frame.f_trace = trace
+                        return trace
+                    if (
+                        event == "line"
+                        and frame.f_code is target.__code__
+                        and frame.f_lineno == cleanup_line
+                        and not cleanup_was_interrupted
+                    ):
+                        cleanup_was_interrupted = True
+                        raise cleanup_interruption
+                    return trace
+
+                def acquire_without_retaining_lease() -> None:
+                    lease = anchored._OutputParentBindingLease()
+                    target(
+                        root,
+                        output,
+                        ("parent", "receipt.json"),
+                        lease,
+                    )
+
+                previous_trace = sys.gettrace()
+                try:
+                    with (
+                        mock.patch.object(
+                            anchored,
+                            "_open_posix_descriptor",
+                            side_effect=open_then_maybe_fail,
+                        ),
+                        mock.patch.object(
+                            anchored._PosixDescriptorLease,
+                            "close",
+                            new=record_close,
+                        ),
+                        mock.patch.object(
+                            anchored.OutputParentBinding,
+                            "verify",
+                            new=verify_then_maybe_fail,
+                        ),
+                        self.assertRaises(anchored.AnchoredOutputError) as raised,
+                    ):
+                        sys.settrace(trace)
+                        acquire_without_retaining_lease()
+                finally:
+                    sys.settrace(previous_trace)
+
+                self.assertTrue(cleanup_was_interrupted)
+                self.assertEqual(raised.exception.code, "output-parent-invalid")
+                self.assertIs(raised.exception.__cause__, body_failure)
+                self.assertIn(
+                    str(cleanup_interruption),
+                    "\n".join(getattr(raised.exception, "__notes__", ())),
+                )
+                raised.exception.__traceback__ = None
+                body_failure.__traceback__ = None
+                cleanup_interruption.__traceback__ = None
+                gc.collect()
+
+                self.assertEqual(closed, list(reversed(opened)))
+                self.assertEqual(len(closed), len(set(closed)))
+                for descriptor in opened:
+                    with self.assertRaises(OSError) as descriptor_error:
+                        os.fstat(descriptor)
+                    self.assertEqual(descriptor_error.exception.errno, errno.EBADF)
+
+    def test_binding_lease_survives_posix_opener_to_wrapper_return_gap(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw).resolve()
+            (root / "parent").mkdir()
+            output = root / "parent" / "receipt.json"
+            interruption = KeyboardInterrupt("POSIX opener returned before wrapper assignment")
+            real_parent_open = anchored._open_rooted_posix_parent
+            captured_lease: anchored._OutputParentBindingLease | None = None
+            opened: list[int] = []
+            closed: list[int] = []
+            triggered = False
+            real_open = anchored._open_posix_descriptor
+            real_close = anchored._PosixDescriptorLease.close
+
+            def open_and_record(
+                descriptor_lease: anchored._PosixDescriptorLease,
+                path: str | os.PathLike[str],
+                flags: int,
+                mode: int = 0o777,
+                *,
+                dir_fd: int | None = None,
+            ) -> int:
+                descriptor = real_open(
+                    descriptor_lease,
+                    path,
+                    flags,
+                    mode,
+                    dir_fd=dir_fd,
+                )
+                opened.append(descriptor)
+                return descriptor
+
+            def close_and_record(descriptor_lease: anchored._PosixDescriptorLease) -> None:
+                descriptor = descriptor_lease.descriptor
+                if descriptor is not None:
+                    closed.append(descriptor)
+                real_close(descriptor_lease)
+
+            def open_then_interrupt(
+                root_anchor: Path,
+                absolute: Path,
+                parts: tuple[str, ...],
+                binding_lease: anchored._OutputParentBindingLease,
+            ) -> anchored.OutputParentBinding:
+                nonlocal captured_lease, triggered
+                real_parent_open(root_anchor, absolute, parts, binding_lease)
+                captured_lease = binding_lease
+                triggered = True
+                raise interruption
+
+            with (
+                mock.patch.object(
+                    anchored,
+                    "_open_posix_descriptor",
+                    side_effect=open_and_record,
+                ),
+                mock.patch.object(
+                    anchored._PosixDescriptorLease,
+                    "close",
+                    new=close_and_record,
+                ),
+                mock.patch.object(
+                    anchored,
+                    "_open_rooted_posix_parent",
+                    side_effect=open_then_interrupt,
+                ),
+                mock.patch.object(anchored, "_publish_posix_receipt_bytes") as publish,
+                self.assertRaises(KeyboardInterrupt) as raised,
+            ):
+                anchored.publish_identical_receipt_bytes(output, b"receipt\n")
+
+            self.assertTrue(triggered)
+            self.assertIs(raised.exception, interruption)
+            self.assertIsNotNone(captured_lease)
+            assert captured_lease is not None
+            binding = captured_lease.binding
+            self.assertIsNotNone(binding)
+            assert binding is not None
+            self.assertTrue(binding.is_closed)
+            publish.assert_not_called()
+            self.assertGreaterEqual(len(opened), 2)
+            self.assertEqual(closed, list(reversed(opened)))
+
+    def test_unsafe_final_or_creation_parent_is_rejected_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw).resolve()
+            unsafe = root / "unsafe"
+            unsafe.mkdir()
+            unsafe.chmod(0o777)
+            try:
+                for output in (unsafe / "receipt.json", unsafe / "missing" / "receipt.json"):
+                    with self.subTest(output=output):
+                        lease = anchored._OutputParentBindingLease()
+                        with self.assertRaises(anchored.AnchoredOutputError) as raised:
+                            anchored._open_rooted_posix_parent(
+                                root,
+                                output,
+                                output.relative_to(root).parts,
+                                lease,
+                            )
+                        self.assertIn(raised.exception.code, {"output-parent-invalid", "output-parent-changed"})
+                        self.assertFalse((unsafe / "missing").exists())
+                        self.assertEqual(lease.close(), ())
+            finally:
+                unsafe.chmod(0o700)
+
+    def test_safe_namespace_predicate_rejects_untrusted_owner(self) -> None:
+        untrusted = mock.Mock(
+            st_mode=stat.S_IFDIR | 0o755,
+            st_uid=os.geteuid() + 1,
+        )
+        with (
+            mock.patch.object(anchored.os, "fstat", return_value=untrusted),
+            mock.patch.object(anchored, "_darwin_descriptor_has_extended_acl", return_value=False),
+            self.assertRaises(anchored.AnchoredOutputError) as raised,
+        ):
+            anchored._validate_safe_posix_directory_descriptor(
+                7,
+                code="output-parent-invalid",
+                context="modeled final parent",
+            )
+        self.assertEqual(raised.exception.code, "output-parent-invalid")
+
+    def test_bound_intermediate_becoming_world_writable_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw).resolve()
+            intermediate = root / "intermediate"
+            final_parent = intermediate / "final"
+            final_parent.mkdir(parents=True)
+            lease = anchored._OutputParentBindingLease()
+            binding = anchored._open_rooted_posix_parent(
+                root,
+                final_parent / "receipt.json",
+                ("intermediate", "final", "receipt.json"),
+                lease,
+            )
+            intermediate.chmod(0o777)
+            try:
+                with self.assertRaises(anchored.AnchoredOutputError) as raised:
+                    binding.verify()
+                self.assertEqual(raised.exception.code, "output-parent-changed")
+            finally:
+                intermediate.chmod(0o700)
+                self.assertEqual(lease.close(), ())
+
+    def test_sticky_safe_parent_is_accepted_and_unsafe_intermediate_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw).resolve()
+            sticky = root / "sticky"
+            sticky.mkdir()
+            sticky.chmod(0o1777)
+            sticky_lease = anchored._OutputParentBindingLease()
+            sticky_binding = anchored._open_rooted_posix_parent(
+                root,
+                sticky / "receipt.json",
+                ("sticky", "receipt.json"),
+                sticky_lease,
+            )
+            self.assertEqual(sticky_lease.close(), ())
+            self.assertTrue(sticky_binding.is_closed)
+
+            unsafe = root / "unsafe-ancestor"
+            safe = unsafe / "safe-final"
+            unsafe.mkdir(mode=0o700)
+            safe.mkdir(mode=0o700)
+            unsafe.chmod(0o777)
+            try:
+                safe_lease = anchored._OutputParentBindingLease()
+                with self.assertRaises(anchored.AnchoredOutputError) as raised:
+                    anchored._open_rooted_posix_parent(
+                        root,
+                        safe / "receipt.json",
+                        ("unsafe-ancestor", "safe-final", "receipt.json"),
+                        safe_lease,
+                    )
+                self.assertEqual(raised.exception.code, "output-parent-invalid")
+                self.assertEqual(safe_lease.close(), ())
+                self.assertIsNotNone(safe_lease.binding)
+                assert safe_lease.binding is not None
+                self.assertTrue(safe_lease.binding.is_closed)
+            finally:
+                unsafe.chmod(0o700)
+
+    def test_created_ancestors_are_private_under_restrictive_umask(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw).resolve()
+            lease = anchored._OutputParentBindingLease()
+            previous_umask = os.umask(0o777)
+            try:
+                binding = anchored._open_rooted_posix_parent(
+                    root,
+                    root / "one" / "two" / "receipt.json",
+                    ("one", "two", "receipt.json"),
+                    lease,
+                )
+            finally:
+                os.umask(previous_umask)
+            self.assertEqual(stat.S_IMODE((root / "one").stat().st_mode), 0o700)
+            self.assertEqual(stat.S_IMODE((root / "one" / "two").stat().st_mode), 0o700)
+            self.assertEqual(lease.close(), ())
+            self.assertTrue(binding.is_closed)
+
+    def test_existing_ancestor_retries_containing_directory_sync(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw).resolve()
+            output = root / "parent" / "receipt.json"
+            first_lease = anchored._OutputParentBindingLease()
+            with (
+                mock.patch.object(anchored.os, "fsync", side_effect=OSError(errno.EIO, "sync")),
+                self.assertRaises(anchored.AnchoredOutputError),
+            ):
+                anchored._open_rooted_posix_parent(
+                    root,
+                    output,
+                    ("parent", "receipt.json"),
+                    first_lease,
+                )
+            self.assertTrue((root / "parent").is_dir())
+            self.assertEqual(first_lease.close(), ())
+
+            second_lease = anchored._OutputParentBindingLease()
+            with mock.patch.object(anchored.os, "fsync") as retry_sync:
+                binding = anchored._open_rooted_posix_parent(
+                    root,
+                    output,
+                    ("parent", "receipt.json"),
+                    second_lease,
+                )
+            retry_sync.assert_called_once_with(binding.descriptors[0])
+            self.assertEqual(second_lease.close(), ())
+
+    def test_binding_lease_survives_wrapper_to_public_assignment_gap(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw).resolve()
+            (root / "parent").mkdir()
+            output = root / "parent" / "receipt.json"
+            interruption = KeyboardInterrupt("wrapper returned before public binding assignment")
+            real_parent_open = anchored.open_rooted_output_parent
+            captured_lease: anchored._OutputParentBindingLease | None = None
+            opened: list[int] = []
+            closed: list[int] = []
+            triggered = False
+            real_open = anchored._open_posix_descriptor
+            real_close = anchored._PosixDescriptorLease.close
+
+            def open_and_record(
+                descriptor_lease: anchored._PosixDescriptorLease,
+                path: str | os.PathLike[str],
+                flags: int,
+                mode: int = 0o777,
+                *,
+                dir_fd: int | None = None,
+            ) -> int:
+                descriptor = real_open(
+                    descriptor_lease,
+                    path,
+                    flags,
+                    mode,
+                    dir_fd=dir_fd,
+                )
+                opened.append(descriptor)
+                return descriptor
+
+            def close_and_record(descriptor_lease: anchored._PosixDescriptorLease) -> None:
+                descriptor = descriptor_lease.descriptor
+                if descriptor is not None:
+                    closed.append(descriptor)
+                real_close(descriptor_lease)
+
+            def open_then_interrupt(
+                path: Path,
+                binding_lease: anchored._OutputParentBindingLease,
+            ) -> anchored.OutputParentBinding:
+                nonlocal captured_lease, triggered
+                real_parent_open(path, binding_lease)
+                captured_lease = binding_lease
+                triggered = True
+                raise interruption
+
+            with (
+                mock.patch.object(
+                    anchored,
+                    "_open_posix_descriptor",
+                    side_effect=open_and_record,
+                ),
+                mock.patch.object(
+                    anchored._PosixDescriptorLease,
+                    "close",
+                    new=close_and_record,
+                ),
+                mock.patch.object(
+                    anchored,
+                    "open_rooted_output_parent",
+                    side_effect=open_then_interrupt,
+                ),
+                mock.patch.object(anchored, "_publish_posix_receipt_bytes") as publish,
+                self.assertRaises(KeyboardInterrupt) as raised,
+            ):
+                anchored.publish_identical_receipt_bytes(output, b"receipt\n")
+
+            self.assertTrue(triggered)
+            self.assertIs(raised.exception, interruption)
+            self.assertIsNotNone(captured_lease)
+            assert captured_lease is not None
+            binding = captured_lease.binding
+            self.assertIsNotNone(binding)
+            assert binding is not None
+            self.assertTrue(binding.is_closed)
+            publish.assert_not_called()
+            self.assertGreaterEqual(len(opened), 2)
+            self.assertEqual(closed, list(reversed(opened)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_anchored_receipt_contract.py
+++ b/tests/test_anchored_receipt_contract.py
@@ -1,0 +1,415 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+import inspect
+import ntpath
+import os
+from pathlib import Path, PureWindowsPath
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable
+from typing import cast
+import unittest
+from unittest import mock
+
+from scripts import _anchored_output as anchored
+
+
+PAYLOAD = b'{"status":"verified"}\n'
+
+
+def _entry_snapshot(path: Path) -> tuple[tuple[int, ...], object]:
+    value = path.lstat()
+    metadata = (
+        value.st_dev,
+        value.st_ino,
+        value.st_mode,
+        value.st_nlink,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+    if path.is_symlink():
+        content: object = os.readlink(path)
+    elif path.is_file():
+        content = path.read_bytes()
+    elif path.is_dir():
+        content = tuple(sorted(os.listdir(path)))
+    else:
+        content = None
+    return metadata, content
+
+
+class AnchoredReceiptContractTests(unittest.TestCase):
+    def test_private_receipt_entry_points_require_caller_held_owners(self) -> None:
+        posix = anchored._posix_receipt_module()
+        windows = anchored._windows_receipt_module()
+        required_parameters = (
+            (anchored._publish_posix_receipt_bytes, "outer_lease"),
+            (anchored._publish_windows_receipt_bytes, "outer_lease"),
+            (anchored._read_exact_receipt, "descriptor_lease"),
+            (posix._publish_posix_receipt_bytes, "publication_lease"),
+            (posix._sync_posix_public_descriptor, "descriptor_lease"),
+            (windows.read_windows_receipt, "publication_lease"),
+            (windows.publish_windows_receipt, "publication_lease"),
+        )
+
+        for function, parameter_name in required_parameters:
+            with self.subTest(function=function.__name__):
+                parameter = inspect.signature(function).parameters[parameter_name]
+                self.assertIs(parameter.default, inspect.Parameter.empty)
+
+    def test_windows_invalid_leaves_are_path_invalid_before_native_parent_open(self) -> None:
+        anchored._windows_receipt_module()
+        invalid_leaves = (
+            "receipt.json:stream",
+            "receipt.",
+            "receipt ",
+            "NUL.txt",
+            "NUL .txt",
+            "cOm¹.log",
+            "lPt9.backup",
+            "bad?name",
+            "bad<name",
+            "bad>name",
+            'bad"name',
+            "bad|name",
+            "bad*name",
+            "bad\x01name",
+            "\ud800",
+        )
+        for leaf in invalid_leaves:
+            with self.subTest(leaf=repr(leaf)):
+                output = Path("receipts") / leaf
+                lease = anchored._OutputParentBindingLease()
+                with (
+                    mock.patch.object(anchored.os, "name", "nt"),
+                    mock.patch.object(anchored, "_open_rooted_windows_parent") as native_open,
+                    self.assertRaises(anchored.AnchoredOutputError) as raised,
+                ):
+                    anchored.open_rooted_output_parent(output, lease)
+                self.assertEqual(raised.exception.code, "path-invalid")
+                native_open.assert_not_called()
+                self.assertIsNone(lease.binding)
+
+    def test_windows_invalid_ancestor_is_rejected_before_any_parent_mutation(self) -> None:
+        anchored._windows_receipt_module()
+        for invalid_component in ("bad?", "NUL"):
+            with self.subTest(component=invalid_component), tempfile.TemporaryDirectory() as raw:
+                root = Path(raw).resolve()
+                missing = root / "valid-missing"
+                output = missing / invalid_component / "receipt.json"
+                lease = anchored._OutputParentBindingLease()
+                with (
+                    mock.patch.object(anchored.os, "name", "nt"),
+                    mock.patch.object(
+                        anchored,
+                        "_open_rooted_windows_parent",
+                        side_effect=AssertionError("native Windows parent open reached"),
+                    ) as native_open,
+                    self.assertRaises(anchored.AnchoredOutputError) as raised,
+                ):
+                    anchored.open_rooted_output_parent(output, lease)
+
+                self.assertEqual(raised.exception.code, "path-invalid")
+                native_open.assert_not_called()
+                self.assertFalse(missing.exists())
+                self.assertIsNone(lease.binding)
+
+    def test_windows_device_namespace_roots_are_path_invalid_before_native_parent_open(self) -> None:
+        anchored._windows_receipt_module()
+        invalid_paths = (
+            PureWindowsPath(r"\\.\C:\parent\receipt.json"),
+            PureWindowsPath(r"\\?\GLOBALROOT\Device\HarddiskVolume1\parent\receipt.json"),
+        )
+        for output in invalid_paths:
+            with self.subTest(path=str(output)):
+                lease = anchored._OutputParentBindingLease()
+                with (
+                    mock.patch.object(anchored.os, "name", "nt"),
+                    mock.patch.object(anchored.os, "path", ntpath),
+                    mock.patch.object(anchored, "Path", PureWindowsPath),
+                    mock.patch.object(anchored, "_open_rooted_windows_parent") as native_open,
+                    self.assertRaises(anchored.AnchoredOutputError) as raised,
+                ):
+                    anchored.open_rooted_output_parent(cast(Path, output), lease)
+
+                self.assertEqual(raised.exception.code, "path-invalid")
+                native_open.assert_not_called()
+                self.assertIsNone(lease.binding)
+
+    def test_posix_helper_loader_failure_preserves_primary_and_closes_binding(self) -> None:
+        primary = KeyboardInterrupt("loader failure")
+
+        class Binding:
+            closed = False
+
+            def close(self) -> tuple[BaseException, ...]:
+                self.closed = True
+                return (OSError("close failure"),)
+
+        binding = Binding()
+        owner = anchored._OutputParentBindingLease()
+        owner.binding = cast(anchored.OutputParentBinding, binding)
+        with (
+            mock.patch.object(anchored, "_posix_receipt_module", side_effect=primary),
+            self.assertRaises(KeyboardInterrupt) as raised,
+        ):
+            anchored._publish_posix_receipt_bytes(
+                Path("parent/receipt.json"),
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                owner,
+            )
+        self.assertIs(raised.exception, primary)
+        self.assertTrue(binding.closed)
+        self.assertIn("close failure", "\n".join(getattr(primary, "__notes__", ())))
+
+    def test_windows_helper_loader_failure_preserves_primary_and_closes_binding(self) -> None:
+        primary = KeyboardInterrupt("loader failure")
+
+        class Binding:
+            parent = Path("parent")
+            leaf = "receipt.json"
+            windows_entries = ((Path("parent"), (1, 2), 3),)
+            windows_api = object()
+            closed = False
+
+            def stat(self, _name: str) -> os.stat_result:
+                raise FileNotFoundError
+
+            def close(self) -> list[BaseException]:
+                self.closed = True
+                return []
+
+        binding = Binding()
+        owner = anchored._OutputParentBindingLease()
+        owner.binding = cast(anchored.OutputParentBinding, binding)
+        with (
+            mock.patch.object(anchored, "_windows_receipt_module", side_effect=primary),
+            self.assertRaises(KeyboardInterrupt) as raised,
+        ):
+            anchored._publish_windows_receipt_bytes(
+                Path("parent/receipt.json"),
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                owner,
+            )
+        self.assertIs(raised.exception, primary)
+        self.assertTrue(binding.closed)
+
+    def test_public_cleanup_return_gap_preserves_active_primary(self) -> None:
+        primary = OSError("acquisition failure")
+        cleanup_interrupt = KeyboardInterrupt("cleanup returned before assignment")
+
+        class Binding:
+            close_calls = 0
+            descriptor_leases: tuple[object, ...] = ()
+
+            @property
+            def is_closed(self) -> bool:
+                return self.close_calls > 0
+
+            def close(self) -> tuple[BaseException, ...]:
+                self.close_calls += 1
+                return ()
+
+        binding = Binding()
+
+        def fail_after_retaining_binding(
+            _path: Path,
+            lease: anchored._OutputParentBindingLease,
+        ) -> anchored.OutputParentBinding:
+            lease.binding = cast(anchored.OutputParentBinding, binding)
+            raise primary
+
+        triggered = False
+
+        real_close = anchored._OutputParentBindingLease.close
+
+        def close_then_interrupt(lease: anchored._OutputParentBindingLease) -> tuple[BaseException, ...]:
+            nonlocal triggered
+            real_close(lease)
+            triggered = True
+            raise cleanup_interrupt
+
+        with (
+            mock.patch.object(
+                anchored,
+                "open_rooted_output_parent",
+                side_effect=fail_after_retaining_binding,
+            ),
+            mock.patch.object(
+                anchored._OutputParentBindingLease,
+                "close",
+                new=close_then_interrupt,
+            ),
+            self.assertRaises(OSError) as raised,
+        ):
+            anchored.publish_identical_receipt_bytes(Path("receipt.json"), PAYLOAD)
+
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, primary)
+        self.assertEqual(binding.close_calls, 1)
+        self.assertIn(str(cleanup_interrupt), "\n".join(getattr(primary, "__notes__", ())))
+
+    def test_verifier_translation_is_stable_in_both_import_orders(self) -> None:
+        for facade_first in (False, True):
+            with self.subTest(facade_first=facade_first):
+                if facade_first:
+                    imports = """
+from scripts import _anchored_output as direct
+direct_helper = direct._posix_receipt_module()
+from scripts import verify_dependency_environment as verifier
+verifier_helper = verifier._ANCHORED_OUTPUT._posix_receipt_module()
+"""
+                else:
+                    imports = """
+from scripts import verify_dependency_environment as verifier
+verifier_helper = verifier._ANCHORED_OUTPUT._posix_receipt_module()
+from scripts import _anchored_output as direct
+direct_helper = direct._posix_receipt_module()
+"""
+                source = (
+                    imports
+                    + """
+from pathlib import Path
+assert direct_helper is not verifier_helper
+assert direct_helper.AnchoredOutputError is direct.AnchoredOutputError
+assert verifier_helper.AnchoredOutputError is verifier._ANCHORED_OUTPUT.AnchoredOutputError
+assert direct_helper.AnchoredOutputError is not verifier_helper.AnchoredOutputError
+error_type = verifier_helper.AnchoredOutputError
+assert error_type is verifier._ANCHORED_OUTPUT.AnchoredOutputError
+def fail(_path, _payload):
+    raise error_type('induced-helper-failure', 'induced')
+verifier._PUBLISH_IDENTICAL_RECEIPT_BYTES = fail
+try:
+    verifier.atomic_write_receipt(Path('unused.json'), {'status': 'failed'})
+except verifier.ReceiptOutputError as error:
+    assert error.code == 'induced-helper-failure'
+else:
+    raise AssertionError('translation did not occur')
+"""
+                )
+                result = subprocess.run(
+                    [sys.executable, "-c", source],
+                    cwd=Path(__file__).resolve().parents[1],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_legacy_publication_does_not_load_receipt_helpers(self) -> None:
+        source = """
+from pathlib import Path
+import tempfile
+from scripts import _anchored_output as anchored
+assert anchored._posix_receipt_cache is None and anchored._windows_receipt_cache is None
+with tempfile.TemporaryDirectory(dir='.') as raw:
+    anchored.publish_new_bytes(Path(raw).resolve() / 'snapshot.json', b'bytes')
+assert anchored._posix_receipt_cache is None and anchored._windows_receipt_cache is None
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", source],
+            cwd=Path(__file__).resolve().parents[1],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_existing_exact_receipt_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory).resolve()
+            previous = Path.cwd()
+            os.chdir(root)
+            try:
+                output = root / "receipt.json"
+                anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+                before = output.stat()
+                metadata = (before.st_ino, before.st_mode, before.st_mtime_ns, before.st_ctime_ns)
+                anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+                after = output.stat()
+                self.assertEqual(
+                    (after.st_ino, after.st_mode, after.st_mtime_ns, after.st_ctime_ns),
+                    metadata,
+                )
+                self.assertEqual(output.read_bytes(), PAYLOAD)
+            finally:
+                os.chdir(previous)
+
+    def test_noncanonical_existing_targets_fail_untouched(self) -> None:
+        def wrong_mode(path: Path) -> None:
+            path.write_bytes(PAYLOAD)
+            path.chmod(0o644)
+
+        def hardlink(path: Path) -> None:
+            source = path.with_name("source")
+            source.write_bytes(PAYLOAD)
+            source.chmod(0o600)
+            os.link(source, path)
+
+        creators: dict[str, Callable[[Path], None]] = {
+            "wrong-mode": wrong_mode,
+            "directory": lambda path: path.mkdir(),
+            "symlink": lambda path: path.symlink_to("missing-target"),
+            "fifo": os.mkfifo,
+            "hardlink": hardlink,
+        }
+        for label, create in creators.items():
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as raw_directory:
+                root = Path(raw_directory).resolve()
+                output = root / "receipt.json"
+                create(output)
+                before = _entry_snapshot(output)
+                source = output.with_name("source")
+                source_before = _entry_snapshot(source) if source.exists() else None
+                linked_before = source_before is not None and os.path.samefile(source, output)
+                previous = Path.cwd()
+                os.chdir(root)
+                try:
+                    with self.assertRaises(anchored.AnchoredOutputError) as raised:
+                        anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+                finally:
+                    os.chdir(previous)
+                self.assertEqual(raised.exception.code, "output-existing-invalid")
+                self.assertEqual(_entry_snapshot(output), before)
+                if source_before is not None:
+                    self.assertEqual(_entry_snapshot(source), source_before)
+                    self.assertEqual(os.path.samefile(source, output), linked_before)
+
+    def test_missing_nested_ancestors_are_created_with_canonical_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory).resolve()
+            output = root / "one" / "two" / "receipt.json"
+            previous = Path.cwd()
+            os.chdir(root)
+            try:
+                anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+            finally:
+                os.chdir(previous)
+            self.assertEqual(output.read_bytes(), PAYLOAD)
+            self.assertEqual(output.stat().st_mode & 0o777, 0o600)
+
+    def test_existing_different_receipt_is_rejected_untouched(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory).resolve()
+            previous = Path.cwd()
+            os.chdir(root)
+            try:
+                output = root / "receipt.json"
+                output.write_bytes(b"different\n")
+                output.chmod(0o600)
+                before = _entry_snapshot(output)
+                with self.assertRaises(anchored.AnchoredOutputError) as raised:
+                    anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+                self.assertEqual(raised.exception.code, "output-different")
+                self.assertEqual(_entry_snapshot(output), before)
+            finally:
+                os.chdir(previous)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_anchored_receipt_darwin.py
+++ b/tests/test_anchored_receipt_darwin.py
@@ -937,7 +937,11 @@ class AnchoredReceiptDarwinTests(unittest.TestCase):
             close=mock.Mock(return_value=()),
         )
         with (
-            mock.patch.object(self.posix.sys, "platform", "darwin"),
+            mock.patch.object(
+                self.posix,
+                "sys",
+                SimpleNamespace(platform="darwin"),
+            ),
             mock.patch.object(
                 self.posix,
                 "_open_posix_receipt_stage",
@@ -2061,6 +2065,11 @@ class AnchoredReceiptDarwinTests(unittest.TestCase):
 
         with (
             mock.patch.object(
+                self.posix,
+                "sys",
+                SimpleNamespace(platform="darwin"),
+            ),
+            mock.patch.object(
                 self.posix.os,
                 "unlink",
                 side_effect=unlink_then_interrupt,
@@ -2239,10 +2248,17 @@ class AnchoredReceiptDarwinTests(unittest.TestCase):
             cleanup_calls += 1
             raise OSError("final named-stage cleanup")
 
-        with mock.patch.object(
-            self.posix,
-            "_cleanup_darwin_named_stage",
-            side_effect=fail_final_cleanup,
+        with (
+            mock.patch.object(
+                self.posix,
+                "sys",
+                SimpleNamespace(platform="darwin"),
+            ),
+            mock.patch.object(
+                self.posix,
+                "_cleanup_darwin_named_stage",
+                side_effect=fail_final_cleanup,
+            ),
         ):
             failures = publication.close()
 

--- a/tests/test_anchored_receipt_darwin.py
+++ b/tests/test_anchored_receipt_darwin.py
@@ -1,0 +1,2261 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+from contextlib import nullcontext
+import ctypes
+import errno
+import gc
+import inspect
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+from types import FrameType, SimpleNamespace
+from typing import Any, Callable
+import unittest
+from unittest import mock
+
+from scripts import _anchored_output as anchored
+
+
+PRIVATE_ROOT = ".gm2godot-receipt-staging"
+
+
+def _source_line(
+    function: Callable[..., object],
+    source_fragment: str,
+) -> int:
+    """Find one cleanup source line without depending on CPython bytecode."""
+
+    lines, first_line = inspect.getsourcelines(function)
+    matching_lines = [
+        first_line + index
+        for index, source_line in enumerate(lines)
+        if source_fragment in source_line
+    ]
+    if len(matching_lines) != 1:
+        raise AssertionError(
+            f"Expected one {function.__name__} source line containing "
+            f"{source_fragment!r}; found {matching_lines}."
+        )
+    return matching_lines[0]
+
+
+class _LeaseAwareNativeCall:
+    argtypes: object = None
+    restype: object = None
+
+    def __init__(self, result: int) -> None:
+        self.result = result
+        self.calls: list[tuple[object, ...]] = []
+
+    def __call__(self, *arguments: object) -> int:
+        self.calls.append(arguments)
+        result_type = self.restype
+        checker = getattr(result_type, "_check_retval_", None)
+        if callable(result_type) and callable(checker):
+            checker(result_type(self.result))
+        return self.result
+
+
+class AnchoredReceiptDarwinTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if os.name == "nt":
+            self.skipTest("descriptor-relative POSIX test")
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name).resolve()
+        self.parent = self.root / "parent"
+        self.parent.mkdir()
+        self.previous_cwd = Path.cwd()
+        os.chdir(self.root)
+        self.binding_lease = anchored._OutputParentBindingLease()
+        self.binding = anchored.open_rooted_output_parent(
+            self.parent / "receipt.json",
+            self.binding_lease,
+        )
+        self.posix = anchored._posix_receipt_module()
+
+    def tearDown(self) -> None:
+        for failure in self.binding_lease.close():
+            self.fail(f"could not close output binding: {failure}")
+        os.chdir(self.previous_cwd)
+        self.temporary.cleanup()
+
+    def _stage_lease(self) -> Any:
+        return self.posix._PosixReceiptStageLease(
+            anchored._PosixDescriptorLease(),
+            anchored._PosixDescriptorLease(),
+        )
+
+    def _add_everyone_acl(self, path: Path, *, inherited: bool = False) -> None:
+        permissions = "read,write,append"
+        if inherited:
+            permissions += ",file_inherit,directory_inherit"
+        subprocess.run(
+            ["chmod", "+a", f"everyone allow {permissions}", os.fspath(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def _add_everyone_deny_acl(self, path: Path) -> None:
+        subprocess.run(
+            ["chmod", "+a", "everyone deny delete", os.fspath(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def _clear_acl(self, path: Path) -> None:
+        subprocess.run(
+            ["chmod", "-RN", os.fspath(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def _modeled_acl_api(
+        self,
+        tags: tuple[int, ...],
+        *,
+        validity_status: int = 0,
+        structural_status: int = 0,
+        enumeration_status: int | None = None,
+        tag_status: int = 0,
+        enumeration_error: BaseException | None = None,
+    ) -> tuple[
+        dict[str, object],
+        _LeaseAwareNativeCall,
+        mock.Mock,
+        mock.Mock,
+        mock.Mock,
+        mock.Mock,
+    ]:
+        get_acl = _LeaseAwareNativeCall(1234)
+        free_acl = _LeaseAwareNativeCall(0)
+        valid_acl = mock.Mock(return_value=validity_status)
+        structurally_valid_acl = mock.Mock(return_value=structural_status)
+        entry_index = 0
+
+        def enumerate_acl(
+            _acl: object,
+            _selector: object,
+            output: Any,
+        ) -> int:
+            nonlocal entry_index
+            if enumeration_error is not None:
+                raise enumeration_error
+            if enumeration_status is not None:
+                return enumeration_status
+            if entry_index >= len(tags):
+                ctypes.set_errno(errno.EINVAL)
+                return -1
+            ctypes.cast(output, ctypes.POINTER(ctypes.c_void_p)).contents.value = (
+                2000 + entry_index
+            )
+            entry_index += 1
+            return 0
+
+        tag_index = 0
+
+        def read_tag(_entry: object, output: Any) -> int:
+            nonlocal tag_index
+            if tag_status != 0:
+                return tag_status
+            ctypes.cast(output, ctypes.POINTER(ctypes.c_int)).contents.value = tags[
+                tag_index
+            ]
+            tag_index += 1
+            return 0
+
+        get_entry = mock.Mock(side_effect=enumerate_acl)
+        get_tag_type = mock.Mock(side_effect=read_tag)
+        return (
+            {
+                "acl_get_fd_np": get_acl,
+                "acl_free": free_acl,
+                "acl_valid_fd_np": valid_acl,
+                "acl_valid": structurally_valid_acl,
+                "acl_get_entry": get_entry,
+                "acl_get_tag_type": get_tag_type,
+            },
+            free_acl,
+            valid_acl,
+            structurally_valid_acl,
+            get_entry,
+            get_tag_type,
+        )
+
+    def _run_acl_line_interruption(
+        self,
+        target: Callable[..., object],
+        source_fragment: str,
+        interruption: KeyboardInterrupt,
+        *,
+        trigger_count: int = 1,
+    ) -> tuple[_LeaseAwareNativeCall, _LeaseAwareNativeCall]:
+        """Interrupt an ACL cleanup line, then release its traceback owner."""
+
+        cleanup_line = _source_line(target, source_fragment)
+        get_acl = _LeaseAwareNativeCall(1234)
+        free_acl = _LeaseAwareNativeCall(0)
+        triggers = 0
+
+        def trace(frame: FrameType, event: str, _argument: object) -> Any:
+            nonlocal triggers
+            if event == "call" and frame.f_code is target.__code__:
+                frame.f_trace = trace
+                return trace
+            if (
+                event == "line"
+                and frame.f_code is target.__code__
+                and frame.f_lineno == cleanup_line
+                and triggers < trigger_count
+            ):
+                triggers += 1
+                raise interruption
+            return trace
+
+        previous_trace = sys.gettrace()
+        try:
+            with (
+                mock.patch.object(
+                    anchored,
+                    "_posix_libc",
+                    return_value={"acl_get_fd_np": get_acl, "acl_free": free_acl},
+                ),
+                mock.patch.object(anchored.sys, "platform", "darwin"),
+                self.assertRaises(KeyboardInterrupt) as raised,
+            ):
+                sys.settrace(trace)
+                anchored._darwin_descriptor_has_extended_acl(7)
+        finally:
+            sys.settrace(previous_trace)
+
+        self.assertEqual(triggers, trigger_count)
+        self.assertIs(raised.exception, interruption)
+        # The interrupted query frame owns the weak-referenceable lease through
+        # its traceback. Clearing it makes the finalizer boundary deterministic.
+        interruption.__traceback__ = None
+        gc.collect()
+        return get_acl, free_acl
+
+    def _close_stage(self, stage: Any, lease: Any, *, verify_root: bool = True) -> None:
+        failures: list[BaseException] = []
+        try:
+            self.posix._cleanup_darwin_named_stage(lease)
+        except BaseException as error:
+            failures.append(error)
+        descriptor_close = self.posix._close_posix_descriptor_lease(
+            lease.descriptor,
+            None,
+            "test receipt staging descriptor",
+        )
+        if descriptor_close is not None:
+            failures.append(descriptor_close)
+        if verify_root:
+            try:
+                self.posix._verify_darwin_private_directory(self.binding, stage)
+            except BaseException as error:
+                failures.append(error)
+        private_close = self.posix._close_posix_descriptor_lease(
+            lease.private_directory,
+            None,
+            "test private receipt directory descriptor",
+        )
+        if private_close is not None:
+            failures.append(private_close)
+        if failures:
+            self.fail("; ".join(str(failure) for failure in failures))
+
+    def test_existing_stable_root_rejects_wrong_type_symlink_mode_and_owner(self) -> None:
+        cases = ("file", "symlink", "mode", "owner")
+        for case in cases:
+            with self.subTest(case=case):
+                private_root = self.parent / PRIVATE_ROOT
+                target = self.parent / "symlink-target"
+                if case == "file":
+                    private_root.write_bytes(b"not a directory")
+                elif case == "symlink":
+                    target.mkdir()
+                    private_root.symlink_to(target.name)
+                else:
+                    private_root.mkdir(mode=0o700)
+                    if case == "mode":
+                        private_root.chmod(0o755)
+
+                expected_owner = os.geteuid()
+                with (
+                    mock.patch.object(
+                        self.posix.os,
+                        "geteuid",
+                        return_value=expected_owner + 1 if case == "owner" else expected_owner,
+                    ),
+                    self.assertRaises(anchored.AnchoredOutputError) as raised,
+                ):
+                    self.posix._open_darwin_receipt_stage(
+                        self.binding,
+                        PRIVATE_ROOT,
+                        self._stage_lease(),
+                    )
+                self.assertEqual(raised.exception.code, "output-temporary-invalid")
+                self.assertFalse((self.parent / "receipt.json").exists())
+
+                if private_root.is_symlink() or private_root.is_file():
+                    private_root.unlink()
+                else:
+                    private_root.rmdir()
+                if target.exists():
+                    target.rmdir()
+
+    def test_outer_root_replacement_after_open_cannot_redirect_inner_stage(self) -> None:
+        real_open = self.posix._open_posix_descriptor
+        private_root = self.parent / PRIVATE_ROOT
+        relocated = self.parent / f"{PRIVATE_ROOT}.relocated"
+        replaced = False
+
+        def open_then_replace(
+            lease: Any,
+            path: object,
+            flags: int,
+            *args: object,
+            **kwargs: object,
+        ) -> int:
+            nonlocal replaced
+            descriptor = real_open(lease, path, flags, *args, **kwargs)
+            if path == PRIVATE_ROOT and not replaced:
+                replaced = True
+                private_root.rename(relocated)
+                private_root.mkdir(mode=0o700)
+            return descriptor
+
+        stage_lease = self._stage_lease()
+        with mock.patch.object(
+            self.posix,
+            "_open_posix_descriptor",
+            side_effect=open_then_replace,
+        ):
+            stage = self.posix._open_darwin_receipt_stage(
+                self.binding,
+                PRIVATE_ROOT,
+                stage_lease,
+            )
+        self.assertTrue(replaced)
+        self.assertFalse((self.parent / "receipt.json").exists())
+        with self.assertRaises(anchored.AnchoredOutputError) as raised:
+            self.posix._verify_darwin_private_directory(self.binding, stage)
+        self.assertEqual(raised.exception.code, "output-cleanup-retained")
+
+        self._close_stage(stage, stage_lease, verify_root=False)
+        private_root.rmdir()
+        relocated.rmdir()
+
+    def test_inner_stage_swap_is_rejected_without_publication_or_unsafe_cleanup(self) -> None:
+        stage_name = "a" * 32 + ".tmp"
+        swapped_name = "swapped.tmp"
+        stage_lease = self._stage_lease()
+        with mock.patch.object(self.posix.secrets, "token_hex", return_value="a" * 32):
+            stage = self.posix._open_darwin_receipt_stage(
+                self.binding,
+                PRIVATE_ROOT,
+                stage_lease,
+            )
+        private_descriptor = stage.private_directory_descriptor
+        os.rename(
+            stage_name,
+            swapped_name,
+            src_dir_fd=private_descriptor,
+            dst_dir_fd=private_descriptor,
+        )
+        replacement = os.open(
+            stage_name,
+            os.O_RDWR | os.O_CREAT | os.O_EXCL,
+            0o600,
+            dir_fd=private_descriptor,
+        )
+        os.close(replacement)
+
+        with self.assertRaises(anchored.AnchoredOutputError) as raised:
+            self.posix._cleanup_darwin_named_stage(stage_lease)
+        self.assertEqual(raised.exception.code, "output-cleanup-retained")
+        self.assertFalse((self.parent / "receipt.json").exists())
+
+        private_root = self.parent / PRIVATE_ROOT
+        self.assertTrue((private_root / stage_name).is_file())
+        self.assertTrue((private_root / swapped_name).is_file())
+        stage_lease.named_stage_retained = True
+        self.posix._close_posix_descriptor_lease(stage_lease.descriptor, None, "test stage")
+        self.posix._close_posix_descriptor_lease(stage_lease.private_directory, None, "test private directory")
+        (private_root / stage_name).unlink()
+        (private_root / swapped_name).unlink()
+        private_root.rmdir()
+
+    def test_new_and_reused_stable_root_are_canonical_under_extreme_umasks(self) -> None:
+        first_lease = self._stage_lease()
+        previous_umask = os.umask(0o777)
+        try:
+            first = self.posix._open_darwin_receipt_stage(
+                self.binding,
+                PRIVATE_ROOT,
+                first_lease,
+            )
+        finally:
+            os.umask(previous_umask)
+        self.assertEqual(stat.S_IMODE((self.parent / PRIVATE_ROOT).stat().st_mode), 0o700)
+        self.assertEqual(stat.S_IMODE(os.fstat(first.descriptor).st_mode), 0o600)
+        self.assertEqual(os.fstat(first.descriptor).st_nlink, 1)
+        self._close_stage(first, first_lease)
+
+        second_lease = self._stage_lease()
+        previous_umask = os.umask(0o000)
+        try:
+            second = self.posix._open_darwin_receipt_stage(
+                self.binding,
+                PRIVATE_ROOT,
+                second_lease,
+            )
+        finally:
+            os.umask(previous_umask)
+        self.assertEqual(stat.S_IMODE((self.parent / PRIVATE_ROOT).stat().st_mode), 0o700)
+        self.assertEqual(stat.S_IMODE(os.fstat(second.descriptor).st_mode), 0o600)
+        self.assertEqual(os.fstat(second.descriptor).st_nlink, 1)
+        self._close_stage(second, second_lease)
+        (self.parent / PRIVATE_ROOT).rmdir()
+
+    def test_effect_then_interruption_at_every_posix_seal_boundary_is_recoverable(
+        self,
+    ) -> None:
+        cases = (
+            ("ancestor-chmod", "ancestor", "chmod", False),
+            ("ancestor-fchmod", "ancestor", "fchmod", False),
+            ("darwin-root-chmod", "darwin", "chmod", False),
+            ("darwin-root-fchmod", "darwin", "fchmod", True),
+            ("darwin-stage-fchmod", "darwin", "fchmod", False),
+        )
+        payload = b'{"status":"verified"}\n'
+
+        for label, scope, operation_name, force_root_fchmod in cases:
+            with self.subTest(boundary=label):
+                primary = KeyboardInterrupt(f"{label} returned before assignment")
+                opened: list[int] = []
+                output = self.root / label / "receipt.json"
+                real_operation = getattr(self.posix.os, operation_name)
+                owner: anchored._OutputParentBindingLease | None = None
+                stage_lease: Any | None = None
+                private_root_name: str | None = None
+
+                def effect_then_interrupt(*arguments: Any, **kwargs: Any) -> object:
+                    real_operation(*arguments, **kwargs)
+                    raise primary
+
+                if scope == "ancestor":
+                    owner = anchored._OutputParentBindingLease()
+                    real_open = anchored._open_posix_descriptor
+
+                    def record_open(
+                        descriptor_lease: anchored._PosixDescriptorLease,
+                        path: os.PathLike[str] | str,
+                        flags: int,
+                        mode: int = 0o777,
+                        *,
+                        dir_fd: int | None = None,
+                    ) -> int:
+                        descriptor = real_open(
+                            descriptor_lease,
+                            path,
+                            flags,
+                            mode,
+                            dir_fd=dir_fd,
+                        )
+                        opened.append(descriptor)
+                        return descriptor
+
+                    def attempt() -> None:
+                        assert owner is not None
+                        anchored._open_rooted_posix_parent(
+                            self.root,
+                            output,
+                            (label, output.name),
+                            owner,
+                        )
+
+                    open_patch = mock.patch.object(
+                        anchored,
+                        "_open_posix_descriptor",
+                        side_effect=record_open,
+                    )
+                else:
+                    stage_lease = self._stage_lease()
+                    private_root_name = f".{label}"
+                    real_open = self.posix._open_posix_descriptor
+
+                    def record_open(
+                        descriptor_lease: anchored._PosixDescriptorLease,
+                        path: os.PathLike[str] | str,
+                        flags: int,
+                        mode: int = 0o777,
+                        *,
+                        dir_fd: int | None = None,
+                    ) -> int:
+                        descriptor = real_open(
+                            descriptor_lease,
+                            path,
+                            flags,
+                            mode,
+                            dir_fd=dir_fd,
+                        )
+                        opened.append(descriptor)
+                        return descriptor
+
+                    def attempt() -> None:
+                        self.posix._open_darwin_receipt_stage(
+                            self.binding,
+                            private_root_name,
+                            stage_lease,
+                        )
+
+                    open_patch = mock.patch.object(
+                        self.posix,
+                        "_open_posix_descriptor",
+                        side_effect=record_open,
+                    )
+
+                canonical_patch = (
+                    mock.patch.object(
+                        self.posix,
+                        "_darwin_private_directory_is_canonical",
+                        side_effect=(True, False),
+                    )
+                    if force_root_fchmod
+                    else nullcontext()
+                )
+                with (
+                    open_patch,
+                    mock.patch.object(
+                        self.posix.os,
+                        operation_name,
+                        side_effect=effect_then_interrupt,
+                    ),
+                    canonical_patch,
+                    self.assertRaises(KeyboardInterrupt) as raised,
+                ):
+                    attempt()
+
+                self.assertIs(raised.exception, primary)
+                self.assertFalse(output.exists())
+                for descriptor in opened:
+                    with self.assertRaises(OSError) as closed:
+                        os.fstat(descriptor)
+                    self.assertEqual(closed.exception.errno, errno.EBADF)
+
+                if scope == "ancestor":
+                    assert owner is not None
+                    binding = owner.binding
+                    self.assertIsNotNone(binding)
+                    assert binding is not None
+                    self.assertTrue(binding.is_closed)
+                    anchored.publish_identical_receipt_bytes(output, payload)
+                    self.assertEqual(output.read_bytes(), payload)
+                else:
+                    assert stage_lease is not None
+                    assert private_root_name is not None
+                    self.assertIsNone(stage_lease.descriptor.descriptor)
+                    self.assertIsNone(stage_lease.private_directory.descriptor)
+                    retry_lease = self._stage_lease()
+                    retry_stage = self.posix._open_darwin_receipt_stage(
+                        self.binding,
+                        private_root_name,
+                        retry_lease,
+                    )
+                    self._close_stage(retry_stage, retry_lease)
+                    (self.parent / private_root_name).rmdir()
+
+    def test_mkdir_effect_then_file_exists_is_treated_as_changed(self) -> None:
+        private_root = self.parent / PRIVATE_ROOT
+        real_mkdir = self.posix.os.mkdir
+
+        def mkdir_then_file_exists(
+            name: str,
+            mode: int,
+            *,
+            dir_fd: int,
+        ) -> None:
+            real_mkdir(name, mode, dir_fd=dir_fd)
+            raise FileExistsError("mkdir completed before its return was observed")
+
+        previous_umask = os.umask(0o777)
+        try:
+            with (
+                mock.patch.object(
+                    self.posix.os,
+                    "mkdir",
+                    side_effect=mkdir_then_file_exists,
+                ),
+                self.assertRaises(anchored.AnchoredOutputError) as changed,
+            ):
+                self.posix._open_darwin_receipt_stage(
+                    self.binding,
+                    PRIVATE_ROOT,
+                    self._stage_lease(),
+                )
+        finally:
+            os.umask(previous_umask)
+
+        self.assertEqual(changed.exception.code, "output-temporary-invalid")
+        self.assertEqual(stat.S_IMODE(private_root.stat().st_mode), 0o000)
+        private_root.rmdir()
+
+        private_root.mkdir(mode=0o700)
+        private_root.chmod(0o755)
+        before = private_root.stat()
+        with self.assertRaises(anchored.AnchoredOutputError) as raised:
+            self.posix._open_darwin_receipt_stage(
+                self.binding,
+                PRIVATE_ROOT,
+                self._stage_lease(),
+            )
+        after = private_root.stat()
+        self.assertEqual(raised.exception.code, "output-temporary-invalid")
+        self.assertEqual((after.st_dev, after.st_ino), (before.st_dev, before.st_ino))
+        self.assertEqual(stat.S_IMODE(after.st_mode), 0o755)
+        self.assertEqual(list(private_root.iterdir()), [])
+        private_root.rmdir()
+
+    def test_native_stage_open_interrupt_before_identity_removes_named_inode(self) -> None:
+        stage_name = "b" * 32 + ".tmp"
+        lease = self._stage_lease()
+        interruption = KeyboardInterrupt("native stage open returned before identity")
+        real_open = self.posix._open_posix_descriptor
+        triggered = False
+        opened_descriptor: int | None = None
+
+        def open_then_interrupt(
+            descriptor_lease: anchored._PosixDescriptorLease,
+            path: os.PathLike[str] | str,
+            flags: int,
+            mode: int = 0o777,
+            *,
+            dir_fd: int | None = None,
+        ) -> int:
+            nonlocal opened_descriptor, triggered
+            descriptor = real_open(
+                descriptor_lease,
+                path,
+                flags,
+                mode,
+                dir_fd=dir_fd,
+            )
+            if not triggered and descriptor_lease is lease.descriptor:
+                triggered = True
+                opened_descriptor = descriptor
+                raise interruption
+            return descriptor
+
+        with (
+            mock.patch.object(self.posix.secrets, "token_hex", return_value="b" * 32),
+            mock.patch.object(
+                self.posix,
+                "_open_posix_descriptor",
+                side_effect=open_then_interrupt,
+            ),
+            self.assertRaises(KeyboardInterrupt) as raised,
+        ):
+            self.posix._open_darwin_receipt_stage(
+                self.binding,
+                PRIVATE_ROOT,
+                lease,
+            )
+
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, interruption)
+        self.assertIsNotNone(opened_descriptor)
+        self.assertFalse((self.parent / PRIVATE_ROOT / stage_name).exists())
+        self.assertIsNone(lease.descriptor.descriptor)
+        self.assertIsNone(lease.private_directory.descriptor)
+        assert opened_descriptor is not None
+        with self.assertRaises(OSError):
+            os.fstat(opened_descriptor)
+        (self.parent / PRIVATE_ROOT).rmdir()
+
+    def test_native_stage_open_interrupt_never_unlinks_swapped_entry(self) -> None:
+        stage_name = "c" * 32 + ".tmp"
+        relocated_name = "relocated.tmp"
+        lease = self._stage_lease()
+        interruption = KeyboardInterrupt("native stage open returned before identity")
+        real_open = self.posix._open_posix_descriptor
+        triggered = False
+
+        def open_then_swap_and_interrupt(
+            descriptor_lease: anchored._PosixDescriptorLease,
+            path: os.PathLike[str] | str,
+            flags: int,
+            mode: int = 0o777,
+            *,
+            dir_fd: int | None = None,
+        ) -> int:
+            nonlocal triggered
+            descriptor = real_open(
+                descriptor_lease,
+                path,
+                flags,
+                mode,
+                dir_fd=dir_fd,
+            )
+            if not triggered and descriptor_lease is lease.descriptor:
+                triggered = True
+                assert dir_fd is not None
+                os.rename(
+                    stage_name,
+                    relocated_name,
+                    src_dir_fd=dir_fd,
+                    dst_dir_fd=dir_fd,
+                )
+                replacement = os.open(
+                    stage_name,
+                    os.O_RDWR | os.O_CREAT | os.O_EXCL,
+                    0o600,
+                    dir_fd=dir_fd,
+                )
+                os.close(replacement)
+                raise interruption
+            return descriptor
+
+        with (
+            mock.patch.object(self.posix.secrets, "token_hex", return_value="c" * 32),
+            mock.patch.object(
+                self.posix,
+                "_open_posix_descriptor",
+                side_effect=open_then_swap_and_interrupt,
+            ),
+            self.assertRaises(KeyboardInterrupt) as raised,
+        ):
+            self.posix._open_darwin_receipt_stage(
+                self.binding,
+                PRIVATE_ROOT,
+                lease,
+            )
+
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, interruption)
+        self.assertIn(
+            "staging entry changed and was left untouched",
+            "\n".join(getattr(interruption, "__notes__", ())),
+        )
+        private_root = self.parent / PRIVATE_ROOT
+        self.assertTrue((private_root / stage_name).is_file())
+        self.assertTrue((private_root / relocated_name).is_file())
+        self.assertIsNone(lease.descriptor.descriptor)
+        self.assertIsNone(lease.private_directory.descriptor)
+        (private_root / stage_name).unlink()
+        (private_root / relocated_name).unlink()
+        private_root.rmdir()
+
+    def test_post_native_file_exists_seam_cleans_original_stage_name(self) -> None:
+        first_stage_name = "e" * 32 + ".tmp"
+        second_stage_name = "f" * 32 + ".tmp"
+        lease = self._stage_lease()
+        collision = FileExistsError("post-native collision seam")
+        real_open = self.posix._open_posix_descriptor
+        opened_descriptor: int | None = None
+
+        def open_then_report_collision(
+            descriptor_lease: Any,
+            path: object,
+            flags: int,
+            mode: int = 0o777,
+            *,
+            dir_fd: int | None = None,
+        ) -> int:
+            nonlocal opened_descriptor
+            descriptor = real_open(
+                descriptor_lease,
+                path,
+                flags,
+                mode,
+                dir_fd=dir_fd,
+            )
+            if path == first_stage_name:
+                opened_descriptor = descriptor
+                raise collision
+            return descriptor
+
+        with (
+            mock.patch.object(
+                self.posix.secrets,
+                "token_hex",
+                side_effect=("e" * 32, "f" * 32),
+            ),
+            mock.patch.object(
+                self.posix,
+                "_open_posix_descriptor",
+                side_effect=open_then_report_collision,
+            ),
+            self.assertRaises(FileExistsError) as raised,
+        ):
+            self.posix._open_darwin_receipt_stage(
+                self.binding,
+                PRIVATE_ROOT,
+                lease,
+            )
+
+        self.assertIs(raised.exception, collision)
+        self.assertIsNotNone(opened_descriptor)
+        private_root = self.parent / PRIVATE_ROOT
+        self.assertFalse((private_root / first_stage_name).exists())
+        self.assertFalse((private_root / second_stage_name).exists())
+        self.assertIsNone(lease.named_stage_name)
+        self.assertIsNone(lease.descriptor.descriptor)
+        self.assertIsNone(lease.private_directory.descriptor)
+        assert opened_descriptor is not None
+        with self.assertRaises(OSError):
+            os.fstat(opened_descriptor)
+        private_root.rmdir()
+
+    def test_failed_stage_keeps_private_parent_when_stage_close_is_exhausted(
+        self,
+    ) -> None:
+        stage_name = "9" * 32 + ".tmp"
+        lease = self._stage_lease()
+        primary = OSError("stage validation failed")
+        close_attempts: list[str] = []
+
+        def leave_stage_open(
+            descriptor_lease: Any,
+            _primary: BaseException | None,
+            _context: str,
+        ) -> BaseException | None:
+            close_attempts.append("stage" if descriptor_lease is lease.descriptor else "private")
+            return OSError("modeled exhausted close")
+
+        with (
+            mock.patch.object(
+                self.posix.secrets,
+                "token_hex",
+                return_value="9" * 32,
+            ),
+            mock.patch.object(
+                self.posix,
+                "_receipt_mode_is_canonical",
+                side_effect=primary,
+            ),
+            mock.patch.object(
+                self.posix,
+                "_close_posix_descriptor_lease",
+                side_effect=leave_stage_open,
+            ),
+            self.assertRaises(OSError) as raised,
+        ):
+            self.posix._open_darwin_receipt_stage(
+                self.binding,
+                PRIVATE_ROOT,
+                lease,
+            )
+
+        self.assertIs(raised.exception, primary)
+        self.assertEqual(close_attempts, ["stage"])
+        self.assertIsNotNone(lease.descriptor.descriptor)
+        self.assertIsNotNone(lease.private_directory.descriptor)
+        private_root = self.parent / PRIVATE_ROOT
+        self.assertFalse((private_root / stage_name).exists())
+
+        self.assertIsNone(
+            self.posix._close_posix_descriptor_lease(
+                lease.descriptor,
+                None,
+                "test retained stage descriptor",
+            )
+        )
+        self.assertIsNone(
+            self.posix._close_posix_descriptor_lease(
+                lease.private_directory,
+                None,
+                "test retained private directory descriptor",
+            )
+        )
+        private_root.rmdir()
+
+    def test_cleanup_reobserves_stage_after_false_missing_return_gap(self) -> None:
+        private_root = self.parent / PRIVATE_ROOT
+        private_root.mkdir(mode=0o700)
+        stage_name = "f" * 32 + ".tmp"
+        stage_path = private_root / stage_name
+        stage_path.write_bytes(b"")
+        stage = stage_path.stat()
+        directory_descriptor = os.open(private_root, os.O_RDONLY | os.O_DIRECTORY)
+        real_stat = os.stat
+        stat_calls = 0
+
+        def stat_then_report_missing(*args: Any, **kwargs: Any) -> os.stat_result:
+            nonlocal stat_calls
+            stat_calls += 1
+            result = real_stat(*args, **kwargs)
+            if stat_calls == 1:
+                raise FileNotFoundError("stat returned before assignment")
+            return result
+
+        try:
+            with mock.patch.object(self.posix.os, "stat", side_effect=stat_then_report_missing):
+                self.posix._unlink_darwin_stage_if_identity(
+                    directory_descriptor,
+                    stage_name,
+                    (stage.st_dev, stage.st_ino),
+                )
+        finally:
+            os.close(directory_descriptor)
+
+        self.assertEqual(stat_calls, 2)
+        self.assertFalse(stage_path.exists())
+        private_root.rmdir()
+
+    def test_publication_fallback_removes_stage_when_opener_cleanup_is_bypassed(self) -> None:
+        private_root = self.parent / PRIVATE_ROOT
+        stage_name = "a" * 32 + ".tmp"
+        primary = KeyboardInterrupt("opener exception-table gap")
+        opened_descriptors: tuple[int, int] | None = None
+
+        def open_then_escape(_binding: Any, _temporary_name: str, lease: Any) -> Any:
+            nonlocal opened_descriptors
+            private_root.mkdir(mode=0o700)
+            private_descriptor = os.open(private_root, os.O_RDONLY | os.O_DIRECTORY)
+            stage_descriptor = os.open(
+                stage_name,
+                os.O_RDWR | os.O_CREAT | os.O_EXCL,
+                0o600,
+                dir_fd=private_descriptor,
+            )
+            lease.private_directory.descriptor_result = ctypes.c_int(private_descriptor)
+            lease.descriptor.descriptor_result = ctypes.c_int(stage_descriptor)
+            lease.named_stage_name = stage_name
+            opened_descriptors = (stage_descriptor, private_descriptor)
+            raise primary
+
+        binding = SimpleNamespace(
+            leaf="receipt.json",
+            stat=mock.Mock(side_effect=FileNotFoundError),
+            close=mock.Mock(return_value=()),
+        )
+        with (
+            mock.patch.object(self.posix.sys, "platform", "darwin"),
+            mock.patch.object(
+                self.posix,
+                "_open_posix_receipt_stage",
+                side_effect=open_then_escape,
+            ),
+            self.assertRaises(KeyboardInterrupt) as raised,
+        ):
+            self.posix._publish_posix_receipt_bytes(
+                self.parent / "receipt.json",
+                b"payload",
+                binding,
+                self.posix._PosixReceiptPublicationLease(binding),
+            )
+
+        self.assertIs(raised.exception, primary)
+        self.assertFalse((private_root / stage_name).exists())
+        binding.close.assert_called_once_with()
+        assert opened_descriptors is not None
+        for descriptor in opened_descriptors:
+            with self.assertRaises(OSError):
+                os.fstat(descriptor)
+        private_root.rmdir()
+
+    def test_binding_close_return_interrupt_preserves_primary_failure(self) -> None:
+        primary = OSError("publication failed")
+        interruption = KeyboardInterrupt("binding close returned before assignment")
+        close_calls = 0
+        triggered = False
+
+        def close() -> tuple[BaseException, ...]:
+            nonlocal close_calls, triggered
+            close_calls += 1
+            triggered = True
+            raise interruption
+
+        binding = SimpleNamespace(
+            leaf="receipt.json",
+            descriptors=(8,),
+            stat=mock.Mock(side_effect=primary),
+            close=close,
+        )
+
+        with self.assertRaises(OSError) as raised:
+            self.posix._publish_posix_receipt_bytes(
+                self.parent / "receipt.json",
+                b"payload",
+                binding,
+                self.posix._PosixReceiptPublicationLease(binding),
+            )
+
+        self.assertTrue(triggered)
+        self.assertEqual(close_calls, 1)
+        self.assertIs(raised.exception, primary)
+        self.assertIn(
+            "binding close returned before assignment",
+            "\n".join(getattr(primary, "__notes__", ())),
+        )
+
+    def test_public_descriptor_close_return_interrupt_preserves_primary_failure(self) -> None:
+        public = self.parent / "public.json"
+        public.write_bytes(b"payload")
+        primary = OSError("public validation failed")
+        interruption = KeyboardInterrupt("public descriptor close returned before assignment")
+        opened_descriptor: int | None = None
+        triggered = False
+        descriptor_lease = anchored._PosixDescriptorLease()
+
+        def open_read(_name: str, lease: Any) -> int:
+            nonlocal opened_descriptor
+            opened_descriptor = anchored._open_posix_descriptor(
+                lease,
+                public,
+                os.O_RDONLY,
+            )
+            return opened_descriptor
+
+        binding = SimpleNamespace(leaf=public.name, open_read=open_read)
+
+        real_close = self.posix._close_posix_descriptor_lease
+
+        def close_then_interrupt(
+            lease: anchored._PosixDescriptorLease,
+            active_primary: BaseException | None,
+            context: str,
+        ) -> BaseException | None:
+            nonlocal triggered
+            result = real_close(lease, active_primary, context)
+            if lease is descriptor_lease and not triggered:
+                triggered = True
+                raise interruption
+            return result
+
+        with (
+            mock.patch.object(
+                self.posix,
+                "_validate_exact_receipt_descriptor",
+                side_effect=primary,
+            ),
+            mock.patch.object(
+                self.posix,
+                "_close_posix_descriptor_lease",
+                side_effect=close_then_interrupt,
+            ),
+            self.assertRaises(OSError) as raised,
+        ):
+            self.posix._sync_posix_public_descriptor(
+                binding,
+                b"payload",
+                (1, 2),
+                descriptor_lease,
+            )
+
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, primary)
+        self.assertIn(
+            "public descriptor close returned before assignment",
+            "\n".join(getattr(primary, "__notes__", ())),
+        )
+        assert opened_descriptor is not None
+        with self.assertRaises(OSError):
+            os.fstat(opened_descriptor)
+
+    def test_darwin_stage_close_return_interrupt_still_closes_private_directory(self) -> None:
+        stage_name = "d" * 32 + ".tmp"
+        lease = self._stage_lease()
+        primary = OSError("stage validation failed")
+        interruption = KeyboardInterrupt("stage close returned before assignment")
+        stage_descriptor: int | None = None
+        private_descriptor: int | None = None
+        triggered = False
+
+        real_close = self.posix._close_posix_descriptor_lease
+
+        def close_then_interrupt(
+            descriptor_lease: anchored._PosixDescriptorLease,
+            active_primary: BaseException | None,
+            context: str,
+        ) -> BaseException | None:
+            nonlocal private_descriptor, stage_descriptor, triggered
+            descriptor = descriptor_lease.descriptor
+            if descriptor_lease is lease.descriptor:
+                stage_descriptor = descriptor
+            elif descriptor_lease is lease.private_directory:
+                private_descriptor = descriptor
+            result = real_close(descriptor_lease, active_primary, context)
+            if descriptor_lease is lease.descriptor and not triggered:
+                triggered = True
+                raise interruption
+            return result
+
+        with (
+            mock.patch.object(self.posix.secrets, "token_hex", return_value="d" * 32),
+            mock.patch.object(
+                self.posix,
+                "_receipt_mode_is_canonical",
+                side_effect=primary,
+            ),
+            mock.patch.object(
+                self.posix,
+                "_close_posix_descriptor_lease",
+                side_effect=close_then_interrupt,
+            ),
+            self.assertRaises(OSError) as raised,
+        ):
+            self.posix._open_darwin_receipt_stage(
+                self.binding,
+                PRIVATE_ROOT,
+                lease,
+            )
+
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, primary)
+        self.assertIn(
+            "stage close returned before assignment",
+            "\n".join(getattr(primary, "__notes__", ())),
+        )
+        self.assertFalse((self.parent / PRIVATE_ROOT / stage_name).exists())
+        self.assertIsNone(lease.descriptor.descriptor)
+        self.assertIsNone(lease.private_directory.descriptor)
+        assert stage_descriptor is not None
+        assert private_descriptor is not None
+        with self.assertRaises(OSError):
+            os.fstat(stage_descriptor)
+        with self.assertRaises(OSError):
+            os.fstat(private_descriptor)
+        (self.parent / PRIVATE_ROOT).rmdir()
+
+    def test_linux_stage_close_return_interrupt_preserves_primary_failure(self) -> None:
+        stage_path = self.parent / "linux-stage.tmp"
+        stage_path.write_bytes(b"")
+        lease = self._stage_lease()
+        primary = OSError("stage chmod failed")
+        interruption = KeyboardInterrupt("Linux stage close returned before assignment")
+        opened_descriptor: int | None = None
+        triggered = False
+
+        def open_stage(
+            descriptor_lease: Any,
+            _path: object,
+            _flags: int,
+            _mode: int = 0o777,
+            *,
+            dir_fd: int | None = None,
+        ) -> int:
+            nonlocal opened_descriptor
+            self.assertIsNotNone(dir_fd)
+            opened_descriptor = os.open(stage_path, os.O_RDWR)
+            descriptor_lease.descriptor_result = ctypes.c_int(opened_descriptor)
+            return opened_descriptor
+
+        real_close = self.posix._close_posix_descriptor_lease
+
+        def close_then_interrupt(
+            descriptor_lease: anchored._PosixDescriptorLease,
+            active_primary: BaseException | None,
+            context: str,
+        ) -> BaseException | None:
+            nonlocal triggered
+            result = real_close(descriptor_lease, active_primary, context)
+            if descriptor_lease is lease.descriptor and not triggered:
+                triggered = True
+                raise interruption
+            return result
+
+        with (
+            mock.patch.object(self.posix.sys, "platform", "linux"),
+            mock.patch.object(self.posix.os, "O_TMPFILE", 0x400000, create=True),
+            mock.patch.object(self.posix, "_open_posix_descriptor", side_effect=open_stage),
+            mock.patch.object(self.posix.os, "fchmod", side_effect=primary),
+            mock.patch.object(
+                self.posix,
+                "_close_posix_descriptor_lease",
+                side_effect=close_then_interrupt,
+            ),
+            self.assertRaises(OSError) as raised,
+        ):
+            self.posix._open_posix_receipt_stage(
+                self.binding,
+                "",
+                lease,
+            )
+
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, primary)
+        self.assertIn(
+            "Linux stage close returned before assignment",
+            "\n".join(getattr(primary, "__notes__", ())),
+        )
+        self.assertIsNone(lease.descriptor.descriptor)
+        assert opened_descriptor is not None
+        with self.assertRaises(OSError):
+            os.fstat(opened_descriptor)
+
+    def test_publication_stage_close_return_interrupt_still_closes_private_lease(self) -> None:
+        stage_path = self.parent / "publisher-stage.tmp"
+        stage_path.write_bytes(b"")
+        primary = OSError("publisher stage inspection failed")
+        interruption = KeyboardInterrupt("publisher stage close returned before assignment")
+        opened_descriptors: tuple[int, int] | None = None
+        close_called = False
+        triggered = False
+
+        def open_stage(_binding: Any, _temporary_name: str, lease: Any) -> Any:
+            nonlocal opened_descriptors
+            stage_descriptor = os.open(stage_path, os.O_RDWR)
+            private_descriptor = os.open(self.parent, os.O_RDONLY | os.O_DIRECTORY)
+            lease.descriptor.descriptor_result = ctypes.c_int(stage_descriptor)
+            lease.private_directory.descriptor_result = ctypes.c_int(private_descriptor)
+            stage = self.posix._PosixReceiptStage(descriptor=stage_descriptor)
+            lease.stage = stage
+            opened_descriptors = (stage_descriptor, private_descriptor)
+            return stage
+
+        def close() -> tuple[BaseException, ...]:
+            nonlocal close_called
+            close_called = True
+            return ()
+
+        binding = SimpleNamespace(
+            leaf="receipt.json",
+            descriptors=(8,),
+            stat=mock.Mock(side_effect=FileNotFoundError),
+            close=close,
+        )
+
+        real_close = self.posix._close_posix_descriptor_lease
+
+        def close_then_interrupt(
+            descriptor_lease: anchored._PosixDescriptorLease,
+            active_primary: BaseException | None,
+            context: str,
+        ) -> BaseException | None:
+            nonlocal triggered
+            result = real_close(descriptor_lease, active_primary, context)
+            if context == "receipt staging descriptor" and not triggered:
+                triggered = True
+                raise interruption
+            return result
+
+        with (
+            mock.patch.object(self.posix.sys, "platform", "darwin"),
+            mock.patch.object(self.posix, "_open_posix_receipt_stage", side_effect=open_stage),
+            mock.patch.object(self.posix.os, "fstat", side_effect=primary),
+            mock.patch.object(
+                self.posix,
+                "_close_posix_descriptor_lease",
+                side_effect=close_then_interrupt,
+            ),
+            self.assertRaises(OSError) as raised,
+        ):
+            self.posix._publish_posix_receipt_bytes(
+                self.parent / "receipt.json",
+                b"payload",
+                binding,
+                self.posix._PosixReceiptPublicationLease(binding),
+            )
+
+        self.assertTrue(triggered)
+        self.assertTrue(close_called)
+        self.assertIs(raised.exception, primary)
+        self.assertIn(
+            "publisher stage close returned before assignment",
+            "\n".join(getattr(primary, "__notes__", ())),
+        )
+        assert opened_descriptors is not None
+        for descriptor in opened_descriptors:
+            with self.assertRaises(OSError):
+                os.fstat(descriptor)
+
+    def test_stage_lease_retains_ownership_when_caller_is_interrupted_before_store(self) -> None:
+        lease = self._stage_lease()
+        interruption = KeyboardInterrupt("stage return boundary")
+        real_open = self.posix._open_darwin_receipt_stage
+
+        def acquire() -> Any:
+            stage = self.posix._open_darwin_receipt_stage(
+                self.binding,
+                PRIVATE_ROOT,
+                lease,
+            )
+            return stage
+
+        def open_then_interrupt(
+            parent_binding: Any,
+            private_directory_name: str,
+            stage_lease: Any,
+        ) -> Any:
+            real_open(parent_binding, private_directory_name, stage_lease)
+            raise interruption
+
+        with mock.patch.object(
+            self.posix,
+            "_open_darwin_receipt_stage",
+            side_effect=open_then_interrupt,
+        ):
+            with self.assertRaises(KeyboardInterrupt) as raised:
+                acquire()
+
+        self.assertIs(raised.exception, interruption)
+        stage = lease.stage
+        self.assertIsNotNone(stage)
+        assert stage is not None
+        descriptor = stage.descriptor
+        private_descriptor = stage.private_directory_descriptor
+        self._close_stage(stage, lease)
+        self.assertIsNone(lease.descriptor.descriptor)
+        self.assertIsNone(lease.private_directory.descriptor)
+        with self.assertRaises(OSError):
+            os.fstat(descriptor)
+        with self.assertRaises(OSError):
+            os.fstat(private_descriptor)
+        (self.parent / PRIVATE_ROOT).rmdir()
+
+    @unittest.skipUnless(sys.platform == "darwin", "native macOS ACL contract")
+    def test_native_acl_query_and_unsupported_query_fail_closed(self) -> None:
+        candidate = self.parent / "acl-candidate"
+        candidate.write_bytes(b"candidate")
+        candidate.chmod(0o600)
+        descriptor = os.open(candidate, os.O_RDONLY)
+        try:
+            self.assertFalse(anchored._darwin_descriptor_has_extended_acl(descriptor))
+            self._add_everyone_acl(candidate)
+            self.assertTrue(anchored._darwin_descriptor_has_extended_acl(descriptor))
+            self.assertTrue(
+                anchored._darwin_descriptor_has_extended_acl(
+                    descriptor,
+                    error_code="output-parent-invalid",
+                    context="native allow-ACL ancestor",
+                    allow_deny_only=True,
+                )
+            )
+            with (
+                mock.patch.object(anchored, "_posix_libc", return_value={}),
+                self.assertRaises(anchored.AnchoredOutputError) as unavailable,
+            ):
+                anchored._darwin_descriptor_has_extended_acl(descriptor)
+            self.assertEqual(unavailable.exception.code, "output-anchor-unavailable")
+        finally:
+            os.close(descriptor)
+            self._clear_acl(candidate)
+            candidate.unlink()
+
+    @unittest.skipUnless(sys.platform == "darwin", "native macOS deny-only ACL contract")
+    def test_native_deny_only_intermediate_supports_publish_and_idempotency(self) -> None:
+        denied_ancestor = self.parent / "deny-only-ancestor"
+        final_parent = denied_ancestor / "final-parent"
+        denied_ancestor.mkdir(mode=0o700)
+        final_parent.mkdir(mode=0o700)
+        self._add_everyone_deny_acl(denied_ancestor)
+        output = final_parent / "receipt.json"
+        try:
+            anchored.publish_identical_receipt_bytes(output, b"receipt")
+            anchored.publish_identical_receipt_bytes(output, b"receipt")
+            self.assertEqual(output.read_bytes(), b"receipt")
+            self._add_everyone_deny_acl(final_parent)
+            try:
+                with self.assertRaises(anchored.AnchoredOutputError) as strict_parent:
+                    anchored.publish_identical_receipt_bytes(output, b"receipt")
+                self.assertEqual(strict_parent.exception.code, "output-parent-invalid")
+            finally:
+                self._clear_acl(final_parent)
+        finally:
+            if output.exists():
+                output.unlink()
+            private_root = final_parent / PRIVATE_ROOT
+            if private_root.exists():
+                private_root.rmdir()
+            self._clear_acl(denied_ancestor)
+            final_parent.rmdir()
+            denied_ancestor.rmdir()
+
+    def test_modeled_deny_only_acl_is_accepted_after_descriptor_validation(self) -> None:
+        (
+            libc,
+            free_acl,
+            valid_acl,
+            structurally_valid_acl,
+            get_entry,
+            get_tag_type,
+        ) = self._modeled_acl_api(
+            (
+                anchored._DARWIN_ACL_EXTENDED_DENY,
+                anchored._DARWIN_ACL_EXTENDED_DENY,
+            )
+        )
+        with (
+            mock.patch.object(anchored, "_posix_libc", return_value=libc),
+            mock.patch.object(anchored.sys, "platform", "darwin"),
+        ):
+            self.assertFalse(
+                anchored._darwin_descriptor_has_extended_acl(
+                    7,
+                    error_code="output-parent-invalid",
+                    context="modeled intermediate ancestor",
+                    allow_deny_only=True,
+                )
+            )
+
+        self.assertEqual(valid_acl.call_args.args[:2], (7, anchored._DARWIN_ACL_TYPE_EXTENDED))
+        structurally_valid_acl.assert_not_called()
+        self.assertEqual(
+            [call.args[1] for call in get_entry.call_args_list],
+            [
+                anchored._DARWIN_ACL_FIRST_ENTRY,
+                anchored._DARWIN_ACL_NEXT_ENTRY,
+                anchored._DARWIN_ACL_NEXT_ENTRY,
+            ],
+        )
+        self.assertEqual(get_tag_type.call_count, 2)
+        self.assertEqual(len(free_acl.calls), 1)
+
+    def test_modeled_acl_allow_and_unknown_entries_are_rejected(self) -> None:
+        for tag_type in (anchored._DARWIN_ACL_EXTENDED_ALLOW, 99):
+            with self.subTest(tag_type=tag_type):
+                libc, free_acl, *_operations = self._modeled_acl_api((tag_type,))
+                with (
+                    mock.patch.object(anchored, "_posix_libc", return_value=libc),
+                    mock.patch.object(anchored.sys, "platform", "darwin"),
+                ):
+                    self.assertTrue(
+                        anchored._darwin_descriptor_has_extended_acl(
+                            7,
+                            error_code="output-parent-invalid",
+                            context="modeled intermediate ancestor",
+                            allow_deny_only=True,
+                        )
+                    )
+                self.assertEqual(len(free_acl.calls), 1)
+
+    def test_modeled_acl_validation_and_enumeration_fail_closed(self) -> None:
+        cases = (
+            (-1, None, 0),
+            (0, 1, 0),
+            (0, None, -1),
+        )
+        for validity_status, enumeration_status, tag_status in cases:
+            with self.subTest(
+                validity_status=validity_status,
+                enumeration_status=enumeration_status,
+                tag_status=tag_status,
+            ):
+                libc, free_acl, *_operations = self._modeled_acl_api(
+                    (anchored._DARWIN_ACL_EXTENDED_DENY,),
+                    validity_status=validity_status,
+                    enumeration_status=enumeration_status,
+                    tag_status=tag_status,
+                )
+                with (
+                    mock.patch.object(anchored, "_posix_libc", return_value=libc),
+                    mock.patch.object(anchored.ctypes, "get_errno", return_value=errno.EINVAL),
+                    mock.patch.object(anchored.sys, "platform", "darwin"),
+                    self.assertRaises(anchored.AnchoredOutputError) as raised,
+                ):
+                    anchored._darwin_descriptor_has_extended_acl(
+                        7,
+                        error_code="output-parent-invalid",
+                        context="modeled intermediate ancestor",
+                        allow_deny_only=True,
+                    )
+                self.assertEqual(raised.exception.code, "output-parent-invalid")
+                self.assertIn("modeled intermediate ancestor", str(raised.exception))
+                self.assertEqual(len(free_acl.calls), 1)
+
+    def test_modeled_nonnull_acl_with_no_entries_is_rejected(self) -> None:
+        libc, free_acl, *_operations = self._modeled_acl_api(())
+        with (
+            mock.patch.object(anchored, "_posix_libc", return_value=libc),
+            mock.patch.object(anchored.sys, "platform", "darwin"),
+        ):
+            self.assertTrue(
+                anchored._darwin_descriptor_has_extended_acl(
+                    7,
+                    error_code="output-parent-invalid",
+                    context="modeled empty extended ACL",
+                    allow_deny_only=True,
+                )
+            )
+        self.assertEqual(len(free_acl.calls), 1)
+
+    def test_modeled_acl_unsupported_context_validation_uses_structural_validation(self) -> None:
+        (
+            libc,
+            free_acl,
+            valid_acl,
+            structurally_valid_acl,
+            _get_entry,
+            _get_tag_type,
+        ) = self._modeled_acl_api((anchored._DARWIN_ACL_EXTENDED_DENY,))
+        def unsupported_context(*_arguments: object) -> int:
+            ctypes.set_errno(errno.ENOTSUP)
+            return -1
+
+        valid_acl.side_effect = unsupported_context
+        with (
+            mock.patch.object(anchored, "_posix_libc", return_value=libc),
+            mock.patch.object(anchored.sys, "platform", "darwin"),
+        ):
+            self.assertFalse(
+                anchored._darwin_descriptor_has_extended_acl(
+                    7,
+                    error_code="output-parent-invalid",
+                    context="modeled intermediate ancestor",
+                    allow_deny_only=True,
+                )
+            )
+        structurally_valid_acl.assert_called_once()
+        self.assertEqual(len(free_acl.calls), 1)
+
+    def test_modeled_acl_structural_validation_failure_is_rejected(self) -> None:
+        libc, free_acl, valid_acl, structurally_valid_acl, *_operations = (
+            self._modeled_acl_api(
+                (anchored._DARWIN_ACL_EXTENDED_DENY,),
+                structural_status=-1,
+            )
+        )
+        def unsupported_context(*_arguments: object) -> int:
+            ctypes.set_errno(errno.ENOTSUP)
+            return -1
+
+        valid_acl.side_effect = unsupported_context
+        with (
+            mock.patch.object(anchored, "_posix_libc", return_value=libc),
+            mock.patch.object(anchored.sys, "platform", "darwin"),
+            self.assertRaises(anchored.AnchoredOutputError) as raised,
+        ):
+            anchored._darwin_descriptor_has_extended_acl(
+                7,
+                error_code="output-parent-invalid",
+                context="modeled intermediate ancestor",
+                allow_deny_only=True,
+            )
+        self.assertEqual(raised.exception.code, "output-parent-invalid")
+        structurally_valid_acl.assert_called_once()
+        self.assertEqual(len(free_acl.calls), 1)
+
+    def test_modeled_acl_enumeration_interrupt_frees_allocation_once(self) -> None:
+        primary = KeyboardInterrupt("ACL enumeration returned before assignment")
+        libc, free_acl, *_operations = self._modeled_acl_api(
+            (anchored._DARWIN_ACL_EXTENDED_DENY,),
+            enumeration_error=primary,
+        )
+        with (
+            mock.patch.object(anchored, "_posix_libc", return_value=libc),
+            mock.patch.object(anchored.sys, "platform", "darwin"),
+            self.assertRaises(KeyboardInterrupt) as raised,
+        ):
+            anchored._darwin_descriptor_has_extended_acl(
+                7,
+                error_code="output-parent-invalid",
+                context="modeled intermediate ancestor",
+                allow_deny_only=True,
+            )
+        self.assertIs(raised.exception, primary)
+        self.assertEqual(len(free_acl.calls), 1)
+
+    def test_modeled_acl_enumeration_is_bounded(self) -> None:
+        libc, free_acl, *_operations, get_entry, get_tag_type = self._modeled_acl_api(
+            (anchored._DARWIN_ACL_EXTENDED_DENY,)
+            * (anchored._DARWIN_ACL_MAX_ENTRIES + 1)
+        )
+        with (
+            mock.patch.object(anchored, "_posix_libc", return_value=libc),
+            mock.patch.object(anchored.sys, "platform", "darwin"),
+            self.assertRaises(anchored.AnchoredOutputError) as raised,
+        ):
+            anchored._darwin_descriptor_has_extended_acl(
+                7,
+                error_code="output-parent-invalid",
+                context="modeled intermediate ancestor",
+                allow_deny_only=True,
+            )
+        self.assertEqual(raised.exception.code, "output-parent-invalid")
+        self.assertEqual(get_entry.call_count, anchored._DARWIN_ACL_MAX_ENTRIES + 1)
+        self.assertEqual(get_tag_type.call_count, anchored._DARWIN_ACL_MAX_ENTRIES)
+        self.assertEqual(len(free_acl.calls), 1)
+
+    def test_acl_query_finalizer_recovers_cleanup_entry_interruption(self) -> None:
+        interruption = KeyboardInterrupt("ACL query cleanup entry")
+        get_acl, free_acl = self._run_acl_line_interruption(
+            anchored._darwin_descriptor_has_extended_acl,
+            "free_error = lease.close()",
+            interruption,
+        )
+
+        self.assertEqual(len(get_acl.calls), 1)
+        self.assertEqual(len(free_acl.calls), 1)
+
+    def test_acl_cleanup_interruption_preserves_query_primary_and_finalizes(
+        self,
+    ) -> None:
+        primary = SystemExit("ACL query primary")
+        cleanup = KeyboardInterrupt("ACL cleanup interruption")
+
+        class InterruptAfterResult(_LeaseAwareNativeCall):
+            def __call__(self, *arguments: object) -> int:
+                super().__call__(*arguments)
+                raise primary
+
+        cleanup_line = _source_line(
+            anchored._close_darwin_acl_query_state,
+            "pointer = state.pointer",
+        )
+        get_acl = InterruptAfterResult(1234)
+        free_acl = _LeaseAwareNativeCall(0)
+        triggered = False
+
+        def trace(frame: FrameType, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if event == "call" and frame.f_code is anchored._close_darwin_acl_query_state.__code__:
+                frame.f_trace = trace
+                return trace
+            if (
+                event == "line"
+                and frame.f_code is anchored._close_darwin_acl_query_state.__code__
+                and frame.f_lineno == cleanup_line
+                and not triggered
+            ):
+                triggered = True
+                raise cleanup
+            return trace
+
+        previous_trace = sys.gettrace()
+        try:
+            with (
+                mock.patch.object(
+                    anchored,
+                    "_posix_libc",
+                    return_value={"acl_get_fd_np": get_acl, "acl_free": free_acl},
+                ),
+                mock.patch.object(anchored.sys, "platform", "darwin"),
+                self.assertRaises(SystemExit) as raised,
+            ):
+                sys.settrace(trace)
+                anchored._darwin_descriptor_has_extended_acl(7)
+        finally:
+            sys.settrace(previous_trace)
+
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, primary)
+        self.assertIn(
+            str(cleanup),
+            "\n".join(getattr(primary, "__notes__", ())),
+        )
+        primary.__traceback__ = None
+        cleanup.__traceback__ = None
+        gc.collect()
+        self.assertEqual(len(get_acl.calls), 1)
+        self.assertEqual(len(free_acl.calls), 1)
+
+    def test_acl_query_finalizer_recovers_bounded_free_precall_interruptions(
+        self,
+    ) -> None:
+        interruption = KeyboardInterrupt("ACL free before native call")
+
+        class InterruptBeforeResult(_LeaseAwareNativeCall):
+            def __init__(self) -> None:
+                super().__init__(0)
+                self.interruptions_remaining = 2
+                self.native_calls = 0
+
+            def __call__(self, *arguments: object) -> int:
+                self.calls.append(arguments)
+                if self.interruptions_remaining:
+                    self.interruptions_remaining -= 1
+                    raise interruption
+                self.native_calls += 1
+                result_type = self.restype
+                checker = getattr(result_type, "_check_retval_", None)
+                if callable(result_type) and callable(checker):
+                    checker(result_type(self.result))
+                return self.result
+
+        get_acl = _LeaseAwareNativeCall(1234)
+        free_acl = InterruptBeforeResult()
+        with (
+            mock.patch.object(
+                anchored,
+                "_posix_libc",
+                return_value={"acl_get_fd_np": get_acl, "acl_free": free_acl},
+            ),
+            mock.patch.object(anchored.sys, "platform", "darwin"),
+            self.assertRaises(KeyboardInterrupt) as raised,
+        ):
+            anchored._darwin_descriptor_has_extended_acl(7)
+
+        # Both explicit attempts were interrupted before the native call. Once
+        # the traceback owner is released, the one finalizer call frees it.
+        self.assertIs(raised.exception, interruption)
+        interruption.__traceback__ = None
+        gc.collect()
+        self.assertEqual(len(free_acl.calls), 3)
+        self.assertEqual(free_acl.native_calls, 1)
+
+    def test_acl_query_recorded_free_result_is_never_replayed_after_gc(self) -> None:
+        interruption = KeyboardInterrupt("ACL free returned before assignment")
+
+        class InterruptAfterResult(_LeaseAwareNativeCall):
+            def __call__(self, *arguments: object) -> int:
+                super().__call__(*arguments)
+                raise interruption
+
+        get_acl = _LeaseAwareNativeCall(1234)
+        free_acl = InterruptAfterResult(0)
+        with (
+            mock.patch.object(
+                anchored,
+                "_posix_libc",
+                return_value={"acl_get_fd_np": get_acl, "acl_free": free_acl},
+            ),
+            mock.patch.object(anchored.sys, "platform", "darwin"),
+            self.assertRaises(KeyboardInterrupt) as raised,
+        ):
+            anchored._darwin_descriptor_has_extended_acl(7)
+
+        self.assertIs(raised.exception, interruption)
+        self.assertEqual(len(free_acl.calls), 1)
+        interruption.__traceback__ = None
+        gc.collect()
+        self.assertEqual(len(free_acl.calls), 1)
+
+    def test_acl_query_null_result_never_calls_free_after_gc(self) -> None:
+        get_acl = _LeaseAwareNativeCall(0)
+        free_acl = _LeaseAwareNativeCall(0)
+        with (
+            mock.patch.object(
+                anchored,
+                "_posix_libc",
+                return_value={"acl_get_fd_np": get_acl, "acl_free": free_acl},
+            ),
+            mock.patch.object(anchored.ctypes, "get_errno", return_value=errno.ENOENT),
+            mock.patch.object(anchored.sys, "platform", "darwin"),
+        ):
+            self.assertFalse(anchored._darwin_descriptor_has_extended_acl(7))
+
+        gc.collect()
+        self.assertEqual(len(get_acl.calls), 1)
+        self.assertEqual(len(free_acl.calls), 0)
+
+    def test_acl_query_retirement_precedes_interruptible_finalizer_detach(self) -> None:
+        interruption = KeyboardInterrupt("ACL finalizer detach")
+        _get_acl, free_acl = self._run_acl_line_interruption(
+            anchored._DarwinAclQueryLease.close,
+            "self._finalizer.detach()",
+            interruption,
+        )
+
+        # The pointer was already retired. The still-live finalizer therefore
+        # becomes a no-op rather than replaying the successful native free.
+        self.assertEqual(len(free_acl.calls), 1)
+
+    def test_acl_query_preserves_primary_and_never_replays_recorded_free(self) -> None:
+        primary = KeyboardInterrupt("ACL query returned before assignment")
+
+        class NativeCall:
+            argtypes: object = None
+            restype: object = None
+
+            def __init__(self, result: int, interruption: BaseException | None = None) -> None:
+                self.result = result
+                self.interruption = interruption
+                self.calls = 0
+
+            def __call__(self, *_arguments: object) -> int:
+                self.calls += 1
+                result_type = self.restype
+                checker = getattr(result_type, "_check_retval_", None)
+                if callable(result_type) and callable(checker):
+                    checker(result_type(self.result))
+                if self.interruption is not None:
+                    raise self.interruption
+                return self.result
+
+        get_acl = NativeCall(1234, primary)
+        free_acl = NativeCall(-1)
+        with (
+            mock.patch.object(
+                anchored,
+                "_posix_libc",
+                return_value={"acl_get_fd_np": get_acl, "acl_free": free_acl},
+            ),
+            mock.patch.object(anchored.ctypes, "get_errno", return_value=errno.EIO),
+            mock.patch.object(anchored.sys, "platform", "darwin"),
+            self.assertRaises(KeyboardInterrupt) as raised,
+        ):
+            anchored._darwin_descriptor_has_extended_acl(7)
+        self.assertIs(raised.exception, primary)
+        self.assertEqual(free_acl.calls, 1)
+        self.assertIn("Could not release", "\n".join(getattr(primary, "__notes__", ())))
+
+    def test_acl_query_maps_null_results_to_phase_context(self) -> None:
+        class NativeCall:
+            argtypes: object = None
+            restype: object = None
+
+            def __init__(self, result: int) -> None:
+                self.result = result
+                self.calls = 0
+
+            def __call__(self, *_arguments: object) -> int:
+                self.calls += 1
+                result_type = self.restype
+                checker = getattr(result_type, "_check_retval_", None)
+                if callable(result_type) and callable(checker):
+                    checker(result_type(self.result))
+                return self.result
+
+        unsupported_errno = getattr(errno, "EOPNOTSUPP", errno.ENOSYS)
+        cases = (
+            (unsupported_errno, "output-anchor-unavailable", unsupported_errno),
+            (errno.EBADF, "output-parent-invalid", errno.EBADF),
+            (errno.EACCES, "output-parent-invalid", errno.EACCES),
+            (errno.EINVAL, "output-parent-invalid", errno.EINVAL),
+            (errno.ENOMEM, "output-parent-invalid", errno.ENOMEM),
+            (0, "output-parent-invalid", errno.EIO),
+        )
+        for reported_errno, expected_code, concrete_errno in cases:
+            with self.subTest(reported_errno=reported_errno):
+                get_acl = NativeCall(0)
+                free_acl = NativeCall(0)
+                with (
+                    mock.patch.object(
+                        anchored,
+                        "_posix_libc",
+                        return_value={"acl_get_fd_np": get_acl, "acl_free": free_acl},
+                    ),
+                    mock.patch.object(
+                        anchored.ctypes,
+                        "get_errno",
+                        return_value=reported_errno,
+                    ),
+                    mock.patch.object(anchored.sys, "platform", "darwin"),
+                    self.assertRaises(anchored.AnchoredOutputError) as raised,
+                ):
+                    anchored._darwin_descriptor_has_extended_acl(
+                        7,
+                        error_code="output-parent-invalid",
+                        context="modeled output parent",
+                    )
+
+                self.assertEqual(raised.exception.code, expected_code)
+                self.assertEqual(get_acl.calls, 1)
+                self.assertEqual(free_acl.calls, 0)
+                self.assertIsInstance(raised.exception.__cause__, OSError)
+                assert isinstance(raised.exception.__cause__, OSError)
+                self.assertEqual(raised.exception.__cause__.errno, concrete_errno)
+                self.assertIn("modeled output parent", str(raised.exception))
+
+    @unittest.skipUnless(sys.platform == "darwin", "native macOS ACL contract")
+    def test_native_acl_parent_root_stage_and_public_receipt_are_rejected(self) -> None:
+        acl_parent = self.root / "acl-parent"
+        acl_parent.mkdir(mode=0o700)
+        self._add_everyone_acl(acl_parent)
+        parent_lease = anchored._OutputParentBindingLease()
+        try:
+            with self.assertRaises(anchored.AnchoredOutputError) as unsafe_parent:
+                anchored._open_rooted_posix_parent(
+                    self.root,
+                    acl_parent / "receipt.json",
+                    (acl_parent.name, "receipt.json"),
+                    parent_lease,
+                )
+            self.assertEqual(unsafe_parent.exception.code, "output-parent-invalid")
+        finally:
+            parent_lease.close()
+            self._clear_acl(acl_parent)
+            acl_parent.rmdir()
+
+        private_root = self.parent / PRIVATE_ROOT
+        private_root.mkdir(mode=0o700)
+        self._add_everyone_acl(private_root)
+        try:
+            with self.assertRaises(anchored.AnchoredOutputError) as unsafe_root:
+                self.posix._open_darwin_receipt_stage(
+                    self.binding,
+                    PRIVATE_ROOT,
+                    self._stage_lease(),
+                )
+            self.assertEqual(unsafe_root.exception.code, "output-temporary-invalid")
+        finally:
+            self._clear_acl(private_root)
+            private_root.rmdir()
+
+        public = self.parent / "acl-public.json"
+        public.write_bytes(b"payload")
+        public.chmod(0o600)
+        self._add_everyone_acl(public)
+        try:
+            with self.assertRaises(anchored.AnchoredOutputError) as unsafe_public:
+                anchored.publish_identical_receipt_bytes(public, b"payload")
+            self.assertEqual(unsafe_public.exception.code, "output-existing-invalid")
+        finally:
+            self._clear_acl(public)
+            public.unlink()
+
+        stage_name = "9" * 32 + ".tmp"
+        stage_lease = self._stage_lease()
+        real_open = self.posix._open_posix_descriptor
+
+        def add_stage_acl_after_open(
+            descriptor_lease: anchored._PosixDescriptorLease,
+            path: os.PathLike[str] | str,
+            flags: int,
+            mode: int = 0o777,
+            *,
+            dir_fd: int | None = None,
+        ) -> int:
+            descriptor = real_open(descriptor_lease, path, flags, mode, dir_fd=dir_fd)
+            if descriptor_lease is stage_lease.descriptor:
+                self._add_everyone_acl(self.parent / PRIVATE_ROOT / stage_name)
+            return descriptor
+
+        with (
+            mock.patch.object(self.posix.secrets, "token_hex", return_value="9" * 32),
+            mock.patch.object(self.posix, "_open_posix_descriptor", side_effect=add_stage_acl_after_open),
+            self.assertRaises(anchored.AnchoredOutputError) as unsafe_stage,
+        ):
+            self.posix._open_darwin_receipt_stage(
+                self.binding,
+                PRIVATE_ROOT,
+                stage_lease,
+            )
+        self.assertEqual(unsafe_stage.exception.code, "output-temporary-invalid")
+        retained_stage = self.parent / PRIVATE_ROOT / stage_name
+        self.assertTrue(retained_stage.exists())
+        self._clear_acl(retained_stage)
+        retained_stage.unlink()
+        (self.parent / PRIVATE_ROOT).rmdir()
+
+    @unittest.skipUnless(sys.platform == "darwin", "native macOS renameatx_np contract")
+    def test_native_rename_moves_same_acl_free_inode_and_collision_preserves_both(self) -> None:
+        stage_lease = self._stage_lease()
+        stage = self.posix._open_darwin_receipt_stage(
+            self.binding,
+            PRIVATE_ROOT,
+            stage_lease,
+        )
+        self.posix._write_and_sync_retained_descriptor(stage.descriptor, b"source")
+        source = os.fstat(stage.descriptor)
+        self._add_everyone_acl(self.parent, inherited=True)
+        try:
+            self.posix._darwin_rename_receipt_stage(
+                stage,
+                stage_lease,
+                self.binding.descriptors[-1],
+                "moved.json",
+            )
+        finally:
+            self._clear_acl(self.parent)
+        moved = (self.parent / "moved.json").stat()
+        self.assertEqual((moved.st_dev, moved.st_ino), (source.st_dev, source.st_ino))
+        self.assertFalse((self.parent / PRIVATE_ROOT / stage.named_stage_name).exists())
+        self.assertFalse(anchored._darwin_descriptor_has_extended_acl(stage.descriptor))
+        self.posix._cleanup_darwin_named_stage(stage_lease)
+        self.assertFalse(stage_lease.private_directory_sync_pending)
+        self._close_stage(stage, stage_lease)
+        (self.parent / "moved.json").unlink()
+
+        winner = self.parent / "winner.json"
+        winner.write_bytes(b"winner")
+        winner.chmod(0o600)
+        collision_lease = self._stage_lease()
+        collision_stage = self.posix._open_darwin_receipt_stage(
+            self.binding,
+            PRIVATE_ROOT,
+            collision_lease,
+        )
+        self.posix._write_and_sync_retained_descriptor(collision_stage.descriptor, b"source")
+        with self.assertRaises(FileExistsError):
+            self.posix._darwin_rename_receipt_stage(
+                collision_stage,
+                collision_lease,
+                self.binding.descriptors[-1],
+                winner.name,
+            )
+        self.assertEqual(winner.read_bytes(), b"winner")
+        self.assertTrue((self.parent / PRIVATE_ROOT / collision_stage.named_stage_name).exists())
+        self._close_stage(collision_stage, collision_lease)
+        winner.unlink()
+        (self.parent / PRIVATE_ROOT).rmdir()
+
+    @unittest.skipUnless(sys.platform == "darwin", "native macOS staging-root selection")
+    def test_reserved_staging_root_leaf_uses_deterministic_alternate(self) -> None:
+        output = self.parent / PRIVATE_ROOT
+        anchored.publish_identical_receipt_bytes(output, b"receipt")
+        anchored.publish_identical_receipt_bytes(output, b"receipt")
+        self.assertTrue(output.is_file())
+        self.assertEqual(output.read_bytes(), b"receipt")
+        alternate = self.parent / self.posix._DARWIN_RECEIPT_STAGING_ROOT_ALTERNATE
+        self.assertTrue(alternate.is_dir())
+        output.unlink()
+        alternate.rmdir()
+
+    @unittest.skipUnless(sys.platform == "darwin", "native macOS private-directory durability")
+    def test_private_stage_unlink_retries_directory_sync_before_close(self) -> None:
+        stage_lease = self._stage_lease()
+        stage = self.posix._open_darwin_receipt_stage(
+            self.binding,
+            PRIVATE_ROOT,
+            stage_lease,
+        )
+        publication = self.posix._PosixReceiptPublicationLease(
+            self.binding,
+            stage=stage_lease,
+        )
+        real_sync = self.posix.os.fsync
+        private_sync_calls = 0
+
+        def fail_private_sync_once(descriptor: int) -> None:
+            nonlocal private_sync_calls
+            if descriptor == stage.private_directory_descriptor:
+                private_sync_calls += 1
+                if private_sync_calls == 1:
+                    raise OSError("private directory sync")
+            real_sync(descriptor)
+
+        with mock.patch.object(self.posix.os, "fsync", side_effect=fail_private_sync_once):
+            failures = publication.close()
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(private_sync_calls, 2)
+        self.assertTrue(publication.is_closed)
+        self.assertFalse((self.parent / PRIVATE_ROOT / stage.named_stage_name).exists())
+        (self.parent / PRIVATE_ROOT).rmdir()
+
+    def test_named_stage_unlink_effect_then_interruption_is_recovered_exactly(
+        self,
+    ) -> None:
+        stage_lease = self._stage_lease()
+        stage = self.posix._open_darwin_receipt_stage(
+            self.binding,
+            PRIVATE_ROOT,
+            stage_lease,
+        )
+        stage_descriptor = stage.descriptor
+        private_descriptor = stage.private_directory_descriptor
+        stage_path = self.parent / PRIVATE_ROOT / stage.named_stage_name
+        neighbor = self.parent / PRIVATE_ROOT / "neighbor.tmp"
+        neighbor.write_bytes(b"untouched")
+        neighbor_before = neighbor.stat()
+        publication = self.posix._PosixReceiptPublicationLease(
+            self.binding,
+            stage=stage_lease,
+        )
+        real_unlink = self.posix.os.unlink
+        real_fsync = self.posix.os.fsync
+        interruption = KeyboardInterrupt("unlink returned before assignment")
+        unlinked_names: list[object] = []
+        synced: list[int] = []
+
+        def unlink_then_interrupt(
+            name: os.PathLike[str] | str,
+            *,
+            dir_fd: int | None = None,
+        ) -> None:
+            unlinked_names.append(name)
+            real_unlink(name, dir_fd=dir_fd)
+            raise interruption
+
+        def record_sync(descriptor: int) -> None:
+            synced.append(descriptor)
+            real_fsync(descriptor)
+
+        with (
+            mock.patch.object(
+                self.posix.os,
+                "unlink",
+                side_effect=unlink_then_interrupt,
+            ),
+            mock.patch.object(self.posix.os, "fsync", side_effect=record_sync),
+        ):
+            failures = publication.close()
+
+        self.assertEqual(failures, (interruption,))
+        self.assertEqual(unlinked_names, [stage.named_stage_name])
+        self.assertEqual(stage_lease.named_cleanup_attempts, 2)
+        self.assertEqual(stage_lease.private_directory_sync_attempts, 1)
+        self.assertEqual(synced, [private_descriptor])
+        self.assertFalse(stage_path.exists())
+        neighbor_after = neighbor.stat()
+        self.assertEqual(
+            (neighbor_after.st_dev, neighbor_after.st_ino, neighbor.read_bytes()),
+            (neighbor_before.st_dev, neighbor_before.st_ino, b"untouched"),
+        )
+        self.assertTrue(publication.is_closed)
+        for descriptor in (stage_descriptor, private_descriptor):
+            with self.assertRaises(OSError) as closed:
+                os.fstat(descriptor)
+            self.assertEqual(closed.exception.errno, errno.EBADF)
+
+        neighbor.unlink()
+        (self.parent / PRIVATE_ROOT).rmdir()
+
+    def test_failed_stage_records_exhausted_private_sync_before_descriptor_close(self) -> None:
+        stage_name = "8" * 32 + ".tmp"
+        lease = self._stage_lease()
+        primary = OSError("stage validation failed")
+        real_fsync = self.posix.os.fsync
+        real_close = self.posix._close_posix_descriptor_lease
+        private_sync_calls = 0
+        private_close_state: list[tuple[bool, bool, int]] = []
+
+        def fail_private_sync(descriptor: int) -> None:
+            nonlocal private_sync_calls
+            if descriptor == lease.private_directory.descriptor:
+                private_sync_calls += 1
+                raise OSError("private directory sync")
+            real_fsync(descriptor)
+
+        def record_close_state(
+            descriptor_lease: anchored._PosixDescriptorLease,
+            active_primary: BaseException | None,
+            context: str,
+        ) -> BaseException | None:
+            if descriptor_lease is lease.private_directory:
+                private_close_state.append(
+                    (
+                        lease.private_directory_sync_retained,
+                        lease.private_directory_sync_pending,
+                        lease.private_directory_sync_attempts,
+                    )
+                )
+            return real_close(descriptor_lease, active_primary, context)
+
+        with (
+            mock.patch.object(self.posix.secrets, "token_hex", return_value="8" * 32),
+            mock.patch.object(
+                self.posix,
+                "_receipt_mode_is_canonical",
+                side_effect=primary,
+            ),
+            mock.patch.object(self.posix.os, "fsync", side_effect=fail_private_sync),
+            mock.patch.object(
+                self.posix,
+                "_close_posix_descriptor_lease",
+                side_effect=record_close_state,
+            ),
+            self.assertRaises(OSError) as raised,
+        ):
+            self.posix._open_darwin_receipt_stage(
+                self.binding,
+                PRIVATE_ROOT,
+                lease,
+            )
+
+        self.assertIs(raised.exception, primary)
+        self.assertEqual(private_sync_calls, 4)
+        self.assertEqual(private_close_state, [(True, True, 4)])
+        self.assertTrue(lease.private_directory_sync_retained)
+        self.assertTrue(lease.private_directory_sync_pending)
+        self.assertFalse((self.parent / PRIVATE_ROOT / stage_name).exists())
+        self.assertIsNone(lease.descriptor.descriptor)
+        self.assertIsNone(lease.private_directory.descriptor)
+        self.assertIn(
+            "could not be durably flushed after bounded retries",
+            "\n".join(getattr(primary, "__notes__", ())),
+        )
+        (self.parent / PRIVATE_ROOT).rmdir()
+
+    def test_publication_cleanup_does_not_exceed_seeded_private_sync_budget(self) -> None:
+        lease = self._stage_lease()
+        stage = self.posix._open_darwin_receipt_stage(
+            self.binding,
+            PRIVATE_ROOT,
+            lease,
+        )
+        os.unlink(
+            stage.named_stage_name,
+            dir_fd=stage.private_directory_descriptor,
+        )
+        lease.named_stage_name = None
+        lease.private_directory_sync_pending = True
+        lease.private_directory_sync_attempts = 3
+        publication = self.posix._PosixReceiptPublicationLease(
+            self.binding,
+            stage=lease,
+        )
+        real_close = self.posix._close_posix_descriptor_lease
+        sync_calls = 0
+        private_close_state: list[tuple[bool, int]] = []
+
+        def fail_final_sync(stage_lease: Any) -> None:
+            nonlocal sync_calls
+            self.assertIs(stage_lease, lease)
+            sync_calls += 1
+            stage_lease.private_directory_sync_attempts += 1
+            raise OSError("final private directory sync")
+
+        def record_private_close(
+            descriptor_lease: anchored._PosixDescriptorLease,
+            active_primary: BaseException | None,
+            context: str,
+        ) -> BaseException | None:
+            if descriptor_lease is lease.private_directory:
+                private_close_state.append(
+                    (
+                        lease.private_directory_sync_retained,
+                        lease.private_directory_sync_attempts,
+                    )
+                )
+            return real_close(descriptor_lease, active_primary, context)
+
+        with (
+            mock.patch.object(
+                self.posix,
+                "_sync_darwin_private_directory_if_pending",
+                side_effect=fail_final_sync,
+            ),
+            mock.patch.object(
+                self.posix,
+                "_close_posix_descriptor_lease",
+                side_effect=record_private_close,
+            ),
+        ):
+            failures = publication.close()
+
+        self.assertEqual(sync_calls, 1)
+        self.assertEqual(lease.private_directory_sync_attempts, 4)
+        self.assertEqual(private_close_state, [(True, 4)])
+        self.assertTrue(publication.is_closed)
+        self.assertEqual(len(failures), 2)
+        (self.parent / PRIVATE_ROOT).rmdir()
+
+    def test_publication_cleanup_does_not_exceed_seeded_named_stage_budget(self) -> None:
+        lease = self._stage_lease()
+        stage = self.posix._open_darwin_receipt_stage(
+            self.binding,
+            PRIVATE_ROOT,
+            lease,
+        )
+        lease.named_cleanup_attempts = 3
+        publication = self.posix._PosixReceiptPublicationLease(
+            self.binding,
+            stage=lease,
+        )
+        cleanup_calls = 0
+
+        def fail_final_cleanup(stage_lease: Any) -> None:
+            nonlocal cleanup_calls
+            self.assertIs(stage_lease, lease)
+            cleanup_calls += 1
+            raise OSError("final named-stage cleanup")
+
+        with mock.patch.object(
+            self.posix,
+            "_cleanup_darwin_named_stage",
+            side_effect=fail_final_cleanup,
+        ):
+            failures = publication.close()
+
+        self.assertEqual(cleanup_calls, 1)
+        self.assertEqual(lease.named_cleanup_attempts, 4)
+        self.assertTrue(lease.named_stage_retained)
+        self.assertTrue(publication.is_closed)
+        self.assertEqual(len(failures), 2)
+        retained = self.parent / PRIVATE_ROOT / stage.named_stage_name
+        self.assertTrue(retained.is_file())
+        retained.unlink()
+        (self.parent / PRIVATE_ROOT).rmdir()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_anchored_receipt_outer_lease.py
+++ b/tests/test_anchored_receipt_outer_lease.py
@@ -1,0 +1,746 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+import ctypes
+import errno
+import gc
+import inspect
+import os
+from pathlib import Path
+import sys
+import tempfile
+from types import FrameType
+from typing import Any, Callable
+import unittest
+from unittest import mock
+
+from scripts import _anchored_output as anchored
+
+
+PAYLOAD = b'{"status":"verified"}\n'
+
+
+def _source_line(
+    function: Callable[..., object],
+    source_fragment: str,
+) -> int:
+    """Find one cleanup source line without depending on CPython bytecode."""
+
+    lines, first_line = inspect.getsourcelines(function)
+    matching_lines = [first_line + index for index, source_line in enumerate(lines) if source_fragment in source_line]
+    if len(matching_lines) != 1:
+        raise AssertionError(
+            f"Expected one {function.__name__} source line containing {source_fragment!r}; found {matching_lines}."
+        )
+    return matching_lines[0]
+
+
+class AnchoredReceiptOuterLeaseTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if os.name == "nt":
+            self.skipTest("descriptor-relative POSIX test")
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name).resolve()
+        self.parent = self.root / "parent"
+        self.parent.mkdir()
+        self.previous_cwd = Path.cwd()
+        os.chdir(self.root)
+        self.posix = anchored._posix_receipt_module()
+
+    def tearDown(self) -> None:
+        os.chdir(self.previous_cwd)
+        self.temporary.cleanup()
+
+    def assert_descriptor_closed(self, descriptor: int) -> None:
+        with self.assertRaises(OSError) as raised:
+            os.fstat(descriptor)
+        self.assertEqual(raised.exception.errno, errno.EBADF)
+
+    def _open_binding_before_platform_model(
+        self,
+        output: Path,
+    ) -> tuple[anchored.OutputParentBinding, anchored._OutputParentBindingLease]:
+        lease = anchored._OutputParentBindingLease()
+        binding = anchored.open_rooted_output_parent(output, lease)
+        self.assertIs(lease.binding, binding)
+        return binding, lease
+
+    def test_binding_preserves_legacy_positional_constructor_contract(self) -> None:
+        descriptors = (11, 12)
+        links = ((11, "parent", 12),)
+        windows_api = object()
+        windows_entries = ((Path("C:/parent"), (1, 2), 13),)
+        binding = anchored.OutputParentBinding(
+            Path("checkout"),
+            Path("parent"),
+            "snapshot.json",
+            "posix-dir-fd",
+            descriptors,
+            links,
+            windows_api,
+            windows_entries,
+        )
+
+        self.assertIs(binding.descriptors, descriptors)
+        self.assertIs(binding.links, links)
+        self.assertIs(binding.windows_api, windows_api)
+        self.assertIs(binding.windows_entries, windows_entries)
+        self.assertFalse(binding.receipt_parent_policy)
+        parameters = inspect.signature(anchored.OutputParentBinding).parameters
+        for name in (
+            "descriptor_leases",
+            "windows_handle_leases",
+            "receipt_parent_policy",
+            "private_posix_descriptor_indexes",
+        ):
+            self.assertEqual(parameters[name].kind, inspect.Parameter.KEYWORD_ONLY)
+        self.assertNotIn("_closed", parameters)
+
+    def test_outer_lease_keeps_older_resources_and_parent_open_until_newest_closes(
+        self,
+    ) -> None:
+        events: list[str] = []
+
+        class Resource:
+            def __init__(self, name: str, close_after: int) -> None:
+                self.name = name
+                self.close_after = close_after
+                self.close_calls = 0
+                self.closed = False
+
+            @property
+            def is_closed(self) -> bool:
+                return self.closed
+
+            def close(self) -> tuple[BaseException, ...]:
+                if self.closed:
+                    return ()
+                self.close_calls += 1
+                events.append(self.name)
+                if self.close_calls < self.close_after:
+                    return (RuntimeError(f"{self.name} is still open"),)
+                self.closed = True
+                return ()
+
+        class Binding:
+            descriptor_leases: tuple[object, ...] = ()
+
+            def __init__(self) -> None:
+                self.closed = False
+
+            @property
+            def is_closed(self) -> bool:
+                return self.closed
+
+            def close(self) -> tuple[BaseException, ...]:
+                events.append("binding")
+                self.closed = True
+                return ()
+
+        binding: Any = Binding()
+        older = Resource("older", close_after=1)
+        newest = Resource("newest", close_after=3)
+        lease = anchored._OutputParentBindingLease(binding)
+        lease.retain_publication_resource(older)
+        lease.retain_publication_resource(newest)
+
+        first_failures = lease.close()
+
+        self.assertEqual(events, ["newest", "newest"])
+        self.assertEqual(len(first_failures), 2)
+        self.assertFalse(older.is_closed)
+        self.assertFalse(binding.is_closed)
+        self.assertTrue(lease._finalizer.alive)
+
+        self.assertEqual(lease.close(), ())
+        self.assertEqual(
+            events,
+            ["newest", "newest", "newest", "older", "binding"],
+        )
+        self.assertTrue(newest.is_closed)
+        self.assertTrue(older.is_closed)
+        self.assertTrue(binding.is_closed)
+        self.assertFalse(lease._finalizer.alive)
+
+    def test_binding_keeps_parent_open_when_child_exhausts_cleanup(self) -> None:
+        root = anchored._PosixDescriptorLease(ctypes.c_int(101))
+        child = anchored._PosixDescriptorLease(ctypes.c_int(102))
+        binding = anchored.OutputParentBinding(
+            checkout=self.root,
+            parent=self.parent,
+            leaf="receipt.json",
+            strategy="posix-dir-fd",
+            descriptors=(101, 102),
+            descriptor_leases=(root, child),
+        )
+        interruption = KeyboardInterrupt("child close remains interrupted")
+        attempts: list[str] = []
+        child_may_close = False
+
+        def close_descriptor(descriptor_lease: anchored._PosixDescriptorLease) -> None:
+            label = "child" if descriptor_lease is child else "root"
+            attempts.append(label)
+            if descriptor_lease is child and not child_may_close:
+                raise interruption
+            descriptor_lease.descriptor_result = None
+
+        with mock.patch.object(
+            anchored._PosixDescriptorLease,
+            "close",
+            new=close_descriptor,
+        ):
+            first_failures = binding.close()
+            self.assertEqual(attempts, ["child", "child"])
+            self.assertIsNotNone(child.descriptor)
+            self.assertIsNotNone(root.descriptor)
+            self.assertFalse(binding.is_closed)
+            self.assertEqual(first_failures, (interruption,))
+
+            child_may_close = True
+            self.assertEqual(binding.close(), ())
+
+        self.assertEqual(attempts, ["child", "child", "child", "root"])
+        self.assertTrue(binding.is_closed)
+
+    def test_posix_publication_lease_keeps_older_descriptors_open_until_newest_closes(
+        self,
+    ) -> None:
+        binding = anchored.OutputParentBinding(
+            checkout=self.root,
+            parent=self.parent,
+            leaf="receipt.json",
+            strategy="posix-dir-fd",
+        )
+        publication_lease = self.posix._PosixReceiptPublicationLease(binding)
+        older = anchored._PosixDescriptorLease(ctypes.c_int(101))
+        newest = anchored._PosixDescriptorLease(ctypes.c_int(102))
+        publication_lease.transient_descriptors.extend((older, newest))
+        publication_lease.stage.descriptor.descriptor_result = ctypes.c_int(103)
+        publication_lease.stage.private_directory.descriptor_result = ctypes.c_int(104)
+        publication_lease.stage.named_stage_name = "retained-stage.tmp"
+        names = {
+            id(older): "older",
+            id(newest): "newest",
+            id(publication_lease.stage.descriptor): "stage",
+            id(publication_lease.stage.private_directory): "private",
+        }
+        close_calls: dict[int, int] = {}
+        events: list[str] = []
+
+        def close_descriptor(
+            descriptor_lease: anchored._PosixDescriptorLease,
+            _primary: BaseException | None,
+            _context: str,
+        ) -> BaseException | None:
+            identity = id(descriptor_lease)
+            close_calls[identity] = close_calls.get(identity, 0) + 1
+            events.append(names[identity])
+            if descriptor_lease is newest and close_calls[identity] < 3:
+                return RuntimeError("newest is still open")
+            descriptor_lease.descriptor_result = None
+            return None
+
+        def cleanup_named_stage(stage: Any) -> None:
+            events.append("named-stage")
+            stage.named_stage_name = None
+
+        with (
+            mock.patch.object(self.posix.sys, "platform", "darwin"),
+            mock.patch.object(
+                self.posix,
+                "_close_posix_descriptor_lease",
+                side_effect=close_descriptor,
+            ),
+            mock.patch.object(
+                self.posix,
+                "_cleanup_darwin_named_stage",
+                side_effect=cleanup_named_stage,
+            ),
+        ):
+            self.assertEqual(len(publication_lease.close()), 1)
+            self.assertEqual(events, ["newest"])
+            self.assertIsNotNone(older.descriptor)
+            self.assertIsNotNone(publication_lease.stage.descriptor.descriptor)
+            self.assertIsNotNone(publication_lease.stage.private_directory.descriptor)
+
+            self.assertEqual(len(publication_lease.close()), 1)
+            self.assertEqual(events, ["newest", "newest"])
+            self.assertIsNotNone(older.descriptor)
+
+            self.assertEqual(publication_lease.close(), ())
+
+        self.assertEqual(
+            events,
+            [
+                "newest",
+                "newest",
+                "newest",
+                "older",
+                "named-stage",
+                "stage",
+                "private",
+            ],
+        )
+        self.assertTrue(publication_lease.is_closed)
+
+    def test_public_finalizer_recovers_when_outer_cleanup_call_is_interrupted(
+        self,
+    ) -> None:
+        target = anchored.publish_identical_receipt_bytes
+        cleanup_line = _source_line(
+            target,
+            "close_failures = lease.close()",
+        )
+        interruption = KeyboardInterrupt("public outer cleanup call")
+        retained = False
+        triggered = False
+
+        class Resource:
+            def __init__(self) -> None:
+                self.closed = False
+                self.close_calls = 0
+
+            @property
+            def is_closed(self) -> bool:
+                return self.closed
+
+            def close(self) -> tuple[BaseException, ...]:
+                self.close_calls += 1
+                self.closed = True
+                raise SystemExit("finalizer-only cleanup interruption")
+
+        class Binding:
+            strategy = "posix-dir-fd"
+
+            def __init__(self) -> None:
+                self.closed = False
+                self.close_calls = 0
+
+            @property
+            def is_closed(self) -> bool:
+                return self.closed
+
+            def close(self) -> tuple[BaseException, ...]:
+                self.close_calls += 1
+                self.closed = True
+                return ()
+
+        resource = Resource()
+        binding: Any = Binding()
+
+        def open_binding(
+            _path: Path,
+            lease: anchored._OutputParentBindingLease,
+        ) -> Any:
+            lease.binding = binding
+            return binding
+
+        def retain_without_cleanup(
+            _path: Path,
+            _payload: bytes,
+            _binding: object,
+            lease: anchored._OutputParentBindingLease,
+        ) -> None:
+            nonlocal retained
+            lease.retain_publication_resource(resource)
+            retained = True
+
+        def trace(frame: FrameType, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if event == "call" and frame.f_code is target.__code__:
+                frame.f_trace = trace
+                return trace
+            if (
+                event == "line"
+                and frame.f_code is target.__code__
+                and frame.f_lineno == cleanup_line
+                and retained
+                and not triggered
+            ):
+                triggered = True
+                raise interruption
+            return trace
+
+        previous_trace = sys.gettrace()
+        try:
+            with (
+                mock.patch.object(
+                    anchored,
+                    "open_rooted_output_parent",
+                    new=open_binding,
+                ),
+                mock.patch.object(
+                    anchored,
+                    "_publish_posix_receipt_bytes",
+                    new=retain_without_cleanup,
+                ),
+                self.assertRaises(KeyboardInterrupt) as raised,
+            ):
+                sys.settrace(trace)
+                anchored.publish_identical_receipt_bytes(
+                    self.parent / "receipt.json",
+                    PAYLOAD,
+                )
+        finally:
+            sys.settrace(previous_trace)
+
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, interruption)
+        # The traceback owns the interrupted frame on every supported Python;
+        # clear it before forcing the portable GC boundary for weakref.finalize.
+        interruption.__traceback__ = None
+        gc.collect()
+        self.assertEqual(resource.close_calls, 1)
+        self.assertTrue(resource.closed)
+        self.assertEqual(binding.close_calls, 1)
+        self.assertTrue(binding.closed)
+
+    def test_posix_publisher_keeps_binding_open_while_publication_lease_is_live(
+        self,
+    ) -> None:
+        body_failure = OSError(errno.EIO, "modeled publisher failure")
+
+        class Binding:
+            leaf = "receipt.json"
+
+            def __init__(self) -> None:
+                self.close_calls = 0
+
+            def stat(self, _name: str) -> os.stat_result:
+                raise body_failure
+
+            def close(self) -> tuple[BaseException, ...]:
+                self.close_calls += 1
+                return ()
+
+        class PublicationLease:
+            stage = object()
+
+            def __init__(self, binding: object) -> None:
+                self.binding = binding
+                self.close_calls = 0
+
+            @property
+            def is_closed(self) -> bool:
+                return False
+
+            def close(self) -> tuple[BaseException, ...]:
+                self.close_calls += 1
+                return (RuntimeError("publication descriptor is still open"),)
+
+        binding: Any = Binding()
+        publication_lease: Any = PublicationLease(binding)
+
+        with self.assertRaises(OSError) as raised:
+            self.posix._publish_posix_receipt_bytes(
+                self.parent / binding.leaf,
+                PAYLOAD,
+                binding,
+                publication_lease,
+            )
+
+        self.assertIs(raised.exception, body_failure)
+        self.assertEqual(publication_lease.close_calls, 2)
+        self.assertEqual(binding.close_calls, 0)
+        self.assertEqual(len(getattr(body_failure, "__notes__", ())), 2)
+
+    def test_public_facade_closes_read_descriptor_when_finally_prelude_is_interrupted(
+        self,
+    ) -> None:
+        output = self.parent / "receipt.json"
+        output.write_bytes(PAYLOAD)
+        output.chmod(0o600)
+        target = anchored._read_exact_receipt
+        cleanup_line = _source_line(
+            target,
+            "close_call_failures: list[BaseException] = []",
+        )
+        interruption = KeyboardInterrupt("receipt reader finally prelude")
+        captured: list[int] = []
+        triggered = False
+
+        def trace(frame: FrameType, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if event == "call" and frame.f_code is target.__code__:
+                frame.f_trace = trace
+                return trace
+            if event == "line" and frame.f_code is target.__code__ and frame.f_lineno == cleanup_line and not triggered:
+                descriptor_lease = frame.f_locals.get("descriptor_lease")
+                if isinstance(descriptor_lease, anchored._PosixDescriptorLease):
+                    descriptor = descriptor_lease.descriptor
+                    if descriptor is not None:
+                        captured.append(descriptor)
+                        triggered = True
+                        raise interruption
+            return trace
+
+        previous_trace = sys.gettrace()
+        try:
+            sys.settrace(trace)
+            with self.assertRaises(KeyboardInterrupt) as raised:
+                anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+        finally:
+            sys.settrace(previous_trace)
+
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, interruption)
+        self.assertEqual(len(captured), 1)
+        self.assert_descriptor_closed(captured[0])
+
+    def test_public_facade_closes_darwin_public_descriptor_when_finally_prelude_is_interrupted(
+        self,
+    ) -> None:
+        output = self.parent / "receipt.json"
+        binding, setup_lease = self._open_binding_before_platform_model(output)
+        target = self.posix._sync_posix_public_descriptor
+        cleanup_line = _source_line(
+            target,
+            "close_call_failures: list[BaseException] = []",
+        )
+        interruption = KeyboardInterrupt("Darwin public descriptor finally prelude")
+        captured: list[int] = []
+        opened_stages: list[int] = []
+        triggered = False
+
+        def reuse_binding(
+            _path: Path,
+            lease: anchored._OutputParentBindingLease,
+        ) -> anchored.OutputParentBinding:
+            lease.binding = binding
+            return binding
+
+        def open_named_stage(
+            _binding: object,
+            _temporary_name: str,
+            lease: Any,
+        ) -> object:
+            private_root = self.parent / ".modeled-darwin-private"
+            private_root.mkdir(mode=0o700)
+            private_descriptor = os.open(private_root, os.O_RDONLY | os.O_DIRECTORY)
+            stage_name = "modeled-darwin-stage.tmp"
+            descriptor = os.open(
+                stage_name,
+                os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0),
+                0o600,
+                dir_fd=private_descriptor,
+            )
+            lease.descriptor.descriptor_result = ctypes.c_int(descriptor)
+            lease.private_directory.descriptor_result = ctypes.c_int(private_descriptor)
+            lease.named_stage_name = stage_name
+            private_value = os.fstat(private_descriptor)
+            stage = self.posix._PosixReceiptStage(
+                descriptor=descriptor,
+                private_directory_descriptor=private_descriptor,
+                private_directory_name=private_root.name,
+                private_directory_identity=(private_value.st_dev, private_value.st_ino),
+                named_stage_name=stage_name,
+            )
+            lease.stage = stage
+            opened_stages.extend((descriptor, private_descriptor))
+            return stage
+
+        def rename_stage(
+            stage: Any,
+            stage_lease: Any,
+            parent_descriptor: int,
+            destination: str,
+        ) -> None:
+            stage_lease.private_directory_sync_pending = True
+            os.rename(
+                stage.named_stage_name,
+                destination,
+                src_dir_fd=stage.private_directory_descriptor,
+                dst_dir_fd=parent_descriptor,
+            )
+
+        def trace(frame: FrameType, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if event == "call" and frame.f_code is target.__code__:
+                frame.f_trace = trace
+                return trace
+            if event == "line" and frame.f_code is target.__code__ and frame.f_lineno == cleanup_line and not triggered:
+                descriptor_lease = frame.f_locals.get("descriptor_lease")
+                if isinstance(descriptor_lease, anchored._PosixDescriptorLease):
+                    descriptor = descriptor_lease.descriptor
+                    if descriptor is not None:
+                        captured.append(descriptor)
+                        triggered = True
+                        raise interruption
+            return trace
+
+        previous_trace = sys.gettrace()
+        try:
+            with (
+                mock.patch.object(anchored, "open_rooted_output_parent", side_effect=reuse_binding),
+                mock.patch.object(self.posix.sys, "platform", "darwin"),
+                mock.patch.object(
+                    self.posix,
+                    "_open_posix_receipt_stage",
+                    side_effect=open_named_stage,
+                ),
+                mock.patch.object(
+                    self.posix,
+                    "_darwin_rename_receipt_stage",
+                    side_effect=rename_stage,
+                ),
+                self.assertRaises(KeyboardInterrupt) as raised,
+            ):
+                sys.settrace(trace)
+                anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+        finally:
+            sys.settrace(previous_trace)
+            setup_failures = setup_lease.close()
+
+        self.assertEqual(setup_failures, ())
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, interruption)
+        self.assertEqual(len(captured), 1)
+        self.assert_descriptor_closed(captured[0])
+        self.assertEqual(len(opened_stages), 2)
+        for descriptor in opened_stages:
+            self.assert_descriptor_closed(descriptor)
+
+    def test_public_facade_outer_lease_closes_stage_when_publisher_finally_prelude_is_interrupted(
+        self,
+    ) -> None:
+        output = self.parent / "receipt.json"
+        target = self.posix._publish_posix_receipt_bytes
+        cleanup_line = _source_line(
+            target,
+            "close_failures: list[BaseException] = []",
+        )
+        interruption = KeyboardInterrupt("publisher finally prelude")
+        body_failure = OSError(errno.EIO, "modeled publication body failure")
+        opened: list[int] = []
+        captured: list[int] = []
+        triggered = False
+
+        def open_stage(_binding: object, _temporary_name: str, lease: Any) -> object:
+            stage_path = self.parent / "unlinked-stage.tmp"
+            descriptor = os.open(
+                stage_path,
+                os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0),
+                0o600,
+            )
+            stage_path.unlink()
+            lease.descriptor.descriptor_result = ctypes.c_int(descriptor)
+            stage = self.posix._PosixReceiptStage(descriptor=descriptor)
+            lease.stage = stage
+            opened.append(descriptor)
+            return stage
+
+        def trace(frame: FrameType, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if event == "call" and frame.f_code is target.__code__:
+                frame.f_trace = trace
+                return trace
+            if event == "line" and frame.f_code is target.__code__ and frame.f_lineno == cleanup_line and not triggered:
+                publication_lease = frame.f_locals.get("publication_lease")
+                if publication_lease is not None and isinstance(
+                    publication_lease,
+                    self.posix._PosixReceiptPublicationLease,
+                ):
+                    descriptor = publication_lease.stage.descriptor.descriptor
+                    if descriptor is not None:
+                        captured.append(descriptor)
+                        triggered = True
+                        raise interruption
+            return trace
+
+        previous_trace = sys.gettrace()
+        try:
+            with (
+                mock.patch.object(self.posix, "_open_posix_receipt_stage", side_effect=open_stage),
+                mock.patch.object(
+                    self.posix,
+                    "_write_and_sync_retained_descriptor",
+                    side_effect=body_failure,
+                ),
+                self.assertRaises(KeyboardInterrupt) as raised,
+            ):
+                sys.settrace(trace)
+                anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+        finally:
+            sys.settrace(previous_trace)
+
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, interruption)
+        self.assertEqual(opened, captured)
+        self.assertEqual(len(captured), 1)
+        self.assert_descriptor_closed(captured[0])
+
+    def test_required_outer_owner_recovers_direct_posix_facade_cleanup_entry(self) -> None:
+        output = self.parent / "receipt.json"
+        binding, outer_lease = self._open_binding_before_platform_model(output)
+        target = self.posix._publish_posix_receipt_bytes
+        cleanup_line = _source_line(
+            target,
+            "close_failures: list[BaseException] = []",
+        )
+        interruption = KeyboardInterrupt("direct POSIX facade cleanup entry")
+        body_failure = OSError(errno.EIO, "modeled publication body failure")
+        opened: list[int] = []
+        triggered = False
+
+        def open_stage(_binding: object, _temporary_name: str, lease: Any) -> object:
+            stage_path = self.parent / "direct-unlinked-stage.tmp"
+            descriptor = os.open(
+                stage_path,
+                os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0),
+                0o600,
+            )
+            stage_path.unlink()
+            lease.descriptor.descriptor_result = ctypes.c_int(descriptor)
+            stage = self.posix._PosixReceiptStage(descriptor=descriptor)
+            lease.stage = stage
+            opened.append(descriptor)
+            return stage
+
+        def trace(frame: FrameType, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if event == "call" and frame.f_code is target.__code__:
+                frame.f_trace = trace
+                return trace
+            if event == "line" and frame.f_code is target.__code__ and frame.f_lineno == cleanup_line and not triggered:
+                publication_lease: Any = frame.f_locals.get("publication_lease")
+                stage_lease: Any = getattr(publication_lease, "stage", None)
+                if isinstance(stage_lease, self.posix._PosixReceiptStageLease):
+                    descriptor = stage_lease.descriptor.descriptor
+                    if descriptor is not None:
+                        triggered = True
+                        raise interruption
+            return trace
+
+        previous_trace = sys.gettrace()
+        try:
+            with (
+                mock.patch.object(self.posix, "_open_posix_receipt_stage", side_effect=open_stage),
+                mock.patch.object(
+                    self.posix,
+                    "_write_and_sync_retained_descriptor",
+                    side_effect=body_failure,
+                ),
+                self.assertRaises(KeyboardInterrupt) as raised,
+            ):
+                sys.settrace(trace)
+                anchored._publish_posix_receipt_bytes(
+                    output,
+                    PAYLOAD,
+                    binding,
+                    outer_lease,
+                )
+        finally:
+            sys.settrace(previous_trace)
+
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, interruption)
+        self.assertEqual(len(opened), 1)
+        os.fstat(opened[0])
+        self.assertEqual(len(outer_lease.publication_resources), 1)
+        self.assertEqual(outer_lease.close(), ())
+        self.assert_descriptor_closed(opened[0])
+        self.assertTrue(binding.is_closed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_anchored_receipt_outer_lease.py
+++ b/tests/test_anchored_receipt_outer_lease.py
@@ -9,7 +9,7 @@ import os
 from pathlib import Path
 import sys
 import tempfile
-from types import FrameType
+from types import FrameType, SimpleNamespace
 from typing import Any, Callable
 import unittest
 from unittest import mock
@@ -572,7 +572,11 @@ class AnchoredReceiptOuterLeaseTests(unittest.TestCase):
         try:
             with (
                 mock.patch.object(anchored, "open_rooted_output_parent", side_effect=reuse_binding),
-                mock.patch.object(self.posix.sys, "platform", "darwin"),
+                mock.patch.object(
+                    self.posix,
+                    "sys",
+                    SimpleNamespace(platform="darwin"),
+                ),
                 mock.patch.object(
                     self.posix,
                     "_open_posix_receipt_stage",

--- a/tests/test_anchored_receipt_posix.py
+++ b/tests/test_anchored_receipt_posix.py
@@ -1,0 +1,435 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+import errno
+import os
+from pathlib import Path
+import stat
+import sys
+import tempfile
+from types import SimpleNamespace
+from typing import cast
+import unittest
+from unittest import mock
+
+from scripts import _anchored_output as anchored
+
+
+PAYLOAD = b'{"status":"verified"}\n'
+
+
+def _entry_snapshot(path: Path) -> tuple[tuple[int, ...], bytes]:
+    value = path.lstat()
+    return (
+        (
+            value.st_dev,
+            value.st_ino,
+            value.st_mode,
+            value.st_nlink,
+            value.st_size,
+            value.st_mtime_ns,
+            value.st_ctime_ns,
+        ),
+        path.read_bytes(),
+    )
+
+
+class AnchoredReceiptPosixTests(unittest.TestCase):
+    def test_retained_writer_syscall_failure_matrix_preserves_primary(self) -> None:
+        posix = anchored._posix_receipt_module()
+        cases = (
+            ("ftruncate", OSError("truncate")),
+            ("lseek", KeyboardInterrupt("seek")),
+            ("write", OSError("write")),
+            ("fsync", SystemExit(23)),
+        )
+        for operation, primary in cases:
+            with self.subTest(operation=operation):
+
+                def effect(name: str, result: object = None) -> object:
+                    if operation == name:
+                        raise primary
+                    return result
+
+                def truncate(_descriptor: int, _size: int) -> object:
+                    return effect("ftruncate")
+
+                def seek(_descriptor: int, _offset: int, _whence: int) -> object:
+                    return effect("lseek")
+
+                def write(_descriptor: int, _payload: bytes) -> object:
+                    return effect("write", len(PAYLOAD))
+
+                def sync(_descriptor: int) -> object:
+                    return effect("fsync")
+
+                with (
+                    mock.patch.object(posix.os, "ftruncate", side_effect=truncate),
+                    mock.patch.object(posix.os, "lseek", side_effect=seek),
+                    mock.patch.object(posix.os, "write", side_effect=write),
+                    mock.patch.object(posix.os, "fsync", side_effect=sync),
+                    self.assertRaises(type(primary)) as raised,
+                ):
+                    posix._write_and_sync_retained_descriptor(7, PAYLOAD)
+                self.assertIs(raised.exception, primary)
+
+    def test_zero_write_progress_fails_boundedly(self) -> None:
+        posix = anchored._posix_receipt_module()
+        with (
+            mock.patch.object(posix.os, "ftruncate"),
+            mock.patch.object(posix.os, "lseek"),
+            mock.patch.object(posix.os, "write", return_value=0) as write,
+            self.assertRaises(OSError),
+        ):
+            posix._write_and_sync_retained_descriptor(7, PAYLOAD)
+        write.assert_called_once()
+
+    def test_retained_descriptor_rejects_identity_link_mode_size_and_content_mutation(self) -> None:
+        posix = anchored._posix_receipt_module()
+        base = {
+            "st_dev": 1,
+            "st_ino": 2,
+            "st_mode": stat.S_IFREG | 0o600,
+            "st_uid": os.geteuid(),
+            "st_nlink": 0,
+            "st_size": len(PAYLOAD),
+            "st_mtime_ns": 3,
+            "st_ctime_ns": 4,
+        }
+        mutations: dict[str, tuple[dict[str, int], bytes]] = {
+            "identity": ({"st_ino": 9}, PAYLOAD),
+            "link": ({"st_nlink": 1}, PAYLOAD),
+            "mode": ({"st_mode": stat.S_IFREG | 0o644}, PAYLOAD),
+            "size": ({"st_size": len(PAYLOAD) + 1}, PAYLOAD),
+            "content": ({}, b"different\n"),
+        }
+        for label, (changes, observed) in mutations.items():
+            with self.subTest(label=label):
+                before = cast(os.stat_result, SimpleNamespace(**base))
+                after = cast(os.stat_result, SimpleNamespace(**{**base, **changes}))
+                with (
+                    mock.patch.object(posix.os, "fstat", side_effect=(before, after)),
+                    mock.patch.object(posix.os, "lseek"),
+                    mock.patch.object(posix.os, "read", side_effect=(observed, b"")),
+                    mock.patch.object(posix, "_darwin_descriptor_has_extended_acl", return_value=False),
+                    self.assertRaises(anchored.AnchoredOutputError) as raised,
+                ):
+                    posix._validate_exact_receipt_descriptor(
+                        7,
+                        PAYLOAD,
+                        (1, 2),
+                        expected_link_count=0,
+                        code="output-temporary-invalid",
+                    )
+                self.assertEqual(raised.exception.code, "output-temporary-invalid")
+
+    def test_unsupported_publication_errnos_map_fail_closed(self) -> None:
+        posix = anchored._posix_receipt_module()
+        for error_number in (errno.EINVAL, errno.ENOSYS, errno.EXDEV):
+            with self.subTest(error_number=error_number), self.assertRaises(anchored.AnchoredOutputError) as raised:
+                posix._raise_posix_publication_error(
+                    error_number,
+                    "receipt.json",
+                    operation="linking",
+                    additional_unavailable=frozenset({errno.EXDEV}),
+                )
+            self.assertEqual(raised.exception.code, "output-anchor-unavailable")
+
+    def setUp(self) -> None:
+        if os.name == "nt" or sys.platform not in {"darwin", "linux"}:
+            self.skipTest("descriptor-bound POSIX receipt primitive unavailable")
+
+    def _in_checkout(self) -> tuple[tempfile.TemporaryDirectory[str], Path, Path]:
+        temporary = tempfile.TemporaryDirectory()
+        root = Path(temporary.name).resolve()
+        parent = root / "parent"
+        parent.mkdir()
+        return temporary, root, parent
+
+    def test_relocation_inside_native_publication_cannot_redirect_output(self) -> None:
+        temporary, root, parent = self._in_checkout()
+        previous = Path.cwd()
+        os.chdir(root)
+        relocated = root / "relocated"
+        try:
+            output = parent / "receipt.json"
+            hook_name = (
+                "_darwin_rename_receipt_stage" if sys.platform == "darwin" else "_linux_link_receipt_descriptor"
+            )
+            posix = anchored._posix_receipt_module()
+            real_hook = getattr(posix, hook_name)
+
+            def relocate_then_publish(*args: object, **kwargs: object) -> None:
+                parent.rename(relocated)
+                parent.mkdir()
+                real_hook(*args, **kwargs)
+
+            with (
+                mock.patch.object(posix, hook_name, side_effect=relocate_then_publish),
+                self.assertRaises(anchored.AnchoredOutputError) as raised,
+            ):
+                anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+            self.assertEqual(raised.exception.code, "output-parent-changed")
+            self.assertFalse(output.exists())
+            self.assertEqual((relocated / output.name).read_bytes(), PAYLOAD)
+        finally:
+            os.chdir(previous)
+            temporary.cleanup()
+
+    def test_native_target_swap_between_stat_and_open_fails_untouched(self) -> None:
+        temporary, root, parent = self._in_checkout()
+        previous = Path.cwd()
+        os.chdir(root)
+        output = parent / "receipt.json"
+        displaced = parent / "displaced"
+        output.write_bytes(PAYLOAD)
+        output.chmod(0o600)
+        real_descriptor_open = anchored._open_posix_descriptor
+        real_os_open = anchored.os.open
+        swapped = False
+        snapshots: dict[str, tuple[tuple[int, ...], bytes]] = {}
+
+        def swap_then_open(
+            descriptor_lease: anchored._PosixDescriptorLease,
+            name: os.PathLike[str] | str,
+            flags: int,
+            mode: int = 0o777,
+            *,
+            dir_fd: int | None = None,
+        ) -> int:
+            nonlocal swapped
+            if name == "receipt.json" and dir_fd is not None and not swapped:
+                swapped = True
+                os.rename(name, "displaced", src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+                attacker = real_os_open(
+                    name,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    0o600,
+                    dir_fd=dir_fd,
+                )
+                try:
+                    self.assertEqual(os.write(attacker, PAYLOAD), len(PAYLOAD))
+                finally:
+                    os.close(attacker)
+                snapshots["displaced"] = _entry_snapshot(displaced)
+                snapshots["public"] = _entry_snapshot(output)
+            return real_descriptor_open(
+                descriptor_lease,
+                name,
+                flags,
+                mode,
+                dir_fd=dir_fd,
+            )
+
+        try:
+            with (
+                mock.patch.object(anchored, "descriptor_relative_output_supported", return_value=True),
+                mock.patch.object(anchored, "_open_posix_descriptor", side_effect=swap_then_open),
+                self.assertRaises(anchored.AnchoredOutputError) as raised,
+            ):
+                anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+            self.assertEqual(raised.exception.code, "output-changed")
+            self.assertTrue(swapped)
+            self.assertEqual(_entry_snapshot(displaced), snapshots["displaced"])
+            self.assertEqual(_entry_snapshot(output), snapshots["public"])
+        finally:
+            os.chdir(previous)
+            temporary.cleanup()
+
+    def test_native_target_swap_after_read_fails_untouched(self) -> None:
+        temporary, root, parent = self._in_checkout()
+        previous = Path.cwd()
+        os.chdir(root)
+        output = parent / "receipt.json"
+        displaced = parent / "displaced"
+        output.write_bytes(PAYLOAD)
+        output.chmod(0o600)
+        real_open = anchored.os.open
+        real_read = anchored.os.read
+        swapped = False
+        snapshots: dict[str, tuple[tuple[int, ...], bytes]] = {}
+
+        def read_then_swap(descriptor: int, size: int) -> bytes:
+            nonlocal swapped
+            observed = real_read(descriptor, size)
+            if observed and not swapped:
+                swapped = True
+                output.rename(displaced)
+                attacker = real_open(
+                    output,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    0o600,
+                )
+                try:
+                    self.assertEqual(os.write(attacker, PAYLOAD), len(PAYLOAD))
+                finally:
+                    os.close(attacker)
+                snapshots["displaced"] = _entry_snapshot(displaced)
+                snapshots["public"] = _entry_snapshot(output)
+            return observed
+
+        try:
+            with (
+                mock.patch.object(anchored.os, "read", side_effect=read_then_swap),
+                self.assertRaises(anchored.AnchoredOutputError) as raised,
+            ):
+                anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+            self.assertEqual(raised.exception.code, "output-changed")
+            self.assertTrue(swapped)
+            self.assertEqual(_entry_snapshot(displaced), snapshots["displaced"])
+            self.assertEqual(_entry_snapshot(output), snapshots["public"])
+        finally:
+            os.chdir(previous)
+            temporary.cleanup()
+
+    def test_directory_sync_failure_keeps_exact_public_receipt_and_closes(self) -> None:
+        temporary, root, parent = self._in_checkout()
+        previous = Path.cwd()
+        os.chdir(root)
+        output = parent / "receipt.json"
+        real_sync = anchored.OutputParentBinding.sync
+        real_open = anchored._open_posix_descriptor
+        real_close = anchored._PosixDescriptorLease.close
+        posix = anchored._posix_receipt_module()
+        opened: list[int] = []
+        closed: list[int] = []
+        live: list[int] = []
+        live_at_failure: list[int] = []
+
+        def sync_then_fail(binding: anchored.OutputParentBinding) -> None:
+            real_sync(binding)
+            if not live_at_failure:
+                live_at_failure.extend(live)
+            raise OSError(errno.EIO, "injected directory sync failure")
+
+        def record_open(
+            descriptor_lease: anchored._PosixDescriptorLease,
+            name: os.PathLike[str] | str,
+            flags: int,
+            mode: int = 0o777,
+            *,
+            dir_fd: int | None = None,
+        ) -> int:
+            descriptor = real_open(
+                descriptor_lease,
+                name,
+                flags,
+                mode,
+                dir_fd=dir_fd,
+            )
+            opened.append(descriptor)
+            live.append(descriptor)
+            return descriptor
+
+        def record_close(descriptor_lease: anchored._PosixDescriptorLease) -> None:
+            descriptor = descriptor_lease.descriptor
+            if descriptor is None:
+                return real_close(descriptor_lease)
+            self.assertIn(descriptor, live)
+            closed.append(descriptor)
+            live.remove(descriptor)
+            real_close(descriptor_lease)
+
+        try:
+            with (
+                mock.patch.object(anchored.OutputParentBinding, "sync", sync_then_fail),
+                mock.patch.object(anchored, "descriptor_relative_output_supported", return_value=True),
+                mock.patch.object(anchored, "_open_posix_descriptor", side_effect=record_open),
+                mock.patch.object(posix, "_open_posix_descriptor", side_effect=record_open),
+                mock.patch.object(anchored._PosixDescriptorLease, "close", new=record_close),
+                self.assertRaises(OSError),
+            ):
+                anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+            self.assertEqual(output.read_bytes(), PAYLOAD)
+            self.assertEqual(live, [])
+            self.assertTrue(live_at_failure)
+            self.assertCountEqual(closed, opened)
+            self.assertEqual(closed[-len(live_at_failure) :], list(reversed(live_at_failure)))
+        finally:
+            os.chdir(previous)
+            temporary.cleanup()
+
+    def test_exact_existing_retry_repeats_public_file_and_parent_durability(self) -> None:
+        temporary, root, parent = self._in_checkout()
+        previous = Path.cwd()
+        os.chdir(root)
+        output = parent / "receipt.json"
+        try:
+            anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+            posix = anchored._posix_receipt_module()
+            real_public_sync = posix._sync_posix_public_descriptor
+            real_parent_sync = anchored.OutputParentBinding.sync
+            public_sync_calls = 0
+            parent_sync_calls = 0
+
+            def fail_public_sync_once(
+                binding: anchored.OutputParentBinding,
+                payload: bytes,
+                identity: tuple[int, int],
+                descriptor_lease: anchored._PosixDescriptorLease,
+            ) -> None:
+                nonlocal public_sync_calls
+                public_sync_calls += 1
+                if public_sync_calls == 1:
+                    raise OSError(errno.EIO, "public receipt sync")
+                real_public_sync(binding, payload, identity, descriptor_lease)
+
+            def record_parent_sync(binding: anchored.OutputParentBinding) -> None:
+                nonlocal parent_sync_calls
+                parent_sync_calls += 1
+                real_parent_sync(binding)
+
+            with (
+                mock.patch.object(posix, "_sync_posix_public_descriptor", side_effect=fail_public_sync_once),
+                mock.patch.object(anchored.OutputParentBinding, "sync", new=record_parent_sync),
+                self.assertRaises(OSError),
+            ):
+                anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+            with (
+                mock.patch.object(posix, "_sync_posix_public_descriptor", side_effect=fail_public_sync_once),
+                mock.patch.object(anchored.OutputParentBinding, "sync", new=record_parent_sync),
+            ):
+                anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+
+            self.assertEqual(public_sync_calls, 2)
+            self.assertEqual(parent_sync_calls, 1)
+            self.assertEqual(output.read_bytes(), PAYLOAD)
+        finally:
+            os.chdir(previous)
+            temporary.cleanup()
+
+    def test_writer_control_flow_failure_preserves_primary_and_notes_close_failure(self) -> None:
+        temporary, root, parent = self._in_checkout()
+        previous = Path.cwd()
+        os.chdir(root)
+        output = parent / "receipt.json"
+        primary = KeyboardInterrupt("injected writer interrupt")
+        real_close = anchored._PosixDescriptorLease.close
+        posix = anchored._posix_receipt_module()
+        close_failure_injected = False
+
+        def close_then_fail(descriptor_lease: anchored._PosixDescriptorLease) -> None:
+            nonlocal close_failure_injected
+            owned_descriptor = descriptor_lease.descriptor
+            real_close(descriptor_lease)
+            if owned_descriptor is not None and not close_failure_injected:
+                close_failure_injected = True
+                raise OSError("injected close failure")
+
+        try:
+            with (
+                mock.patch.object(posix, "_write_and_sync_retained_descriptor", side_effect=primary),
+                mock.patch.object(anchored._PosixDescriptorLease, "close", new=close_then_fail),
+                self.assertRaises(KeyboardInterrupt) as raised,
+            ):
+                anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+            self.assertIs(raised.exception, primary)
+            self.assertIn("injected close failure", "\n".join(getattr(primary, "__notes__", ())))
+            self.assertFalse(output.exists())
+        finally:
+            os.chdir(previous)
+            temporary.cleanup()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_anchored_receipt_posix_failclosed.py
+++ b/tests/test_anchored_receipt_posix_failclosed.py
@@ -1,0 +1,285 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+import ctypes
+import errno
+import os
+from pathlib import Path
+from types import SimpleNamespace
+import tempfile
+from typing import Any
+import unittest
+from unittest import mock
+
+from scripts import _anchored_output as anchored
+
+
+PAYLOAD = b'{"status":"verified"}\n'
+
+
+def _entry_snapshot(path: Path) -> tuple[tuple[int, ...], bytes]:
+    value = path.lstat()
+    return (
+        (
+            value.st_dev,
+            value.st_ino,
+            value.st_mode,
+            value.st_nlink,
+            value.st_size,
+            value.st_mtime_ns,
+            value.st_ctime_ns,
+        ),
+        path.read_bytes(),
+    )
+
+
+class AnchoredReceiptPosixFailClosedTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if os.name == "nt" or not anchored.descriptor_relative_output_supported():
+            self.skipTest("descriptor-bound POSIX receipt primitive unavailable")
+        self.posix = anchored._posix_receipt_module()
+
+    def _record_anchored_opens(self, opened: list[int]):
+        real_open = anchored._open_posix_descriptor
+
+        def record_open(
+            lease: anchored._PosixDescriptorLease,
+            path: os.PathLike[str] | str,
+            flags: int,
+            mode: int = 0o777,
+            *,
+            dir_fd: int | None = None,
+        ) -> int:
+            descriptor = real_open(lease, path, flags, mode, dir_fd=dir_fd)
+            opened.append(descriptor)
+            return descriptor
+
+        return mock.patch.object(
+            anchored,
+            "_open_posix_descriptor",
+            side_effect=record_open,
+        )
+
+    def _assert_closed(self, descriptors: list[int]) -> None:
+        self.assertTrue(descriptors)
+        self.assertEqual(len(descriptors), len(set(descriptors)))
+        for descriptor in descriptors:
+            with self.subTest(descriptor=descriptor), self.assertRaises(OSError) as raised:
+                os.fstat(descriptor)
+            self.assertEqual(raised.exception.errno, errno.EBADF)
+
+    def _assert_absent_target_and_unchanged_sentinel(
+        self,
+        output: Path,
+        sentinel: Path,
+        sentinel_before: tuple[tuple[int, ...], bytes],
+    ) -> None:
+        self.assertFalse(output.exists())
+        self.assertEqual(_entry_snapshot(sentinel), sentinel_before)
+        self.assertEqual({entry.name for entry in output.parent.iterdir()}, {sentinel.name})
+
+    def _anonymous_stage(self, parent: Path) -> int:
+        descriptor, name = tempfile.mkstemp(prefix=".receipt-stage-", dir=parent)
+        os.fchmod(descriptor, 0o600)
+        os.unlink(name)
+        return descriptor
+
+    def _retained_stage_opener(
+        self,
+        descriptor: int,
+        *,
+        private_descriptor: int = -1,
+        private_name: str = "",
+        stage_name: str = "",
+    ):
+        def open_stage(
+            _binding: object,
+            _temporary_name: str,
+            lease: Any,
+        ) -> object:
+            lease.descriptor.descriptor_result = ctypes.c_int(descriptor)
+            if private_descriptor >= 0:
+                lease.private_directory.descriptor_result = ctypes.c_int(private_descriptor)
+                lease.named_stage_name = stage_name
+            stage = self.posix._PosixReceiptStage(
+                descriptor=descriptor,
+                private_directory_descriptor=private_descriptor,
+                private_directory_name=private_name,
+                private_directory_identity=(
+                    (os.fstat(private_descriptor).st_dev, os.fstat(private_descriptor).st_ino)
+                    if private_descriptor >= 0
+                    else None
+                ),
+                named_stage_name=stage_name,
+            )
+            lease.stage = stage
+            return stage
+
+        return open_stage
+
+    def test_linux_tmpfile_unavailable_and_unsupported_full_facade_fail_closed(self) -> None:
+        cases = (
+            ("flag unavailable", 0, None),
+            ("filesystem unsupported", 1 << 29, getattr(errno, "EOPNOTSUPP", errno.EINVAL)),
+            ("kernel unsupported", 1 << 29, errno.ENOENT),
+        )
+        for label, temporary_flag, stage_errno in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as temporary:
+                parent = Path(temporary).resolve() / "output"
+                parent.mkdir()
+                output = parent / "receipt.json"
+                sentinel = parent / "sentinel.bin"
+                sentinel.write_bytes(b"untouched\n")
+                sentinel_before = _entry_snapshot(sentinel)
+                opened: list[int] = []
+
+                def reject_stage_open(
+                    _lease: anchored._PosixDescriptorLease,
+                    _path: os.PathLike[str] | str,
+                    _flags: int,
+                    _mode: int = 0o777,
+                    *,
+                    dir_fd: int | None = None,
+                ) -> int:
+                    self.assertIsNotNone(dir_fd)
+                    assert stage_errno is not None
+                    raise OSError(stage_errno, os.strerror(stage_errno))
+
+                stage_open = mock.Mock(side_effect=reject_stage_open)
+                with (
+                    mock.patch.object(self.posix, "sys", SimpleNamespace(platform="linux")),
+                    mock.patch.object(self.posix.os, "O_TMPFILE", temporary_flag, create=True),
+                    self._record_anchored_opens(opened),
+                    mock.patch.object(
+                        self.posix,
+                        "_open_posix_descriptor",
+                        stage_open,
+                    ),
+                    self.assertRaises(anchored.AnchoredOutputError) as raised,
+                ):
+                    anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+
+                self.assertEqual(raised.exception.code, "output-anchor-unavailable")
+                self._assert_absent_target_and_unchanged_sentinel(
+                    output,
+                    sentinel,
+                    sentinel_before,
+                )
+                self._assert_closed(opened)
+                self.assertEqual(stage_open.call_count, 0 if stage_errno is None else 1)
+
+    def test_native_link_and_rename_unavailable_full_facade_fail_closed(self) -> None:
+        for platform in ("linux", "darwin"):
+            with self.subTest(platform=platform), tempfile.TemporaryDirectory() as temporary:
+                parent = Path(temporary).resolve() / "output"
+                parent.mkdir()
+                output = parent / "receipt.json"
+                sentinel = parent / "sentinel.bin"
+                sentinel.write_bytes(b"untouched\n")
+                private_root = parent / ".modeled-private-root"
+                private_descriptor = -1
+                stage_name = "stage.tmp"
+                if platform == "darwin":
+                    private_root.mkdir(mode=0o700)
+                    private_descriptor = os.open(private_root, os.O_RDONLY | os.O_DIRECTORY)
+                    stage_descriptor = os.open(
+                        stage_name,
+                        os.O_RDWR | os.O_CREAT | os.O_EXCL,
+                        0o600,
+                        dir_fd=private_descriptor,
+                    )
+                else:
+                    stage_descriptor = self._anonymous_stage(parent)
+                sentinel_before = _entry_snapshot(sentinel)
+                opened = [stage_descriptor]
+                if private_descriptor >= 0:
+                    opened.append(private_descriptor)
+                native_libc = anchored._posix_libc()
+                try:
+                    with (
+                        mock.patch.object(self.posix, "sys", SimpleNamespace(platform=platform)),
+                        self._record_anchored_opens(opened),
+                        mock.patch.object(
+                            self.posix,
+                            "_open_posix_receipt_stage",
+                            side_effect=self._retained_stage_opener(
+                                stage_descriptor,
+                                private_descriptor=private_descriptor,
+                                private_name=private_root.name if private_descriptor >= 0 else "",
+                                stage_name=stage_name if private_descriptor >= 0 else "",
+                            ),
+                        ),
+                        mock.patch.object(anchored, "_posix_libc", return_value=native_libc),
+                        mock.patch.object(
+                            self.posix.ctypes,
+                            "CDLL",
+                            return_value=SimpleNamespace(),
+                        ),
+                        self.assertRaises(anchored.AnchoredOutputError) as raised,
+                    ):
+                        anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+
+                    self.assertEqual(raised.exception.code, "output-anchor-unavailable")
+                    if private_root.exists():
+                        private_root.rmdir()
+                    self._assert_absent_target_and_unchanged_sentinel(
+                        output,
+                        sentinel,
+                        sentinel_before,
+                    )
+                    self._assert_closed(opened)
+                finally:
+                    try:
+                        os.close(stage_descriptor)
+                    except OSError:
+                        pass
+
+    def test_pre_publication_primary_is_preserved_and_all_resources_close(self) -> None:
+        primaries: tuple[BaseException, ...] = (
+            OSError(errno.EIO, "injected native publication failure"),
+            KeyboardInterrupt("injected native publication interrupt"),
+        )
+        for primary in primaries:
+            with self.subTest(primary=type(primary).__name__), tempfile.TemporaryDirectory() as temporary:
+                parent = Path(temporary).resolve() / "output"
+                parent.mkdir()
+                output = parent / "receipt.json"
+                sentinel = parent / "sentinel.bin"
+                sentinel.write_bytes(b"untouched\n")
+                stage_descriptor = self._anonymous_stage(parent)
+                sentinel_before = _entry_snapshot(sentinel)
+                opened = [stage_descriptor]
+                try:
+                    with (
+                        mock.patch.object(self.posix, "sys", SimpleNamespace(platform="linux")),
+                        self._record_anchored_opens(opened),
+                        mock.patch.object(
+                            self.posix,
+                            "_open_posix_receipt_stage",
+                            side_effect=self._retained_stage_opener(stage_descriptor),
+                        ),
+                        mock.patch.object(
+                            self.posix,
+                            "_publish_posix_receipt_descriptor",
+                            side_effect=primary,
+                        ),
+                        self.assertRaises(type(primary)) as raised,
+                    ):
+                        anchored.publish_identical_receipt_bytes(output, PAYLOAD)
+
+                    self.assertIs(raised.exception, primary)
+                    self._assert_absent_target_and_unchanged_sentinel(
+                        output,
+                        sentinel,
+                        sentinel_before,
+                    )
+                    self._assert_closed(opened)
+                finally:
+                    try:
+                        os.close(stage_descriptor)
+                    except OSError:
+                        pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_anchored_receipt_posix_failures.py
+++ b/tests/test_anchored_receipt_posix_failures.py
@@ -1,0 +1,1096 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+import ctypes
+import errno
+import os
+from pathlib import Path
+import stat
+from types import SimpleNamespace
+import tempfile
+from typing import Any, cast
+import unittest
+from unittest import mock
+
+from scripts import _anchored_output as anchored
+
+
+PAYLOAD = b'{"status":"verified"}\n'
+
+
+def _metadata(**changes: int) -> os.stat_result:
+    values = {
+        "st_dev": 11,
+        "st_ino": 22,
+        "st_mode": 0o100600,
+        "st_uid": os.geteuid(),
+        "st_nlink": 0,
+        "st_size": len(PAYLOAD),
+        "st_mtime_ns": 33,
+        "st_ctime_ns": 44,
+    }
+    values.update(changes)
+    return cast(os.stat_result, SimpleNamespace(**values))
+
+
+class _NativeCall:
+    argtypes: object = None
+    restype: object = None
+
+    def __init__(self, result: int) -> None:
+        self.result = result
+        self.calls: list[tuple[object, ...]] = []
+
+    def __call__(self, *arguments: object) -> int:
+        self.calls.append(arguments)
+        result_type = self.restype
+        checker = getattr(result_type, "_check_retval_", None)
+        if callable(result_type) and callable(checker):
+            checker(result_type(self.result))
+        return self.result
+
+
+def _retain_descriptor(descriptor: int):
+    def open_read(_name: str, lease: anchored._PosixDescriptorLease) -> int:
+        lease.descriptor_result = ctypes.c_int(descriptor)
+        return descriptor
+
+    return open_read
+
+
+def _retain_stage(posix: Any, descriptor: int):
+    stage = posix._PosixReceiptStage(descriptor=descriptor)
+
+    def open_stage(
+        _binding: object,
+        _temporary_name: str,
+        lease: Any,
+    ) -> object:
+        lease.descriptor.descriptor_result = ctypes.c_int(descriptor)
+        lease.stage = stage
+        return stage
+
+    return stage, open_stage
+
+
+class AnchoredReceiptPosixFailureTests(unittest.TestCase):
+    def setUp(self) -> None:
+        if os.name == "nt":
+            self.skipTest("POSIX receipt failure model")
+        self.posix = anchored._posix_receipt_module()
+        acl_patch = mock.patch.object(
+            self.posix,
+            "_darwin_descriptor_has_extended_acl",
+            return_value=False,
+        )
+        acl_patch.start()
+        self.addCleanup(acl_patch.stop)
+        reader_acl_patch = mock.patch.object(
+            anchored,
+            "_darwin_descriptor_has_extended_acl",
+            return_value=False,
+        )
+        reader_acl_patch.start()
+        self.addCleanup(reader_acl_patch.stop)
+
+    def test_canonical_receipt_requires_effective_user_ownership(self) -> None:
+        wrong_owner = _metadata(st_uid=os.geteuid() + 1)
+        with (
+            mock.patch.object(self.posix.os, "fstat", return_value=wrong_owner),
+            self.assertRaises(anchored.AnchoredOutputError) as raised,
+        ):
+            self.posix._validate_exact_receipt_descriptor(
+                7,
+                PAYLOAD,
+                (wrong_owner.st_dev, wrong_owner.st_ino),
+                expected_link_count=0,
+                code="output-temporary-invalid",
+            )
+        self.assertEqual(raised.exception.code, "output-temporary-invalid")
+
+        binding = SimpleNamespace(
+            parent=Path("."),
+            stat=mock.Mock(return_value=_metadata(st_nlink=1, st_uid=os.geteuid() + 1)),
+        )
+        with self.assertRaises(anchored.AnchoredOutputError) as public_raised:
+            anchored._read_exact_receipt(
+                cast(anchored.OutputParentBinding, binding),
+                "receipt.json",
+                PAYLOAD,
+                descriptor_lease=anchored._PosixDescriptorLease(),
+            )
+        self.assertEqual(public_raised.exception.code, "output-existing-invalid")
+
+    def test_retained_validation_rejects_bounded_read_and_metadata_drift(self) -> None:
+        cases = (
+            ("early EOF", (PAYLOAD[:-1], b""), _metadata(), _metadata()),
+            ("extra byte", (PAYLOAD + b"x",), _metadata(), _metadata()),
+            ("mismatch", (b"different\n", b""), _metadata(), _metadata()),
+            ("identity drift", (PAYLOAD, b""), _metadata(), _metadata(st_ino=23)),
+            ("metadata drift", (PAYLOAD, b""), _metadata(), _metadata(st_mtime_ns=34)),
+            ("ownership drift", (PAYLOAD, b""), _metadata(), _metadata(st_uid=os.geteuid() + 1)),
+        )
+        for label, reads, before, after in cases:
+            with self.subTest(label=label):
+                with (
+                    mock.patch.object(self.posix.os, "fstat", side_effect=(before, after)),
+                    mock.patch.object(self.posix.os, "lseek"),
+                    mock.patch.object(self.posix.os, "read", side_effect=reads) as read,
+                    self.assertRaises(anchored.AnchoredOutputError) as raised,
+                ):
+                    self.posix._validate_exact_receipt_descriptor(
+                        7,
+                        PAYLOAD,
+                        (11, 22),
+                        expected_link_count=0,
+                        code="output-temporary-invalid",
+                    )
+                self.assertEqual(raised.exception.code, "output-temporary-invalid")
+                self.assertLessEqual(read.call_count, 2)
+
+    def test_public_validation_rejects_bounded_read_and_namespace_drift(self) -> None:
+        stable = _metadata(st_nlink=1)
+        cases = (
+            ("early EOF", (PAYLOAD[:-1], b""), stable, stable, stable, "output-different"),
+            ("extra byte", (PAYLOAD + b"x",), stable, stable, stable, "output-different"),
+            ("mismatch", (b"different\n", b""), stable, stable, stable, "output-different"),
+            (
+                "descriptor drift",
+                (PAYLOAD, b""),
+                stable,
+                _metadata(st_nlink=1, st_ino=23),
+                stable,
+                "output-changed",
+            ),
+            (
+                "namespace drift",
+                (PAYLOAD, b""),
+                stable,
+                stable,
+                _metadata(st_nlink=1, st_ino=23),
+                "output-changed",
+            ),
+        )
+        for label, reads, before, opened_after, after, expected_code in cases:
+            with self.subTest(label=label):
+                close_operation = _NativeCall(0)
+                binding = SimpleNamespace(
+                    parent=Path("parent"),
+                    stat=mock.Mock(side_effect=(before, after)),
+                    open_read=mock.Mock(side_effect=_retain_descriptor(71)),
+                    verify=mock.Mock(),
+                )
+                with (
+                    mock.patch.object(anchored.os, "fstat", side_effect=(before, opened_after)),
+                    mock.patch.object(anchored.os, "read", side_effect=reads) as read,
+                    mock.patch.object(
+                        anchored,
+                        "_posix_libc",
+                        return_value={"close": close_operation},
+                    ),
+                    self.assertRaises(anchored.AnchoredOutputError) as raised,
+                ):
+                    anchored._read_exact_receipt(
+                        cast(Any, binding),
+                        "receipt.json",
+                        PAYLOAD,
+                        descriptor_lease=anchored._PosixDescriptorLease(),
+                    )
+                self.assertEqual(raised.exception.code, expected_code)
+                self.assertLessEqual(read.call_count, 2)
+                self.assertEqual(close_operation.calls, [(71,)])
+
+    def test_namespace_shaped_reader_failures_have_stable_changed_code(self) -> None:
+        stable = _metadata(st_nlink=1)
+        for label, primary in (
+            ("missing", FileNotFoundError(errno.ENOENT, "missing")),
+            ("symlink race", OSError(errno.ELOOP, "symlink loop")),
+        ):
+            with self.subTest(label=label):
+                primary.add_note("native namespace note")
+                binding = SimpleNamespace(
+                    parent=Path("parent"),
+                    stat=mock.Mock(return_value=stable),
+                    open_read=mock.Mock(side_effect=primary),
+                )
+                with self.assertRaises(anchored.AnchoredOutputError) as raised:
+                    anchored._read_exact_receipt(
+                        cast(Any, binding),
+                        "receipt.json",
+                        PAYLOAD,
+                        descriptor_lease=anchored._PosixDescriptorLease(),
+                    )
+                self.assertEqual(raised.exception.code, "output-changed")
+                self.assertIs(raised.exception.__cause__, primary)
+                self.assertIn("native namespace note", getattr(raised.exception, "__notes__", ()))
+
+        generic = OSError(errno.EIO, "read open")
+        binding = SimpleNamespace(
+            parent=Path("parent"),
+            stat=mock.Mock(return_value=stable),
+            open_read=mock.Mock(side_effect=generic),
+        )
+        with self.assertRaises(OSError) as raised:
+            anchored._read_exact_receipt(
+                cast(Any, binding),
+                "receipt.json",
+                PAYLOAD,
+                descriptor_lease=anchored._PosixDescriptorLease(),
+            )
+        self.assertIs(raised.exception, generic)
+
+    def test_final_namespace_and_contract_drift_remap_to_output_changed(self) -> None:
+        stable = _metadata(st_nlink=1)
+        close_operation = _NativeCall(0)
+        missing = FileNotFoundError(errno.ENOENT, "missing after read")
+        binding = SimpleNamespace(
+            parent=Path("parent"),
+            stat=mock.Mock(side_effect=(stable, missing)),
+            open_read=mock.Mock(side_effect=_retain_descriptor(71)),
+            verify=mock.Mock(),
+        )
+        with (
+            mock.patch.object(anchored.os, "fstat", side_effect=(stable, stable)),
+            mock.patch.object(anchored.os, "read", side_effect=(PAYLOAD, b"")),
+            mock.patch.object(anchored, "_posix_libc", return_value={"close": close_operation}),
+            self.assertRaises(anchored.AnchoredOutputError) as raised,
+        ):
+            anchored._read_exact_receipt(
+                cast(Any, binding),
+                "receipt.json",
+                PAYLOAD,
+                descriptor_lease=anchored._PosixDescriptorLease(),
+                expected_identity=(11, 22),
+            )
+        self.assertEqual(raised.exception.code, "output-changed")
+        self.assertIs(raised.exception.__cause__, missing)
+        self.assertEqual(close_operation.calls, [(71,)])
+
+        invalid = _metadata(st_nlink=1, st_mode=stat.S_IFREG | 0o644)
+        invalid_binding = SimpleNamespace(parent=Path("parent"), stat=mock.Mock(return_value=invalid))
+        with self.assertRaises(anchored.AnchoredOutputError) as invalid_raised:
+            anchored._read_exact_receipt(
+                cast(Any, invalid_binding),
+                "receipt.json",
+                PAYLOAD,
+                descriptor_lease=anchored._PosixDescriptorLease(),
+                expected_identity=(11, 22),
+            )
+        self.assertEqual(invalid_raised.exception.code, "output-changed")
+
+        different_close = _NativeCall(0)
+        different_binding = SimpleNamespace(
+            parent=Path("parent"),
+            stat=mock.Mock(side_effect=(stable, stable)),
+            open_read=mock.Mock(side_effect=_retain_descriptor(72)),
+            verify=mock.Mock(),
+        )
+        with (
+            mock.patch.object(anchored.os, "fstat", side_effect=(stable, stable)),
+            mock.patch.object(anchored.os, "read", side_effect=(b"different\n", b"")),
+            mock.patch.object(anchored, "_posix_libc", return_value={"close": different_close}),
+            self.assertRaises(anchored.AnchoredOutputError) as different_raised,
+        ):
+            anchored._read_exact_receipt(
+                cast(Any, different_binding),
+                "receipt.json",
+                PAYLOAD,
+                descriptor_lease=anchored._PosixDescriptorLease(),
+                expected_identity=(11, 22),
+            )
+        self.assertEqual(different_raised.exception.code, "output-changed")
+        self.assertEqual(different_close.calls, [(72,)])
+
+    def test_darwin_public_open_namespace_failure_has_stable_changed_code(self) -> None:
+        primary = OSError(errno.ELOOP, "public name became a symlink")
+        primary.add_note("public open note")
+        binding = SimpleNamespace(
+            parent=Path("parent"),
+            leaf="receipt.json",
+            open_read=mock.Mock(side_effect=primary),
+        )
+        with self.assertRaises(anchored.AnchoredOutputError) as raised:
+            self.posix._sync_posix_public_descriptor(
+                binding,
+                PAYLOAD,
+                (11, 22),
+                anchored._PosixDescriptorLease(),
+            )
+        self.assertEqual(raised.exception.code, "output-changed")
+        self.assertIs(raised.exception.__cause__, primary)
+        self.assertIn("public open note", getattr(raised.exception, "__notes__", ()))
+
+    def test_darwin_public_descriptor_validation_uses_changed_code(self) -> None:
+        binding = SimpleNamespace(
+            parent=Path("parent"),
+            leaf="receipt.json",
+            open_read=mock.Mock(side_effect=_retain_descriptor(71)),
+        )
+        close_operation = _NativeCall(0)
+        with (
+            mock.patch.object(self.posix, "_validate_exact_receipt_descriptor") as validate,
+            mock.patch.object(self.posix.os, "fsync"),
+            mock.patch.object(anchored, "_posix_libc", return_value={"close": close_operation}),
+        ):
+            self.posix._sync_posix_public_descriptor(
+                binding,
+                PAYLOAD,
+                (11, 22),
+                anchored._PosixDescriptorLease(),
+            )
+        validate.assert_called_once_with(
+            71,
+            PAYLOAD,
+            (11, 22),
+            expected_link_count=1,
+            code="output-changed",
+        )
+        self.assertEqual(close_operation.calls, [(71,)])
+
+    def test_native_publication_classifies_collision_unavailable_and_io_error(self) -> None:
+        cases = (
+            ("linux", errno.EEXIST, FileExistsError),
+            ("linux", errno.EXDEV, anchored.AnchoredOutputError),
+            ("darwin", errno.EINVAL, anchored.AnchoredOutputError),
+            ("darwin", errno.EIO, OSError),
+        )
+        for platform, error_number, expected in cases:
+            with self.subTest(platform=platform, error_number=error_number):
+                operation = _NativeCall(-1)
+                library = SimpleNamespace(linkat=operation, renameatx_np=operation)
+                stage_lease = self.posix._PosixReceiptStageLease(
+                    anchored._PosixDescriptorLease(),
+                    anchored._PosixDescriptorLease(),
+                    named_stage_name="stage.tmp",
+                )
+                stage = self.posix._PosixReceiptStage(
+                    descriptor=7,
+                    private_directory_descriptor=6,
+                    named_stage_name="stage.tmp",
+                )
+                with (
+                    mock.patch.object(self.posix.ctypes, "CDLL", return_value=library),
+                    mock.patch.object(self.posix.ctypes, "get_errno", return_value=error_number),
+                    mock.patch.object(self.posix.os, "stat", return_value=_metadata(st_nlink=1)),
+                    mock.patch.object(self.posix.os, "fstat", return_value=_metadata(st_nlink=1)),
+                    self.assertRaises(expected),
+                ):
+                    if platform == "linux":
+                        self.posix._linux_link_receipt_descriptor(7, 8, "receipt.json")
+                    else:
+                        self.posix._darwin_rename_receipt_stage(
+                            stage,
+                            stage_lease,
+                            8,
+                            "receipt.json",
+                        )
+                self.assertEqual(len(operation.calls), 1)
+
+    def test_public_descriptor_failures_close_once_and_preserve_primary(self) -> None:
+        cases = (
+            ("open", OSError("open")),
+            ("validate", KeyboardInterrupt("read")),
+            ("fsync", SystemExit(19)),
+        )
+        for boundary, primary in cases:
+            with self.subTest(boundary=boundary):
+                close_operation = _NativeCall(0)
+                binding = SimpleNamespace(
+                    leaf="receipt.json",
+                    open_read=mock.Mock(side_effect=_retain_descriptor(71)),
+                )
+                if boundary == "open":
+                    binding.open_read.side_effect = primary
+                with (
+                    mock.patch.object(
+                        self.posix,
+                        "_validate_exact_receipt_descriptor",
+                        side_effect=primary if boundary == "validate" else None,
+                    ),
+                    mock.patch.object(
+                        self.posix.os,
+                        "fsync",
+                        side_effect=primary if boundary == "fsync" else None,
+                    ),
+                    mock.patch.object(
+                        anchored,
+                        "_posix_libc",
+                        return_value={"close": close_operation},
+                    ),
+                    self.assertRaises(type(primary)) as raised,
+                ):
+                    self.posix._sync_posix_public_descriptor(
+                        binding,
+                        PAYLOAD,
+                        (11, 22),
+                        anchored._PosixDescriptorLease(),
+                    )
+                self.assertIs(raised.exception, primary)
+                self.assertEqual(len(close_operation.calls), 0 if boundary == "open" else 1)
+
+    def test_public_descriptor_primary_gets_close_failure_note(self) -> None:
+        primary = KeyboardInterrupt("read")
+        close_operation = _NativeCall(-1)
+        binding = SimpleNamespace(
+            leaf="receipt.json",
+            open_read=mock.Mock(side_effect=_retain_descriptor(71)),
+        )
+        with (
+            mock.patch.object(self.posix, "_validate_exact_receipt_descriptor", side_effect=primary),
+            mock.patch.object(
+                anchored,
+                "_posix_libc",
+                return_value={"close": close_operation},
+            ),
+            mock.patch.object(anchored.ctypes, "get_errno", return_value=29),
+            self.assertRaises(KeyboardInterrupt) as raised,
+        ):
+            self.posix._sync_posix_public_descriptor(
+                binding,
+                PAYLOAD,
+                (11, 22),
+                anchored._PosixDescriptorLease(),
+            )
+        self.assertIs(raised.exception, primary)
+        self.assertEqual(close_operation.calls, [(71,)])
+        self.assertIn("29", "\n".join(getattr(primary, "__notes__", ())))
+
+    def test_native_open_return_interrupt_is_owned_and_closed_once(self) -> None:
+        stable = _metadata(st_nlink=1)
+        interruption = KeyboardInterrupt("native open returned before Python assignment")
+        triggered = False
+
+        class _InterruptingNativeCall(_NativeCall):
+            def __call__(self, *arguments: object) -> int:
+                nonlocal triggered
+                result = super().__call__(*arguments)
+                if not triggered:
+                    triggered = True
+                    raise interruption
+                return result
+
+        open_operation = _InterruptingNativeCall(71)
+        close_operation = _NativeCall(0)
+        library = {"openat": open_operation, "close": close_operation}
+
+        def open_read(
+            name: str,
+            lease: anchored._PosixDescriptorLease,
+        ) -> int:
+            return anchored._open_posix_descriptor(
+                lease,
+                name,
+                os.O_RDONLY,
+                dir_fd=8,
+            )
+
+        binding = SimpleNamespace(
+            parent=Path("parent"),
+            stat=mock.Mock(return_value=stable),
+            open_read=open_read,
+            verify=mock.Mock(),
+        )
+
+        with (
+            mock.patch.object(anchored, "_posix_libc", return_value=library),
+            self.assertRaises(KeyboardInterrupt) as raised,
+        ):
+            anchored._read_exact_receipt(
+                cast(Any, binding),
+                "receipt.json",
+                PAYLOAD,
+                descriptor_lease=anchored._PosixDescriptorLease(),
+            )
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, interruption)
+        self.assertEqual(len(open_operation.calls), 1)
+        self.assertEqual(close_operation.calls, [(71,)])
+
+    def test_native_close_result_survives_interrupt_without_reusing_descriptor(self) -> None:
+        lease = anchored._PosixDescriptorLease(
+            descriptor_result=ctypes.c_int(71),
+        )
+        close_operation = _NativeCall(-1)
+        interruption = KeyboardInterrupt("native close returned before Python assignment")
+        real_native_int_result = anchored._native_int_result
+        triggered = False
+
+        def interrupt_result_interpretation(value: object) -> int:
+            nonlocal triggered
+            if (
+                not triggered
+                and value is lease.close_result
+                and lease.close_result is not anchored._POSIX_NATIVE_RESULT_PENDING
+            ):
+                triggered = True
+                raise interruption
+            return real_native_int_result(value)
+
+        with (
+            mock.patch.object(
+                anchored,
+                "_posix_libc",
+                return_value={"close": close_operation},
+            ),
+            mock.patch.object(anchored, "_native_int_result", interrupt_result_interpretation),
+            mock.patch.object(anchored.ctypes, "get_errno", return_value=errno.EIO),
+        ):
+            observed = anchored._close_posix_descriptor_lease(
+                lease,
+                None,
+                "test descriptor",
+            )
+        self.assertTrue(triggered)
+        self.assertIs(observed, interruption)
+        self.assertEqual(close_operation.calls, [(71,)])
+        self.assertIsNone(lease.descriptor)
+        self.assertIs(lease.close_result, anchored._POSIX_NATIVE_RESULT_PENDING)
+        self.assertIn("Input/output error", "\n".join(getattr(interruption, "__notes__", ())))
+
+    def test_retired_close_marker_is_normalized_before_lease_reuse(self) -> None:
+        lease = anchored._PosixDescriptorLease(
+            descriptor_result=ctypes.c_int(71),
+        )
+        open_operation = _NativeCall(72)
+        close_operation = _NativeCall(0)
+        interruption = KeyboardInterrupt("descriptor retired before close marker reset")
+        triggered = False
+
+        def interrupt_marker_reset(
+            target: anchored._PosixDescriptorLease,
+            name: str,
+            value: object,
+        ) -> None:
+            nonlocal triggered
+            if (
+                not triggered
+                and target is lease
+                and name == "close_result"
+                and value is anchored._POSIX_NATIVE_RESULT_PENDING
+                and target.descriptor_result is None
+                and target.close_result is not anchored._POSIX_NATIVE_RESULT_PENDING
+            ):
+                triggered = True
+                raise interruption
+            object.__setattr__(target, name, value)
+
+        with (
+            mock.patch.object(
+                anchored,
+                "_posix_libc",
+                return_value={"openat": open_operation, "close": close_operation},
+            ),
+            mock.patch.object(
+                anchored._PosixDescriptorLease,
+                "__setattr__",
+                new=interrupt_marker_reset,
+            ),
+        ):
+            with self.assertRaises(KeyboardInterrupt) as raised:
+                lease.close()
+            self.assertEqual(
+                anchored._open_posix_descriptor(lease, "next", os.O_RDONLY, dir_fd=8),
+                72,
+            )
+            lease.close()
+
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, interruption)
+        self.assertEqual(close_operation.calls, [(71,), (72,)])
+        self.assertIsNone(lease.descriptor)
+        self.assertIs(lease.close_result, anchored._POSIX_NATIVE_RESULT_PENDING)
+
+    def test_binding_retries_interrupted_child_before_closing_parent(self) -> None:
+        root = anchored._PosixDescriptorLease(descriptor_result=ctypes.c_int(70))
+        child = anchored._PosixDescriptorLease(descriptor_result=ctypes.c_int(71))
+        binding = anchored.OutputParentBinding(
+            checkout=Path("checkout"),
+            parent=Path("parent"),
+            leaf="receipt.json",
+            strategy="posix-dir-fd",
+            descriptors=(70, 71),
+            descriptor_leases=(root, child),
+        )
+        interruption = KeyboardInterrupt("child close interrupted before effect")
+        attempts: list[str] = []
+        completed: list[str] = []
+
+        def close_lease(lease: anchored._PosixDescriptorLease) -> None:
+            label = "child" if lease is child else "root"
+            attempts.append(label)
+            if lease is child and attempts.count("child") == 1:
+                raise interruption
+            lease.descriptor_result = None
+            completed.append(label)
+
+        with mock.patch.object(anchored._PosixDescriptorLease, "close", new=close_lease):
+            failures = binding.close()
+
+        self.assertEqual(attempts, ["child", "child", "root"])
+        self.assertEqual(completed, ["child", "root"])
+        self.assertEqual(failures, (interruption,))
+        self.assertTrue(binding.is_closed)
+
+    def test_binding_retries_helper_boundary_before_moving_to_parent(self) -> None:
+        root = anchored._PosixDescriptorLease(descriptor_result=ctypes.c_int(70))
+        child = anchored._PosixDescriptorLease(descriptor_result=ctypes.c_int(71))
+        binding = anchored.OutputParentBinding(
+            checkout=Path("checkout"),
+            parent=Path("parent"),
+            leaf="receipt.json",
+            strategy="posix-dir-fd",
+            descriptors=(70, 71),
+            descriptor_leases=(root, child),
+        )
+        interruption = KeyboardInterrupt("helper call interrupted before child close")
+        real_helper = anchored._close_posix_descriptor_lease
+        helper_attempts: list[str] = []
+        completed: list[str] = []
+
+        def interrupt_helper_once(
+            lease: anchored._PosixDescriptorLease,
+            primary: BaseException | None,
+            context: str,
+        ) -> BaseException | None:
+            label = "child" if lease is child else "root"
+            helper_attempts.append(label)
+            if lease is child and helper_attempts.count("child") == 1:
+                raise interruption
+            return real_helper(lease, primary, context)
+
+        def close_lease(lease: anchored._PosixDescriptorLease) -> None:
+            completed.append("child" if lease is child else "root")
+            lease.descriptor_result = None
+
+        with (
+            mock.patch.object(
+                anchored,
+                "_close_posix_descriptor_lease",
+                side_effect=interrupt_helper_once,
+            ),
+            mock.patch.object(anchored._PosixDescriptorLease, "close", new=close_lease),
+        ):
+            failures = anchored._OutputParentBindingLease(binding).close()
+
+        self.assertEqual(helper_attempts, ["child", "child", "root"])
+        self.assertEqual(completed, ["child", "root"])
+        self.assertEqual(failures, (interruption,))
+        self.assertTrue(binding.is_closed)
+
+    def test_receipt_reader_retries_cleanup_helper_boundary_without_leaking(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary).resolve()
+            output = directory / "receipt.json"
+            output.write_bytes(PAYLOAD)
+            output.chmod(0o600)
+            opened: list[int] = []
+
+            def open_read(
+                _name: str,
+                lease: anchored._PosixDescriptorLease,
+            ) -> int:
+                descriptor = os.open(output, os.O_RDONLY)
+                opened.append(descriptor)
+                lease.descriptor_result = ctypes.c_int(descriptor)
+                return descriptor
+
+            def output_stat(_name: str) -> os.stat_result:
+                return output.lstat()
+
+            binding = SimpleNamespace(
+                parent=directory,
+                stat=output_stat,
+                open_read=open_read,
+                verify=lambda: None,
+            )
+            cleanup_interrupt = KeyboardInterrupt("reader cleanup helper boundary")
+            real_helper = anchored._close_posix_descriptor_lease
+            attempts = 0
+
+            def interrupt_helper_once(
+                lease: anchored._PosixDescriptorLease,
+                primary: BaseException | None,
+                context: str,
+            ) -> BaseException | None:
+                nonlocal attempts
+                attempts += 1
+                if attempts == 1:
+                    raise cleanup_interrupt
+                return real_helper(lease, primary, context)
+
+            with (
+                mock.patch.object(
+                    anchored,
+                    "_close_posix_descriptor_lease",
+                    side_effect=interrupt_helper_once,
+                ),
+                self.assertRaises(KeyboardInterrupt) as raised,
+            ):
+                anchored._read_exact_receipt(
+                    cast(Any, binding),
+                    output.name,
+                    PAYLOAD,
+                    descriptor_lease=anchored._PosixDescriptorLease(),
+                )
+
+            self.assertIs(raised.exception, cleanup_interrupt)
+            self.assertEqual(attempts, 2)
+            self.assertEqual(len(opened), 1)
+            with self.assertRaises(OSError):
+                os.fstat(opened[0])
+
+    def test_stage_helper_return_interrupt_closes_retained_descriptor_once(self) -> None:
+        binding = SimpleNamespace(
+            leaf="receipt.json",
+            descriptors=(8,),
+            stat=mock.Mock(side_effect=FileNotFoundError),
+            verify=mock.Mock(),
+            sync=mock.Mock(),
+            close=mock.Mock(return_value=()),
+        )
+        _stage, open_stage = _retain_stage(self.posix, 71)
+        close_operation = _NativeCall(0)
+        interruption = KeyboardInterrupt("stage returned before publisher assignment")
+        triggered = False
+
+        def open_stage_then_interrupt(
+            parent_binding: object,
+            temporary_name: str,
+            stage_lease: Any,
+        ) -> object:
+            nonlocal triggered
+            stage = open_stage(parent_binding, temporary_name, stage_lease)
+            if not triggered:
+                triggered = True
+                raise interruption
+            return stage
+
+        with (
+            mock.patch.object(self.posix.sys, "platform", "linux"),
+            mock.patch.object(
+                self.posix,
+                "_open_posix_receipt_stage",
+                side_effect=open_stage_then_interrupt,
+            ),
+            mock.patch.object(
+                anchored,
+                "_posix_libc",
+                return_value={"close": close_operation},
+            ),
+            self.assertRaises(KeyboardInterrupt) as raised,
+        ):
+            self.posix._publish_posix_receipt_bytes(
+                Path("receipt.json"),
+                PAYLOAD,
+                binding,
+                self.posix._PosixReceiptPublicationLease(binding),
+            )
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, interruption)
+        self.assertEqual(close_operation.calls, [(71,)])
+        binding.close.assert_called_once_with()
+
+    def test_collision_observes_exact_winner_and_never_unlinks_public_name(self) -> None:
+        binding = SimpleNamespace(
+            leaf="receipt.json",
+            descriptors=(8,),
+            stat=mock.Mock(side_effect=FileNotFoundError),
+            verify=mock.Mock(),
+            sync=mock.Mock(),
+            close=mock.Mock(return_value=()),
+        )
+        source = _metadata()
+        _stage, open_stage = _retain_stage(self.posix, 7)
+        exact_identity = (55, 66)
+        close_operation = _NativeCall(0)
+        public_sync = mock.Mock()
+        with (
+            mock.patch.object(self.posix.sys, "platform", "linux"),
+            mock.patch.object(self.posix, "_open_posix_receipt_stage", side_effect=open_stage),
+            mock.patch.object(self.posix.os, "fstat", return_value=source),
+            mock.patch.object(self.posix, "_write_and_sync_retained_descriptor"),
+            mock.patch.object(self.posix, "_validate_exact_receipt_descriptor"),
+            mock.patch.object(self.posix, "_publish_posix_receipt_descriptor", side_effect=FileExistsError),
+            mock.patch.object(self.posix, "_read_exact_receipt", return_value=exact_identity) as observe,
+            mock.patch.object(self.posix, "_sync_posix_public_descriptor", public_sync),
+            mock.patch.object(
+                anchored,
+                "_posix_libc",
+                return_value={"close": close_operation},
+            ),
+        ):
+            self.posix._publish_posix_receipt_bytes(
+                Path("receipt.json"),
+                PAYLOAD,
+                binding,
+                self.posix._PosixReceiptPublicationLease(binding),
+            )
+        self.assertEqual(observe.call_count, 2)
+        self.assertEqual(observe.call_args_list[0], mock.call(
+            binding,
+            "receipt.json",
+            PAYLOAD,
+            descriptor_lease=mock.ANY,
+        ))
+        public_sync.assert_called_once()
+        binding.sync.assert_called_once_with()
+        self.assertEqual(close_operation.calls, [(7,)])
+
+    def test_successful_collision_promotes_control_flow_close_failure(self) -> None:
+        ordinary_close = OSError("ordinary binding close")
+        control_flow_close = KeyboardInterrupt("binding close interrupt")
+        binding = SimpleNamespace(
+            leaf="receipt.json",
+            descriptors=(8,),
+            stat=mock.Mock(side_effect=FileNotFoundError),
+            verify=mock.Mock(),
+            sync=mock.Mock(),
+            close=mock.Mock(return_value=(ordinary_close, control_flow_close)),
+        )
+        _stage, open_stage = _retain_stage(self.posix, 7)
+        close_operation = _NativeCall(0)
+        with (
+            mock.patch.object(self.posix.sys, "platform", "linux"),
+            mock.patch.object(self.posix, "_open_posix_receipt_stage", side_effect=open_stage),
+            mock.patch.object(self.posix.os, "fstat", return_value=_metadata()),
+            mock.patch.object(self.posix, "_write_and_sync_retained_descriptor"),
+            mock.patch.object(self.posix, "_validate_exact_receipt_descriptor"),
+            mock.patch.object(self.posix, "_publish_posix_receipt_descriptor", side_effect=FileExistsError),
+            mock.patch.object(self.posix, "_read_exact_receipt", return_value=(55, 66)),
+            mock.patch.object(self.posix, "_sync_posix_public_descriptor"),
+            mock.patch.object(
+                anchored,
+                "_posix_libc",
+                return_value={"close": close_operation},
+            ),
+            self.assertRaises(KeyboardInterrupt) as raised,
+        ):
+            self.posix._publish_posix_receipt_bytes(
+                Path("receipt.json"),
+                PAYLOAD,
+                binding,
+                self.posix._PosixReceiptPublicationLease(binding),
+            )
+
+        self.assertIs(raised.exception, control_flow_close)
+        self.assertIn("ordinary binding close", "\n".join(getattr(control_flow_close, "__notes__", ())))
+
+    def test_post_publication_parent_sync_failure_keeps_public_name_and_closes(self) -> None:
+        primary = OSError(errno.EIO, "directory sync")
+        binding = SimpleNamespace(
+            leaf="receipt.json",
+            descriptors=(8,),
+            stat=mock.Mock(side_effect=FileNotFoundError),
+            verify=mock.Mock(),
+            sync=mock.Mock(side_effect=primary),
+            close=mock.Mock(return_value=()),
+        )
+        source = _metadata()
+        _stage, open_stage = _retain_stage(self.posix, 7)
+        reads = mock.Mock(return_value=(11, 22))
+        close_operation = _NativeCall(0)
+        with (
+            mock.patch.object(self.posix.sys, "platform", "linux"),
+            mock.patch.object(self.posix, "_open_posix_receipt_stage", side_effect=open_stage),
+            mock.patch.object(self.posix.os, "fstat", return_value=source),
+            mock.patch.object(self.posix, "_write_and_sync_retained_descriptor"),
+            mock.patch.object(self.posix, "_validate_exact_receipt_descriptor") as validate,
+            mock.patch.object(self.posix, "_publish_posix_receipt_descriptor"),
+            mock.patch.object(self.posix, "_read_exact_receipt", reads),
+            mock.patch.object(self.posix, "_sync_posix_public_descriptor"),
+            mock.patch.object(
+                anchored,
+                "_posix_libc",
+                return_value={"close": close_operation},
+            ),
+            self.assertRaises(OSError) as raised,
+        ):
+            self.posix._publish_posix_receipt_bytes(
+                Path("receipt.json"),
+                PAYLOAD,
+                binding,
+                self.posix._PosixReceiptPublicationLease(binding),
+            )
+        self.assertIs(raised.exception, primary)
+        self.assertGreaterEqual(reads.call_count, 2)
+        self.assertEqual(
+            [call.kwargs["code"] for call in validate.call_args_list],
+            ["output-temporary-invalid", "output-changed"],
+        )
+        self.assertIn("left untouched", "\n".join(getattr(primary, "__notes__", ())))
+        self.assertEqual(close_operation.calls, [(7,)])
+        binding.close.assert_called_once_with()
+
+    def test_effect_then_control_flow_still_runs_durability_pipeline(self) -> None:
+        for platform, output_identity in (
+            ("linux", (11, 22)),
+            ("darwin", (33, 44)),
+        ):
+            with self.subTest(platform=platform):
+                primary = KeyboardInterrupt(f"{platform} native publication returned before assignment")
+                binding = SimpleNamespace(
+                    leaf="receipt.json",
+                    descriptors=(8,),
+                    stat=mock.Mock(side_effect=(FileNotFoundError(), _metadata())),
+                    verify=mock.Mock(),
+                    sync=mock.Mock(),
+                    close=mock.Mock(return_value=()),
+                )
+                source = _metadata()
+                _stage, open_stage = _retain_stage(self.posix, 7)
+                close_operation = _NativeCall(0)
+                reads = mock.Mock(return_value=output_identity)
+                public_sync = mock.Mock()
+                with (
+                    mock.patch.object(self.posix.sys, "platform", platform),
+                    mock.patch.object(self.posix, "_open_posix_receipt_stage", side_effect=open_stage),
+                    mock.patch.object(self.posix.os, "fstat", return_value=source),
+                    mock.patch.object(self.posix, "_write_and_sync_retained_descriptor"),
+                    mock.patch.object(self.posix, "_validate_exact_receipt_descriptor") as validate,
+                    mock.patch.object(
+                        self.posix,
+                        "_publish_posix_receipt_descriptor",
+                        side_effect=primary,
+                    ),
+                    mock.patch.object(self.posix, "_read_exact_receipt", reads),
+                    mock.patch.object(
+                        self.posix,
+                        "_sync_posix_public_descriptor",
+                        public_sync,
+                    ),
+                    mock.patch.object(
+                        anchored,
+                        "_posix_libc",
+                        return_value={"close": close_operation},
+                    ),
+                    self.assertRaises(KeyboardInterrupt) as raised,
+                ):
+                    self.posix._publish_posix_receipt_bytes(
+                        Path("receipt.json"),
+                        PAYLOAD,
+                        binding,
+                        self.posix._PosixReceiptPublicationLease(binding),
+                    )
+
+                self.assertIs(raised.exception, primary)
+                self.assertEqual(
+                    [call.kwargs["code"] for call in validate.call_args_list],
+                    ["output-temporary-invalid"],
+                )
+                binding.sync.assert_called_once_with()
+                self.assertEqual(reads.call_count, 2)
+                public_sync.assert_called_once()
+                self.assertEqual(close_operation.calls, [(7,)])
+                binding.close.assert_called_once_with()
+
+    def test_effect_then_file_exists_runs_durability_pipeline(self) -> None:
+        for platform, output_identity in (
+            ("linux", (11, 22)),
+            ("darwin", (33, 44)),
+        ):
+            with self.subTest(platform=platform):
+                binding = SimpleNamespace(
+                    leaf="receipt.json",
+                    descriptors=(8,),
+                    stat=mock.Mock(side_effect=FileNotFoundError),
+                    verify=mock.Mock(),
+                    sync=mock.Mock(),
+                    close=mock.Mock(return_value=()),
+                )
+                source = _metadata()
+                _stage, open_stage = _retain_stage(self.posix, 7)
+                close_operation = _NativeCall(0)
+                reads = mock.Mock(return_value=output_identity)
+                public_sync = mock.Mock()
+                with (
+                    mock.patch.object(self.posix.sys, "platform", platform),
+                    mock.patch.object(self.posix, "_open_posix_receipt_stage", side_effect=open_stage),
+                    mock.patch.object(self.posix.os, "fstat", return_value=source),
+                    mock.patch.object(self.posix, "_write_and_sync_retained_descriptor"),
+                    mock.patch.object(self.posix, "_validate_exact_receipt_descriptor"),
+                    mock.patch.object(
+                        self.posix,
+                        "_publish_posix_receipt_descriptor",
+                        side_effect=FileExistsError("native call completed before exception"),
+                    ),
+                    mock.patch.object(self.posix, "_read_exact_receipt", reads),
+                    mock.patch.object(
+                        self.posix,
+                        "_sync_posix_public_descriptor",
+                        public_sync,
+                    ),
+                    mock.patch.object(
+                        anchored,
+                        "_posix_libc",
+                        return_value={"close": close_operation},
+                    ),
+                ):
+                    self.posix._publish_posix_receipt_bytes(
+                        Path("receipt.json"),
+                        PAYLOAD,
+                        binding,
+                        self.posix._PosixReceiptPublicationLease(binding),
+                    )
+
+                binding.sync.assert_called_once_with()
+                self.assertEqual(reads.call_count, 2)
+                public_sync.assert_called_once()
+                self.assertEqual(close_operation.calls, [(7,)])
+                binding.close.assert_called_once_with()
+
+    def test_new_ancestor_sync_failure_prevents_publication_and_closes_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            previous = Path.cwd()
+            os.chdir(temporary)
+            real_open = anchored._open_posix_descriptor
+            real_close = anchored._PosixDescriptorLease.close
+            opened: list[int] = []
+            closed: list[int] = []
+
+            def record_open(
+                descriptor_lease: anchored._PosixDescriptorLease,
+                name: os.PathLike[str] | str,
+                flags: int,
+                mode: int = 0o777,
+                *,
+                dir_fd: int | None = None,
+            ) -> int:
+                descriptor = real_open(
+                    descriptor_lease,
+                    name,
+                    flags,
+                    mode,
+                    dir_fd=dir_fd,
+                )
+                opened.append(descriptor)
+                return descriptor
+
+            def record_close(descriptor_lease: anchored._PosixDescriptorLease) -> None:
+                descriptor = descriptor_lease.descriptor
+                if descriptor is None:
+                    return real_close(descriptor_lease)
+                closed.append(descriptor)
+                real_close(descriptor_lease)
+
+            try:
+                with (
+                    mock.patch.object(anchored, "descriptor_relative_output_supported", return_value=True),
+                    mock.patch.object(anchored, "_open_posix_descriptor", side_effect=record_open),
+                    mock.patch.object(anchored._PosixDescriptorLease, "close", new=record_close),
+                    mock.patch.object(anchored.os, "fsync", side_effect=OSError(errno.EIO, "ancestor sync")),
+                ):
+                    with self.assertRaises(anchored.AnchoredOutputError) as raised:
+                        anchored.open_rooted_output_parent(
+                            Path("new-parent/receipt.json"),
+                            anchored._OutputParentBindingLease(),
+                        )
+                self.assertEqual(raised.exception.code, "output-parent-invalid")
+                self.assertFalse(Path("new-parent/receipt.json").exists())
+                self.assertTrue(opened)
+                self.assertEqual(closed, list(reversed(opened)))
+            finally:
+                os.chdir(previous)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_anchored_receipt_windows.py
+++ b/tests/test_anchored_receipt_windows.py
@@ -39,6 +39,9 @@ class FakeKernel32:
         self.info_failure_at: tuple[int, int, BaseException] | None = None
         self.info_counts: dict[int, int] = {}
         self.read_failure_seek: tuple[int, BaseException] | None = None
+        self.rename_status = 0
+        self.rename_completion_status = 0
+        self.rename_information = 0
 
     def get_last_error(self) -> int:
         return self._last_error
@@ -110,6 +113,37 @@ class FakeKernel32:
         if ctypes.c_uint32(status).value == receipt.STATUS_OBJECT_NAME_COLLISION:
             return self.error
         return self.error
+
+    def NtSetInformationFile(
+        self,
+        handle: int,
+        io_status: Any,
+        pointer: Any,
+        size: int,
+        info_class: int,
+    ) -> int:
+        raw = ctypes.string_at(pointer, size)
+        self.calls.append(("NtSetInformationFile", (handle, info_class, raw, size)))
+        padded = raw + bytes(max(0, ctypes.sizeof(receipt._FileRenameInformation) - len(raw)))
+        rename = receipt._FileRenameInformation.from_buffer_copy(padded)
+        minimum_size = ctypes.sizeof(receipt._FileRenameInformation) + rename.FileNameLength
+        if info_class != receipt.FILE_RENAME_INFORMATION or size < minimum_size:
+            return ctypes.c_int32(0xC0000004).value
+        action = self.failures.get("Rename")
+        if isinstance(action, BaseException):
+            raise action
+        if action is False:
+            status = receipt.STATUS_OBJECT_NAME_COLLISION if self.error in (
+                receipt.ERROR_FILE_EXISTS,
+                receipt.ERROR_ALREADY_EXISTS,
+            ) else 0xC0000022
+            return ctypes.c_int32(status).value
+        completion = ctypes.cast(io_status, ctypes.POINTER(receipt._IoStatusBlock)).contents
+        completion.Status = ctypes.c_int32(self.rename_completion_status).value
+        completion.Information = self.rename_information
+        if self.rename_status == 0 and self.rename_completion_status == 0:
+            self.rename_succeeded = True
+        return ctypes.c_int32(self.rename_status).value
 
     def WriteFile(self, handle: int, buffer: Any, size: int, written: Any, _overlap: object) -> bool:
         self.calls.append(("WriteFile", (handle, size)))
@@ -189,10 +223,8 @@ class FakeKernel32:
     def SetFileInformationByHandle(self, handle: int, info_class: int, pointer: Any, size: int) -> bool:
         raw = ctypes.string_at(pointer, size)
         self.calls.append(("SetFileInformationByHandle", (handle, info_class, raw, size)))
-        name = "Rename" if info_class == receipt.FILE_RENAME_INFO else "Disposition"
+        name = "Disposition" if info_class == receipt.FILE_DISPOSITION_INFO else f"SetInfo:{info_class}"
         result = self._action(name)
-        if name == "Rename" and result:
-            self.rename_succeeded = True
         return result
 
     def CloseHandle(self, handle: int) -> bool:
@@ -241,19 +273,23 @@ class WindowsAnchoredReceiptTests(unittest.TestCase):
         rename_call = next(
             args
             for name, args in api.calls
-            if name == "SetFileInformationByHandle" and args[1] == receipt.FILE_RENAME_INFO
+            if name == "NtSetInformationFile" and args[1] == receipt.FILE_RENAME_INFORMATION
         )
         raw = cast(bytes, rename_call[2])
-        info = receipt._FileRenameInfo.from_buffer_copy(
-            raw + bytes(max(0, ctypes.sizeof(receipt._FileRenameInfo) - len(raw)))
+        info = receipt._FileRenameInformation.from_buffer_copy(
+            raw + bytes(max(0, ctypes.sizeof(receipt._FileRenameInformation) - len(raw)))
         )
         encoded = "receipt.json".encode("utf-16-le")
         self.assertEqual(info.ReplaceIfExists, 0)
-        self.assertEqual(info.RootDirectory, 0x4567)
+        self.assertIsNone(info.RootDirectory)
         self.assertEqual(info.FileNameLength, len(encoded))
-        offset = receipt._FileRenameInfo.FileName.offset
+        offset = receipt._FileRenameInformation.FileName.offset
         self.assertEqual(raw[offset : offset + len(encoded)], encoded)
-        self.assertEqual(rename_call[3], max(ctypes.sizeof(receipt._FileRenameInfo), offset + len(encoded)))
+        self.assertEqual(rename_call[3], ctypes.sizeof(receipt._FileRenameInformation) + len(encoded))
+        self.assertEqual(
+            raw[offset + len(encoded) :],
+            bytes(ctypes.sizeof(receipt._FileRenameInformation) - offset),
+        )
         self.assertNotIn(
             receipt.FILE_DISPOSITION_INFO, [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
         )
@@ -272,11 +308,62 @@ class WindowsAnchoredReceiptTests(unittest.TestCase):
         rename_call = next(
             args
             for name, args in api.calls
-            if name == "SetFileInformationByHandle" and args[1] == receipt.FILE_RENAME_INFO
+            if name == "NtSetInformationFile" and args[1] == receipt.FILE_RENAME_INFORMATION
         )
-        self.assertEqual(rename_call[3], ctypes.sizeof(receipt._FileRenameInfo))
-        info = receipt._FileRenameInfo.from_buffer_copy(cast(bytes, rename_call[2]))
+        self.assertEqual(
+            rename_call[3],
+            ctypes.sizeof(receipt._FileRenameInformation) + len("x".encode("utf-16-le")),
+        )
+        info = receipt._FileRenameInformation.from_buffer_copy(cast(bytes, rename_call[2]))
         self.assertEqual(info.FileNameLength, len("x".encode("utf-16-le")))
+
+    def test_modeled_nt_rejects_undersized_rename_buffer(self) -> None:
+        api = FakeKernel32()
+        encoded = "receipt.json".encode("utf-16-le")
+        undersized = ctypes.create_string_buffer(
+            receipt._FileRenameInformation.FileName.offset + len(encoded)
+        )
+        rename = receipt._FileRenameInformation.from_buffer(undersized)
+        rename.FileNameLength = len(encoded)
+
+        self.assertFalse(
+            receipt._nt_success(
+                api.NtSetInformationFile(
+                    api.handle,
+                    ctypes.byref(receipt._IoStatusBlock()),
+                    undersized,
+                    len(undersized),
+                    receipt.FILE_RENAME_INFORMATION,
+                )
+            )
+        )
+
+    def test_modeled_nt_allows_explicit_root_handle_for_relative_target(self) -> None:
+        api = FakeKernel32()
+        encoded = "receipt.json".encode("utf-16-le")
+        storage = ctypes.create_string_buffer(
+            ctypes.sizeof(receipt._FileRenameInformation) + len(encoded)
+        )
+        rename = receipt._FileRenameInformation.from_buffer(storage)
+        rename.RootDirectory = 0x4567
+        rename.FileNameLength = len(encoded)
+        ctypes.memmove(
+            ctypes.addressof(storage) + receipt._FileRenameInformation.FileName.offset,
+            encoded,
+            len(encoded),
+        )
+
+        self.assertTrue(
+            receipt._nt_success(
+                api.NtSetInformationFile(
+                    api.handle,
+                    ctypes.byref(receipt._IoStatusBlock()),
+                    storage,
+                    len(storage),
+                    receipt.FILE_RENAME_INFORMATION,
+                )
+            )
+        )
 
     def test_write_loops_and_read_requires_exact_eof(self) -> None:
         api = FakeKernel32()
@@ -347,9 +434,9 @@ class WindowsAnchoredReceiptTests(unittest.TestCase):
                     self.publish(api)
                 self.assertFalse(
                     any(
-                        args[1] == receipt.FILE_RENAME_INFO
+                        args[1] == receipt.FILE_RENAME_INFORMATION
                         for name, args in api.calls
-                        if name == "SetFileInformationByHandle"
+                        if name == "NtSetInformationFile"
                     )
                 )
 
@@ -367,9 +454,9 @@ class WindowsAnchoredReceiptTests(unittest.TestCase):
         self.assertEqual(receipt._FileId128.Identifier.offset, 0)
         expected_root_offset = 8 if ctypes.sizeof(ctypes.c_void_p) == 8 else 4
         expected_name_length_offset = expected_root_offset + ctypes.sizeof(ctypes.c_void_p)
-        self.assertEqual(receipt._FileRenameInfo.RootDirectory.offset, expected_root_offset)
-        self.assertEqual(receipt._FileRenameInfo.FileNameLength.offset, expected_name_length_offset)
-        self.assertEqual(receipt._FileRenameInfo.FileName.offset, expected_name_length_offset + 4)
+        self.assertEqual(receipt._FileRenameInformation.RootDirectory.offset, expected_root_offset)
+        self.assertEqual(receipt._FileRenameInformation.FileNameLength.offset, expected_name_length_offset)
+        self.assertEqual(receipt._FileRenameInformation.FileName.offset, expected_name_length_offset + 4)
 
     def test_native_api_declarations_use_fixed_width_counts(self) -> None:
         class Function:
@@ -577,7 +664,7 @@ class WindowsAnchoredReceiptTests(unittest.TestCase):
                 self.publish(api)
             self.assertEqual(caught.exception.errno, code)
 
-    def test_definite_false_rename_disposes_but_raised_rename_is_unknown(self) -> None:
+    def test_definite_negative_rename_disposes_but_raised_rename_is_unknown(self) -> None:
         api = FakeKernel32({"Rename": False})
         api.error = 5
         with self.assertRaises(receipt._DefiniteRenameError):
@@ -605,6 +692,49 @@ class WindowsAnchoredReceiptTests(unittest.TestCase):
                 classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
                 self.assertNotIn(receipt.FILE_DISPOSITION_INFO, classes)
                 self.assertIn("Could not close", "\n".join(getattr(failure, "__notes__", [])))
+
+    def test_raw_collision_status_is_authenticated_before_dos_code_mapping(self) -> None:
+        api = FakeKernel32()
+        api.rename_status = receipt.STATUS_OBJECT_NAME_COLLISION
+        api.error = 5
+
+        with self.assertRaises(receipt._DefiniteRenameCollision) as caught:
+            self.publish(api)
+
+        self.assertTrue(receipt.is_internal_definite_rename_collision(caught.exception))
+        self.assertIn(
+            receipt.FILE_DISPOSITION_INFO,
+            [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"],
+        )
+
+    def test_nonfinal_return_and_nonzero_completion_keep_unknown_outcome(self) -> None:
+        cases = (
+            ("nonfinal-return", receipt.STATUS_PENDING, 0),
+            ("failing-completion", 0, 0xC0000022),
+            ("nonfinal-completion", 0, receipt.STATUS_PENDING),
+        )
+        for label, status, completion_status in cases:
+            with self.subTest(label=label):
+                api = FakeKernel32()
+                api.rename_status = status
+                api.rename_completion_status = completion_status
+
+                with self.assertRaises(OSError) as caught:
+                    self.publish(api)
+
+                outcome = receipt.outcome_from_error(caught.exception)
+                self.assertIsNotNone(outcome)
+                assert outcome is not None
+                self.assertEqual(outcome.state, "unknown")
+                self.assertFalse(api.rename_succeeded)
+                self.assertEqual(
+                    sum(name == "NtSetInformationFile" for name, _args in api.calls),
+                    1,
+                )
+                self.assertNotIn(
+                    receipt.FILE_DISPOSITION_INFO,
+                    [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"],
+                )
 
     def test_trace_boundaries_never_dispose_unknown_or_published_rename(self) -> None:
         publisher_code = receipt.publish_windows_receipt.__code__
@@ -654,8 +784,9 @@ class WindowsAnchoredReceiptTests(unittest.TestCase):
                 self.assertIsNotNone(outcome)
                 assert outcome is not None
                 self.assertEqual(outcome.state, "published" if boundary == "post-confirmation" else "unknown")
+                rename_calls = [args for name, args in api.calls if name == "NtSetInformationFile"]
+                self.assertEqual(len(rename_calls), 0 if boundary == "pre-call" else 1)
                 classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
-                self.assertEqual(classes.count(receipt.FILE_RENAME_INFO), 0 if boundary == "pre-call" else 1)
                 self.assertNotIn(receipt.FILE_DISPOSITION_INFO, classes)
                 self.assertEqual(api.calls[-1][0], "CloseHandle")
 

--- a/tests/test_anchored_receipt_windows.py
+++ b/tests/test_anchored_receipt_windows.py
@@ -1,0 +1,784 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+import ctypes
+import inspect
+import sys
+import unittest
+from unittest import mock
+from typing import Any, Callable, cast
+
+from scripts import _anchored_receipt_windows as receipt
+
+
+PAYLOAD = b'{"ok":true}\n'
+
+
+class FakeKernel32:
+    def __init__(self, failures: dict[str, BaseException | bool] | None = None) -> None:
+        self.failures = failures or {}
+        self.error = 5
+        self._last_error = 0
+        self.handle = 0x1234
+        self.data = bytearray()
+        self.position = 0
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+        self.identity = bytes(range(16))
+        self.attributes = receipt.FILE_ATTRIBUTE_NORMAL
+        self.directory = 0
+        self.links = 1
+        self.read_override: bytes | None = None
+        self.read_sequences: list[bytes] | None = None
+        self.seek_index = -1
+        self.write_zero = False
+        self.metadata_index = 0
+        self.metadata_overrides: list[dict[str, object]] = [{}, {}, {}]
+        self.rename_succeeded = False
+        self.create_succeeded = False
+        self.excessive_read_count = False
+        self.info_failure_at: tuple[int, int, BaseException] | None = None
+        self.info_counts: dict[int, int] = {}
+        self.read_failure_seek: tuple[int, BaseException] | None = None
+
+    def get_last_error(self) -> int:
+        return self._last_error
+
+    def set_last_error(self, value: int) -> None:
+        self._last_error = value
+
+    def _action(self, name: str) -> bool:
+        action = self.failures.get(name)
+        if isinstance(action, BaseException):
+            raise action
+        if action is False:
+            self._last_error = self.error
+        return action is not False
+
+    def NtCreateFile(
+        self,
+        output: Any,
+        desired_access: int,
+        object_attributes: Any,
+        io_status: Any,
+        allocation_size: object,
+        attributes: int,
+        share_access: int,
+        disposition: int,
+        options: int,
+        ea_buffer: object,
+        ea_length: int,
+    ) -> int:
+        native = ctypes.cast(object_attributes, ctypes.POINTER(receipt._ObjectAttributes)).contents
+        name = native.ObjectName.contents
+        raw_name = ctypes.string_at(name.Buffer, name.Length)
+        self.calls.append(
+            (
+                "NtCreateFile",
+                (
+                    desired_access,
+                    native.RootDirectory,
+                    raw_name.decode("utf-16-le"),
+                    name.Length,
+                    name.MaximumLength,
+                    native.Attributes,
+                    allocation_size,
+                    attributes,
+                    share_access,
+                    disposition,
+                    options,
+                    ea_buffer,
+                    ea_length,
+                ),
+            )
+        )
+        action = self.failures.get("NtCreateFile")
+        if isinstance(action, BaseException):
+            raise action
+        if action is False:
+            if self.error in (receipt.ERROR_FILE_EXISTS, receipt.ERROR_ALREADY_EXISTS):
+                return ctypes.c_int32(receipt.STATUS_OBJECT_NAME_COLLISION).value
+            return ctypes.c_int32(0xC0000022).value
+        ctypes.cast(output, ctypes.POINTER(ctypes.c_void_p)).contents.value = self.handle
+        completion = ctypes.cast(io_status, ctypes.POINTER(receipt._IoStatusBlock)).contents
+        completion.Status = 0
+        completion.Information = receipt.FILE_CREATED
+        self.create_succeeded = True
+        return 0
+
+    def RtlNtStatusToDosError(self, status: int) -> int:
+        self.calls.append(("RtlNtStatusToDosError", (status,)))
+        if ctypes.c_uint32(status).value == receipt.STATUS_OBJECT_NAME_COLLISION:
+            return self.error
+        return self.error
+
+    def WriteFile(self, handle: int, buffer: Any, size: int, written: Any, _overlap: object) -> bool:
+        self.calls.append(("WriteFile", (handle, size)))
+        if not self._action("WriteFile"):
+            return False
+        amount = 0 if self.write_zero else min(size, 3)
+        self.data.extend(ctypes.string_at(buffer, amount))
+        ctypes.cast(written, ctypes.POINTER(receipt.DWORD)).contents.value = amount
+        return True
+
+    def FlushFileBuffers(self, handle: int) -> bool:
+        self.calls.append(("FlushFileBuffers", (handle,)))
+        return self._action("FlushFileBuffers")
+
+    def SetFilePointerEx(self, handle: int, offset: int, _new: object, method: int) -> bool:
+        self.calls.append(("SetFilePointerEx", (handle, offset, method)))
+        if not self._action("SetFilePointerEx"):
+            return False
+        self.position = offset
+        self.seek_index += 1
+        return True
+
+    def ReadFile(self, handle: int, buffer: Any, size: int, read: Any, _overlap: object) -> bool:
+        self.calls.append(("ReadFile", (handle, size)))
+        if self.read_failure_seek is not None and self.read_failure_seek[0] == self.seek_index:
+            raise self.read_failure_seek[1]
+        if not self._action("ReadFile"):
+            return False
+        source: bytes | bytearray = self.data
+        if self.read_sequences is not None:
+            source = self.read_sequences[min(self.seek_index, len(self.read_sequences) - 1)]
+        elif self.read_override is not None:
+            source = self.read_override
+        chunk = bytes(source[self.position : self.position + size])
+        if chunk:
+            ctypes.memmove(buffer, chunk, len(chunk))
+        self.position += len(chunk)
+        reported = size + 1 if self.excessive_read_count else len(chunk)
+        ctypes.cast(read, ctypes.POINTER(receipt.DWORD)).contents.value = reported
+        return True
+
+    def GetFileType(self, handle: int) -> int:
+        self.calls.append(("GetFileType", (handle,)))
+        if not self._action("GetFileType"):
+            return 0
+        return receipt.FILE_TYPE_DISK
+
+    def GetFileInformationByHandleEx(self, handle: int, info_class: int, pointer: Any, size: int) -> bool:
+        self.calls.append(("GetFileInformationByHandleEx", (handle, info_class, size)))
+        count = self.info_counts.get(info_class, 0) + 1
+        self.info_counts[info_class] = count
+        if self.info_failure_at is not None and self.info_failure_at[:2] == (info_class, count):
+            raise self.info_failure_at[2]
+        if not self._action(f"GetInfo:{info_class}"):
+            return False
+        if info_class == receipt.FILE_BASIC_INFO:
+            override = self.metadata_overrides[min(self.metadata_index, 2)]
+            value = ctypes.cast(pointer, ctypes.POINTER(receipt._FileBasicInfo)).contents
+            value.FileAttributes = cast(int, override.get("attributes", self.attributes))
+        elif info_class == receipt.FILE_STANDARD_INFO:
+            override = self.metadata_overrides[min(self.metadata_index, 2)]
+            value = ctypes.cast(pointer, ctypes.POINTER(receipt._FileStandardInfo)).contents
+            default_size = 0 if self.metadata_index == 0 else len(self.data)
+            value.EndOfFile = cast(int, override.get("size", default_size))
+            value.NumberOfLinks = cast(int, override.get("links", self.links))
+            value.Directory = cast(int, override.get("directory", self.directory))
+        else:
+            override = self.metadata_overrides[min(self.metadata_index, 2)]
+            value = ctypes.cast(pointer, ctypes.POINTER(receipt._FileIdInfo)).contents
+            value.VolumeSerialNumber = 77
+            identity = cast(bytes, override.get("identity", self.identity))
+            for index, byte in enumerate(identity):
+                value.FileId.Identifier[index] = byte
+            self.metadata_index += 1
+        return True
+
+    def SetFileInformationByHandle(self, handle: int, info_class: int, pointer: Any, size: int) -> bool:
+        raw = ctypes.string_at(pointer, size)
+        self.calls.append(("SetFileInformationByHandle", (handle, info_class, raw, size)))
+        name = "Rename" if info_class == receipt.FILE_RENAME_INFO else "Disposition"
+        result = self._action(name)
+        if name == "Rename" and result:
+            self.rename_succeeded = True
+        return result
+
+    def CloseHandle(self, handle: int) -> bool:
+        self.calls.append(("CloseHandle", (handle,)))
+        return self._action("CloseHandle")
+
+
+class WindowsAnchoredReceiptTests(unittest.TestCase):
+    def publish(self, api: FakeKernel32) -> receipt.WindowsReceiptResult:
+        return receipt.publish_windows_receipt(
+            0x4567,
+            "receipt.json",
+            PAYLOAD,
+            api=api,
+            stage_token="feed",
+            publication_lease=receipt._WindowsReceiptPublicationLease(api),
+        )
+
+    def test_success_uses_exact_access_and_retained_handle_abi(self) -> None:
+        api = FakeKernel32()
+        result = self.publish(api)
+        self.assertEqual(
+            result,
+            receipt.WindowsReceiptResult("receipt.json", 77, bytes(range(16)), len(PAYLOAD)),
+        )
+        self.assertEqual(api.calls[0][0], "NtCreateFile")
+        creation = api.calls[0][1]
+        self.assertEqual(
+            creation,
+            (
+                receipt._STAGE_ACCESS,
+                0x4567,
+                ".receipt.json.feed.tmp",
+                len(".receipt.json.feed.tmp".encode("utf-16-le")),
+                len(".receipt.json.feed.tmp".encode("utf-16-le")) + 2,
+                receipt.OBJ_CASE_INSENSITIVE,
+                None,
+                receipt.FILE_ATTRIBUTE_NORMAL,
+                receipt.FILE_SHARE_READ,
+                receipt.FILE_CREATE,
+                receipt._FILE_OPEN_OPTIONS,
+                None,
+                0,
+            ),
+        )
+        rename_call = next(
+            args
+            for name, args in api.calls
+            if name == "SetFileInformationByHandle" and args[1] == receipt.FILE_RENAME_INFO
+        )
+        raw = cast(bytes, rename_call[2])
+        info = receipt._FileRenameInfo.from_buffer_copy(
+            raw + bytes(max(0, ctypes.sizeof(receipt._FileRenameInfo) - len(raw)))
+        )
+        encoded = "receipt.json".encode("utf-16-le")
+        self.assertEqual(info.ReplaceIfExists, 0)
+        self.assertEqual(info.RootDirectory, 0x4567)
+        self.assertEqual(info.FileNameLength, len(encoded))
+        offset = receipt._FileRenameInfo.FileName.offset
+        self.assertEqual(raw[offset : offset + len(encoded)], encoded)
+        self.assertEqual(rename_call[3], max(ctypes.sizeof(receipt._FileRenameInfo), offset + len(encoded)))
+        self.assertNotIn(
+            receipt.FILE_DISPOSITION_INFO, [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+        )
+        self.assertEqual(api.calls[-1], ("CloseHandle", (api.handle,)))
+
+    def test_one_character_leaf_passes_full_allocated_rename_structure(self) -> None:
+        api = FakeKernel32()
+        receipt.publish_windows_receipt(
+            0x4567,
+            "x",
+            PAYLOAD,
+            api=api,
+            stage_token="feed",
+            publication_lease=receipt._WindowsReceiptPublicationLease(api),
+        )
+        rename_call = next(
+            args
+            for name, args in api.calls
+            if name == "SetFileInformationByHandle" and args[1] == receipt.FILE_RENAME_INFO
+        )
+        self.assertEqual(rename_call[3], ctypes.sizeof(receipt._FileRenameInfo))
+        info = receipt._FileRenameInfo.from_buffer_copy(cast(bytes, rename_call[2]))
+        self.assertEqual(info.FileNameLength, len("x".encode("utf-16-le")))
+
+    def test_write_loops_and_read_requires_exact_eof(self) -> None:
+        api = FakeKernel32()
+        self.publish(api)
+        self.assertGreater(len([call for call in api.calls if call[0] == "WriteFile"]), 1)
+        self.assertEqual(bytes(api.data), PAYLOAD)
+        self.assertGreaterEqual(len([call for call in api.calls if call[0] == "ReadFile"]), 2)
+
+    def test_creation_failure_has_no_handle_cleanup(self) -> None:
+        api = FakeKernel32({"NtCreateFile": False})
+        with self.assertRaises(OSError):
+            self.publish(api)
+        self.assertEqual([name for name, _args in api.calls], ["NtCreateFile", "RtlNtStatusToDosError"])
+
+    def test_every_primary_boundary_disposes_and_closes(self) -> None:
+        cases = (
+            "GetInfo:0",
+            "GetInfo:1",
+            "GetInfo:18",
+            "GetFileType",
+            "WriteFile",
+            "FlushFileBuffers",
+            "SetFilePointerEx",
+            "ReadFile",
+        )
+        for boundary in cases:
+            with self.subTest(boundary=boundary):
+                error = RuntimeError(boundary)
+                api = FakeKernel32({boundary: error})
+                with self.assertRaises(BaseException) as caught:
+                    self.publish(api)
+                self.assertIs(caught.exception, error)
+                info_classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+                self.assertIn(receipt.FILE_DISPOSITION_INFO, info_classes)
+                self.assertEqual(api.calls[-1][0], "CloseHandle")
+
+    def test_kind_identity_size_and_payload_drift_fail_before_rename(self) -> None:
+        def reparse(api: FakeKernel32) -> None:
+            api.attributes = receipt.FILE_ATTRIBUTE_REPARSE_POINT
+
+        def readonly(api: FakeKernel32) -> None:
+            api.attributes = receipt.FILE_ATTRIBUTE_READONLY
+
+        def basic_directory(api: FakeKernel32) -> None:
+            api.attributes = receipt.FILE_ATTRIBUTE_DIRECTORY
+
+        def directory(api: FakeKernel32) -> None:
+            api.directory = 1
+
+        def links(api: FakeKernel32) -> None:
+            api.links = 2
+
+        def wrong_type(api: FakeKernel32) -> None:
+            api.failures["GetFileType"] = False
+
+        for label, mutate in (
+            ("reparse", cast(Callable[[FakeKernel32], None], reparse)),
+            ("readonly", readonly),
+            ("basic-directory", basic_directory),
+            ("directory", directory),
+            ("links", links),
+            ("type", wrong_type),
+        ):
+            with self.subTest(label=label):
+                api = FakeKernel32()
+                mutate(api)
+                with self.assertRaises(OSError):
+                    self.publish(api)
+                self.assertFalse(
+                    any(
+                        args[1] == receipt.FILE_RENAME_INFO
+                        for name, args in api.calls
+                        if name == "SetFileInformationByHandle"
+                    )
+                )
+
+    def test_fixed_width_win32_abi_layouts(self) -> None:
+        self.assertEqual(ctypes.sizeof(receipt.DWORD), 4)
+        self.assertEqual(ctypes.sizeof(receipt.BOOLEAN), 1)
+        self.assertEqual(ctypes.sizeof(receipt.WCHAR), 2)
+        self.assertEqual(ctypes.sizeof(receipt._FileBasicInfo), 40)
+        self.assertEqual(ctypes.sizeof(receipt._FileStandardInfo), 24)
+        self.assertEqual(ctypes.sizeof(receipt._FileDispositionInfo), 1)
+        self.assertEqual(ctypes.sizeof(receipt._FileId128), 16)
+        self.assertEqual(ctypes.sizeof(receipt._FileIdInfo), 24)
+        self.assertEqual(receipt._FileIdInfo.VolumeSerialNumber.offset, 0)
+        self.assertEqual(receipt._FileIdInfo.FileId.offset, 8)
+        self.assertEqual(receipt._FileId128.Identifier.offset, 0)
+        expected_root_offset = 8 if ctypes.sizeof(ctypes.c_void_p) == 8 else 4
+        expected_name_length_offset = expected_root_offset + ctypes.sizeof(ctypes.c_void_p)
+        self.assertEqual(receipt._FileRenameInfo.RootDirectory.offset, expected_root_offset)
+        self.assertEqual(receipt._FileRenameInfo.FileNameLength.offset, expected_name_length_offset)
+        self.assertEqual(receipt._FileRenameInfo.FileName.offset, expected_name_length_offset + 4)
+
+    def test_native_api_declarations_use_fixed_width_counts(self) -> None:
+        class Function:
+            argtypes: object = None
+            restype: object = None
+
+            def __call__(self, *_args: object) -> int:
+                return 1
+
+        api = type("Api", (), {})()
+        for name in (
+            "WriteFile",
+            "ReadFile",
+            "FlushFileBuffers",
+            "SetFilePointerEx",
+            "GetFileInformationByHandleEx",
+            "SetFileInformationByHandle",
+            "GetFileType",
+            "CloseHandle",
+        ):
+            setattr(api, name, Function())
+        configured: Any = receipt._configure_api(api)
+        self.assertIs(configured.WriteFile.argtypes[2], receipt.DWORD)
+        self.assertIs(configured.WriteFile.argtypes[3]._type_, receipt.DWORD)
+        self.assertEqual(configured.ReadFile.argtypes, configured.WriteFile.argtypes)
+        self.assertIs(configured.SetFileInformationByHandle.argtypes[3], receipt.DWORD)
+
+    def test_leaf_and_stage_token_reject_paths_and_ads(self) -> None:
+        for leaf in (
+            "",
+            ".",
+            "..",
+            "NUL.txt",
+            "CoM¹.log",
+            "receipt.",
+            "receipt ",
+            "a?b",
+            "a/b",
+            r"a\b",
+            "a:b",
+            "a\x00b",
+            "a\x1fb",
+            "\ud800",
+        ):
+            with self.subTest(leaf=repr(leaf)):
+                api = FakeKernel32()
+                with self.assertRaises(ValueError):
+                    receipt.publish_windows_receipt(
+                        1,
+                        leaf,
+                        PAYLOAD,
+                        api=api,
+                        publication_lease=receipt._WindowsReceiptPublicationLease(api),
+                    )
+                self.assertEqual(api.calls, [])
+        api = FakeKernel32()
+        for token in ("", "ABC", "a/b", "a:b"):
+            with self.subTest(token=token), self.assertRaises(ValueError):
+                receipt.publish_windows_receipt(
+                    1,
+                    "receipt.json",
+                    PAYLOAD,
+                    api=api,
+                    stage_token=token,
+                    publication_lease=receipt._WindowsReceiptPublicationLease(api),
+                )
+
+    def test_valid_unicode_and_long_leaves_publish_without_normalization(self) -> None:
+        leaves = (
+            "NUL\N{NO-BREAK SPACE}.txt",
+            "receipt-ž-文件-\N{GRINNING FACE}.json",
+            f"{'long-' * 60}.json",
+        )
+        for leaf in leaves:
+            with self.subTest(leaf=repr(leaf)):
+                api = FakeKernel32()
+                result = receipt.publish_windows_receipt(
+                    0x4567,
+                    leaf,
+                    PAYLOAD,
+                    api=api,
+                    stage_token="feed",
+                    publication_lease=receipt._WindowsReceiptPublicationLease(api),
+                )
+                self.assertEqual(result.leaf, leaf)
+                create = next(arguments for name, arguments in api.calls if name == "NtCreateFile")
+                self.assertEqual(create[2], f".{leaf}.feed.tmp")
+
+    def test_zero_write_progress_early_eof_extra_and_mismatch_fail(self) -> None:
+        cases: list[tuple[str, Callable[[FakeKernel32], None]]] = []
+
+        def zero(api: FakeKernel32) -> None:
+            api.write_zero = True
+
+        def early(api: FakeKernel32) -> None:
+            api.read_override = PAYLOAD[:-1]
+
+        def extra(api: FakeKernel32) -> None:
+            api.read_override = PAYLOAD + b"x"
+
+        def mismatch(api: FakeKernel32) -> None:
+            api.read_override = b"X" + PAYLOAD[1:]
+
+        def excessive(api: FakeKernel32) -> None:
+            api.excessive_read_count = True
+
+        cases.extend(
+            (("zero", zero), ("early", early), ("extra", extra), ("mismatch", mismatch), ("excessive", excessive))
+        )
+        for label, configure in cases:
+            with self.subTest(label=label):
+                api = FakeKernel32()
+                configure(api)
+                with self.assertRaises(OSError):
+                    self.publish(api)
+                classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+                self.assertIn(receipt.FILE_DISPOSITION_INFO, classes)
+
+    def test_initial_nonempty_and_metadata_drift_fail_closed(self) -> None:
+        cases = (
+            ("initial-size", 0, "size", 1),
+            ("identity", 1, "identity", bytes(reversed(range(16)))),
+            ("attributes", 1, "attributes", receipt.FILE_ATTRIBUTE_READONLY),
+            ("links", 1, "links", 2),
+            ("size", 1, "size", len(PAYLOAD) + 1),
+        )
+        for label, phase, field, value in cases:
+            with self.subTest(label=label):
+                api = FakeKernel32()
+                api.metadata_overrides[phase][field] = value
+                with self.assertRaises(OSError):
+                    self.publish(api)
+
+    def test_post_rename_exact_read_and_metadata_drift_are_detected_without_disposition(self) -> None:
+        def bytes_drift(api: FakeKernel32) -> None:
+            api.read_sequences = [PAYLOAD, b"X" + PAYLOAD[1:]]
+
+        def identity_drift(api: FakeKernel32) -> None:
+            api.metadata_overrides[2]["identity"] = b"z" * 16
+
+        def attributes_drift(api: FakeKernel32) -> None:
+            api.metadata_overrides[2]["attributes"] = receipt.FILE_ATTRIBUTE_READONLY
+
+        def links_drift(api: FakeKernel32) -> None:
+            api.metadata_overrides[2]["links"] = 2
+
+        def size_drift(api: FakeKernel32) -> None:
+            api.metadata_overrides[2]["size"] = len(PAYLOAD) + 1
+
+        for label, configure in (
+            ("bytes", bytes_drift),
+            ("identity", identity_drift),
+            ("attributes", attributes_drift),
+            ("links", links_drift),
+            ("size", size_drift),
+        ):
+            with self.subTest(label=label):
+                api = FakeKernel32()
+                configure(api)
+                with self.assertRaises(OSError) as caught:
+                    self.publish(api)
+                outcome = receipt.outcome_from_error(caught.exception)
+                self.assertIsNotNone(outcome)
+                assert outcome is not None
+                self.assertEqual(outcome.state, "published")
+                classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+                self.assertNotIn(receipt.FILE_DISPOSITION_INFO, classes)
+
+    def test_second_and_third_pass_api_failures_report_exact_phase(self) -> None:
+        for info_class in (receipt.FILE_BASIC_INFO, receipt.FILE_STANDARD_INFO, receipt.FILE_ID_INFO):
+            for pass_number, expected_state, disposition in (
+                (2, None, True),
+                (3, "published", False),
+            ):
+                with self.subTest(info_class=info_class, pass_number=pass_number):
+                    failure = KeyboardInterrupt(f"info-{info_class}-{pass_number}")
+                    api = FakeKernel32()
+                    api.info_failure_at = (info_class, pass_number, failure)
+                    with self.assertRaises(KeyboardInterrupt) as caught:
+                        self.publish(api)
+                    self.assertIs(caught.exception, failure)
+                    outcome = receipt.outcome_from_error(failure)
+                    self.assertEqual(None if outcome is None else outcome.state, expected_state)
+                    classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+                    self.assertEqual(receipt.FILE_DISPOSITION_INFO in classes, disposition)
+
+        for seek_index, expected_state, disposition in ((0, None, True), (1, "published", False)):
+            with self.subTest(read_pass=seek_index + 1):
+                failure = SystemExit(f"read-{seek_index}")
+                api = FakeKernel32()
+                api.read_failure_seek = (seek_index, failure)
+                with self.assertRaises(SystemExit) as caught:
+                    self.publish(api)
+                self.assertIs(caught.exception, failure)
+                outcome = receipt.outcome_from_error(failure)
+                self.assertEqual(None if outcome is None else outcome.state, expected_state)
+                classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+                self.assertEqual(receipt.FILE_DISPOSITION_INFO in classes, disposition)
+
+    def test_create_new_collision_codes_are_retryable_file_exists(self) -> None:
+        for code in (receipt.ERROR_FILE_EXISTS, receipt.ERROR_ALREADY_EXISTS):
+            api = FakeKernel32({"NtCreateFile": False})
+            api.error = code
+            with self.subTest(code=code), self.assertRaises(FileExistsError) as caught:
+                self.publish(api)
+            self.assertEqual(caught.exception.errno, code)
+
+    def test_definite_false_rename_disposes_but_raised_rename_is_unknown(self) -> None:
+        api = FakeKernel32({"Rename": False})
+        api.error = 5
+        with self.assertRaises(receipt._DefiniteRenameError):
+            self.publish(api)
+        self.assertIn(
+            receipt.FILE_DISPOSITION_INFO,
+            [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"],
+        )
+        for failure in (
+            OSError("rename"),
+            FileExistsError("raised collision"),
+            KeyboardInterrupt("rename"),
+            SystemExit("rename"),
+        ):
+            with self.subTest(failure=type(failure).__name__):
+                api = FakeKernel32({"Rename": failure, "CloseHandle": OSError("close")})
+                with self.assertRaises(type(failure)) as caught:
+                    self.publish(api)
+                self.assertIs(caught.exception, failure)
+                outcome = receipt.outcome_from_error(failure)
+                self.assertIsNotNone(outcome)
+                assert outcome is not None
+                self.assertEqual(outcome.state, "unknown")
+                self.assertEqual(outcome.receipt.file_id, bytes(range(16)))
+                classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+                self.assertNotIn(receipt.FILE_DISPOSITION_INFO, classes)
+                self.assertIn("Could not close", "\n".join(getattr(failure, "__notes__", [])))
+
+    def test_trace_boundaries_never_dispose_unknown_or_published_rename(self) -> None:
+        publisher_code = receipt.publish_windows_receipt.__code__
+        source_lines, source_start = inspect.getsourcelines(receipt.publish_windows_receipt)
+        rename_index = next(index for index, line in enumerate(source_lines) if line.lstrip().startswith("_rename("))
+        publish_index = next(
+            index for index, line in enumerate(source_lines) if line.strip() == 'publication_lease.phase = "published"'
+        )
+        post_confirmation_index = next(
+            index
+            for index, line in enumerate(source_lines)
+            if index > publish_index and line.lstrip().startswith("if _read_exact(")
+        )
+        boundary_lines = {
+            "pre-call": source_start + rename_index,
+            "post-native": source_start + publish_index,
+            "post-confirmation": source_start + post_confirmation_index,
+        }
+        for boundary in ("pre-call", "post-native", "post-confirmation"):
+            with self.subTest(boundary=boundary):
+                api = FakeKernel32()
+                interruption = KeyboardInterrupt(boundary)
+                triggered = False
+
+                def trace(frame: Any, event: str, _argument: object) -> Any:
+                    nonlocal triggered
+                    if (
+                        not triggered
+                        and event == "line"
+                        and frame.f_code is publisher_code
+                        and frame.f_lineno == boundary_lines[boundary]
+                    ):
+                        triggered = True
+                        raise interruption
+                    return trace
+
+                previous = sys.gettrace()
+                try:
+                    sys.settrace(trace)
+                    with self.assertRaises(KeyboardInterrupt) as caught:
+                        self.publish(api)
+                finally:
+                    sys.settrace(previous)
+
+                self.assertIs(caught.exception, interruption)
+                outcome = receipt.outcome_from_error(interruption)
+                self.assertIsNotNone(outcome)
+                assert outcome is not None
+                self.assertEqual(outcome.state, "published" if boundary == "post-confirmation" else "unknown")
+                classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+                self.assertEqual(classes.count(receipt.FILE_RENAME_INFO), 0 if boundary == "pre-call" else 1)
+                self.assertNotIn(receipt.FILE_DISPOSITION_INFO, classes)
+                self.assertEqual(api.calls[-1][0], "CloseHandle")
+
+    def test_trace_after_create_acquisition_disposes_and_closes_tracked_handle(self) -> None:
+        api = FakeKernel32()
+        interruption = KeyboardInterrupt("post-create acquisition")
+        publisher_code = receipt.publish_windows_receipt.__code__
+        source_lines, source_start = inspect.getsourcelines(receipt.publish_windows_receipt)
+        ownership_line = source_start + next(
+            index for index, line in enumerate(source_lines) if line.strip() == "handle = lease.handle"
+        )
+        triggered = False
+
+        def trace(frame: Any, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if (
+                event == "line"
+                and frame.f_code is publisher_code
+                and not triggered
+                and frame.f_lineno == ownership_line
+                and api.create_succeeded
+            ):
+                triggered = True
+                raise interruption
+            return trace
+
+        previous = sys.gettrace()
+        try:
+            sys.settrace(trace)
+            with self.assertRaises(KeyboardInterrupt) as caught:
+                self.publish(api)
+        finally:
+            sys.settrace(previous)
+        self.assertIs(caught.exception, interruption)
+        classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+        self.assertIn(receipt.FILE_DISPOSITION_INFO, classes)
+        self.assertEqual(api.calls[-1][0], "CloseHandle")
+
+    def test_both_collision_codes_map_to_file_exists(self) -> None:
+        for code in (receipt.ERROR_FILE_EXISTS, receipt.ERROR_ALREADY_EXISTS):
+            with self.subTest(code=code):
+                api = FakeKernel32({"Rename": False})
+                api.error = code
+                with self.assertRaises(FileExistsError) as caught:
+                    self.publish(api)
+                self.assertEqual(caught.exception.errno, code)
+
+    def test_cleanup_failures_preserve_primary_and_order_notes(self) -> None:
+        for primary_factory in (
+            lambda: OSError("write"),
+            lambda: KeyboardInterrupt("write"),
+            lambda: SystemExit("write"),
+        ):
+            with self.subTest(primary=primary_factory().__class__.__name__):
+                primary = primary_factory()
+                disposition = KeyboardInterrupt("dispose")
+                close = SystemExit("close")
+                api = FakeKernel32({"WriteFile": primary, "Disposition": disposition, "CloseHandle": close})
+                with self.assertRaises(BaseException) as caught:
+                    self.publish(api)
+                self.assertIs(caught.exception, primary)
+                self.assertEqual(
+                    getattr(primary, "__notes__", []),
+                    [
+                        "Could not mark receipt staging file for deletion: dispose",
+                        "Could not close receipt staging handle: close",
+                    ],
+                )
+                self.assertEqual(receipt.cleanup_failures_from_error(primary), (disposition, close))
+
+    def test_close_call_return_gap_preserves_active_primary(self) -> None:
+        primary = RuntimeError("write")
+        interruption = KeyboardInterrupt("between close return and result assignment")
+        api = FakeKernel32({"WriteFile": primary})
+        triggered = False
+
+        real_close = receipt._WindowsReceiptPublicationLease.close
+
+        def close_then_interrupt(
+            publication_lease: receipt._WindowsReceiptPublicationLease,
+        ) -> tuple[BaseException, ...]:
+            nonlocal triggered
+            result = real_close(publication_lease)
+            if not triggered:
+                triggered = True
+                raise interruption
+            return result
+
+        with mock.patch.object(
+            receipt._WindowsReceiptPublicationLease,
+            "close",
+            new=close_then_interrupt,
+        ):
+            with self.assertRaises(RuntimeError) as caught:
+                self.publish(api)
+
+        self.assertTrue(triggered)
+        self.assertIs(caught.exception, primary)
+        self.assertEqual(receipt.cleanup_failures_from_error(primary), (interruption,))
+        self.assertIn(
+            "Could not close receipt staging handle: between close return and result assignment",
+            getattr(primary, "__notes__", ()),
+        )
+        self.assertEqual(sum(name == "CloseHandle" for name, _args in api.calls), 1)
+
+    def test_cleanup_and_definite_rename_evidence_rejects_spoofed_attributes(self) -> None:
+        spoof = receipt._DefiniteRenameCollision(receipt.ERROR_FILE_EXISTS, "spoof")
+        setattr(spoof, "_windows_receipt_cleanup_failures", (KeyboardInterrupt("spoof"),))
+        setattr(spoof, "_windows_receipt_cleanup_record", (KeyboardInterrupt("spoof"),))
+        setattr(spoof, "_windows_receipt_definite_provenance", object())
+
+        self.assertEqual(receipt.cleanup_failures_from_error(spoof), ())
+        self.assertFalse(receipt.is_internal_definite_rename_collision(spoof))
+
+    def test_post_rename_close_failure_does_not_dispose_public_name(self) -> None:
+        close = OSError("close")
+        api = FakeKernel32({"CloseHandle": close})
+        with self.assertRaises(OSError) as caught:
+            self.publish(api)
+        self.assertIs(caught.exception, close)
+        info_classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+        self.assertNotIn(receipt.FILE_DISPOSITION_INFO, info_classes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_anchored_receipt_windows_integration.py
+++ b/tests/test_anchored_receipt_windows_integration.py
@@ -1,0 +1,1643 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+import ctypes
+import gc
+import inspect
+from pathlib import Path
+import sys
+from types import FrameType
+from typing import Any, cast
+import unittest
+from unittest import mock
+
+from scripts import _anchored_output as anchored
+from scripts import _anchored_receipt_windows as receipt
+from scripts import verify_dependency_environment as verifier
+from tests.test_anchored_receipt_windows import FakeKernel32
+from tests.test_anchored_receipt_windows_relative import (
+    FakeKernelApi,
+    FakeNtApi,
+    _SequencedCloseKernelApi,
+)
+
+
+PAYLOAD = b'{"status":"verified"}\n'
+_API_NAMES = (
+    "NtCreateFile",
+    "RtlNtStatusToDosError",
+    "WriteFile",
+    "ReadFile",
+    "FlushFileBuffers",
+    "SetFilePointerEx",
+    "GetFileInformationByHandleEx",
+    "SetFileInformationByHandle",
+    "GetFileType",
+    "CloseHandle",
+)
+
+
+class _Binding:
+    def __init__(self, api: FakeKernel32) -> None:
+        self.parent = Path("C:/bound")
+        self.leaf = "receipt.json"
+        self.windows_entries = ((self.parent, (1, 2), 0x4567),)
+        self.windows_api = api
+        self.closed = 0
+        self.verified = 0
+        self._closed = False
+
+    @property
+    def is_closed(self) -> bool:
+        return self._closed
+
+    def stat(self, _name: str) -> Any:
+        raise FileNotFoundError
+
+    def verify(self) -> None:
+        self.verified += 1
+
+    def close(self) -> tuple[BaseException, ...]:
+        if not self._closed:
+            self.closed += 1
+            self._closed = True
+        return ()
+
+
+def _assignable_api(api: FakeKernel32) -> FakeKernel32:
+    """Give the behavioral fake ctypes-like callables with writable ABI metadata."""
+
+    for name in _API_NAMES:
+        setattr(api, name, mock.Mock(wraps=getattr(api, name)))
+    return api
+
+
+class _SequencedNtApi(FakeNtApi):
+    def __init__(self, handles: tuple[int, ...], information: tuple[int, ...]) -> None:
+        super().__init__(information=information[0], handle=handles[0])
+        self._handles = handles
+        self._information = information
+
+    def NtCreateFile(
+        self,
+        output: Any,
+        desired_access: int,
+        object_attributes: Any,
+        io_status: Any,
+        allocation_size: object,
+        file_attributes: int,
+        share_access: int,
+        disposition: int,
+        options: int,
+        ea_buffer: object,
+        ea_length: int,
+    ) -> int:
+        index = len(self.calls)
+        self.handle = self._handles[index]
+        self.information = self._information[index]
+        return super().NtCreateFile(
+            output,
+            desired_access,
+            object_attributes,
+            io_status,
+            allocation_size,
+            file_attributes,
+            share_access,
+            disposition,
+            options,
+            ea_buffer,
+            ea_length,
+        )
+
+
+class _ExistingWinnerKernel32(FakeKernel32):
+    """Model a public winner that would be overwritten by replace semantics."""
+
+    def __init__(self, public_data: bytes) -> None:
+        super().__init__({"Rename": False})
+        self.error = receipt.ERROR_FILE_EXISTS
+        self.public_data = bytearray(public_data)
+
+    def SetFileInformationByHandle(self, handle: int, info_class: int, pointer: Any, size: int) -> bool:
+        if info_class == receipt.FILE_RENAME_INFO:
+            raw = ctypes.string_at(pointer, size)
+            info = receipt._FileRenameInfo.from_buffer_copy(
+                raw + bytes(max(0, ctypes.sizeof(receipt._FileRenameInfo) - len(raw)))
+            )
+            if info.ReplaceIfExists:
+                self.failures["Rename"] = True
+                try:
+                    result = super().SetFileInformationByHandle(handle, info_class, pointer, size)
+                finally:
+                    self.failures["Rename"] = False
+                if result:
+                    self.public_data[:] = self.data
+                return result
+        return super().SetFileInformationByHandle(handle, info_class, pointer, size)
+
+
+class WindowsReceiptFacadeIntegrationTests(unittest.TestCase):
+    def _owner(self, binding: _Binding) -> anchored._OutputParentBindingLease:
+        owner = anchored._OutputParentBindingLease()
+        owner.binding = cast(anchored.OutputParentBinding, binding)
+        return owner
+
+    def _scripted_reader(self) -> tuple[Any, mock.Mock]:
+        helper = anchored._windows_receipt_module()
+        observed = helper.WindowsReceiptResult("receipt.json", 77, bytes(range(16)), len(PAYLOAD))
+        return helper, mock.Mock(side_effect=(FileNotFoundError(), observed))
+
+    def _publish(self, api: FakeKernel32) -> tuple[_Binding, mock.Mock]:
+        binding = _Binding(_assignable_api(api))
+        helper, reader = self._scripted_reader()
+        with mock.patch.object(helper, "read_windows_receipt", reader):
+            anchored._publish_windows_receipt_bytes(
+                binding.parent / binding.leaf,
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                self._owner(binding),
+            )
+        return binding, reader
+
+    def test_initial_exact_receipt_returns_without_native_publication(self) -> None:
+        api = _assignable_api(FakeKernel32())
+        binding = _Binding(api)
+        helper = anchored._windows_receipt_module()
+        observed = helper.WindowsReceiptResult("receipt.json", 77, bytes(range(16)), len(PAYLOAD))
+        with (
+            mock.patch.object(helper, "read_windows_receipt", return_value=observed) as reader,
+            mock.patch.object(helper, "publish_windows_receipt") as publish,
+        ):
+            anchored._publish_windows_receipt_bytes(
+                binding.parent / binding.leaf,
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                self._owner(binding),
+            )
+
+        reader.assert_called_once()
+        publish.assert_not_called()
+        self.assertEqual(cast(Any, api).NtCreateFile.call_count, 0)
+        self.assertEqual(binding.closed, 1)
+
+    def test_missing_target_does_not_swallow_missing_ancestor_verification(self) -> None:
+        api = _assignable_api(FakeKernel32())
+        binding = _Binding(api)
+        parent_missing = FileNotFoundError("bound ancestor disappeared")
+        binding.verify = mock.Mock(side_effect=(None, None, parent_missing))
+        helper = anchored._windows_receipt_module()
+        with (
+            mock.patch.object(helper, "read_windows_receipt", side_effect=FileNotFoundError),
+            mock.patch.object(helper, "publish_windows_receipt") as publish,
+            self.assertRaises(FileNotFoundError) as raised,
+        ):
+            anchored._publish_windows_receipt_bytes(
+                binding.parent / binding.leaf,
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                self._owner(binding),
+            )
+
+        self.assertIs(raised.exception, parent_missing)
+        publish.assert_not_called()
+        self.assertEqual(binding.closed, 1)
+
+    def test_helper_validation_error_keeps_code_and_closes_binding(self) -> None:
+        api = _assignable_api(FakeKernel32())
+        binding = _Binding(api)
+        helper = anchored._windows_receipt_module()
+        validation = helper.WindowsReceiptValidationError(
+            "output-existing-invalid",
+            "induced retained-handle validation failure",
+        )
+        validation.add_note("validation note")
+        with (
+            mock.patch.object(helper, "read_windows_receipt", side_effect=validation),
+            mock.patch.object(helper, "publish_windows_receipt") as publish,
+            self.assertRaises(anchored.AnchoredOutputError) as raised,
+        ):
+            anchored._publish_windows_receipt_bytes(
+                binding.parent / binding.leaf,
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                self._owner(binding),
+            )
+
+        self.assertEqual(raised.exception.code, "output-existing-invalid")
+        self.assertIs(raised.exception.__cause__, validation)
+        self.assertIn("validation note", "\n".join(getattr(raised.exception, "__notes__", ())))
+        publish.assert_not_called()
+        self.assertEqual(binding.closed, 1)
+
+    def test_post_open_missing_validation_cannot_masquerade_as_initial_absence(self) -> None:
+        native_error = FileNotFoundError(
+            receipt.ERROR_FILE_NOT_FOUND,
+            "opened receipt disappeared during metadata validation",
+        )
+        native_error.add_note("post-open namespace note")
+        kernel = FakeKernelApi()
+        kernel.failures["GetInfo:0"] = native_error
+        native = FakeNtApi(information=receipt.FILE_OPENED)
+        binding = _Binding(cast(Any, kernel))
+        helper = anchored._windows_receipt_module()
+
+        def unchanged(api: Any) -> Any:
+            return api
+
+        with (
+            mock.patch.object(helper, "_select_apis", return_value=(kernel, native)),
+            mock.patch.object(helper, "_configure_api", side_effect=unchanged),
+            mock.patch.object(helper, "_configure_nt_api", side_effect=unchanged),
+            mock.patch.object(helper, "publish_windows_receipt") as publish,
+            self.assertRaises(anchored.AnchoredOutputError) as raised,
+        ):
+            anchored._publish_windows_receipt_bytes(
+                binding.parent / binding.leaf,
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                self._owner(binding),
+            )
+
+        self.assertEqual(raised.exception.code, "output-changed")
+        helper_error = raised.exception.__cause__
+        assert helper_error is not None
+        self.assertIsInstance(helper_error, helper.WindowsReceiptValidationError)
+        self.assertIs(helper_error.__cause__, native_error)
+        self.assertIn("post-open namespace note", getattr(raised.exception, "__notes__", ()))
+        publish.assert_not_called()
+        self.assertEqual(binding.closed, 1)
+
+    def test_helper_validation_code_reaches_verifier_adapter(self) -> None:
+        facade = verifier._ANCHORED_OUTPUT
+        helper = facade._windows_receipt_module()
+        api = _assignable_api(FakeKernel32())
+        binding = _Binding(api)
+        validation = helper.WindowsReceiptValidationError(
+            "output-existing-invalid",
+            "induced verifier-facing validation failure",
+        )
+
+        def publish(path: Path, payload: bytes) -> None:
+            with mock.patch.object(helper, "read_windows_receipt", side_effect=validation):
+                facade._publish_windows_receipt_bytes(
+                    path,
+                    payload,
+                    binding,
+                    self._owner(binding),
+                )
+
+        with (
+            mock.patch.object(verifier, "_PUBLISH_IDENTICAL_RECEIPT_BYTES", side_effect=publish),
+            self.assertRaises(verifier.ReceiptOutputError) as raised,
+        ):
+            verifier.atomic_write_receipt(
+                binding.parent / binding.leaf,
+                {"status": "verified"},
+            )
+
+        self.assertEqual(raised.exception.code, "output-existing-invalid")
+        facade_error = raised.exception.__cause__
+        self.assertIsInstance(facade_error, facade.AnchoredOutputError)
+        assert facade_error is not None
+        self.assertIs(facade_error.__cause__, validation)
+        self.assertEqual(binding.closed, 1)
+
+    def test_unpaired_surrogate_leaf_maps_to_path_invalid_without_native_call(self) -> None:
+        api = _assignable_api(FakeKernel32())
+        binding = _Binding(api)
+        binding.leaf = "receipt-\ud800.json"
+        helper = anchored._windows_receipt_module()
+        with (
+            mock.patch.object(helper, "publish_windows_receipt") as publish,
+            self.assertRaises(anchored.AnchoredOutputError) as raised,
+        ):
+            anchored._publish_windows_receipt_bytes(
+                binding.parent / binding.leaf,
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                self._owner(binding),
+            )
+
+        self.assertEqual(raised.exception.code, "path-invalid")
+        publish.assert_not_called()
+        self.assertEqual(cast(Any, api).NtCreateFile.call_count, 0)
+        self.assertEqual(binding.closed, 1)
+
+    def test_final_observation_must_match_published_volume_and_file_id(self) -> None:
+        api = _assignable_api(FakeKernel32())
+        binding = _Binding(api)
+        helper = anchored._windows_receipt_module()
+        changed = helper.WindowsReceiptResult("receipt.json", 78, b"z" * 16, len(PAYLOAD))
+        reader = mock.Mock(side_effect=(FileNotFoundError(), changed))
+        with (
+            mock.patch.object(helper, "read_windows_receipt", reader),
+            self.assertRaises(anchored.AnchoredOutputError) as raised,
+        ):
+            anchored._publish_windows_receipt_bytes(
+                binding.parent / binding.leaf,
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                self._owner(binding),
+            )
+
+        self.assertEqual(raised.exception.code, "output-changed")
+        self.assertEqual(reader.call_count, 2)
+        self.assertEqual(binding.closed, 1)
+
+    def test_final_validation_failures_remap_to_output_changed(self) -> None:
+        helper = anchored._windows_receipt_module()
+        for code in ("output-existing-invalid", "output-different"):
+            with self.subTest(code=code):
+                api = _assignable_api(FakeKernel32())
+                binding = _Binding(api)
+                validation = helper.WindowsReceiptValidationError(code, f"induced final {code}")
+                validation.add_note("final validation note")
+                reader = mock.Mock(side_effect=(FileNotFoundError(), validation))
+                with (
+                    mock.patch.object(helper, "read_windows_receipt", reader),
+                    self.assertRaises(anchored.AnchoredOutputError) as raised,
+                ):
+                    anchored._publish_windows_receipt_bytes(
+                        binding.parent / binding.leaf,
+                        PAYLOAD,
+                        cast(anchored.OutputParentBinding, binding),
+                        self._owner(binding),
+                    )
+
+                self.assertEqual(raised.exception.code, "output-changed")
+                self.assertIs(raised.exception.__cause__, validation)
+                self.assertIn("final validation note", getattr(raised.exception, "__notes__", ()))
+                self.assertEqual(reader.call_count, 2)
+                self.assertEqual(binding.closed, 1)
+
+    def test_unsupported_win32_publication_has_stable_anchor_code(self) -> None:
+        api = _assignable_api(FakeKernel32({"Rename": False}))
+        api.error = receipt.ERROR_NOT_SUPPORTED
+        binding = _Binding(api)
+        helper = anchored._windows_receipt_module()
+        reader = mock.Mock(side_effect=FileNotFoundError())
+        with (
+            mock.patch.object(helper, "read_windows_receipt", reader),
+            self.assertRaises(anchored.AnchoredOutputError) as raised,
+        ):
+            anchored._publish_windows_receipt_bytes(
+                binding.parent / binding.leaf,
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                self._owner(binding),
+            )
+
+        self.assertEqual(raised.exception.code, "output-anchor-unavailable")
+        self.assertIsInstance(raised.exception.__cause__, helper._DefiniteRenameError)
+        self.assertEqual(reader.call_count, 1)
+        self.assertEqual(binding.closed, 1)
+        classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+        self.assertIn(receipt.FILE_DISPOSITION_INFO, classes)
+
+    def test_unsupported_stage_metadata_maps_before_publication_and_keeps_notes(self) -> None:
+        native_error = OSError(receipt.ERROR_NOT_SUPPORTED, "unsupported staging metadata")
+        native_error.add_note("native staging metadata note")
+        api = _assignable_api(FakeKernel32({"GetInfo:0": native_error}))
+        binding = _Binding(api)
+        helper = anchored._windows_receipt_module()
+        reader = mock.Mock(side_effect=FileNotFoundError())
+        with (
+            mock.patch.object(helper, "read_windows_receipt", reader),
+            self.assertRaises(anchored.AnchoredOutputError) as raised,
+        ):
+            anchored._publish_windows_receipt_bytes(
+                binding.parent / binding.leaf,
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                self._owner(binding),
+            )
+
+        self.assertEqual(raised.exception.code, "output-anchor-unavailable")
+        self.assertIs(raised.exception.__cause__, native_error)
+        self.assertIn("native staging metadata note", getattr(raised.exception, "__notes__", ()))
+        self.assertIsNone(helper.outcome_from_error(native_error))
+        self.assertEqual(reader.call_count, 1)
+        self.assertEqual(binding.closed, 1)
+        classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+        self.assertNotIn(receipt.FILE_RENAME_INFO, classes)
+        self.assertIn(receipt.FILE_DISPOSITION_INFO, classes)
+
+    def test_unsupported_error_after_rename_keeps_published_outcome_and_primary(self) -> None:
+        native_error = OSError(receipt.ERROR_NOT_SUPPORTED, "unsupported post-rename read")
+        native_error.add_note("native post-rename note")
+        api = _assignable_api(FakeKernel32())
+        api.read_failure_seek = (1, native_error)
+        binding = _Binding(api)
+        helper, reader = self._scripted_reader()
+        with (
+            mock.patch.object(helper, "read_windows_receipt", reader),
+            self.assertRaises(OSError) as raised,
+        ):
+            anchored._publish_windows_receipt_bytes(
+                binding.parent / binding.leaf,
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                self._owner(binding),
+            )
+
+        self.assertIs(raised.exception, native_error)
+        outcome = helper.outcome_from_error(native_error)
+        self.assertIsNotNone(outcome)
+        assert outcome is not None
+        self.assertEqual(outcome.state, "published")
+        notes = "\n".join(getattr(native_error, "__notes__", ()))
+        self.assertIn("native post-rename note", notes)
+        self.assertIn("took effect", notes)
+        self.assertEqual(reader.call_count, 2)
+        self.assertEqual(binding.closed, 1)
+        classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+        self.assertIn(receipt.FILE_RENAME_INFO, classes)
+        self.assertNotIn(receipt.FILE_DISPOSITION_INFO, classes)
+
+    def test_unsupported_rename_exception_keeps_unknown_outcome_and_primary(self) -> None:
+        native_error = OSError(receipt.ERROR_CALL_NOT_IMPLEMENTED, "uncertain rename result")
+        api = _assignable_api(FakeKernel32({"Rename": native_error}))
+        binding = _Binding(api)
+        helper, reader = self._scripted_reader()
+        with (
+            mock.patch.object(helper, "read_windows_receipt", reader),
+            self.assertRaises(OSError) as raised,
+        ):
+            anchored._publish_windows_receipt_bytes(
+                binding.parent / binding.leaf,
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                self._owner(binding),
+            )
+
+        self.assertIs(raised.exception, native_error)
+        outcome = helper.outcome_from_error(native_error)
+        self.assertIsNotNone(outcome)
+        assert outcome is not None
+        self.assertEqual(outcome.state, "unknown")
+        self.assertIn("took effect", "\n".join(getattr(native_error, "__notes__", ())))
+        self.assertEqual(reader.call_count, 2)
+        self.assertEqual(binding.closed, 1)
+        classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+        self.assertIn(receipt.FILE_RENAME_INFO, classes)
+        self.assertNotIn(receipt.FILE_DISPOSITION_INFO, classes)
+
+    def test_generic_win32_publication_io_error_remains_native(self) -> None:
+        api = _assignable_api(FakeKernel32({"Rename": False}))
+        api.error = 1117
+        binding = _Binding(api)
+        helper = anchored._windows_receipt_module()
+        with (
+            mock.patch.object(helper, "read_windows_receipt", side_effect=FileNotFoundError),
+            self.assertRaises(helper._DefiniteRenameError) as raised,
+        ):
+            anchored._publish_windows_receipt_bytes(
+                binding.parent / binding.leaf,
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                self._owner(binding),
+            )
+
+        self.assertEqual(raised.exception.errno, 1117)
+        self.assertEqual(binding.closed, 1)
+
+    def test_facade_configures_full_fixed_width_api_before_real_helper_use(self) -> None:
+        api = FakeKernel32()
+        binding, reader = self._publish(api)
+        ctypes_api = cast(Any, api)
+
+        self.assertEqual(ctypes_api.WriteFile.argtypes[0], ctypes.c_void_p)
+        self.assertEqual(ctypes_api.WriteFile.argtypes[2], ctypes.c_uint32)
+        self.assertEqual(ctypes_api.ReadFile.argtypes, ctypes_api.WriteFile.argtypes)
+        self.assertEqual(ctypes_api.FlushFileBuffers.argtypes, (ctypes.c_void_p,))
+        self.assertEqual(ctypes_api.SetFilePointerEx.argtypes[0], ctypes.c_void_p)
+        self.assertEqual(ctypes_api.CloseHandle.argtypes, (ctypes.c_void_p,))
+        self.assertEqual(binding.closed, 1)
+        self.assertEqual(binding.verified, 7)
+        self.assertEqual(reader.call_count, 2)
+
+    def test_one_stage_collision_retries_real_helper_then_succeeds(self) -> None:
+        api = _assignable_api(FakeKernel32())
+        real_create: Any = api.NtCreateFile
+        attempts = 0
+
+        def collide_once(*args: object) -> int:
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                api.error = receipt.ERROR_FILE_EXISTS
+                return ctypes.c_int32(receipt.STATUS_OBJECT_NAME_COLLISION).value
+            return real_create(*args)
+
+        cast(Any, api).NtCreateFile = mock.Mock(side_effect=collide_once)
+        binding = _Binding(api)
+        helper, reader = self._scripted_reader()
+        with mock.patch.object(helper, "read_windows_receipt", reader):
+            anchored._publish_windows_receipt_bytes(
+                binding.parent / binding.leaf,
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                self._owner(binding),
+            )
+
+        self.assertEqual(attempts, 2)
+        self.assertEqual(binding.closed, 1)
+        self.assertEqual(reader.call_count, 2)
+
+    def test_stage_collision_exhaustion_is_bounded_and_closes_binding(self) -> None:
+        api = _assignable_api(FakeKernel32({"NtCreateFile": False}))
+        api.error = receipt.ERROR_ALREADY_EXISTS
+        binding = _Binding(api)
+        helper = anchored._windows_receipt_module()
+
+        with (
+            mock.patch.object(helper, "read_windows_receipt", side_effect=FileNotFoundError),
+            self.assertRaises(anchored.AnchoredOutputError) as raised,
+        ):
+            anchored._publish_windows_receipt_bytes(
+                binding.parent / binding.leaf,
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                self._owner(binding),
+            )
+
+        self.assertEqual(raised.exception.code, "output-temporary-unavailable")
+        self.assertEqual(cast(Any, api).NtCreateFile.call_count, 100)
+        self.assertEqual(binding.closed, 1)
+
+    def test_clean_definite_collision_observes_exact_winner_and_succeeds(self) -> None:
+        api = _assignable_api(FakeKernel32({"Rename": False}))
+        api.error = receipt.ERROR_FILE_EXISTS
+        binding, reader = self._publish(api)
+
+        self.assertEqual(binding.closed, 1)
+        self.assertEqual(reader.call_count, 2)
+        classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+        self.assertIn(receipt.FILE_DISPOSITION_INFO, classes)
+
+    def _assert_collision_preserves_rejected_winner(self, code: str) -> None:
+        original = b"pre-existing public winner"
+        api = cast(_ExistingWinnerKernel32, _assignable_api(_ExistingWinnerKernel32(original)))
+        binding = _Binding(api)
+        helper = anchored._windows_receipt_module()
+        validation = helper.WindowsReceiptValidationError(code, f"induced {code} winner")
+        reader = mock.Mock(side_effect=(FileNotFoundError(), validation))
+
+        with (
+            mock.patch.object(helper, "read_windows_receipt", reader),
+            self.assertRaises(anchored.AnchoredOutputError) as raised,
+        ):
+            anchored._publish_windows_receipt_bytes(
+                binding.parent / binding.leaf,
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                self._owner(binding),
+            )
+
+        self.assertEqual(raised.exception.code, code)
+        self.assertEqual(bytes(api.public_data), original)
+        self.assertFalse(api.rename_succeeded)
+        self.assertEqual(reader.call_count, 2)
+        self.assertEqual(binding.closed, 1)
+        classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+        self.assertIn(receipt.FILE_RENAME_INFO, classes)
+        self.assertIn(receipt.FILE_DISPOSITION_INFO, classes)
+
+    def test_definite_collision_preserves_different_existing_winner(self) -> None:
+        self._assert_collision_preserves_rejected_winner("output-different")
+
+    def test_definite_collision_preserves_noncanonical_existing_winner(self) -> None:
+        self._assert_collision_preserves_rejected_winner("output-existing-invalid")
+
+    def test_unknown_file_exists_after_native_call_is_observed_but_re_raised(self) -> None:
+        unknown = FileExistsError("uncertain native return")
+        api = _assignable_api(FakeKernel32({"Rename": unknown}))
+        binding = _Binding(api)
+        helper, reader = self._scripted_reader()
+
+        with (
+            mock.patch.object(helper, "read_windows_receipt", reader),
+            self.assertRaises(FileExistsError) as raised,
+        ):
+            anchored._publish_windows_receipt_bytes(
+                binding.parent / binding.leaf,
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                self._owner(binding),
+            )
+
+        self.assertIs(raised.exception, unknown)
+        self.assertEqual(binding.closed, 1)
+        self.assertEqual(reader.call_count, 2)
+        classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+        self.assertNotIn(receipt.FILE_DISPOSITION_INFO, classes)
+        self.assertIn("took effect", "\n".join(getattr(unknown, "__notes__", ())))
+
+    def test_publisher_cleanup_entry_interrupt_closes_child_before_parent_and_verifies_effect(self) -> None:
+        api = _assignable_api(FakeKernel32())
+        binding = _Binding(api)
+        helper, reader = self._scripted_reader()
+        outer_lease = anchored._OutputParentBindingLease()
+        outer_lease.binding = cast(anchored.OutputParentBinding, binding)
+        interruption = KeyboardInterrupt("publisher cleanup entry")
+        target_code = helper.publish_windows_receipt.__code__
+        source, first_line = inspect.getsourcelines(helper.publish_windows_receipt)
+        active_error_line = first_line + next(
+            index for index, line in enumerate(source) if "active_error = sys.exception()" in line
+        )
+        triggered = False
+
+        original_close = binding.close
+
+        def close_parent() -> tuple[BaseException, ...]:
+            self.assertEqual(
+                [call for call in api.calls if call[0] == "CloseHandle"],
+                [("CloseHandle", (api.handle,))],
+            )
+            return original_close()
+
+        binding.close = close_parent
+
+        def trace(frame: Any, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if event == "call" and frame.f_code is target_code:
+                frame.f_trace = trace
+                return trace
+            if (
+                event == "line"
+                and frame.f_code is target_code
+                and frame.f_lineno == active_error_line
+                and not triggered
+                and getattr(frame.f_locals.get("publication_lease"), "phase", None) == "published"
+            ):
+                triggered = True
+                raise interruption
+            return trace
+
+        previous = sys.gettrace()
+        try:
+            with (
+                mock.patch.object(helper, "read_windows_receipt", reader),
+                self.assertRaises(KeyboardInterrupt) as caught,
+            ):
+                sys.settrace(trace)
+                anchored._publish_windows_receipt_bytes(
+                    binding.parent / binding.leaf,
+                    PAYLOAD,
+                    cast(anchored.OutputParentBinding, binding),
+                    outer_lease,
+                )
+        finally:
+            sys.settrace(previous)
+
+        self.assertTrue(triggered)
+        self.assertIs(caught.exception, interruption)
+        self.assertEqual(reader.call_count, 2)
+        self.assertIn("took effect", "\n".join(getattr(interruption, "__notes__", ())))
+        self.assertEqual(binding.closed, 1)
+        self.assertEqual(outer_lease.close(), ())
+        self.assertEqual(sum(name == "CloseHandle" for name, _args in api.calls), 1)
+
+    def test_required_outer_owner_recovers_facade_cleanup_entry(self) -> None:
+        api = _assignable_api(FakeKernel32())
+        binding = _Binding(api)
+        helper, reader = self._scripted_reader()
+        outer_lease = self._owner(binding)
+        interruption = KeyboardInterrupt("Windows facade cleanup entry")
+        target_code = anchored._publish_windows_receipt_bytes.__code__
+        source, first_line = inspect.getsourcelines(anchored._publish_windows_receipt_bytes)
+        cleanup_line = first_line + next(
+            index for index, line in enumerate(source) if "close_failures: tuple[BaseException, ...] = ()" in line
+        )
+        triggered = False
+
+        def trace(frame: Any, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if event == "call" and frame.f_code is target_code:
+                frame.f_trace = trace
+                return trace
+            if (
+                event == "line"
+                and frame.f_code is target_code
+                and frame.f_lineno == cleanup_line
+                and not triggered
+                and outer_lease.publication_resources
+            ):
+                triggered = True
+                raise interruption
+            return trace
+
+        previous = sys.gettrace()
+        try:
+            with (
+                mock.patch.object(helper, "read_windows_receipt", reader),
+                self.assertRaises(KeyboardInterrupt) as caught,
+            ):
+                sys.settrace(trace)
+                anchored._publish_windows_receipt_bytes(
+                    binding.parent / binding.leaf,
+                    PAYLOAD,
+                    cast(anchored.OutputParentBinding, binding),
+                    outer_lease,
+                )
+        finally:
+            sys.settrace(previous)
+
+        self.assertTrue(triggered)
+        self.assertIs(caught.exception, interruption)
+        self.assertEqual(binding.closed, 0)
+        self.assertEqual(len(outer_lease.publication_resources), 1)
+        publication_lease = cast(Any, outer_lease.publication_resources[0])
+        outcome = publication_lease.outcome
+        self.assertIsNotNone(outcome)
+        self.assertEqual(outcome.state, "published")
+        self.assertEqual(outer_lease.close(), ())
+        self.assertEqual(binding.closed, 1)
+        self.assertEqual(sum(name == "CloseHandle" for name, _args in api.calls), 1)
+
+    def test_definite_collision_cannot_swallow_disposition_or_close_failure(self) -> None:
+        cases: tuple[tuple[str, dict[str, BaseException | bool]], ...] = (
+            ("disposition", {"Rename": False, "Disposition": False}),
+            ("close", {"Rename": False, "CloseHandle": False}),
+        )
+        for label, failures in cases:
+            with self.subTest(label=label):
+                api = _assignable_api(FakeKernel32(failures))
+                api.error = receipt.ERROR_FILE_EXISTS
+                binding = _Binding(api)
+                helper, reader = self._scripted_reader()
+                with (
+                    mock.patch.object(helper, "read_windows_receipt", reader),
+                    self.assertRaises(anchored.AnchoredOutputError) as raised,
+                ):
+                    anchored._publish_windows_receipt_bytes(
+                        binding.parent / binding.leaf,
+                        PAYLOAD,
+                        cast(anchored.OutputParentBinding, binding),
+                        self._owner(binding),
+                    )
+
+                self.assertEqual(raised.exception.code, "output-cleanup-retained")
+                self.assertEqual(binding.closed, 0 if label == "close" else 1)
+                self.assertEqual(reader.call_count, 2)
+                notes = "\n".join(getattr(raised.exception, "__notes__", ()))
+                self.assertIn("Could not", notes)
+
+    def test_api_raised_collision_and_spoofed_cleanup_evidence_remain_unknown(self) -> None:
+        helper = anchored._windows_receipt_module()
+        spoof = helper._DefiniteRenameCollision(receipt.ERROR_FILE_EXISTS, "spoofed native exception")
+        setattr(spoof, "_windows_receipt_cleanup_failures", (KeyboardInterrupt("spoof"),))
+        setattr(spoof, "_windows_receipt_cleanup_record", (KeyboardInterrupt("spoof"),))
+        api = _assignable_api(FakeKernel32({"Rename": spoof}))
+        binding = _Binding(api)
+        _, reader = self._scripted_reader()
+
+        with (
+            mock.patch.object(helper, "read_windows_receipt", reader),
+            self.assertRaises(helper._DefiniteRenameCollision) as raised,
+        ):
+            anchored._publish_windows_receipt_bytes(
+                binding.parent / binding.leaf,
+                PAYLOAD,
+                cast(anchored.OutputParentBinding, binding),
+                self._owner(binding),
+            )
+
+        self.assertIs(raised.exception, spoof)
+        outcome = helper.outcome_from_error(spoof)
+        self.assertIsNotNone(outcome)
+        assert outcome is not None
+        self.assertEqual(outcome.state, "unknown")
+        self.assertEqual(helper.cleanup_failures_from_error(spoof), ())
+        classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+        self.assertNotIn(receipt.FILE_DISPOSITION_INFO, classes)
+        self.assertEqual(reader.call_count, 2)
+        self.assertEqual(binding.closed, 1)
+
+
+class WindowsRootedParentFacadeTests(unittest.TestCase):
+    def test_binding_keeps_parent_handle_open_when_child_cleanup_is_retained(self) -> None:
+        helper = anchored._windows_receipt_module()
+        interruption = KeyboardInterrupt("child handle remains retained")
+
+        for failure_mode in ("return", "raise"):
+            with self.subTest(failure_mode=failure_mode):
+                root = helper.WindowsHandleLease(0xA001)
+                child = helper.WindowsHandleLease(0xA002)
+                binding = anchored.OutputParentBinding(
+                    checkout=Path("C:/"),
+                    parent=Path("C:/parent"),
+                    leaf="receipt.json",
+                    strategy="windows-handle",
+                    windows_api=object(),
+                    windows_handle_leases=(root, child),
+                )
+                calls: list[int] = []
+                child_may_close = False
+
+                def close_handle(
+                    _api: object,
+                    lease: Any,
+                    _primary: BaseException | None,
+                    _context: str,
+                ) -> BaseException | None:
+                    calls.append(lease.handle)
+                    if lease is child and not child_may_close:
+                        if failure_mode == "raise":
+                            raise interruption
+                        return interruption
+                    lease.handle = None
+                    return None
+
+                with mock.patch.object(
+                    helper,
+                    "close_windows_handle_lease",
+                    side_effect=close_handle,
+                ):
+                    first_failures = binding.close()
+                    self.assertIn(interruption, first_failures)
+                    self.assertTrue(all(handle == 0xA002 for handle in calls))
+                    self.assertEqual(root.handle, 0xA001)
+                    self.assertEqual(child.handle, 0xA002)
+                    self.assertFalse(binding.is_closed)
+
+                    child_may_close = True
+                    self.assertEqual(binding.close(), ())
+
+                self.assertEqual(calls[-2:], [0xA002, 0xA001])
+                self.assertIsNone(child.handle)
+                self.assertIsNone(root.handle)
+                self.assertTrue(binding.is_closed)
+
+    def test_recorded_false_keeps_root_open_after_parent_close_reentry(self) -> None:
+        kernel = _SequencedCloseKernelApi((False, False))
+        root = receipt.WindowsHandleLease(0xD001)
+        child = receipt.WindowsHandleLease(0xD002)
+        binding = anchored.OutputParentBinding(
+            checkout=Path("C:/"),
+            parent=Path("C:/parent"),
+            leaf="receipt.json",
+            strategy="windows-handle",
+            windows_api=kernel,
+            windows_handle_leases=(root, child),
+            receipt_parent_policy=True,
+        )
+
+        first_failures = binding.close()
+        second_failures = binding.close()
+
+        self.assertTrue(first_failures)
+        self.assertTrue(second_failures)
+        self.assertEqual(
+            [args[0] for name, args in kernel.calls if name == "CloseHandle"],
+            [0xD002, 0xD002],
+        )
+        self.assertEqual(child.handle, 0xD002)
+        self.assertEqual(root.handle, 0xD001)
+        self.assertFalse(binding.is_closed)
+
+    def test_parent_lease_finalizer_obeys_close_result_lifo(self) -> None:
+        cases = (
+            ("child-retained", (False, False), [0xE002, 0xE002], False),
+            ("retry-succeeds", (False, True, True), [0xE002, 0xE002, 0xE001], True),
+        )
+        for label, close_results, expected_handles, expected_closed in cases:
+            with self.subTest(label=label):
+                kernel = _SequencedCloseKernelApi(close_results)
+                root = receipt.WindowsHandleLease(0xE001)
+                child = receipt.WindowsHandleLease(0xE002)
+                binding = anchored.OutputParentBinding(
+                    checkout=Path("C:/"),
+                    parent=Path("C:/parent"),
+                    leaf="receipt.json",
+                    strategy="windows-handle",
+                    windows_api=kernel,
+                    windows_handle_leases=(root, child),
+                    receipt_parent_policy=True,
+                )
+                owner = anchored._OutputParentBindingLease(binding)
+
+                del owner
+                gc.collect()
+
+                self.assertEqual(
+                    [args[0] for name, args in kernel.calls if name == "CloseHandle"],
+                    expected_handles,
+                )
+                self.assertEqual(binding.is_closed, expected_closed)
+                if expected_closed:
+                    self.assertIsNone(child.handle)
+                    self.assertIsNone(root.handle)
+                else:
+                    self.assertEqual(child.handle, 0xE002)
+                    self.assertEqual(root.handle, 0xE001)
+
+    def test_parent_lease_finalizer_never_reenters_unobserved_child_close(
+        self,
+    ) -> None:
+        kernel = FakeKernelApi(b"", directory=True)
+        root = receipt.WindowsHandleLease(0xF001)
+        child = receipt.WindowsHandleLease(0xF002)
+        binding = anchored.OutputParentBinding(
+            checkout=Path("C:/"),
+            parent=Path("C:/parent"),
+            leaf="receipt.json",
+            strategy="windows-handle",
+            windows_api=kernel,
+            windows_handle_leases=(root, child),
+            receipt_parent_policy=True,
+        )
+        owner = anchored._OutputParentBindingLease(binding)
+        interruption = KeyboardInterrupt("unobserved native child close")
+        close_entries = 0
+
+        def interrupt_without_observation(*_arguments: object) -> None:
+            nonlocal close_entries
+            close_entries += 1
+            raise interruption
+
+        helper = anchored._windows_receipt_module()
+        with (
+            mock.patch.object(
+                helper,
+                "_native_close_handle_address",
+                return_value=0x123456,
+            ),
+            mock.patch.object(
+                helper,
+                "_record_close_handle_result",
+                side_effect=interrupt_without_observation,
+            ),
+        ):
+            del owner
+            gc.collect()
+
+        self.assertEqual(close_entries, 1)
+        self.assertEqual(child.handle, 0xF002)
+        self.assertEqual(root.handle, 0xF001)
+        self.assertFalse(binding.is_closed)
+
+    def test_cleanup_handler_interrupt_prearms_before_outer_finalizer(self) -> None:
+        kernel = FakeKernelApi(b"", directory=True)
+        native = _SequencedNtApi(
+            (0xF101, 0xF102),
+            (receipt.FILE_OPENED, receipt.FILE_CREATED),
+        )
+        helper = anchored._windows_receipt_module()
+        target = helper.close_windows_handle_lease
+        source, first_line = inspect.getsourcelines(target)
+        handler_line = first_line + next(
+            index for index, line in enumerate(source) if line.strip() == "retain_failure(close_error)"
+        )
+        body_primary = SystemExit("parent verification primary")
+        unobserved_error = RuntimeError("native CloseHandle result was not recorded")
+        handler_interruption = KeyboardInterrupt("CloseHandle handler entry")
+        captured_bindings: list[anchored.OutputParentBinding] = []
+        native_entries: list[int] = []
+        triggered = False
+
+        def reject_binding(binding: anchored.OutputParentBinding) -> None:
+            captured_bindings.append(binding)
+            raise body_primary
+
+        def interrupt_without_observation(
+            _api: object,
+            _lease: object,
+            handle: int,
+            _native_address: int | None,
+        ) -> None:
+            native_entries.append(handle)
+            raise unobserved_error
+
+        def trace(frame: FrameType, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if event == "call" and frame.f_code is target.__code__:
+                frame.f_trace = trace
+                return trace
+            if (
+                event == "line"
+                and frame.f_code is target.__code__
+                and frame.f_lineno == handler_line
+                and not triggered
+            ):
+                triggered = True
+                raise handler_interruption
+            return trace
+
+        owner = anchored._OutputParentBindingLease()
+        finalizer = owner._finalizer
+        patches = self._patch_parent_apis(kernel, native)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            mock.patch.object(
+                anchored.OutputParentBinding,
+                "verify",
+                new=reject_binding,
+            ),
+            mock.patch.object(
+                helper,
+                "_native_close_handle_address",
+                return_value=0x123456,
+            ),
+            mock.patch.object(
+                helper,
+                "_record_close_handle_result",
+                side_effect=interrupt_without_observation,
+            ),
+        ):
+            previous = sys.gettrace()
+            try:
+                sys.settrace(trace)
+                with self.assertRaises(SystemExit) as raised:
+                    anchored._open_rooted_windows_parent(
+                        Path("C:\\"),
+                        Path("C:\\") / "parent" / "receipt.json",
+                        ("parent", "receipt.json"),
+                        owner,
+                    )
+            finally:
+                sys.settrace(previous)
+
+            self.assertTrue(owner.close())
+
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, body_primary)
+        self.assertEqual(len(captured_bindings), 1)
+        binding = captured_bindings[0]
+        root, child = binding.windows_handle_leases
+        self.assertEqual(native_entries, [0xF102])
+        self.assertEqual(root.handle, 0xF101)
+        self.assertEqual(child.handle, 0xF102)
+        self.assertTrue(child.close_retry_blocked)
+        self.assertFalse(binding.is_closed)
+        self.assertIn(
+            str(handler_interruption),
+            "\n".join(getattr(body_primary, "__notes__", ())),
+        )
+
+        body_primary.__traceback__ = None
+        handler_interruption.__traceback__ = None
+        unobserved_error.__traceback__ = None
+        del owner
+        gc.collect()
+
+        self.assertFalse(finalizer.alive)
+        self.assertEqual(native_entries, [0xF102])
+        self.assertEqual(root.handle, 0xF101)
+        self.assertEqual(child.handle, 0xF102)
+
+    def _patch_parent_apis(
+        self,
+        kernel: FakeKernelApi,
+        native: FakeNtApi,
+    ) -> tuple[Any, ...]:
+        helper = anchored._windows_receipt_module()
+
+        def unchanged(api: Any) -> Any:
+            return api
+
+        return (
+            mock.patch.object(anchored, "_windows_file_api", return_value=kernel),
+            mock.patch.object(anchored, "_windows_receipt_module", return_value=helper),
+            mock.patch.object(helper, "_select_apis", return_value=(kernel, native)),
+            mock.patch.object(helper, "_configure_api", side_effect=unchanged),
+            mock.patch.object(helper, "_configure_nt_api", side_effect=unchanged),
+        )
+
+    def test_binding_verification_io_failure_has_stable_parent_changed_code(self) -> None:
+        missing = FileNotFoundError("bound Windows ancestor disappeared")
+        binding = anchored.OutputParentBinding(
+            checkout=Path("C:/"),
+            parent=Path("C:/bound"),
+            leaf="receipt.json",
+            strategy="windows-handle",
+            receipt_parent_policy=True,
+            windows_api=FakeKernelApi(b"", directory=True),
+            windows_entries=((Path("C:/bound"), (1, 2), 0x4567),),
+        )
+        with (
+            mock.patch.object(Path, "lstat", side_effect=missing),
+            self.assertRaises(anchored.AnchoredOutputError) as raised,
+        ):
+            binding.verify()
+        self.assertEqual(raised.exception.code, "output-parent-changed")
+        self.assertIs(raised.exception.__cause__, missing)
+
+    def test_root_file_type_unsupported_preserves_stable_code_cause_and_notes(self) -> None:
+        helper = anchored._windows_receipt_module()
+        native_error = OSError(receipt.ERROR_NOT_SUPPORTED, "unsupported root file type")
+        native_error.add_note("native root file type note")
+        kernel = FakeKernelApi(b"", directory=True)
+        kernel.failures["GetFileType"] = native_error
+        native = FakeNtApi(information=receipt.FILE_OPENED)
+        lease = anchored._OutputParentBindingLease()
+        patches = self._patch_parent_apis(kernel, native)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            self.assertRaises(anchored.AnchoredOutputError) as raised,
+        ):
+            anchored._open_rooted_windows_parent(
+                Path("C:\\"),
+                Path("C:\\") / "receipt.json",
+                ("receipt.json",),
+                lease,
+            )
+
+        self.assertEqual(raised.exception.code, "output-anchor-unavailable")
+        helper_error = raised.exception.__cause__
+        assert helper_error is not None
+        self.assertIsInstance(helper_error, helper.WindowsReceiptValidationError)
+        self.assertIs(helper_error.__cause__, native_error)
+        self.assertIn("native root file type note", getattr(helper_error, "__notes__", ()))
+        self.assertIn("native root file type note", getattr(raised.exception, "__notes__", ()))
+        self.assertEqual(
+            [args[0] for name, args in kernel.calls if name == "CloseHandle"],
+            [native.handle],
+        )
+
+    def test_root_file_type_generic_io_maps_parent_invalid_with_raw_cause(self) -> None:
+        native_error = OSError(1117, "root device I/O failure")
+        kernel = FakeKernelApi(b"", directory=True)
+        kernel.failures["GetFileType"] = native_error
+        native = FakeNtApi(information=receipt.FILE_OPENED)
+        lease = anchored._OutputParentBindingLease()
+        patches = self._patch_parent_apis(kernel, native)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            self.assertRaises(anchored.AnchoredOutputError) as raised,
+        ):
+            anchored._open_rooted_windows_parent(
+                Path("C:\\"),
+                Path("C:\\") / "receipt.json",
+                ("receipt.json",),
+                lease,
+            )
+
+        self.assertEqual(raised.exception.code, "output-parent-invalid")
+        self.assertIs(raised.exception.__cause__, native_error)
+        self.assertEqual(
+            [args[0] for name, args in kernel.calls if name == "CloseHandle"],
+            [native.handle],
+        )
+
+    def test_root_and_child_leases_transfer_and_binding_closes_in_reverse(self) -> None:
+        kernel = FakeKernelApi(b"", directory=True)
+        native = _SequencedNtApi(
+            (0xA101, 0xA102),
+            (receipt.FILE_OPENED, receipt.FILE_CREATED),
+        )
+        lease = anchored._OutputParentBindingLease()
+        patches = self._patch_parent_apis(kernel, native)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            mock.patch.object(anchored.OutputParentBinding, "verify"),
+            mock.patch.object(anchored.Path, "lstat", side_effect=AssertionError("path stat used")),
+            mock.patch.object(anchored.Path, "mkdir", side_effect=AssertionError("path mkdir used")),
+            mock.patch.object(anchored.os, "open", side_effect=AssertionError("path open used")),
+        ):
+            binding = anchored._open_rooted_windows_parent(
+                Path("C:\\"),
+                Path("C:\\") / "parent" / "receipt.json",
+                ("parent", "receipt.json"),
+                lease,
+            )
+
+        self.assertIs(lease.binding, binding)
+        self.assertEqual([entry[2] for entry in binding.windows_entries], [0xA101, 0xA102])
+        self.assertEqual(
+            [(call["root"], call["name"], call["share_access"], call["disposition"]) for call in native.calls],
+            [
+                (
+                    None,
+                    "\\??\\C:\\",
+                    receipt.FILE_SHARE_READ | receipt.FILE_SHARE_WRITE,
+                    receipt.FILE_OPEN,
+                ),
+                (
+                    0xA101,
+                    "parent",
+                    receipt.FILE_SHARE_READ | receipt.FILE_SHARE_WRITE,
+                    receipt.FILE_OPEN_IF,
+                ),
+            ],
+        )
+        self.assertEqual(lease.close(), ())
+        self.assertEqual(
+            [args[0] for name, args in kernel.calls if name == "CloseHandle"],
+            [0xA102, 0xA101],
+        )
+
+    def test_binding_lease_survives_windows_opener_to_wrapper_return_gap(self) -> None:
+        kernel = FakeKernelApi(b"", directory=True)
+        native = _SequencedNtApi(
+            (0xA201, 0xA202),
+            (receipt.FILE_OPENED, receipt.FILE_CREATED),
+        )
+        anchor = Path("C:\\")
+        absolute = anchor / "parent" / "receipt.json"
+        interruption = KeyboardInterrupt("Windows opener returned before wrapper return")
+        real_open = anchored._open_rooted_windows_parent
+        captured_binding: anchored.OutputParentBinding | None = None
+        triggered = False
+
+        def open_then_interrupt(
+            root_anchor: Path,
+            output_path: Path,
+            parts: tuple[str, ...],
+            binding_lease: anchored._OutputParentBindingLease,
+        ) -> anchored.OutputParentBinding:
+            nonlocal captured_binding, triggered
+            captured_binding = real_open(root_anchor, output_path, parts, binding_lease)
+            triggered = True
+            raise interruption
+
+        patches = self._patch_parent_apis(kernel, native)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            mock.patch.object(
+                anchored,
+                "_rooted_output_parts",
+                return_value=(anchor, absolute, ("parent", "receipt.json")),
+            ),
+            mock.patch.object(
+                anchored,
+                "descriptor_relative_output_supported",
+                return_value=False,
+            ),
+            mock.patch.object(anchored.os, "name", "nt"),
+            mock.patch.object(anchored.OutputParentBinding, "verify"),
+            mock.patch.object(
+                anchored,
+                "_open_rooted_windows_parent",
+                side_effect=open_then_interrupt,
+            ),
+            mock.patch.object(anchored, "_publish_windows_receipt_bytes") as publish,
+            self.assertRaises(KeyboardInterrupt) as raised,
+        ):
+            anchored.publish_identical_receipt_bytes(absolute, PAYLOAD)
+
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, interruption)
+        self.assertIsNotNone(captured_binding)
+        assert captured_binding is not None
+        self.assertTrue(captured_binding._closed)
+        publish.assert_not_called()
+        self.assertEqual(
+            [args[0] for name, args in kernel.calls if name == "CloseHandle"],
+            [0xA202, 0xA201],
+        )
+
+    def test_binding_lease_survives_wrapper_to_public_assignment_gap(self) -> None:
+        kernel = FakeKernelApi(b"", directory=True)
+        native = _SequencedNtApi(
+            (0xA301, 0xA302),
+            (receipt.FILE_OPENED, receipt.FILE_CREATED),
+        )
+        anchor = Path("C:\\")
+        absolute = anchor / "parent" / "receipt.json"
+        interruption = KeyboardInterrupt("wrapper returned before public binding assignment")
+        real_open = anchored.open_rooted_output_parent
+        captured_binding: anchored.OutputParentBinding | None = None
+        triggered = False
+
+        def open_then_interrupt(
+            output_path: Path,
+            binding_lease: anchored._OutputParentBindingLease,
+        ) -> anchored.OutputParentBinding:
+            nonlocal captured_binding, triggered
+            captured_binding = real_open(output_path, binding_lease)
+            triggered = True
+            raise interruption
+
+        patches = self._patch_parent_apis(kernel, native)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            mock.patch.object(
+                anchored,
+                "_rooted_output_parts",
+                return_value=(anchor, absolute, ("parent", "receipt.json")),
+            ),
+            mock.patch.object(
+                anchored,
+                "descriptor_relative_output_supported",
+                return_value=False,
+            ),
+            mock.patch.object(anchored.os, "name", "nt"),
+            mock.patch.object(anchored.OutputParentBinding, "verify"),
+            mock.patch.object(
+                anchored,
+                "open_rooted_output_parent",
+                side_effect=open_then_interrupt,
+            ),
+            mock.patch.object(anchored, "_publish_windows_receipt_bytes") as publish,
+            self.assertRaises(KeyboardInterrupt) as raised,
+        ):
+            anchored.publish_identical_receipt_bytes(absolute, PAYLOAD)
+
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, interruption)
+        self.assertIsNotNone(captured_binding)
+        assert captured_binding is not None
+        self.assertTrue(captured_binding._closed)
+        publish.assert_not_called()
+        self.assertEqual(
+            [args[0] for name, args in kernel.calls if name == "CloseHandle"],
+            [0xA302, 0xA301],
+        )
+
+    def test_helper_return_interrupt_closes_pending_then_retained_handles_once(self) -> None:
+        helper = anchored._windows_receipt_module()
+        cases: tuple[
+            tuple[str, tuple[int, ...], tuple[int, ...], tuple[int, ...]],
+            ...,
+        ] = (
+            ("root", (0xB101,), (receipt.FILE_OPENED,), (0xB101,)),
+            (
+                "child",
+                (0xB201, 0xB202),
+                (receipt.FILE_OPENED, receipt.FILE_CREATED),
+                (0xB202, 0xB201),
+            ),
+        )
+        for label, handles, information, expected_closes in cases:
+            with self.subTest(label=label):
+                kernel = FakeKernelApi(b"", directory=True)
+                native = _SequencedNtApi(handles, information)
+                lease = anchored._OutputParentBindingLease()
+                interruption = KeyboardInterrupt(f"{label} helper returned before facade assignment")
+                helper_name = "open_windows_directory_anchor" if label == "root" else "open_or_create_windows_directory"
+                real_helper: Any = getattr(helper, helper_name)
+                triggered = False
+
+                def helper_then_interrupt(*arguments: Any, **keywords: Any) -> Any:
+                    nonlocal triggered
+                    result = real_helper(*arguments, **keywords)
+                    if not triggered:
+                        triggered = True
+                        raise interruption
+                    return result
+
+                patches = self._patch_parent_apis(kernel, native)
+                with (
+                    patches[0],
+                    patches[1],
+                    patches[2],
+                    patches[3],
+                    patches[4],
+                    mock.patch.object(
+                        helper,
+                        helper_name,
+                        side_effect=helper_then_interrupt,
+                    ),
+                    mock.patch.object(anchored.OutputParentBinding, "verify"),
+                    self.assertRaises(KeyboardInterrupt) as raised,
+                ):
+                    anchored._open_rooted_windows_parent(
+                        Path("C:\\"),
+                        Path("C:\\") / "parent" / "receipt.json",
+                        ("parent", "receipt.json"),
+                        lease,
+                    )
+
+                self.assertTrue(triggered)
+                self.assertIs(raised.exception, interruption)
+                self.assertEqual(
+                    [args[0] for name, args in kernel.calls if name == "CloseHandle"],
+                    list(expected_closes),
+                )
+
+    def test_preinstalled_owner_recovers_root_child_and_verification_interrupts(self) -> None:
+        target = anchored._open_rooted_windows_parent
+        source, first_line = inspect.getsourcelines(target)
+        cleanup_lines = [
+            first_line + index
+            for index, line in enumerate(source)
+            if "cleanup_failures = lease.close()" in line
+        ]
+        self.assertEqual(len(cleanup_lines), 1)
+        cleanup_line = cleanup_lines[0]
+
+        cases = (
+            ("root", (0xBA01,), (receipt.FILE_OPENED,)),
+            (
+                "child",
+                (0xBB01, 0xBB02),
+                (receipt.FILE_OPENED, receipt.FILE_CREATED),
+            ),
+            (
+                "verify",
+                (0xBC01, 0xBC02),
+                (receipt.FILE_OPENED, receipt.FILE_CREATED),
+            ),
+        )
+        for seam, handles, information in cases:
+            with self.subTest(seam=seam):
+                kernel = FakeKernelApi(b"", directory=True)
+                native = _SequencedNtApi(handles, information)
+                helper = anchored._windows_receipt_module()
+                real_root_open = helper.open_windows_directory_anchor
+                real_child_open = helper.open_or_create_windows_directory
+                body_failure = RuntimeError(f"modeled {seam} acquisition failure")
+                cleanup_interruption = KeyboardInterrupt(
+                    f"interrupt {seam} exception-handler cleanup entry"
+                )
+                cleanup_was_interrupted = False
+
+                def root_then_maybe_fail(*arguments: Any, **keywords: Any) -> Any:
+                    result = real_root_open(*arguments, **keywords)
+                    if seam == "root":
+                        raise body_failure
+                    return result
+
+                def child_then_maybe_fail(*arguments: Any, **keywords: Any) -> Any:
+                    result = real_child_open(*arguments, **keywords)
+                    if seam == "child":
+                        raise body_failure
+                    return result
+
+                def verify_then_maybe_fail(_binding: anchored.OutputParentBinding) -> None:
+                    if seam == "verify":
+                        raise body_failure
+
+                def trace(frame: FrameType, event: str, _argument: object) -> Any:
+                    nonlocal cleanup_was_interrupted
+                    if event == "call" and frame.f_code is target.__code__:
+                        frame.f_trace = trace
+                        return trace
+                    if (
+                        event == "line"
+                        and frame.f_code is target.__code__
+                        and frame.f_lineno == cleanup_line
+                        and not cleanup_was_interrupted
+                    ):
+                        cleanup_was_interrupted = True
+                        raise cleanup_interruption
+                    return trace
+
+                def acquire_without_retaining_lease() -> None:
+                    lease = anchored._OutputParentBindingLease()
+                    target(
+                        Path("C:\\"),
+                        Path("C:\\") / "parent" / "receipt.json",
+                        ("parent", "receipt.json"),
+                        lease,
+                    )
+
+                patches = self._patch_parent_apis(kernel, native)
+                previous_trace = sys.gettrace()
+                try:
+                    with (
+                        patches[0],
+                        patches[1],
+                        patches[2],
+                        patches[3],
+                        patches[4],
+                        mock.patch.object(
+                            helper,
+                            "open_windows_directory_anchor",
+                            side_effect=root_then_maybe_fail,
+                        ),
+                        mock.patch.object(
+                            helper,
+                            "open_or_create_windows_directory",
+                            side_effect=child_then_maybe_fail,
+                        ),
+                        mock.patch.object(
+                            anchored.OutputParentBinding,
+                            "verify",
+                            new=verify_then_maybe_fail,
+                        ),
+                        self.assertRaises(anchored.AnchoredOutputError) as raised,
+                    ):
+                        sys.settrace(trace)
+                        acquire_without_retaining_lease()
+                finally:
+                    sys.settrace(previous_trace)
+
+                self.assertTrue(cleanup_was_interrupted)
+                self.assertEqual(raised.exception.code, "output-parent-invalid")
+                self.assertIs(raised.exception.__cause__, body_failure)
+                self.assertIn(
+                    str(cleanup_interruption),
+                    "\n".join(getattr(raised.exception, "__notes__", ())),
+                )
+                raised.exception.__traceback__ = None
+                body_failure.__traceback__ = None
+                cleanup_interruption.__traceback__ = None
+                gc.collect()
+
+                close_handles = [
+                    args[0]
+                    for name, args in kernel.calls
+                    if name == "CloseHandle"
+                ]
+                self.assertEqual(close_handles, list(reversed(handles)))
+                self.assertEqual(len(close_handles), len(set(close_handles)))
+
+    def test_final_binding_verification_failure_preserves_primary_and_reverses_close(self) -> None:
+        kernel = FakeKernelApi(b"", directory=True)
+        kernel.failures["CloseHandle"] = False
+        native = _SequencedNtApi(
+            (0xC101, 0xC102),
+            (receipt.FILE_OPENED, receipt.FILE_CREATED),
+        )
+        primary = KeyboardInterrupt("final binding verification")
+        lease = anchored._OutputParentBindingLease()
+        patches = self._patch_parent_apis(kernel, native)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            mock.patch.object(anchored.OutputParentBinding, "verify", side_effect=primary),
+            self.assertRaises(KeyboardInterrupt) as raised,
+        ):
+            anchored._open_rooted_windows_parent(
+                Path("C:\\"),
+                Path("C:\\") / "parent" / "receipt.json",
+                ("parent", "receipt.json"),
+                lease,
+            )
+
+        self.assertIs(raised.exception, primary)
+        self.assertEqual(
+            [args[0] for name, args in kernel.calls if name == "CloseHandle"],
+            [0xC102, 0xC102],
+        )
+        self.assertGreaterEqual(
+            "\n".join(getattr(primary, "__notes__", ())).count(
+                "Could not close a receipt output directory handle"
+            ),
+            1,
+        )
+
+    def test_returned_child_handle_mismatch_closes_pending_then_root(self) -> None:
+        kernel = FakeKernelApi(b"", directory=True)
+        native = _SequencedNtApi(
+            (0xD101, 0xD102),
+            (receipt.FILE_OPENED, receipt.FILE_CREATED),
+        )
+        helper = anchored._windows_receipt_module()
+        lease = anchored._OutputParentBindingLease()
+        real_child_open = helper.open_or_create_windows_directory
+
+        def return_mismatch(*args: Any, **kwargs: Any) -> Any:
+            result = real_child_open(*args, **kwargs)
+            return helper.WindowsDirectoryResult(
+                result.handle + 1,
+                result.volume_serial_number,
+                result.file_id,
+                result.created,
+            )
+
+        patches = self._patch_parent_apis(kernel, native)
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            mock.patch.object(helper, "open_or_create_windows_directory", side_effect=return_mismatch),
+            self.assertRaises(anchored.AnchoredOutputError) as raised,
+        ):
+            anchored._open_rooted_windows_parent(
+                Path("C:\\"),
+                Path("C:\\") / "parent" / "receipt.json",
+                ("parent", "receipt.json"),
+                lease,
+            )
+
+        self.assertEqual(raised.exception.code, "output-parent-invalid")
+        self.assertEqual(
+            [args[0] for name, args in kernel.calls if name == "CloseHandle"],
+            [0xD102, 0xD101],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_anchored_receipt_windows_integration.py
+++ b/tests/test_anchored_receipt_windows_integration.py
@@ -25,6 +25,7 @@ from tests.test_anchored_receipt_windows_relative import (
 PAYLOAD = b'{"status":"verified"}\n'
 _API_NAMES = (
     "NtCreateFile",
+    "NtSetInformationFile",
     "RtlNtStatusToDosError",
     "WriteFile",
     "ReadFile",
@@ -118,22 +119,34 @@ class _ExistingWinnerKernel32(FakeKernel32):
         self.error = receipt.ERROR_FILE_EXISTS
         self.public_data = bytearray(public_data)
 
-    def SetFileInformationByHandle(self, handle: int, info_class: int, pointer: Any, size: int) -> bool:
-        if info_class == receipt.FILE_RENAME_INFO:
-            raw = ctypes.string_at(pointer, size)
-            info = receipt._FileRenameInfo.from_buffer_copy(
-                raw + bytes(max(0, ctypes.sizeof(receipt._FileRenameInfo) - len(raw)))
-            )
-            if info.ReplaceIfExists:
-                self.failures["Rename"] = True
-                try:
-                    result = super().SetFileInformationByHandle(handle, info_class, pointer, size)
-                finally:
-                    self.failures["Rename"] = False
-                if result:
-                    self.public_data[:] = self.data
-                return result
-        return super().SetFileInformationByHandle(handle, info_class, pointer, size)
+    def NtSetInformationFile(
+        self,
+        handle: int,
+        io_status: Any,
+        pointer: Any,
+        size: int,
+        info_class: int,
+    ) -> int:
+        raw = ctypes.string_at(pointer, size)
+        info = receipt._FileRenameInformation.from_buffer_copy(
+            raw + bytes(max(0, ctypes.sizeof(receipt._FileRenameInformation) - len(raw)))
+        )
+        if info.ReplaceIfExists:
+            self.failures["Rename"] = True
+            try:
+                result = super().NtSetInformationFile(
+                    handle,
+                    io_status,
+                    pointer,
+                    size,
+                    info_class,
+                )
+            finally:
+                self.failures["Rename"] = False
+            if receipt._nt_success(result):
+                self.public_data[:] = self.data
+            return result
+        return super().NtSetInformationFile(handle, io_status, pointer, size, info_class)
 
 
 class WindowsReceiptFacadeIntegrationTests(unittest.TestCase):
@@ -372,7 +385,7 @@ class WindowsReceiptFacadeIntegrationTests(unittest.TestCase):
 
     def test_unsupported_win32_publication_has_stable_anchor_code(self) -> None:
         api = _assignable_api(FakeKernel32({"Rename": False}))
-        api.error = receipt.ERROR_NOT_SUPPORTED
+        api.error = receipt.ERROR_INVALID_PARAMETER
         binding = _Binding(api)
         helper = anchored._windows_receipt_module()
         reader = mock.Mock(side_effect=FileNotFoundError())
@@ -389,6 +402,16 @@ class WindowsReceiptFacadeIntegrationTests(unittest.TestCase):
 
         self.assertEqual(raised.exception.code, "output-anchor-unavailable")
         self.assertIsInstance(raised.exception.__cause__, helper._DefiniteRenameError)
+        diagnostic = next(
+            note
+            for note in getattr(raised.exception, "__notes__", ())
+            if note.startswith("Windows retained-handle publication diagnostic:")
+        )
+        self.assertIn("type=_DefiniteRenameError", diagnostic)
+        self.assertIn(f"errno={receipt.ERROR_INVALID_PARAMETER}", diagnostic)
+        self.assertIn("NT FileRenameInformation failed", diagnostic)
+        self.assertIn("cause_type=OSError", diagnostic)
+        self.assertIn(f"cause_errno={receipt.ERROR_INVALID_PARAMETER}", diagnostic)
         self.assertEqual(reader.call_count, 1)
         self.assertEqual(binding.closed, 1)
         classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
@@ -419,7 +442,7 @@ class WindowsReceiptFacadeIntegrationTests(unittest.TestCase):
         self.assertEqual(reader.call_count, 1)
         self.assertEqual(binding.closed, 1)
         classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
-        self.assertNotIn(receipt.FILE_RENAME_INFO, classes)
+        self.assertFalse(any(name == "NtSetInformationFile" for name, _args in api.calls))
         self.assertIn(receipt.FILE_DISPOSITION_INFO, classes)
 
     def test_unsupported_error_after_rename_keeps_published_outcome_and_primary(self) -> None:
@@ -451,7 +474,7 @@ class WindowsReceiptFacadeIntegrationTests(unittest.TestCase):
         self.assertEqual(reader.call_count, 2)
         self.assertEqual(binding.closed, 1)
         classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
-        self.assertIn(receipt.FILE_RENAME_INFO, classes)
+        self.assertTrue(any(name == "NtSetInformationFile" for name, _args in api.calls))
         self.assertNotIn(receipt.FILE_DISPOSITION_INFO, classes)
 
     def test_unsupported_rename_exception_keeps_unknown_outcome_and_primary(self) -> None:
@@ -479,7 +502,7 @@ class WindowsReceiptFacadeIntegrationTests(unittest.TestCase):
         self.assertEqual(reader.call_count, 2)
         self.assertEqual(binding.closed, 1)
         classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
-        self.assertIn(receipt.FILE_RENAME_INFO, classes)
+        self.assertTrue(any(name == "NtSetInformationFile" for name, _args in api.calls))
         self.assertNotIn(receipt.FILE_DISPOSITION_INFO, classes)
 
     def test_generic_win32_publication_io_error_remains_native(self) -> None:
@@ -505,6 +528,7 @@ class WindowsReceiptFacadeIntegrationTests(unittest.TestCase):
         api = FakeKernel32()
         binding, reader = self._publish(api)
         ctypes_api = cast(Any, api)
+        helper = anchored._windows_receipt_module()
 
         self.assertEqual(ctypes_api.WriteFile.argtypes[0], ctypes.c_void_p)
         self.assertEqual(ctypes_api.WriteFile.argtypes[2], ctypes.c_uint32)
@@ -512,6 +536,17 @@ class WindowsReceiptFacadeIntegrationTests(unittest.TestCase):
         self.assertEqual(ctypes_api.FlushFileBuffers.argtypes, (ctypes.c_void_p,))
         self.assertEqual(ctypes_api.SetFilePointerEx.argtypes[0], ctypes.c_void_p)
         self.assertEqual(ctypes_api.CloseHandle.argtypes, (ctypes.c_void_p,))
+        self.assertEqual(
+            ctypes_api.NtSetInformationFile.argtypes,
+            (
+                ctypes.c_void_p,
+                ctypes.POINTER(helper._IoStatusBlock),
+                ctypes.c_void_p,
+                helper.ULONG,
+                helper.FILE_INFORMATION_CLASS,
+            ),
+        )
+        self.assertIs(ctypes_api.NtSetInformationFile.restype, helper.NTSTATUS)
         self.assertEqual(binding.closed, 1)
         self.assertEqual(binding.verified, 7)
         self.assertEqual(reader.call_count, 2)
@@ -600,7 +635,7 @@ class WindowsReceiptFacadeIntegrationTests(unittest.TestCase):
         self.assertEqual(reader.call_count, 2)
         self.assertEqual(binding.closed, 1)
         classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
-        self.assertIn(receipt.FILE_RENAME_INFO, classes)
+        self.assertTrue(any(name == "NtSetInformationFile" for name, _args in api.calls))
         self.assertIn(receipt.FILE_DISPOSITION_INFO, classes)
 
     def test_definite_collision_preserves_different_existing_winner(self) -> None:
@@ -818,6 +853,7 @@ class WindowsReceiptFacadeIntegrationTests(unittest.TestCase):
 class WindowsRootedParentFacadeTests(unittest.TestCase):
     def test_binding_keeps_parent_handle_open_when_child_cleanup_is_retained(self) -> None:
         helper = anchored._windows_receipt_module()
+        original_close = helper.close_windows_handle_lease
         interruption = KeyboardInterrupt("child handle remains retained")
 
         for failure_mode in ("return", "raise"):
@@ -841,6 +877,11 @@ class WindowsRootedParentFacadeTests(unittest.TestCase):
                     _primary: BaseException | None,
                     _context: str,
                 ) -> BaseException | None:
+                    # A delayed lease finalizer from another test can run while
+                    # this module-level helper is patched. Keep that cleanup
+                    # real and exclude it from this binding's call order.
+                    if lease is not child and lease is not root:
+                        return original_close(_api, lease, _primary, _context)
                     calls.append(lease.handle)
                     if lease is child and not child_may_close:
                         if failure_mode == "raise":

--- a/tests/test_anchored_receipt_windows_relative.py
+++ b/tests/test_anchored_receipt_windows_relative.py
@@ -126,6 +126,9 @@ class FakeNtApi:
         self.raise_create: BaseException | None = None
         self.raise_after_acquire: BaseException | None = None
         self.raise_convert: BaseException | None = None
+        self.rename_status = 0
+        self.rename_completion_status = 0
+        self.rename_calls: list[dict[str, object]] = []
         self.error_codes: dict[int, int] = {
             0xC000000F: receipt.ERROR_FILE_NOT_FOUND,
             0xC0000022: 5,
@@ -190,6 +193,37 @@ class FakeNtApi:
         bits = ctypes.c_uint32(status).value
         self.conversions.append(bits)
         return self.error_codes.get(bits, 317)
+
+    def NtSetInformationFile(
+        self,
+        handle: int,
+        io_status: Any,
+        pointer: Any,
+        size: int,
+        info_class: int,
+    ) -> int:
+        raw = ctypes.string_at(pointer, size)
+        info = receipt._FileRenameInformation.from_buffer_copy(
+            raw + bytes(max(0, ctypes.sizeof(receipt._FileRenameInformation) - len(raw)))
+        )
+        self.rename_calls.append(
+            {
+                "handle": handle,
+                "class": info_class,
+                "size": size,
+                "root": info.RootDirectory,
+                "replace": info.ReplaceIfExists,
+                "name_length": info.FileNameLength,
+                "name": raw[
+                    receipt._FileRenameInformation.FileName.offset :
+                    receipt._FileRenameInformation.FileName.offset + info.FileNameLength
+                ].decode("utf-16-le"),
+            }
+        )
+        completion = ctypes.cast(io_status, ctypes.POINTER(receipt._IoStatusBlock)).contents
+        completion.Status = ctypes.c_int32(self.rename_completion_status).value
+        completion.Information = 0
+        return ctypes.c_int32(self.rename_status).value
 
 
 class FakeKernelApi:
@@ -324,6 +358,7 @@ class WindowsNtAbiTests(unittest.TestCase):
         self.assertEqual(ctypes.sizeof(receipt.USHORT), 2)
         self.assertEqual(ctypes.sizeof(receipt.ULONG), 4)
         self.assertEqual(ctypes.sizeof(receipt.NTSTATUS), 4)
+        self.assertEqual(ctypes.sizeof(receipt.FILE_INFORMATION_CLASS), 4)
         self.assertEqual(ctypes.sizeof(receipt._UnicodeString), expected["unicode"])
         self.assertEqual(receipt._UnicodeString.Buffer.offset, expected["unicode_buffer"])
         self.assertEqual(ctypes.sizeof(receipt._ObjectAttributes), expected["object"])
@@ -341,7 +376,15 @@ class WindowsNtAbiTests(unittest.TestCase):
             def __call__(self, *_args: object) -> int:
                 return 0
 
-        api = type("Api", (), {"NtCreateFile": Function(), "RtlNtStatusToDosError": Function()})()
+        api = type(
+            "Api",
+            (),
+            {
+                "NtCreateFile": Function(),
+                "NtSetInformationFile": Function(),
+                "RtlNtStatusToDosError": Function(),
+            },
+        )()
         configured: Any = receipt._configure_nt_api(api)
         args = configured.NtCreateFile.argtypes
         self.assertIs(args[0]._type_, ctypes.c_void_p)
@@ -353,6 +396,18 @@ class WindowsNtAbiTests(unittest.TestCase):
         self.assertIs(args[9], ctypes.c_void_p)
         self.assertIs(args[10], receipt.ULONG)
         self.assertIs(configured.NtCreateFile.restype, receipt.NTSTATUS)
+        set_args = configured.NtSetInformationFile.argtypes
+        self.assertEqual(
+            set_args,
+            (
+                ctypes.c_void_p,
+                ctypes.POINTER(receipt._IoStatusBlock),
+                ctypes.c_void_p,
+                receipt.ULONG,
+                receipt.FILE_INFORMATION_CLASS,
+            ),
+        )
+        self.assertIs(configured.NtSetInformationFile.restype, receipt.NTSTATUS)
         self.assertEqual(configured.RtlNtStatusToDosError.argtypes, (receipt.NTSTATUS,))
         self.assertIs(configured.RtlNtStatusToDosError.restype, receipt.ULONG)
 

--- a/tests/test_anchored_receipt_windows_relative.py
+++ b/tests/test_anchored_receipt_windows_relative.py
@@ -1,0 +1,2109 @@
+# pyright: reportPrivateUsage=false
+from __future__ import annotations
+
+import ctypes
+import inspect
+from pathlib import Path
+import sys
+import unittest
+from unittest import mock
+from typing import Any, Callable, cast
+
+from scripts import _anchored_receipt_windows as receipt
+from tests.test_anchored_receipt_windows import FakeKernel32
+
+
+PAYLOAD = b'{"status":"verified"}\n'
+
+INVALID_WINDOWS_RELATIVE_LEAVES = (
+    "",
+    ".",
+    "..",
+    "receipt.",
+    "receipt ",
+    "CON",
+    "PrN.txt",
+    "aUx.backup.tar",
+    "NUL.txt",
+    "NUL .txt",
+    *(f"CoM{index}.txt" for index in range(1, 10)),
+    *(f"lPt{index}.backup" for index in range(1, 10)),
+    "COM¹",
+    "com².txt",
+    "CoM³.backup",
+    "LPT¹",
+    "lpt².txt",
+    "LpT³.backup",
+    "a?b",
+    "a<b",
+    "a>b",
+    'a"b',
+    "a|b",
+    "a*b",
+    "a:b",
+    "a/b",
+    r"a\b",
+    "a\x00b",
+    "a\x01b",
+    "a\x1fb",
+    "\ud800",
+)
+
+VALID_WINDOWS_RELATIVE_LEAVES = (
+    "COM0",
+    "com10.txt",
+    "LPT0",
+    "lpt10.backup",
+    "CONSOLE",
+    "AUXiliary.txt",
+    "NULl.txt",
+    "COM¹x.txt",
+    "NUL\N{NO-BREAK SPACE}.txt",
+    "receipt\N{NO-BREAK SPACE}",
+    "receipt\N{ONE DOT LEADER}",
+    "ＣＯＮ.txt",
+    "receipt-ž-文件-\N{GRINNING FACE}.json",
+    f"{'long-' * 60}.json",
+)
+
+
+def _interrupt_relative_handle_handler(
+    action: Callable[[], object],
+    interruption: BaseException,
+) -> BaseException:
+    """Interrupt recovery after NtCreateFile has populated its output handle."""
+
+    source, first_line = inspect.getsourcelines(receipt._relative_handle)
+    handler_line = first_line + next(
+        index for index, line in enumerate(source) if line.strip() == "if primary is not None:"
+    )
+    triggered = False
+    observed: BaseException | None = None
+
+    def trace(frame: Any, event: str, _argument: object) -> Any:
+        nonlocal triggered
+        if (
+            event == "line"
+            and frame.f_code is receipt._relative_handle.__code__
+            and frame.f_lineno == handler_line
+            and not triggered
+        ):
+            triggered = True
+            raise interruption
+        return trace
+
+    previous = sys.gettrace()
+    try:
+        sys.settrace(trace)
+        try:
+            action()
+        except BaseException as error:
+            observed = error
+    finally:
+        sys.settrace(previous)
+    if not triggered:
+        raise AssertionError("The relative-handle recovery boundary was not reached.")
+    if observed is None:
+        raise AssertionError("The relative-handle recovery interruption did not escape.")
+    return observed
+
+
+class FakeNtApi:
+    def __init__(
+        self,
+        *,
+        information: int,
+        status: int = 0,
+        completion_status: int = 0,
+        handle: int = 0xA123,
+    ) -> None:
+        self.information = information
+        self.status = ctypes.c_int32(status).value
+        self.completion_status = ctypes.c_int32(completion_status).value
+        self.handle = handle
+        self.calls: list[dict[str, object]] = []
+        self.conversions: list[int] = []
+        self.raise_create: BaseException | None = None
+        self.raise_after_acquire: BaseException | None = None
+        self.raise_convert: BaseException | None = None
+        self.error_codes: dict[int, int] = {
+            0xC000000F: receipt.ERROR_FILE_NOT_FOUND,
+            0xC0000022: 5,
+            0xC0000034: receipt.ERROR_FILE_NOT_FOUND,
+            0xC0000035: receipt.ERROR_FILE_EXISTS,
+            0xC000003A: receipt.ERROR_PATH_NOT_FOUND,
+        }
+
+    def NtCreateFile(
+        self,
+        output: Any,
+        desired_access: int,
+        object_attributes: Any,
+        io_status: Any,
+        allocation_size: object,
+        file_attributes: int,
+        share_access: int,
+        disposition: int,
+        options: int,
+        ea_buffer: object,
+        ea_length: int,
+    ) -> int:
+        attributes = ctypes.cast(object_attributes, ctypes.POINTER(receipt._ObjectAttributes)).contents
+        name = attributes.ObjectName.contents
+        encoded = ctypes.string_at(name.Buffer, name.Length)
+        terminator = ctypes.string_at(name.Buffer + name.Length, ctypes.sizeof(receipt.WCHAR))
+        self.calls.append(
+            {
+                "desired_access": desired_access,
+                "root": attributes.RootDirectory,
+                "name": encoded.decode("utf-16-le"),
+                "name_length": name.Length,
+                "name_maximum": name.MaximumLength,
+                "terminator": terminator,
+                "object_length": attributes.Length,
+                "object_flags": attributes.Attributes,
+                "security": attributes.SecurityDescriptor,
+                "quality": attributes.SecurityQualityOfService,
+                "allocation": allocation_size,
+                "file_attributes": file_attributes,
+                "share_access": share_access,
+                "disposition": disposition,
+                "options": options,
+                "ea_buffer": ea_buffer,
+                "ea_length": ea_length,
+            }
+        )
+        if self.raise_create is not None:
+            raise self.raise_create
+        if receipt._nt_success(self.status):
+            ctypes.cast(output, ctypes.POINTER(ctypes.c_void_p)).contents.value = self.handle
+            completion = ctypes.cast(io_status, ctypes.POINTER(receipt._IoStatusBlock)).contents
+            completion.Status = self.completion_status
+            completion.Information = self.information
+            if self.raise_after_acquire is not None:
+                raise self.raise_after_acquire
+        return self.status
+
+    def RtlNtStatusToDosError(self, status: int) -> int:
+        if self.raise_convert is not None:
+            raise self.raise_convert
+        bits = ctypes.c_uint32(status).value
+        self.conversions.append(bits)
+        return self.error_codes.get(bits, 317)
+
+
+class FakeKernelApi:
+    def __init__(self, data: bytes = PAYLOAD, *, directory: bool = False) -> None:
+        self.data = data
+        self.position = 0
+        self.handle = 0xA123
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+        self.failures: dict[str, BaseException | bool] = {}
+        self.error = 5
+        self._last_error = 0
+        self.file_type = receipt.FILE_TYPE_DISK
+        self.identity = bytes(range(16))
+        self.volume = 91
+        self.attributes = receipt.FILE_ATTRIBUTE_DIRECTORY if directory else receipt.FILE_ATTRIBUTE_NORMAL
+        self.directory = int(directory)
+        self.delete_pending = 0
+        self.links = 1
+        self.metadata_pass = 0
+        self.metadata_overrides: list[dict[str, object]] = [{}, {}]
+        self.excessive_read_count = False
+
+    def get_last_error(self) -> int:
+        return self._last_error
+
+    def set_last_error(self, value: int) -> None:
+        self._last_error = value
+
+    def _action(self, name: str) -> bool:
+        action = self.failures.get(name)
+        if isinstance(action, BaseException):
+            raise action
+        if action is False:
+            self._last_error = self.error
+        return action is not False
+
+    def SetFilePointerEx(self, handle: int, offset: int, _new: object, method: int) -> bool:
+        self.calls.append(("SetFilePointerEx", (handle, offset, method)))
+        if not self._action("SetFilePointerEx"):
+            return False
+        self.position = offset
+        return True
+
+    def ReadFile(self, handle: int, buffer: Any, size: int, read: Any, _overlap: object) -> bool:
+        self.calls.append(("ReadFile", (handle, size)))
+        if not self._action("ReadFile"):
+            return False
+        chunk = self.data[self.position : self.position + size]
+        if chunk:
+            ctypes.memmove(buffer, chunk, len(chunk))
+        self.position += len(chunk)
+        reported = size + 1 if self.excessive_read_count else len(chunk)
+        ctypes.cast(read, ctypes.POINTER(receipt.DWORD)).contents.value = reported
+        return True
+
+    def GetFileType(self, handle: int) -> int:
+        self.calls.append(("GetFileType", (handle,)))
+        if not self._action("GetFileType"):
+            return 0
+        return self.file_type
+
+    def GetFileInformationByHandleEx(self, handle: int, info_class: int, pointer: Any, size: int) -> bool:
+        self.calls.append(("GetFileInformationByHandleEx", (handle, info_class, size)))
+        if not self._action(f"GetInfo:{info_class}"):
+            return False
+        override = self.metadata_overrides[min(self.metadata_pass, len(self.metadata_overrides) - 1)]
+        if info_class == receipt.FILE_BASIC_INFO:
+            value = ctypes.cast(pointer, ctypes.POINTER(receipt._FileBasicInfo)).contents
+            value.FileAttributes = cast(int, override.get("attributes", self.attributes))
+        elif info_class == receipt.FILE_STANDARD_INFO:
+            value = ctypes.cast(pointer, ctypes.POINTER(receipt._FileStandardInfo)).contents
+            value.EndOfFile = cast(int, override.get("size", len(self.data)))
+            value.NumberOfLinks = cast(int, override.get("links", self.links))
+            value.DeletePending = cast(int, override.get("delete_pending", self.delete_pending))
+            value.Directory = cast(int, override.get("directory", self.directory))
+        elif info_class == receipt.FILE_ID_INFO:
+            value = ctypes.cast(pointer, ctypes.POINTER(receipt._FileIdInfo)).contents
+            value.VolumeSerialNumber = cast(int, override.get("volume", self.volume))
+            identity = cast(bytes, override.get("identity", self.identity))
+            for index, byte in enumerate(identity):
+                value.FileId.Identifier[index] = byte
+            self.metadata_pass += 1
+        else:
+            raise AssertionError(f"Unexpected info class: {info_class}")
+        return True
+
+    def CloseHandle(self, handle: int) -> bool:
+        self.calls.append(("CloseHandle", (handle,)))
+        return self._action("CloseHandle")
+
+
+class _SequencedCloseKernelApi(FakeKernelApi):
+    def __init__(self, close_results: tuple[bool, ...]) -> None:
+        super().__init__()
+        self.close_results = list(close_results)
+
+    def CloseHandle(self, handle: int) -> bool:
+        self.calls.append(("CloseHandle", (handle,)))
+        if not self.close_results:
+            raise AssertionError("Unexpected extra CloseHandle call")
+        result = self.close_results.pop(0)
+        if not result:
+            self._last_error = self.error
+        return result
+
+
+class WindowsNtAbiTests(unittest.TestCase):
+    def test_fixed_width_native_layout_matches_current_pointer_abi(self) -> None:
+        pointer_size = ctypes.sizeof(ctypes.c_void_p)
+        expected = {
+            4: {
+                "unicode": 8,
+                "unicode_buffer": 4,
+                "object": 24,
+                "object_root": 4,
+                "object_name": 8,
+                "object_flags": 12,
+                "io": 8,
+                "io_information": 4,
+            },
+            8: {
+                "unicode": 16,
+                "unicode_buffer": 8,
+                "object": 48,
+                "object_root": 8,
+                "object_name": 16,
+                "object_flags": 24,
+                "io": 16,
+                "io_information": 8,
+            },
+        }[pointer_size]
+        self.assertEqual(ctypes.sizeof(receipt.USHORT), 2)
+        self.assertEqual(ctypes.sizeof(receipt.ULONG), 4)
+        self.assertEqual(ctypes.sizeof(receipt.NTSTATUS), 4)
+        self.assertEqual(ctypes.sizeof(receipt._UnicodeString), expected["unicode"])
+        self.assertEqual(receipt._UnicodeString.Buffer.offset, expected["unicode_buffer"])
+        self.assertEqual(ctypes.sizeof(receipt._ObjectAttributes), expected["object"])
+        self.assertEqual(receipt._ObjectAttributes.RootDirectory.offset, expected["object_root"])
+        self.assertEqual(receipt._ObjectAttributes.ObjectName.offset, expected["object_name"])
+        self.assertEqual(receipt._ObjectAttributes.Attributes.offset, expected["object_flags"])
+        self.assertEqual(ctypes.sizeof(receipt._IoStatusBlock), expected["io"])
+        self.assertEqual(receipt._IoStatusBlock.Information.offset, expected["io_information"])
+
+    def test_native_declarations_use_pointer_safe_exact_types(self) -> None:
+        class Function:
+            argtypes: object = None
+            restype: object = None
+
+            def __call__(self, *_args: object) -> int:
+                return 0
+
+        api = type("Api", (), {"NtCreateFile": Function(), "RtlNtStatusToDosError": Function()})()
+        configured: Any = receipt._configure_nt_api(api)
+        args = configured.NtCreateFile.argtypes
+        self.assertIs(args[0]._type_, ctypes.c_void_p)
+        self.assertIs(args[1], receipt.ULONG)
+        self.assertIs(args[2]._type_, receipt._ObjectAttributes)
+        self.assertIs(args[3]._type_, receipt._IoStatusBlock)
+        self.assertIs(args[4]._type_, ctypes.c_int64)
+        self.assertEqual(args[5:9], (receipt.ULONG,) * 4)
+        self.assertIs(args[9], ctypes.c_void_p)
+        self.assertIs(args[10], receipt.ULONG)
+        self.assertIs(configured.NtCreateFile.restype, receipt.NTSTATUS)
+        self.assertEqual(configured.RtlNtStatusToDosError.argtypes, (receipt.NTSTATUS,))
+        self.assertIs(configured.RtlNtStatusToDosError.restype, receipt.ULONG)
+
+    def test_nt_success_uses_signed_32_bit_semantics(self) -> None:
+        self.assertTrue(receipt._nt_success(0))
+        self.assertTrue(receipt._nt_success(0x40000000))
+        self.assertFalse(receipt._nt_success(0x80000005))
+        self.assertFalse(receipt._nt_success(0xC0000034))
+
+    def test_relative_native_open_requires_a_retained_parent(self) -> None:
+        kernel = FakeKernelApi()
+        native = FakeNtApi(information=receipt.FILE_OPENED)
+        with self.assertRaisesRegex(ValueError, "retained parent"):
+            receipt._relative_handle(
+                kernel,
+                native,
+                None,
+                "receipt.json",
+                receipt.WindowsHandleLease(),
+                desired_access=receipt._TARGET_READ_ACCESS,
+                share_access=receipt.FILE_SHARE_READ,
+                disposition=receipt.FILE_OPEN,
+                options=receipt._FILE_OPEN_OPTIONS,
+                expected_information=(receipt.FILE_OPENED,),
+                operation="open receipt",
+            )
+        self.assertEqual(native.calls, [])
+        self.assertEqual(kernel.calls, [])
+
+
+class WindowsHandleLeaseTests(unittest.TestCase):
+    def test_recorded_false_retries_once_then_success_retires_handle(self) -> None:
+        kernel = _SequencedCloseKernelApi((False, True))
+        lease = receipt.WindowsHandleLease(kernel.handle)
+
+        close_error = receipt.close_windows_handle_lease(
+            kernel,
+            lease,
+            None,
+            "test handle",
+        )
+
+        self.assertIsInstance(close_error, OSError)
+        self.assertIsNone(lease.handle)
+        self.assertIs(lease.close_result, receipt._WINDOWS_CLOSE_RESULT_PENDING)
+        self.assertEqual(
+            kernel.calls,
+            [
+                ("CloseHandle", (kernel.handle,)),
+                ("CloseHandle", (kernel.handle,)),
+            ],
+        )
+
+    def test_repeated_recorded_false_exhausts_retry_and_retains_handle(self) -> None:
+        kernel = _SequencedCloseKernelApi((False, False))
+        lease = receipt.WindowsHandleLease(kernel.handle)
+
+        close_error = receipt.close_windows_handle_lease(
+            kernel,
+            lease,
+            None,
+            "test handle",
+        )
+
+        self.assertIsInstance(close_error, OSError)
+        self.assertEqual(lease.handle, kernel.handle)
+        self.assertEqual(lease.close_result, 0)
+        self.assertEqual(len(lease.recorded_close_results), 2)
+        self.assertEqual(len(kernel.calls), 2)
+
+        # Retry exhaustion persists across nested callers and finalizer entry.
+        repeated_error = receipt.close_windows_handle_lease(
+            kernel,
+            lease,
+            None,
+            "test handle",
+        )
+        self.assertIsInstance(repeated_error, OSError)
+        self.assertEqual(lease.handle, kernel.handle)
+        self.assertEqual(len(kernel.calls), 2)
+
+    def test_recorded_false_preserves_primary_base_exception(self) -> None:
+        kernel = _SequencedCloseKernelApi((False, False))
+        lease = receipt.WindowsHandleLease(kernel.handle)
+        primary = KeyboardInterrupt("body primary")
+
+        result = receipt.close_windows_handle_lease(
+            kernel,
+            lease,
+            primary,
+            "test handle",
+        )
+
+        self.assertIs(result, primary)
+        self.assertEqual(lease.handle, kernel.handle)
+        self.assertEqual(len(kernel.calls), 2)
+        self.assertGreaterEqual(
+            "\n".join(getattr(primary, "__notes__", ())).count("CloseHandle"),
+            2,
+        )
+
+    def test_native_true_return_interruption_never_replays_close(self) -> None:
+        kernel = FakeKernelApi()
+        lease = receipt.WindowsHandleLease(kernel.handle)
+        interruption = KeyboardInterrupt("native CloseHandle returned TRUE")
+        native_calls: list[int] = []
+
+        def prototype_factory(
+            result_type: type[ctypes.c_int],
+            *_argument_types: object,
+            **_options: object,
+        ) -> Callable[[int], Callable[[int], int]]:
+            def bind(_address: int) -> Callable[[int], int]:
+                def close(handle: int) -> int:
+                    native_calls.append(handle)
+                    checker = getattr(result_type, "_check_retval_")
+                    checker(result_type(1))
+                    raise interruption
+
+                return close
+
+            return bind
+
+        with (
+            mock.patch.object(
+                receipt,
+                "_native_close_handle_address",
+                return_value=0x123456,
+            ),
+            mock.patch.object(
+                receipt.ctypes,
+                "WINFUNCTYPE",
+                new=prototype_factory,
+                create=True,
+            ),
+            mock.patch.object(
+                receipt.ctypes,
+                "get_last_error",
+                return_value=0,
+                create=True,
+            ),
+        ):
+            result = receipt.close_windows_handle_lease(
+                kernel,
+                lease,
+                None,
+                "test handle",
+            )
+
+        self.assertIs(result, interruption)
+        self.assertIsNone(lease.handle)
+        self.assertIs(lease.close_result, receipt._WINDOWS_CLOSE_RESULT_PENDING)
+        self.assertEqual(native_calls, [kernel.handle])
+
+    def test_unobserved_native_call_blocks_all_reentry(self) -> None:
+        kernel = FakeKernelApi()
+        lease = receipt.WindowsHandleLease(kernel.handle)
+        interruption = KeyboardInterrupt("native CloseHandle result was not recorded")
+        calls = 0
+
+        def interrupt_without_observation(*_arguments: object) -> None:
+            nonlocal calls
+            calls += 1
+            raise interruption
+
+        with (
+            mock.patch.object(
+                receipt,
+                "_native_close_handle_address",
+                return_value=0x123456,
+            ),
+            mock.patch.object(
+                receipt,
+                "_record_close_handle_result",
+                side_effect=interrupt_without_observation,
+            ),
+        ):
+            first_result = receipt.close_windows_handle_lease(
+                kernel,
+                lease,
+                None,
+                "test handle",
+            )
+            second_result = receipt.close_windows_handle_lease(
+                kernel,
+                lease,
+                None,
+                "test handle",
+            )
+
+        self.assertIs(first_result, interruption)
+        self.assertIsNone(second_result)
+        self.assertEqual(calls, 1)
+        self.assertEqual(lease.handle, kernel.handle)
+        self.assertTrue(lease.close_retry_blocked)
+
+    def test_unobserved_native_call_handler_interrupt_stays_prearmed(self) -> None:
+        kernel = FakeKernelApi()
+        lease = receipt.WindowsHandleLease(kernel.handle)
+        body_primary = SystemExit("body primary")
+        unobserved_error = RuntimeError("native CloseHandle result was not recorded")
+        handler_interruption = KeyboardInterrupt("CloseHandle handler entry")
+        native_entries = 0
+        target = receipt.close_windows_handle_lease
+        source, first_line = inspect.getsourcelines(target)
+        handler_line = first_line + next(
+            index for index, line in enumerate(source) if line.strip() == "retain_failure(close_error)"
+        )
+        triggered = False
+
+        def interrupt_without_observation(*_arguments: object) -> None:
+            nonlocal native_entries
+            native_entries += 1
+            raise unobserved_error
+
+        def trace(frame: Any, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if event == "call" and frame.f_code is target.__code__:
+                frame.f_trace = trace
+                return trace
+            if (
+                event == "line"
+                and frame.f_code is target.__code__
+                and frame.f_lineno == handler_line
+                and not triggered
+            ):
+                triggered = True
+                raise handler_interruption
+            return trace
+
+        with (
+            mock.patch.object(
+                receipt,
+                "_native_close_handle_address",
+                return_value=0x123456,
+            ),
+            mock.patch.object(
+                receipt,
+                "_record_close_handle_result",
+                side_effect=interrupt_without_observation,
+            ),
+        ):
+            previous = sys.gettrace()
+            try:
+                sys.settrace(trace)
+                with self.assertRaises(KeyboardInterrupt) as raised:
+                    target(kernel, lease, body_primary, "test handle")
+            finally:
+                sys.settrace(previous)
+
+            repeated_result = target(kernel, lease, body_primary, "test handle")
+
+        self.assertTrue(triggered)
+        self.assertIs(raised.exception, handler_interruption)
+        self.assertIs(repeated_result, body_primary)
+        self.assertEqual(native_entries, 1)
+        self.assertEqual(lease.handle, kernel.handle)
+        self.assertEqual(lease.recorded_close_results, [])
+        self.assertTrue(lease.close_retry_blocked)
+
+    def test_observed_false_before_prearm_clear_uses_only_safe_retry(self) -> None:
+        target = receipt.close_windows_handle_lease
+        source, first_line = inspect.getsourcelines(target)
+        clear_line = first_line + next(
+            index
+            for index, line in enumerate(source)
+            if line.strip() == "lease.close_retry_blocked = False"
+        )
+        cases = (
+            ("retry-succeeds", (0, 1), False),
+            ("retry-fails", (0, 0), True),
+        )
+        for label, close_results, expected_live in cases:
+            with self.subTest(label=label):
+                kernel = FakeKernelApi()
+                lease = receipt.WindowsHandleLease(kernel.handle)
+                body_primary = SystemExit("body primary")
+                interruption = KeyboardInterrupt("after definitive CloseHandle FALSE")
+                statuses = iter(close_results)
+                native_entries: list[int] = []
+                triggered = False
+
+                def record_result(
+                    _api: object,
+                    active_lease: receipt.WindowsHandleLease,
+                    handle: int,
+                    _native_address: int | None,
+                ) -> None:
+                    native_entries.append(handle)
+                    status = next(statuses)
+                    active_lease.recorded_close_results.append(
+                        receipt._WindowsCloseObservation(status, 123 if not status else 0)
+                    )
+
+                def trace(frame: Any, event: str, _argument: object) -> Any:
+                    nonlocal triggered
+                    if event == "call" and frame.f_code is target.__code__:
+                        frame.f_trace = trace
+                        return trace
+                    if (
+                        event == "line"
+                        and frame.f_code is target.__code__
+                        and frame.f_lineno == clear_line
+                        and not triggered
+                    ):
+                        triggered = True
+                        raise interruption
+                    return trace
+
+                with (
+                    mock.patch.object(
+                        receipt,
+                        "_native_close_handle_address",
+                        return_value=0x123456,
+                    ),
+                    mock.patch.object(
+                        receipt,
+                        "_record_close_handle_result",
+                        side_effect=record_result,
+                    ),
+                ):
+                    previous = sys.gettrace()
+                    try:
+                        sys.settrace(trace)
+                        with self.assertRaises(KeyboardInterrupt) as raised:
+                            target(kernel, lease, None, "test handle")
+                    finally:
+                        sys.settrace(previous)
+
+                    repeated_result = target(kernel, lease, body_primary, "test handle")
+                    final_result = target(kernel, lease, body_primary, "test handle")
+
+                self.assertTrue(triggered)
+                self.assertIs(raised.exception, interruption)
+                self.assertIs(repeated_result, body_primary)
+                self.assertIs(final_result, body_primary)
+                self.assertEqual(native_entries, [kernel.handle, kernel.handle])
+                self.assertEqual(lease.handle is not None, expected_live)
+                self.assertIn("CloseHandle", "\n".join(getattr(body_primary, "__notes__", ())))
+                if expected_live:
+                    self.assertEqual(len(lease.recorded_close_results), 2)
+                else:
+                    self.assertEqual(lease.recorded_close_results, [])
+
+    def test_native_false_captures_last_error_before_successful_retry(self) -> None:
+        kernel = FakeKernelApi()
+        lease = receipt.WindowsHandleLease(kernel.handle)
+        statuses = iter((0, 1))
+        native_calls: list[int] = []
+
+        def prototype_factory(
+            result_type: type[ctypes.c_int],
+            *_argument_types: object,
+            **_options: object,
+        ) -> Callable[[int], Callable[[int], int]]:
+            def bind(_address: int) -> Callable[[int], int]:
+                def close(handle: int) -> int:
+                    native_calls.append(handle)
+                    status = next(statuses)
+                    checker = getattr(result_type, "_check_retval_")
+                    checker(result_type(status))
+                    return status
+
+                return close
+
+            return bind
+
+        with (
+            mock.patch.object(
+                receipt,
+                "_native_close_handle_address",
+                return_value=0x123456,
+            ),
+            mock.patch.object(
+                receipt.ctypes,
+                "WINFUNCTYPE",
+                new=prototype_factory,
+                create=True,
+            ),
+            mock.patch.object(
+                receipt.ctypes,
+                "get_last_error",
+                side_effect=(123, 0),
+                create=True,
+            ),
+        ):
+            result = receipt.close_windows_handle_lease(
+                kernel,
+                lease,
+                None,
+                "test handle",
+            )
+
+        self.assertIsInstance(result, OSError)
+        assert isinstance(result, OSError)
+        self.assertEqual(result.errno, 123)
+        self.assertIsNone(lease.handle)
+        self.assertEqual(native_calls, [kernel.handle, kernel.handle])
+
+    def test_publication_close_stops_before_older_handles_on_false_exhaustion(
+        self,
+    ) -> None:
+        kernel = _SequencedCloseKernelApi((False, False))
+        publication = receipt._WindowsReceiptPublicationLease(kernel)
+        publication.stage.handle = 0xA100
+        older_child = publication.new_transient_handle()
+        older_child.handle = 0xA200
+        newest_child = publication.new_transient_handle()
+        newest_child.handle = 0xA300
+
+        failures = publication.close()
+
+        self.assertTrue(failures)
+        self.assertEqual(
+            kernel.calls,
+            [
+                ("CloseHandle", (0xA300,)),
+                ("CloseHandle", (0xA300,)),
+            ],
+        )
+        self.assertEqual(newest_child.handle, 0xA300)
+        self.assertEqual(older_child.handle, 0xA200)
+        self.assertEqual(publication.stage.handle, 0xA100)
+        self.assertFalse(publication.is_closed)
+        self.assertEqual(publication.close(), ())
+        self.assertEqual(len(kernel.calls), 2)
+
+    def test_close_address_resolution_interrupt_is_bounded_and_does_not_skip_close(self) -> None:
+        kernel = FakeKernelApi()
+        lease = receipt.WindowsHandleLease(kernel.handle)
+        interruption = KeyboardInterrupt("resolve CloseHandle")
+        original = receipt._native_close_handle_address
+        attempts = 0
+
+        def interrupted_once(_api: object) -> int | None:
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise interruption
+            return None
+
+        receipt._native_close_handle_address = interrupted_once
+        try:
+            primary = receipt.close_windows_handle_lease(kernel, lease, None, "test handle")
+        finally:
+            receipt._native_close_handle_address = original
+
+        self.assertIs(primary, interruption)
+        self.assertEqual(attempts, 2)
+        self.assertIsNone(lease.handle)
+        self.assertEqual(kernel.calls, [("CloseHandle", (kernel.handle,))])
+
+    def test_close_result_extraction_failure_preserves_primary(self) -> None:
+        extraction_error = KeyboardInterrupt("extract CloseHandle result")
+
+        class Result:
+            @property
+            def value(self) -> int:
+                raise extraction_error
+
+        kernel = FakeKernelApi()
+        primary = RuntimeError("primary")
+        recorded = Result()
+        lease = receipt.WindowsHandleLease(kernel.handle, recorded)
+        result = receipt.close_windows_handle_lease(kernel, lease, primary, "test handle")
+
+        self.assertIs(result, primary)
+        self.assertEqual(lease.handle, kernel.handle)
+        self.assertIs(lease.close_result, recorded)
+        self.assertIn("extract CloseHandle result", "\n".join(getattr(primary, "__notes__", ())))
+        self.assertEqual(kernel.calls, [])
+
+    def test_close_failure_translation_failure_preserves_primary(self) -> None:
+        translation_error = SystemExit("translate CloseHandle failure")
+
+        class ErrorKernel(FakeKernelApi):
+            def get_last_error(self) -> int:
+                raise translation_error
+
+        kernel = ErrorKernel()
+        kernel.failures["CloseHandle"] = False
+        primary = RuntimeError("primary")
+        lease = receipt.WindowsHandleLease(kernel.handle)
+        result = receipt.close_windows_handle_lease(kernel, lease, primary, "test handle")
+
+        self.assertIs(result, primary)
+        self.assertEqual(lease.handle, kernel.handle)
+        self.assertEqual(lease.close_result, 0)
+        self.assertIn("translate CloseHandle failure", "\n".join(getattr(primary, "__notes__", ())))
+        self.assertEqual(
+            kernel.calls,
+            [
+                ("CloseHandle", (kernel.handle,)),
+                ("CloseHandle", (kernel.handle,)),
+            ],
+        )
+
+    def test_recorded_result_consumption_retries_before_handle_retirement(self) -> None:
+        kernel = FakeKernelApi()
+        primary = RuntimeError("primary")
+        interruption = KeyboardInterrupt("before recorded handle retirement")
+        lease = receipt.WindowsHandleLease(kernel.handle, 1)
+        target_code = receipt.close_windows_handle_lease.__code__
+        source_lines, source_start = inspect.getsourcelines(receipt.close_windows_handle_lease)
+        retirement_line = source_start + [
+            index
+            for index, line in enumerate(source_lines)
+            if line.strip() == "lease.handle = None"
+        ][-1]
+        triggered = False
+
+        def trace(frame: Any, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if (
+                event == "line"
+                and frame.f_code is target_code
+                and not triggered
+                and frame.f_lineno == retirement_line
+                and getattr(frame.f_locals.get("recorded"), "status", None) == 1
+                and frame.f_locals.get("raw_status") == 1
+                and lease.handle == kernel.handle
+            ):
+                triggered = True
+                raise interruption
+            return trace
+
+        previous = sys.gettrace()
+        try:
+            sys.settrace(trace)
+            result = receipt.close_windows_handle_lease(kernel, lease, primary, "recorded handle")
+        finally:
+            sys.settrace(previous)
+
+        self.assertTrue(triggered)
+        self.assertIs(result, primary)
+        self.assertIsNone(lease.handle)
+        self.assertIs(lease.close_result, receipt._WINDOWS_CLOSE_RESULT_PENDING)
+        self.assertIn("before recorded handle retirement", "\n".join(getattr(primary, "__notes__", ())))
+        self.assertEqual(kernel.calls, [])
+
+    def test_empty_lease_with_stale_close_marker_is_safe_to_reuse(self) -> None:
+        kernel = FakeKernelApi()
+        first_handle = kernel.handle
+        lease = receipt.WindowsHandleLease(first_handle)
+        interruption = KeyboardInterrupt("after handle retirement")
+        target_code = receipt.close_windows_handle_lease.__code__
+        source_lines, source_start = inspect.getsourcelines(receipt.close_windows_handle_lease)
+        result_line = source_start + next(
+            index
+            for index, line in enumerate(source_lines)
+            if line.strip() == "lease.recorded_close_results.clear()"
+        )
+        triggered = False
+
+        def trace(frame: Any, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if (
+                not triggered
+                and event == "line"
+                and frame.f_code is target_code
+                and frame.f_lineno == result_line
+                and lease.handle is None
+                and lease.close_result is not receipt._WINDOWS_CLOSE_RESULT_PENDING
+            ):
+                triggered = True
+                raise interruption
+            return trace
+
+        previous = sys.gettrace()
+        try:
+            sys.settrace(trace)
+            first_result = receipt.close_windows_handle_lease(kernel, lease, None, "first handle")
+        finally:
+            sys.settrace(previous)
+
+        self.assertTrue(triggered)
+        self.assertIs(first_result, interruption)
+        self.assertIsNone(lease.handle)
+        self.assertIs(lease.close_result, receipt._WINDOWS_CLOSE_RESULT_PENDING)
+
+        # Model a second interruption after handle retirement but before the
+        # history reset; acquisition must normalize this empty stale state.
+        lease.close_result = 1
+        second_handle = 0xBEEF
+        native = FakeNtApi(information=receipt.FILE_OPENED, handle=second_handle)
+        information = receipt._relative_handle(
+            kernel,
+            native,
+            7,
+            "receipt.json",
+            lease,
+            desired_access=receipt._TARGET_READ_ACCESS,
+            share_access=receipt.FILE_SHARE_READ,
+            disposition=receipt.FILE_OPEN,
+            options=receipt._FILE_OPEN_OPTIONS,
+            expected_information=(receipt.FILE_OPENED,),
+            operation="open receipt",
+        )
+        self.assertEqual(information, receipt.FILE_OPENED)
+        self.assertEqual(lease.handle, second_handle)
+        self.assertIs(lease.close_result, receipt._WINDOWS_CLOSE_RESULT_PENDING)
+        self.assertIsNone(receipt.close_windows_handle_lease(kernel, lease, None, "second handle"))
+        self.assertEqual(
+            [call for call in kernel.calls if call[0] == "CloseHandle"],
+            [("CloseHandle", (first_handle,)), ("CloseHandle", (second_handle,))],
+        )
+
+
+class WindowsRelativeReceiptReaderTests(unittest.TestCase):
+    def read(
+        self,
+        kernel: FakeKernelApi,
+        native: FakeNtApi,
+        *,
+        leaf: str = "receipt-ž.json",
+        payload: bytes = PAYLOAD,
+    ) -> receipt.WindowsReceiptResult:
+        return receipt.read_windows_receipt(
+            0x4567,
+            leaf,
+            payload,
+            api=kernel,
+            nt_api=native,
+            publication_lease=receipt._WindowsReceiptPublicationLease(kernel),
+        )
+
+    def test_exact_relative_open_abi_and_result(self) -> None:
+        kernel = FakeKernelApi()
+        native = FakeNtApi(information=receipt.FILE_OPENED)
+
+        result = self.read(kernel, native)
+
+        self.assertEqual(result, receipt.WindowsReceiptResult("receipt-ž.json", 91, bytes(range(16)), len(PAYLOAD)))
+        self.assertEqual(len(native.calls), 1)
+        call = native.calls[0]
+        encoded_length = len("receipt-ž.json".encode("utf-16-le"))
+        self.assertEqual(call["root"], 0x4567)
+        self.assertEqual(call["name"], "receipt-ž.json")
+        self.assertEqual(call["name_length"], encoded_length)
+        self.assertEqual(call["name_maximum"], encoded_length + 2)
+        self.assertEqual(call["terminator"], b"\x00\x00")
+        self.assertEqual(call["object_length"], ctypes.sizeof(receipt._ObjectAttributes))
+        self.assertEqual(call["object_flags"], receipt.OBJ_CASE_INSENSITIVE)
+        self.assertIsNone(call["security"])
+        self.assertIsNone(call["quality"])
+        self.assertIsNone(call["allocation"])
+        self.assertEqual(call["desired_access"], receipt._TARGET_READ_ACCESS)
+        self.assertEqual(call["file_attributes"], receipt.FILE_ATTRIBUTE_NORMAL)
+        self.assertEqual(call["share_access"], receipt.FILE_SHARE_READ)
+        self.assertEqual(call["disposition"], receipt.FILE_OPEN)
+        self.assertEqual(call["options"], receipt._FILE_OPEN_OPTIONS)
+        self.assertIsNone(call["ea_buffer"])
+        self.assertEqual(call["ea_length"], 0)
+        self.assertEqual(kernel.calls[-1], ("CloseHandle", (native.handle,)))
+        self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), 1)
+
+    def test_native_not_found_statuses_translate_through_rtl(self) -> None:
+        cases = (
+            (0xC000000F, receipt.ERROR_FILE_NOT_FOUND),
+            (0xC0000034, receipt.ERROR_FILE_NOT_FOUND),
+            (0xC000003A, receipt.ERROR_PATH_NOT_FOUND),
+        )
+        for status, code in cases:
+            with self.subTest(status=hex(status)):
+                kernel = FakeKernelApi()
+                native = FakeNtApi(information=receipt.FILE_OPENED, status=status)
+                with self.assertRaises(FileNotFoundError) as caught:
+                    self.read(kernel, native)
+                self.assertEqual(caught.exception.errno, code)
+                self.assertEqual(native.conversions, [status])
+                self.assertFalse(any(name == "CloseHandle" for name, _args in kernel.calls))
+
+    def test_completion_not_found_after_handle_acquisition_is_changed(self) -> None:
+        for error_number in (receipt.ERROR_FILE_NOT_FOUND, receipt.ERROR_PATH_NOT_FOUND):
+            with self.subTest(error_number=error_number):
+                kernel = FakeKernelApi()
+                native = FakeNtApi(
+                    information=receipt.FILE_OPENED,
+                    completion_status=0xC0000022,
+                )
+                native.error_codes[0xC0000022] = error_number
+
+                with self.assertRaises(receipt.WindowsReceiptValidationError) as raised:
+                    self.read(kernel, native)
+
+                self.assertEqual(raised.exception.code, "output-changed")
+                self.assertIsInstance(raised.exception.__cause__, FileNotFoundError)
+                assert isinstance(raised.exception.__cause__, FileNotFoundError)
+                self.assertEqual(raised.exception.__cause__.errno, error_number)
+                self.assertEqual(
+                    [call for call in kernel.calls if call[0] == "CloseHandle"],
+                    [("CloseHandle", (native.handle,))],
+                )
+
+    def test_native_directory_rejection_has_stable_existing_invalid_code(self) -> None:
+        native = FakeNtApi(
+            information=receipt.FILE_OPENED,
+            status=receipt.STATUS_FILE_IS_A_DIRECTORY,
+        )
+        native.error_codes[receipt.STATUS_FILE_IS_A_DIRECTORY] = 5
+        kernel = FakeKernelApi(directory=True)
+        with self.assertRaises(receipt.WindowsReceiptValidationError) as raised:
+            self.read(kernel, native)
+        self.assertEqual(raised.exception.code, "output-existing-invalid")
+        self.assertIsInstance(raised.exception.__cause__, OSError)
+        assert isinstance(raised.exception.__cause__, OSError)
+        self.assertEqual(raised.exception.__cause__.errno, 5)
+        self.assertEqual(native.conversions, [receipt.STATUS_FILE_IS_A_DIRECTORY])
+        self.assertFalse(any(name == "CloseHandle" for name, _args in kernel.calls))
+
+    def test_post_open_unsupported_operations_have_stable_anchor_code(self) -> None:
+        cases = (
+            ("metadata", "GetInfo:0", receipt.ERROR_NOT_SUPPORTED),
+            ("file type", "GetFileType", receipt.ERROR_INVALID_FUNCTION),
+            ("seek", "SetFilePointerEx", receipt.ERROR_INVALID_PARAMETER),
+            ("read", "ReadFile", receipt.ERROR_CALL_NOT_IMPLEMENTED),
+        )
+        for label, operation, error_number in cases:
+            with self.subTest(label=label):
+                kernel = FakeKernelApi()
+                kernel.failures[operation] = False
+                kernel.error = error_number
+                with self.assertRaises(receipt.WindowsReceiptValidationError) as raised:
+                    self.read(kernel, FakeNtApi(information=receipt.FILE_OPENED))
+                self.assertEqual(raised.exception.code, "output-anchor-unavailable")
+                self.assertIsInstance(raised.exception.__cause__, OSError)
+                assert isinstance(raised.exception.__cause__, OSError)
+                self.assertEqual(raised.exception.__cause__.errno, error_number)
+                self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), 1)
+
+    def test_post_open_unsupported_translation_preserves_native_notes(self) -> None:
+        native_error = OSError(receipt.ERROR_NOT_SUPPORTED, "unsupported metadata query")
+        native_error.add_note("native metadata note")
+        kernel = FakeKernelApi()
+        kernel.failures["GetInfo:0"] = native_error
+
+        with self.assertRaises(receipt.WindowsReceiptValidationError) as raised:
+            self.read(kernel, FakeNtApi(information=receipt.FILE_OPENED))
+
+        self.assertEqual(raised.exception.code, "output-anchor-unavailable")
+        self.assertIs(raised.exception.__cause__, native_error)
+        self.assertIn("native metadata note", getattr(raised.exception, "__notes__", ()))
+        self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), 1)
+
+    def test_post_open_namespace_failures_have_stable_changed_code(self) -> None:
+        cases = (
+            (
+                "metadata",
+                "GetInfo:0",
+                FileNotFoundError(receipt.ERROR_FILE_NOT_FOUND, "metadata target disappeared"),
+            ),
+            (
+                "read",
+                "ReadFile",
+                OSError(receipt.ERROR_PATH_NOT_FOUND, "receipt path disappeared"),
+            ),
+        )
+        for label, operation, native_error in cases:
+            with self.subTest(label=label):
+                native_error.add_note("native namespace note")
+                kernel = FakeKernelApi()
+                kernel.failures[operation] = native_error
+
+                with self.assertRaises(receipt.WindowsReceiptValidationError) as raised:
+                    self.read(kernel, FakeNtApi(information=receipt.FILE_OPENED))
+
+                self.assertEqual(raised.exception.code, "output-changed")
+                self.assertIs(raised.exception.__cause__, native_error)
+                self.assertIn("native namespace note", getattr(raised.exception, "__notes__", ()))
+                self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), 1)
+
+    def test_post_open_generic_io_operations_remain_native(self) -> None:
+        for operation in ("GetInfo:0", "GetFileType", "SetFilePointerEx", "ReadFile"):
+            with self.subTest(operation=operation):
+                kernel = FakeKernelApi()
+                kernel.failures[operation] = False
+                kernel.error = 1117
+                with self.assertRaises(OSError) as raised:
+                    self.read(kernel, FakeNtApi(information=receipt.FILE_OPENED))
+                self.assertEqual(raised.exception.errno, 1117)
+                self.assertNotIsInstance(raised.exception, receipt.WindowsReceiptValidationError)
+                self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), 1)
+
+    def test_native_and_completion_failures_close_only_owned_handles(self) -> None:
+        native_failure = FakeNtApi(information=receipt.FILE_OPENED, status=0xC0000022)
+        kernel = FakeKernelApi()
+        with self.assertRaises(OSError) as caught:
+            self.read(kernel, native_failure)
+        self.assertEqual(caught.exception.errno, 5)
+        self.assertFalse(any(name == "CloseHandle" for name, _args in kernel.calls))
+
+        completion_failure = FakeNtApi(
+            information=receipt.FILE_OPENED,
+            completion_status=0xC0000022,
+        )
+        kernel = FakeKernelApi()
+        with self.assertRaises(OSError) as caught:
+            self.read(kernel, completion_failure)
+        self.assertEqual(caught.exception.errno, 5)
+        self.assertEqual([name for name, _args in kernel.calls], ["CloseHandle"])
+
+        wrong_information = FakeNtApi(information=receipt.FILE_CREATED)
+        kernel = FakeKernelApi()
+        with self.assertRaisesRegex(OSError, "IO_STATUS_BLOCK.Information"):
+            self.read(kernel, wrong_information)
+        self.assertEqual([name for name, _args in kernel.calls], ["CloseHandle"])
+
+    def test_exception_after_native_handle_acquisition_closes_exactly_once(self) -> None:
+        for primary in (OSError("acquire"), KeyboardInterrupt("acquire"), SystemExit("acquire")):
+            with self.subTest(primary=type(primary).__name__):
+                kernel = FakeKernelApi()
+                native = FakeNtApi(information=receipt.FILE_OPENED)
+                native.raise_after_acquire = primary
+                with self.assertRaises(BaseException) as caught:
+                    self.read(kernel, native)
+                self.assertIs(caught.exception, primary)
+                self.assertEqual(
+                    [call for call in kernel.calls if call[0] == "CloseHandle"],
+                    [("CloseHandle", (native.handle,))],
+                )
+
+        primary = KeyboardInterrupt("acquire")
+        kernel = FakeKernelApi()
+        kernel.failures["CloseHandle"] = SystemExit("close")
+        native = FakeNtApi(information=receipt.FILE_OPENED)
+        native.raise_after_acquire = primary
+        with self.assertRaises(KeyboardInterrupt) as caught:
+            self.read(kernel, native)
+        self.assertIs(caught.exception, primary)
+        self.assertIn("Could not close", "\n".join(getattr(primary, "__notes__", ())))
+
+    def test_handler_entry_interrupt_closes_lease_owned_native_output(self) -> None:
+        kernel = FakeKernelApi()
+        native = FakeNtApi(information=receipt.FILE_OPENED)
+        native.raise_after_acquire = RuntimeError("native read acquisition returned before raising")
+        interruption = KeyboardInterrupt("relative read acquisition handler entry")
+        publication_lease = receipt._WindowsReceiptPublicationLease(kernel)
+
+        caught = _interrupt_relative_handle_handler(
+            lambda: receipt.read_windows_receipt(
+                7,
+                "receipt.json",
+                PAYLOAD,
+                api=kernel,
+                nt_api=native,
+                publication_lease=publication_lease,
+            ),
+            interruption,
+        )
+
+        self.assertIs(caught, interruption)
+        self.assertTrue(publication_lease.is_closed)
+        self.assertEqual(
+            [call for call in kernel.calls if call[0] == "CloseHandle"],
+            [("CloseHandle", (native.handle,))],
+        )
+
+    def test_opcode_interrupt_after_native_return_closes_acquired_handle(self) -> None:
+        kernel = FakeKernelApi()
+        native = FakeNtApi(information=receipt.FILE_OPENED)
+        interruption = KeyboardInterrupt("between native return and Python assignment")
+        real_create = native.NtCreateFile
+        triggered = False
+
+        class _InterruptingStatus:
+            def __int__(self) -> int:
+                nonlocal triggered
+                triggered = True
+                raise interruption
+
+        def create_then_return_status(*arguments: Any, **keywords: Any) -> object:
+            real_create(*arguments, **keywords)
+            return _InterruptingStatus()
+
+        with mock.patch.object(
+            native,
+            "NtCreateFile",
+            side_effect=create_then_return_status,
+        ):
+            with self.assertRaises(KeyboardInterrupt) as caught:
+                self.read(kernel, native)
+        self.assertTrue(triggered)
+        self.assertIs(caught.exception, interruption)
+        self.assertEqual(
+            [call for call in kernel.calls if call[0] == "CloseHandle"],
+            [("CloseHandle", (native.handle,))],
+        )
+
+    def test_reader_call_return_gap_is_owned_by_shared_lease(self) -> None:
+        kernel = FakeKernelApi()
+        native = FakeNtApi(information=receipt.FILE_OPENED)
+        interruption = KeyboardInterrupt("relative helper returned before caller assignment")
+        target_code = receipt.read_windows_receipt.__code__
+        source_lines, source_start = inspect.getsourcelines(receipt.read_windows_receipt)
+        ownership_line = source_start + next(
+            index for index, line in enumerate(source_lines) if line.strip() == "handle = lease.handle"
+        )
+        triggered = False
+
+        def trace(frame: Any, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if event == "line" and frame.f_code is target_code and not triggered and frame.f_lineno == ownership_line:
+                triggered = True
+                raise interruption
+            return trace
+
+        previous = sys.gettrace()
+        try:
+            sys.settrace(trace)
+            with self.assertRaises(KeyboardInterrupt) as caught:
+                self.read(kernel, native)
+        finally:
+            sys.settrace(previous)
+        self.assertTrue(triggered)
+        self.assertIs(caught.exception, interruption)
+        self.assertEqual(
+            [call for call in kernel.calls if call[0] == "CloseHandle"],
+            [("CloseHandle", (native.handle,))],
+        )
+
+    def test_leaf_and_payload_validation_precede_native_call(self) -> None:
+        for leaf in INVALID_WINDOWS_RELATIVE_LEAVES:
+            with self.subTest(leaf=repr(leaf)):
+                kernel = FakeKernelApi()
+                native = FakeNtApi(information=receipt.FILE_OPENED)
+                with self.assertRaises(ValueError):
+                    self.read(kernel, native, leaf=leaf)
+                self.assertEqual(native.calls, [])
+                self.assertEqual(kernel.calls, [])
+        empty_kernel = FakeKernelApi(b"")
+        empty_native = FakeNtApi(information=receipt.FILE_OPENED)
+        with self.assertRaises(ValueError):
+            self.read(empty_kernel, empty_native, payload=b"")
+        self.assertEqual(empty_native.calls, [])
+        self.assertEqual(empty_kernel.calls, [])
+
+    def test_valid_near_miss_unicode_and_long_leaves_reach_native_unchanged(self) -> None:
+        for leaf in VALID_WINDOWS_RELATIVE_LEAVES:
+            with self.subTest(leaf=repr(leaf)):
+                kernel = FakeKernelApi()
+                native = FakeNtApi(information=receipt.FILE_OPENED)
+                result = self.read(kernel, native, leaf=leaf)
+                self.assertEqual(result.leaf, leaf)
+                self.assertEqual(len(native.calls), 1)
+                self.assertEqual(native.calls[0]["name"], leaf)
+
+    def test_noncanonical_targets_have_stable_validation_code(self) -> None:
+        cases: tuple[tuple[str, Callable[[FakeKernelApi], None]], ...] = (
+            ("readonly", lambda api: setattr(api, "attributes", receipt.FILE_ATTRIBUTE_READONLY)),
+            ("basic-directory", lambda api: setattr(api, "attributes", receipt.FILE_ATTRIBUTE_DIRECTORY)),
+            ("reparse", lambda api: setattr(api, "attributes", receipt.FILE_ATTRIBUTE_REPARSE_POINT)),
+            ("standard-directory", lambda api: setattr(api, "directory", 1)),
+            ("delete-pending", lambda api: setattr(api, "delete_pending", 1)),
+            ("multiple-links", lambda api: setattr(api, "links", 2)),
+            ("non-disk", lambda api: setattr(api, "file_type", 0)),
+        )
+        for label, configure in cases:
+            with self.subTest(label=label):
+                kernel = FakeKernelApi()
+                configure(kernel)
+                with self.assertRaises(receipt.WindowsReceiptValidationError) as caught:
+                    self.read(kernel, FakeNtApi(information=receipt.FILE_OPENED))
+                self.assertEqual(caught.exception.code, "output-existing-invalid")
+                self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), 1)
+
+    def test_exact_size_bytes_and_eof_are_required(self) -> None:
+        for label, data in (
+            ("short", PAYLOAD[:-1]),
+            ("long", PAYLOAD + b"x"),
+            ("same-size-different", b"X" + PAYLOAD[1:]),
+        ):
+            with self.subTest(label=label):
+                kernel = FakeKernelApi(data)
+                with self.assertRaises(receipt.WindowsReceiptValidationError) as caught:
+                    self.read(kernel, FakeNtApi(information=receipt.FILE_OPENED))
+                self.assertEqual(caught.exception.code, "output-different")
+                self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), 1)
+
+    def test_identity_attributes_links_and_size_must_remain_stable(self) -> None:
+        cases: tuple[tuple[str, str, object], ...] = (
+            ("identity", "identity", b"z" * 16),
+            ("volume", "volume", 92),
+            ("attributes", "attributes", receipt.FILE_ATTRIBUTE_READONLY),
+            ("links", "links", 2),
+            ("size", "size", len(PAYLOAD) + 1),
+        )
+        for label, field, value in cases:
+            with self.subTest(label=label):
+                kernel = FakeKernelApi()
+                kernel.metadata_overrides[1][field] = value
+                with self.assertRaises(receipt.WindowsReceiptValidationError) as caught:
+                    self.read(kernel, FakeNtApi(information=receipt.FILE_OPENED))
+                self.assertEqual(caught.exception.code, "output-changed")
+
+    def test_read_failures_and_control_flow_preserve_primary_over_close(self) -> None:
+        for operation in ("SetFilePointerEx", "ReadFile"):
+            with self.subTest(operation=operation):
+                kernel = FakeKernelApi()
+                kernel.failures[operation] = False
+                with self.assertRaises(OSError):
+                    self.read(kernel, FakeNtApi(information=receipt.FILE_OPENED))
+                self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), 1)
+
+        for primary in (OSError("read"), KeyboardInterrupt("read"), SystemExit("read")):
+            with self.subTest(primary=type(primary).__name__):
+                kernel = FakeKernelApi()
+                cleanup = RuntimeError("close")
+                kernel.failures.update({"ReadFile": primary, "CloseHandle": cleanup})
+                with self.assertRaises(BaseException) as caught:
+                    self.read(kernel, FakeNtApi(information=receipt.FILE_OPENED))
+                self.assertIs(caught.exception, primary)
+                self.assertIn("Could not close", "\n".join(getattr(primary, "__notes__", ())))
+                self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), 1)
+
+    def test_reader_close_call_return_gap_preserves_primary(self) -> None:
+        kernel = FakeKernelApi()
+        primary = RuntimeError("read")
+        kernel.failures["ReadFile"] = primary
+        interruption = KeyboardInterrupt("between reader close return and assignment")
+        triggered = False
+
+        real_close = receipt._WindowsReceiptPublicationLease.close
+
+        def close_then_interrupt(
+            publication_lease: receipt._WindowsReceiptPublicationLease,
+        ) -> tuple[BaseException, ...]:
+            nonlocal triggered
+            result = real_close(publication_lease)
+            if not triggered:
+                triggered = True
+                raise interruption
+            return result
+
+        with mock.patch.object(
+            receipt._WindowsReceiptPublicationLease,
+            "close",
+            new=close_then_interrupt,
+        ):
+            with self.assertRaises(RuntimeError) as caught:
+                self.read(kernel, FakeNtApi(information=receipt.FILE_OPENED))
+
+        self.assertTrue(triggered)
+        self.assertIs(caught.exception, primary)
+        self.assertIn(
+            "Could not close receipt verification handle: between reader close return and assignment",
+            getattr(primary, "__notes__", ()),
+        )
+        self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), 1)
+
+    def test_reader_cleanup_entry_interrupt_is_recovered_by_shared_owner(self) -> None:
+        kernel = FakeKernelApi()
+        native = FakeNtApi(information=receipt.FILE_OPENED)
+        publication_lease = receipt._WindowsReceiptPublicationLease(kernel)
+        interruption = KeyboardInterrupt("reader cleanup entry")
+        target_code = receipt.read_windows_receipt.__code__
+        source, first_line = inspect.getsourcelines(receipt.read_windows_receipt)
+        cleanup_line = first_line + next(
+            index for index, line in enumerate(source) if "close_failures = publication_lease.close()" in line
+        )
+        triggered = False
+
+        def trace(frame: Any, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if event == "call" and frame.f_code is target_code:
+                frame.f_trace = trace
+                return trace
+            if event == "line" and frame.f_code is target_code and frame.f_lineno == cleanup_line and not triggered:
+                triggered = True
+                raise interruption
+            return trace
+
+        previous = sys.gettrace()
+        try:
+            sys.settrace(trace)
+            with self.assertRaises(KeyboardInterrupt) as caught:
+                receipt.read_windows_receipt(
+                    0x4567,
+                    "receipt.json",
+                    PAYLOAD,
+                    api=kernel,
+                    nt_api=native,
+                    publication_lease=publication_lease,
+                )
+        finally:
+            sys.settrace(previous)
+
+        self.assertTrue(triggered)
+        self.assertIs(caught.exception, interruption)
+        self.assertFalse(publication_lease.is_closed)
+        self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), 0)
+        self.assertEqual(publication_lease.close(), ())
+        self.assertTrue(publication_lease.is_closed)
+        self.assertEqual(
+            [call for call in kernel.calls if call[0] == "CloseHandle"],
+            [("CloseHandle", (native.handle,))],
+        )
+
+    def test_invalid_read_count_and_close_failure_are_not_hidden(self) -> None:
+        kernel = FakeKernelApi()
+        kernel.excessive_read_count = True
+        with self.assertRaisesRegex(OSError, "more bytes"):
+            self.read(kernel, FakeNtApi(information=receipt.FILE_OPENED))
+        self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), 1)
+
+        for close_error in (False, KeyboardInterrupt("close"), SystemExit("close")):
+            with self.subTest(close=type(close_error).__name__):
+                kernel = FakeKernelApi()
+                kernel.failures["CloseHandle"] = close_error
+                with self.assertRaises(BaseException) as caught:
+                    self.read(kernel, FakeNtApi(information=receipt.FILE_OPENED))
+                if close_error is False:
+                    self.assertIsInstance(caught.exception, OSError)
+                else:
+                    self.assertIs(caught.exception, close_error)
+                expected_calls = 2 if close_error is False else 1
+                self.assertEqual(
+                    sum(name == "CloseHandle" for name, _args in kernel.calls),
+                    expected_calls,
+                )
+
+
+class WindowsRelativeDirectoryTests(unittest.TestCase):
+    def test_drive_and_unc_anchors_use_absolute_nt_names_with_external_lease(self) -> None:
+        cases = (
+            (Path("C:\\"), "\\??\\C:\\"),
+            (Path("\\\\server\\share\\"), "\\??\\UNC\\server\\share\\"),
+            (Path("\\\\?\\D:\\"), "\\??\\D:\\"),
+            (Path("\\\\?\\UNC\\server\\share\\"), "\\??\\UNC\\server\\share\\"),
+            (Path("\\\\?\\unc\\server\\share\\"), "\\??\\UNC\\server\\share\\"),
+        )
+        for path, expected_name in cases:
+            with self.subTest(path=str(path)):
+                kernel = FakeKernelApi(b"", directory=True)
+                native = FakeNtApi(information=receipt.FILE_OPENED)
+                lease = receipt.WindowsHandleLease()
+                result = receipt.open_windows_directory_anchor(path, lease, api=kernel, nt_api=native)
+                self.assertEqual(result.handle, native.handle)
+                self.assertFalse(result.created)
+                self.assertEqual(lease.handle, native.handle)
+                call = native.calls[0]
+                self.assertIsNone(call["root"])
+                self.assertEqual(call["name"], expected_name)
+                self.assertEqual(call["disposition"], receipt.FILE_OPEN)
+                self.assertEqual(call["options"], receipt._DIRECTORY_OPEN_OPTIONS)
+                self.assertFalse(any(name == "CloseHandle" for name, _args in kernel.calls))
+
+    def test_anchor_rejects_relative_paths_before_native_open(self) -> None:
+        kernel = FakeKernelApi(b"", directory=True)
+        native = FakeNtApi(information=receipt.FILE_OPENED)
+        for path in (
+            Path("relative"),
+            Path("C:relative"),
+            Path("é:\\"),
+            Path("C:\\nested"),
+            Path("\\\\server"),
+            Path("\\\\server\\share\\nested"),
+            Path("\\\\?\\GLOBALROOT\\Device\\HarddiskVolume1\\"),
+            Path("\\\\.\\C:\\"),
+            Path("\\\\?\\UNC\\server\\share\\nested"),
+            Path("\\\\?\\UNC\\.\\share\\"),
+        ):
+            with self.subTest(path=str(path)), self.assertRaises(ValueError):
+                receipt.open_windows_directory_anchor(
+                    path,
+                    receipt.WindowsHandleLease(),
+                    api=kernel,
+                    nt_api=native,
+                )
+        self.assertEqual(native.calls, [])
+
+    def test_invalid_directory_leaves_are_rejected_before_native_open(self) -> None:
+        for leaf in ("NUL.txt", "CoM¹.log", "directory.", "bad?directory", "bad\x1fdirectory"):
+            with self.subTest(leaf=repr(leaf)):
+                kernel = FakeKernelApi(b"", directory=True)
+                native = FakeNtApi(information=receipt.FILE_CREATED)
+                lease = receipt.WindowsHandleLease()
+                with self.assertRaises(ValueError):
+                    receipt.open_or_create_windows_directory(
+                        0xBEEF,
+                        leaf,
+                        lease,
+                        api=kernel,
+                        nt_api=native,
+                    )
+                self.assertEqual(native.calls, [])
+                self.assertEqual(kernel.calls, [])
+                self.assertIsNone(lease.handle)
+
+    def test_anchor_relative_helper_return_gap_closes_shared_lease(self) -> None:
+        kernel = FakeKernelApi(b"", directory=True)
+        native = FakeNtApi(information=receipt.FILE_OPENED)
+        lease = receipt.WindowsHandleLease()
+        interruption = KeyboardInterrupt("relative helper returned before anchor assignment")
+        target_code = receipt.open_windows_directory_anchor.__code__
+        source_lines, source_start = inspect.getsourcelines(receipt.open_windows_directory_anchor)
+        ownership_line = source_start + next(
+            index for index, line in enumerate(source_lines) if line.strip() == "handle = lease.handle"
+        )
+        triggered = False
+
+        def trace(frame: Any, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if event == "line" and frame.f_code is target_code and not triggered and frame.f_lineno == ownership_line:
+                triggered = True
+                raise interruption
+            return trace
+
+        previous = sys.gettrace()
+        try:
+            sys.settrace(trace)
+            with self.assertRaises(KeyboardInterrupt) as caught:
+                receipt.open_windows_directory_anchor(Path("C:\\"), lease, api=kernel, nt_api=native)
+        finally:
+            sys.settrace(previous)
+        self.assertTrue(triggered)
+        self.assertIs(caught.exception, interruption)
+        self.assertIsNone(lease.handle)
+        self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), 1)
+
+    def test_anchor_handler_entry_interrupt_closes_lease_owned_native_output(self) -> None:
+        kernel = FakeKernelApi(b"", directory=True)
+        native = FakeNtApi(information=receipt.FILE_OPENED)
+        native.raise_after_acquire = RuntimeError("native root acquisition returned before raising")
+        interruption = KeyboardInterrupt("relative root acquisition handler entry")
+        lease = receipt.WindowsHandleLease()
+
+        caught = _interrupt_relative_handle_handler(
+            lambda: receipt.open_windows_directory_anchor(
+                Path("C:\\"),
+                lease,
+                api=kernel,
+                nt_api=native,
+            ),
+            interruption,
+        )
+
+        self.assertIs(caught, interruption)
+        self.assertIsNone(lease.handle)
+        self.assertEqual(
+            [call for call in kernel.calls if call[0] == "CloseHandle"],
+            [("CloseHandle", (native.handle,))],
+        )
+
+    def test_open_if_is_relative_and_returns_created_or_opened_identity(self) -> None:
+        for information, created in ((receipt.FILE_CREATED, True), (receipt.FILE_OPENED, False)):
+            with self.subTest(information=information):
+                kernel = FakeKernelApi(b"", directory=True)
+                native = FakeNtApi(information=information)
+                lease = receipt.WindowsHandleLease()
+                result = receipt.open_or_create_windows_directory(
+                    0xBEEF,
+                    "cache-ž",
+                    lease,
+                    api=kernel,
+                    nt_api=native,
+                )
+                self.assertEqual(
+                    result,
+                    receipt.WindowsDirectoryResult(native.handle, 91, bytes(range(16)), created),
+                )
+                self.assertEqual(lease.handle, native.handle)
+                call = native.calls[0]
+                self.assertEqual(call["root"], 0xBEEF)
+                self.assertEqual(call["name"], "cache-ž")
+                self.assertEqual(call["desired_access"], receipt._DIRECTORY_ACCESS)
+                self.assertEqual(call["share_access"], receipt.FILE_SHARE_READ | receipt.FILE_SHARE_WRITE)
+                self.assertEqual(call["disposition"], receipt.FILE_OPEN_IF)
+                self.assertEqual(call["options"], receipt._DIRECTORY_OPEN_OPTIONS)
+                self.assertFalse(any(name == "CloseHandle" for name, _args in kernel.calls))
+
+    def test_directory_helper_call_return_gap_closes_its_shared_lease(self) -> None:
+        kernel = FakeKernelApi(b"", directory=True)
+        native = FakeNtApi(information=receipt.FILE_OPENED)
+        lease = receipt.WindowsHandleLease()
+        interruption = KeyboardInterrupt("relative helper returned before directory assignment")
+        target_code = receipt.open_or_create_windows_directory.__code__
+        source_lines, source_start = inspect.getsourcelines(receipt.open_or_create_windows_directory)
+        ownership_line = source_start + next(
+            index for index, line in enumerate(source_lines) if line.strip() == "handle = lease.handle"
+        )
+        triggered = False
+
+        def trace(frame: Any, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if event == "line" and frame.f_code is target_code and not triggered and frame.f_lineno == ownership_line:
+                triggered = True
+                raise interruption
+            return trace
+
+        previous = sys.gettrace()
+        try:
+            sys.settrace(trace)
+            with self.assertRaises(KeyboardInterrupt) as caught:
+                receipt.open_or_create_windows_directory(7, "child", lease, api=kernel, nt_api=native)
+        finally:
+            sys.settrace(previous)
+        self.assertTrue(triggered)
+        self.assertIs(caught.exception, interruption)
+        self.assertIsNone(lease.handle)
+        self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), 1)
+
+    def test_child_handler_entry_interrupt_closes_lease_owned_native_output(self) -> None:
+        kernel = FakeKernelApi(b"", directory=True)
+        native = FakeNtApi(information=receipt.FILE_CREATED)
+        native.raise_after_acquire = RuntimeError("native child acquisition returned before raising")
+        interruption = KeyboardInterrupt("relative child acquisition handler entry")
+        lease = receipt.WindowsHandleLease()
+
+        caught = _interrupt_relative_handle_handler(
+            lambda: receipt.open_or_create_windows_directory(
+                7,
+                "child",
+                lease,
+                api=kernel,
+                nt_api=native,
+            ),
+            interruption,
+        )
+
+        self.assertIs(caught, interruption)
+        self.assertIsNone(lease.handle)
+        self.assertEqual(
+            [call for call in kernel.calls if call[0] == "CloseHandle"],
+            [("CloseHandle", (native.handle,))],
+        )
+
+    def test_directory_rejection_and_metadata_drift_close_once(self) -> None:
+        cases: tuple[tuple[str, Callable[[FakeKernelApi], None]], ...] = (
+            ("file", lambda api: setattr(api, "directory", 0)),
+            ("no-directory-attribute", lambda api: setattr(api, "attributes", receipt.FILE_ATTRIBUTE_NORMAL)),
+            (
+                "reparse",
+                lambda api: setattr(
+                    api,
+                    "attributes",
+                    receipt.FILE_ATTRIBUTE_DIRECTORY | receipt.FILE_ATTRIBUTE_REPARSE_POINT,
+                ),
+            ),
+            ("delete-pending", lambda api: setattr(api, "delete_pending", 1)),
+            ("non-disk", lambda api: setattr(api, "file_type", 0)),
+            ("identity-drift", lambda api: api.metadata_overrides[1].update(identity=b"z" * 16)),
+            (
+                "attribute-drift",
+                lambda api: api.metadata_overrides[1].update(
+                    attributes=receipt.FILE_ATTRIBUTE_DIRECTORY | receipt.FILE_ATTRIBUTE_REPARSE_POINT
+                ),
+            ),
+        )
+        for label, configure in cases:
+            with self.subTest(label=label):
+                kernel = FakeKernelApi(b"", directory=True)
+                configure(kernel)
+                with self.assertRaises(receipt.WindowsReceiptValidationError) as caught:
+                    receipt.open_or_create_windows_directory(
+                        7,
+                        "child",
+                        receipt.WindowsHandleLease(),
+                        api=kernel,
+                        nt_api=FakeNtApi(information=receipt.FILE_OPENED),
+                    )
+                self.assertEqual(caught.exception.code, "output-parent-invalid")
+                self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), 1)
+
+    def test_directory_file_type_failure_distinguishes_unsupported_and_io(self) -> None:
+        cases = (
+            (receipt.ERROR_NOT_SUPPORTED, receipt.WindowsReceiptValidationError, "output-anchor-unavailable"),
+            (1117, OSError, None),
+        )
+        for error_number, expected_type, expected_code in cases:
+            with self.subTest(error_number=error_number):
+                kernel = FakeKernelApi(b"", directory=True)
+                kernel.failures["GetFileType"] = False
+                kernel.error = error_number
+                with self.assertRaises(expected_type) as raised:
+                    receipt.open_or_create_windows_directory(
+                        7,
+                        "child",
+                        receipt.WindowsHandleLease(),
+                        api=kernel,
+                        nt_api=FakeNtApi(information=receipt.FILE_OPENED),
+                    )
+                self.assertEqual(getattr(raised.exception, "code", None), expected_code)
+                if expected_code is not None:
+                    self.assertIsInstance(raised.exception.__cause__, OSError)
+                    assert isinstance(raised.exception.__cause__, OSError)
+                    self.assertEqual(raised.exception.__cause__.errno, error_number)
+                else:
+                    self.assertEqual(cast(OSError, raised.exception).errno, error_number)
+                self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), 1)
+
+    def test_directory_native_status_completion_and_information_fail_closed(self) -> None:
+        cases = (
+            FakeNtApi(information=receipt.FILE_OPENED, status=0xC0000035),
+            FakeNtApi(information=receipt.FILE_OPENED, completion_status=0xC0000022),
+            FakeNtApi(information=99),
+        )
+        for native in cases:
+            with self.subTest(status=native.status, completion=native.completion_status):
+                kernel = FakeKernelApi(b"", directory=True)
+                with self.assertRaises(OSError):
+                    receipt.open_or_create_windows_directory(
+                        7,
+                        "child",
+                        receipt.WindowsHandleLease(),
+                        api=kernel,
+                        nt_api=native,
+                    )
+                expected_closes = int(receipt._nt_success(native.status))
+                self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), expected_closes)
+
+    def test_directory_primary_base_exception_beats_close_failure(self) -> None:
+        for primary in (OSError("metadata"), KeyboardInterrupt("metadata"), SystemExit("metadata")):
+            with self.subTest(primary=type(primary).__name__):
+                kernel = FakeKernelApi(b"", directory=True)
+                kernel.failures["GetInfo:0"] = primary
+                kernel.failures["CloseHandle"] = RuntimeError("close")
+                with self.assertRaises(BaseException) as caught:
+                    receipt.open_or_create_windows_directory(
+                        7,
+                        "child",
+                        receipt.WindowsHandleLease(),
+                        api=kernel,
+                        nt_api=FakeNtApi(information=receipt.FILE_OPENED),
+                    )
+                self.assertIs(caught.exception, primary)
+                self.assertIn("Could not close", "\n".join(getattr(primary, "__notes__", ())))
+                self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), 1)
+
+    def test_directory_close_call_return_gap_preserves_primary(self) -> None:
+        kernel = FakeKernelApi(b"", directory=True)
+        primary = RuntimeError("metadata")
+        kernel.failures["GetInfo:0"] = primary
+        interruption = KeyboardInterrupt("between directory close return and completion")
+        triggered = False
+
+        real_close = receipt.close_windows_handle_lease
+
+        def close_then_interrupt(
+            api: Any,
+            lease: receipt.WindowsHandleLease,
+            active_primary: BaseException | None,
+            context: str,
+        ) -> BaseException | None:
+            nonlocal triggered
+            result = real_close(api, lease, active_primary, context)
+            if not triggered:
+                triggered = True
+                raise interruption
+            return result
+
+        with mock.patch.object(
+            receipt,
+            "close_windows_handle_lease",
+            side_effect=close_then_interrupt,
+        ):
+            with self.assertRaises(RuntimeError) as caught:
+                receipt.open_or_create_windows_directory(
+                    7,
+                    "child",
+                    receipt.WindowsHandleLease(),
+                    api=kernel,
+                    nt_api=FakeNtApi(information=receipt.FILE_OPENED),
+                )
+
+        self.assertTrue(triggered)
+        self.assertIs(caught.exception, primary)
+        self.assertIn(
+            "Could not close rejected directory handle: between directory close return and completion",
+            getattr(primary, "__notes__", ()),
+        )
+        self.assertEqual(sum(name == "CloseHandle" for name, _args in kernel.calls), 1)
+
+
+class WindowsRelativeStageTests(unittest.TestCase):
+    def test_staging_uses_only_relative_file_create(self) -> None:
+        api = FakeKernel32()
+        result = receipt.publish_windows_receipt(
+            0x4567,
+            "receipt.json",
+            PAYLOAD,
+            api=api,
+            nt_api=api,
+            stage_token="feed",
+            publication_lease=receipt._WindowsReceiptPublicationLease(api),
+        )
+        self.assertEqual(result.leaf, "receipt.json")
+        create = next(args for name, args in api.calls if name == "NtCreateFile")
+        self.assertEqual(create[0], receipt._STAGE_ACCESS)
+        self.assertEqual(create[1], 0x4567)
+        self.assertEqual(create[2], ".receipt.json.feed.tmp")
+        self.assertEqual(create[8], receipt.FILE_SHARE_READ)
+        self.assertEqual(create[9], receipt.FILE_CREATE)
+        self.assertEqual(create[10], receipt._FILE_OPEN_OPTIONS)
+
+    def test_staging_call_return_gap_disposes_and_closes_shared_lease(self) -> None:
+        api = FakeKernel32()
+        interruption = KeyboardInterrupt("relative helper returned before publisher assignment")
+        target_code = receipt.publish_windows_receipt.__code__
+        source_lines, source_start = inspect.getsourcelines(receipt.publish_windows_receipt)
+        ownership_line = source_start + next(
+            index for index, line in enumerate(source_lines) if line.strip() == "handle = lease.handle"
+        )
+        triggered = False
+
+        def trace(frame: Any, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if event == "line" and frame.f_code is target_code and not triggered and frame.f_lineno == ownership_line:
+                triggered = True
+                raise interruption
+            return trace
+
+        previous = sys.gettrace()
+        try:
+            sys.settrace(trace)
+            with self.assertRaises(KeyboardInterrupt) as caught:
+                receipt.publish_windows_receipt(
+                    7,
+                    "receipt.json",
+                    PAYLOAD,
+                    api=api,
+                    nt_api=api,
+                    stage_token="feed",
+                    publication_lease=receipt._WindowsReceiptPublicationLease(api),
+                )
+        finally:
+            sys.settrace(previous)
+        self.assertTrue(triggered)
+        self.assertIs(caught.exception, interruption)
+        classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+        self.assertIn(receipt.FILE_DISPOSITION_INFO, classes)
+        self.assertEqual(api.calls[-1], ("CloseHandle", (api.handle,)))
+
+    def test_stage_handler_entry_interrupt_disposes_and_closes_lease_owned_native_output(self) -> None:
+        kernel = FakeKernel32()
+        native = FakeNtApi(information=receipt.FILE_CREATED, handle=kernel.handle)
+        native.raise_after_acquire = RuntimeError("native stage acquisition returned before raising")
+        interruption = KeyboardInterrupt("relative stage acquisition handler entry")
+        publication_lease = receipt._WindowsReceiptPublicationLease(kernel)
+
+        caught = _interrupt_relative_handle_handler(
+            lambda: receipt.publish_windows_receipt(
+                7,
+                "receipt.json",
+                PAYLOAD,
+                api=kernel,
+                nt_api=native,
+                stage_token="feed",
+                publication_lease=publication_lease,
+            ),
+            interruption,
+        )
+
+        self.assertIs(caught, interruption)
+        self.assertTrue(publication_lease.is_closed)
+        disposition_calls = [
+            args
+            for name, args in kernel.calls
+            if name == "SetFileInformationByHandle" and args[1] == receipt.FILE_DISPOSITION_INFO
+        ]
+        self.assertEqual(len(disposition_calls), 1)
+        self.assertEqual(
+            [call for call in kernel.calls if call[0] == "CloseHandle"],
+            [("CloseHandle", (native.handle,))],
+        )
+
+    def test_caller_held_lease_recovers_publisher_cleanup_entry_and_outcome(self) -> None:
+        api = FakeKernel32()
+        publication_lease = receipt._WindowsReceiptPublicationLease(api)
+        interruption = KeyboardInterrupt("publisher cleanup entry")
+        target_code = receipt.publish_windows_receipt.__code__
+        source, first_line = inspect.getsourcelines(receipt.publish_windows_receipt)
+        cleanup_line = first_line + next(
+            index for index, line in enumerate(source) if "active_error = sys.exception()" in line
+        )
+        triggered = False
+
+        def trace(frame: Any, event: str, _argument: object) -> Any:
+            nonlocal triggered
+            if event == "call" and frame.f_code is target_code:
+                frame.f_trace = trace
+                return trace
+            if (
+                event == "line"
+                and frame.f_code is target_code
+                and frame.f_lineno == cleanup_line
+                and not triggered
+                and publication_lease.phase == "published"
+            ):
+                triggered = True
+                raise interruption
+            return trace
+
+        previous = sys.gettrace()
+        try:
+            sys.settrace(trace)
+            with self.assertRaises(KeyboardInterrupt) as caught:
+                receipt.publish_windows_receipt(
+                    7,
+                    "receipt.json",
+                    PAYLOAD,
+                    api=api,
+                    nt_api=api,
+                    stage_token="feed",
+                    publication_lease=publication_lease,
+                )
+        finally:
+            sys.settrace(previous)
+
+        self.assertTrue(triggered)
+        self.assertIs(caught.exception, interruption)
+        self.assertEqual(receipt.outcome_from_error(interruption), None)
+        outcome = publication_lease.outcome
+        self.assertIsNotNone(outcome)
+        assert outcome is not None
+        self.assertEqual(outcome.state, "published")
+        self.assertEqual(outcome.receipt.leaf, "receipt.json")
+        self.assertFalse(publication_lease.is_closed)
+        self.assertFalse(any(name == "CloseHandle" for name, _args in api.calls))
+        self.assertEqual(publication_lease.close(), ())
+        self.assertTrue(publication_lease.is_closed)
+        self.assertEqual(sum(name == "CloseHandle" for name, _args in api.calls), 1)
+        classes = [args[1] for name, args in api.calls if name == "SetFileInformationByHandle"]
+        self.assertNotIn(receipt.FILE_DISPOSITION_INFO, classes)
+
+    def test_post_native_stage_rejections_dispose_before_exactly_once_close(self) -> None:
+        interruption = KeyboardInterrupt("native create returned a handle before raising")
+        cases = (
+            (
+                "native-interruption",
+                FakeNtApi(information=receipt.FILE_CREATED, handle=0x1234),
+                interruption,
+            ),
+            (
+                "completion-error",
+                FakeNtApi(
+                    information=receipt.FILE_CREATED,
+                    completion_status=0xC0000022,
+                    handle=0x1234,
+                ),
+                None,
+            ),
+            (
+                "information-error",
+                FakeNtApi(information=receipt.FILE_OPENED, handle=0x1234),
+                None,
+            ),
+        )
+        cases[0][1].raise_after_acquire = interruption
+
+        for label, native, expected_primary in cases:
+            with self.subTest(label=label):
+                kernel = FakeKernel32()
+                with self.assertRaises(BaseException) as caught:
+                    receipt.publish_windows_receipt(
+                        7,
+                        "receipt.json",
+                        PAYLOAD,
+                        api=kernel,
+                        nt_api=native,
+                        stage_token="feed",
+                        publication_lease=receipt._WindowsReceiptPublicationLease(kernel),
+                    )
+                if expected_primary is not None:
+                    self.assertIs(caught.exception, expected_primary)
+
+                disposition_indexes = [
+                    index
+                    for index, (name, args) in enumerate(kernel.calls)
+                    if name == "SetFileInformationByHandle" and args[1] == receipt.FILE_DISPOSITION_INFO
+                ]
+                close_indexes = [index for index, (name, _args) in enumerate(kernel.calls) if name == "CloseHandle"]
+                self.assertEqual(len(disposition_indexes), 1)
+                self.assertEqual(len(close_indexes), 1)
+                self.assertLess(disposition_indexes[0], close_indexes[0])
+                self.assertEqual(kernel.calls[close_indexes[0]], ("CloseHandle", (native.handle,)))
+
+    def test_stage_opcode_interrupt_after_native_return_disposes_before_close(self) -> None:
+        kernel = FakeKernel32()
+        native = FakeNtApi(information=receipt.FILE_CREATED, handle=kernel.handle)
+        interruption = KeyboardInterrupt("between NtCreateFile return and stage handoff")
+        real_create = native.NtCreateFile
+        triggered = False
+
+        class _InterruptingStatus:
+            def __int__(self) -> int:
+                nonlocal triggered
+                triggered = True
+                raise interruption
+
+        def create_then_return_status(*arguments: Any, **keywords: Any) -> object:
+            real_create(*arguments, **keywords)
+            return _InterruptingStatus()
+
+        with mock.patch.object(
+            native,
+            "NtCreateFile",
+            side_effect=create_then_return_status,
+        ):
+            with self.assertRaises(KeyboardInterrupt) as caught:
+                receipt.publish_windows_receipt(
+                    7,
+                    "receipt.json",
+                    PAYLOAD,
+                    api=kernel,
+                    nt_api=native,
+                    stage_token="feed",
+                    publication_lease=receipt._WindowsReceiptPublicationLease(kernel),
+                )
+
+        self.assertTrue(triggered)
+        self.assertIs(caught.exception, interruption)
+        disposition_indexes = [
+            index
+            for index, (name, args) in enumerate(kernel.calls)
+            if name == "SetFileInformationByHandle" and args[1] == receipt.FILE_DISPOSITION_INFO
+        ]
+        close_indexes = [index for index, (name, _args) in enumerate(kernel.calls) if name == "CloseHandle"]
+        self.assertEqual(len(disposition_indexes), 1)
+        self.assertEqual(len(close_indexes), 1)
+        self.assertLess(disposition_indexes[0], close_indexes[0])
+
+    def test_only_native_collision_status_has_internal_retry_provenance(self) -> None:
+        api = FakeKernel32({"NtCreateFile": False})
+        api.error = receipt.ERROR_FILE_EXISTS
+        with self.assertRaises(receipt._StageNameCollision) as caught:
+            receipt.publish_windows_receipt(
+                7,
+                "receipt.json",
+                PAYLOAD,
+                api=api,
+                nt_api=api,
+                stage_token="feed",
+                publication_lease=receipt._WindowsReceiptPublicationLease(api),
+            )
+        self.assertTrue(receipt.is_internal_stage_name_collision(caught.exception))
+
+        spoof = receipt._StageNameCollision(receipt.ERROR_FILE_EXISTS, "spoof")
+        api = FakeKernel32({"NtCreateFile": spoof})
+        with self.assertRaises(receipt._StageNameCollision) as caught:
+            receipt.publish_windows_receipt(
+                7,
+                "receipt.json",
+                PAYLOAD,
+                api=api,
+                nt_api=api,
+                stage_token="feed",
+                publication_lease=receipt._WindowsReceiptPublicationLease(api),
+            )
+        self.assertIs(caught.exception, spoof)
+        self.assertFalse(receipt.is_internal_stage_name_collision(spoof))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dependency_policy.py
+++ b/tests/test_dependency_policy.py
@@ -30,6 +30,20 @@ BASE_PINS = {
 _OMIT = object()
 
 
+def _file_snapshot(path: Path) -> tuple[tuple[int, ...], bytes]:
+    value = path.lstat()
+    metadata = (
+        value.st_dev,
+        value.st_ino,
+        value.st_mode,
+        value.st_nlink,
+        value.st_size,
+        value.st_mtime_ns,
+        value.st_ctime_ns,
+    )
+    return metadata, path.read_bytes()
+
+
 def _installed_item(
     name: str,
     version: str,
@@ -400,6 +414,375 @@ class TestDependencyEnvironmentVerifier(unittest.TestCase, DependencyVerifierHar
         ]
         self.assertEqual(calls[0][0], [*command_prefix, "inspect"])
         self.assertEqual(calls[1][0], [*command_prefix, "check"])
+
+    def test_main_same_receipt_rerun_preserves_inode_and_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory).resolve()
+            prefix = directory / "isolated"
+            prefix.mkdir()
+            report = copy.deepcopy(_inspect_report())
+            _materialize_default_metadata_locations(report, prefix)
+            constraint = directory / "constraints-linux.txt"
+            constraint.write_text(_constraint_text(BASE_PINS), encoding="utf-8")
+            bootstrap = directory / "requirements-bootstrap.txt"
+            bootstrap.write_text(_bootstrap_text(), encoding="utf-8")
+            output = directory / "receipt.json"
+            arguments = [
+                "--constraint",
+                str(constraint),
+                "--mode",
+                "subset",
+                "--require",
+                "root-package",
+                "--expected-python",
+                PYTHON_VERSION,
+                "--expected-platform",
+                "linux",
+                "--expected-machine",
+                "x86_64",
+                "--bootstrap",
+                str(bootstrap),
+                "--bootstrap-policy",
+                "stable",
+                "--output",
+                str(output),
+            ]
+            inspect_output = json.dumps(report, ensure_ascii=True, sort_keys=True)
+            popen_factory = _PopenFactory(
+                [
+                    _completed(inspect_output),
+                    _completed("No broken requirements found.\n"),
+                    _completed(inspect_output),
+                    _completed("No broken requirements found.\n"),
+                ]
+            )
+            with (
+                mock.patch.object(verifier.subprocess, "Popen", side_effect=popen_factory),
+                mock.patch.object(verifier.sys, "prefix", str(prefix)),
+                redirect_stdout(StringIO()),
+                redirect_stderr(StringIO()),
+            ):
+                first_result = verifier.main(arguments)
+                before = _file_snapshot(output)
+                second_result = verifier.main(arguments)
+
+            self.assertEqual((first_result, second_result), (0, 0))
+            self.assertEqual(_file_snapshot(output), before)
+
+    def test_main_rejects_different_existing_receipt_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory).resolve()
+            prefix = directory / "isolated"
+            prefix.mkdir()
+            report = copy.deepcopy(_inspect_report())
+            _materialize_default_metadata_locations(report, prefix)
+            constraint = directory / "constraints-linux.txt"
+            constraint.write_text(_constraint_text(BASE_PINS), encoding="utf-8")
+            bootstrap = directory / "requirements-bootstrap.txt"
+            bootstrap.write_text(_bootstrap_text(), encoding="utf-8")
+            output = directory / "receipt.json"
+            output.write_bytes(b"different existing receipt\n")
+            output.chmod(0o600)
+            before = _file_snapshot(output)
+            popen_factory = _PopenFactory(
+                [
+                    _completed(json.dumps(report, ensure_ascii=True, sort_keys=True)),
+                    _completed("No broken requirements found.\n"),
+                ]
+            )
+            stderr = StringIO()
+            with (
+                mock.patch.object(verifier.subprocess, "Popen", side_effect=popen_factory),
+                mock.patch.object(verifier.sys, "prefix", str(prefix)),
+                redirect_stdout(StringIO()),
+                redirect_stderr(stderr),
+            ):
+                result = verifier.main(
+                    [
+                        "--constraint",
+                        str(constraint),
+                        "--mode",
+                        "subset",
+                        "--require",
+                        "root-package",
+                        "--expected-python",
+                        PYTHON_VERSION,
+                        "--expected-platform",
+                        "linux",
+                        "--expected-machine",
+                        "x86_64",
+                        "--bootstrap",
+                        str(bootstrap),
+                        "--bootstrap-policy",
+                        "stable",
+                        "--output",
+                        str(output),
+                    ]
+                )
+
+            self.assertEqual(result, 2)
+            self.assertEqual(_file_snapshot(output), before)
+            diagnostic = stderr.getvalue()
+            self.assertEqual(len(diagnostic.splitlines()), 1)
+            self.assertIn("Cannot write dependency verification receipt", diagnostic)
+            self.assertIn("[output-different]", diagnostic)
+            self.assertIn("Refusing to replace different existing receipt output", diagnostic)
+
+    def test_main_receipt_diagnostic_includes_stable_code_and_cleanup_notes(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory).resolve()
+            constraint = directory / "constraints-linux.txt"
+            constraint.write_text(_constraint_text(BASE_PINS), encoding="utf-8")
+            bootstrap = directory / "requirements-bootstrap.txt"
+            bootstrap.write_text(_bootstrap_text(), encoding="utf-8")
+            output = directory / "receipt\n\t\x1b.json"
+            message = "publication\nfailed\t\x1b"
+            note = "Could not close receipt parent descriptor:\ninjected\t\x1b close failure"
+            error = verifier.ReceiptOutputError("output-parent-changed", message)
+            error.add_note(note)
+            stderr = StringIO()
+
+            with (
+                mock.patch.object(verifier, "atomic_write_receipt", side_effect=error),
+                mock.patch.object(verifier.subprocess, "Popen") as popen_mock,
+                redirect_stdout(StringIO()),
+                redirect_stderr(stderr),
+            ):
+                result = verifier.main(
+                    [
+                        "--constraint",
+                        str(constraint),
+                        "--mode",
+                        "subset",
+                        "--expected-python",
+                        "invalid",
+                        "--expected-platform",
+                        "linux",
+                        "--expected-machine",
+                        "x86_64",
+                        "--bootstrap",
+                        str(bootstrap),
+                        "--bootstrap-policy",
+                        "stable",
+                        "--output",
+                        str(output),
+                    ]
+                )
+
+            self.assertEqual(result, 2)
+            popen_mock.assert_not_called()
+            self.assertEqual(
+                stderr.getvalue().splitlines(),
+                [
+                    "Cannot write dependency verification receipt [output-parent-changed]: "
+                    + json.dumps(
+                        {
+                            "code": "output-parent-changed",
+                            "message": message,
+                            "path": os.fspath(output),
+                        },
+                        ensure_ascii=True,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                    "Receipt output cleanup note: "
+                    + json.dumps(
+                        {"note": note},
+                        ensure_ascii=True,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                ],
+            )
+
+    def test_main_raw_receipt_error_diagnostic_escapes_controls_and_notes(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory).resolve()
+            constraint = directory / "constraints-linux.txt"
+            constraint.write_text(_constraint_text(BASE_PINS), encoding="utf-8")
+            bootstrap = directory / "requirements-bootstrap.txt"
+            bootstrap.write_text(_bootstrap_text(), encoding="utf-8")
+            output = directory / "receipt\n\t\x1b.json"
+            error = PermissionError(13, "device\n\t\x1b failure")
+            note = "raw cleanup note\n\t\x1b"
+            error.add_note(note)
+            stderr = StringIO()
+
+            with (
+                mock.patch.object(verifier, "atomic_write_receipt", side_effect=error),
+                mock.patch.object(verifier.subprocess, "Popen") as popen_mock,
+                redirect_stdout(StringIO()),
+                redirect_stderr(stderr),
+            ):
+                result = verifier.main(
+                    [
+                        "--constraint",
+                        str(constraint),
+                        "--mode",
+                        "subset",
+                        "--expected-python",
+                        "invalid",
+                        "--expected-platform",
+                        "linux",
+                        "--expected-machine",
+                        "x86_64",
+                        "--bootstrap",
+                        str(bootstrap),
+                        "--bootstrap-policy",
+                        "stable",
+                        "--output",
+                        str(output),
+                    ]
+                )
+
+            self.assertEqual(result, 2)
+            popen_mock.assert_not_called()
+            self.assertEqual(
+                stderr.getvalue().splitlines(),
+                [
+                    "Cannot write dependency verification receipt: "
+                    + json.dumps(
+                        {
+                            "message": str(error),
+                            "path": os.fspath(output),
+                            "type": "PermissionError",
+                        },
+                        ensure_ascii=True,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                    "Receipt output cleanup note: "
+                    + json.dumps(
+                        {"note": note},
+                        ensure_ascii=True,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                ],
+            )
+
+    def test_atomic_write_receipt_translates_anchored_error_without_losing_context(self) -> None:
+        original_publisher = cast(
+            Callable[[Path, bytes], None],
+            verifier.atomic_write_receipt.__globals__["_PUBLISH_IDENTICAL_RECEIPT_BYTES"],
+        )
+        source_errors: list[ValueError] = []
+        published: list[tuple[Path, bytes]] = []
+
+        def publish_with_notes(path: Path, payload: bytes) -> None:
+            published.append((path, payload))
+            try:
+                original_publisher(path, payload)
+            except ValueError as error:
+                source_errors.append(error)
+                error.add_note("first cleanup note")
+                error.add_note("second cleanup note")
+                raise
+
+        with tempfile.TemporaryDirectory() as raw_directory:
+            output = Path(raw_directory).resolve() / "receipt.json"
+            output.write_bytes(b"different receipt\n")
+            output.chmod(0o600)
+            with (
+                mock.patch.object(
+                    verifier,
+                    "_PUBLISH_IDENTICAL_RECEIPT_BYTES",
+                    side_effect=publish_with_notes,
+                ),
+                self.assertRaises(verifier.ReceiptOutputError) as raised,
+            ):
+                verifier.atomic_write_receipt(output, {"status": "verified"})
+
+        translated = raised.exception
+        self.assertEqual(translated.code, "output-different")
+        self.assertIn("Refusing to replace different existing receipt output", str(translated))
+        self.assertEqual(len(source_errors), 1)
+        self.assertIs(translated.__cause__, source_errors[0])
+        self.assertEqual(
+            getattr(translated, "__notes__", ()),
+            ["first cleanup note", "second cleanup note"],
+        )
+        self.assertIsNot(
+            getattr(translated, "__notes__", None),
+            getattr(source_errors[0], "__notes__", None),
+        )
+        self.assertEqual(len(published), 1)
+        published_path, payload = published[0]
+        self.assertEqual(published_path, output)
+        self.assertEqual(
+            json.loads(payload),
+            {"status": "verified"},
+        )
+
+    def test_verifier_exact_loader_ignores_active_hostile_import_search_path(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory).resolve()
+            hostile = directory / "hostile"
+            hostile.mkdir()
+            shadow = hostile / "_anchored_output.py"
+            sentinel = directory / "shadow-loader-ran"
+            shadow.write_text(
+                "from pathlib import Path\n"
+                f"Path({str(sentinel)!r}).write_text('shadowed', encoding='utf-8')\n"
+                "raise RuntimeError('hostile anchored output shadow loaded')\n",
+                encoding="utf-8",
+            )
+            script = Path(verifier.__file__).resolve(strict=True)
+            environment = os.environ.copy()
+            environment["PYTHONPATH"] = str(hostile)
+            program = (
+                "import importlib.util, pathlib, runpy, sys\n"
+                f"shadow = pathlib.Path({str(shadow)!r}).resolve()\n"
+                "specification = importlib.util.find_spec('_anchored_output')\n"
+                "assert specification is not None\n"
+                "assert pathlib.Path(specification.origin).resolve() == shadow\n"
+                f"sys.argv = [{str(script)!r}, '--help']\n"
+                f"runpy.run_path({str(script)!r}, run_name='__main__')\n"
+            )
+
+            result = subprocess.run(
+                [sys.executable, "-c", program],
+                cwd=hostile,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=verifier.COMMAND_TIMEOUT_SECONDS,
+                env=environment,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Verify that a Python environment", result.stdout)
+            self.assertFalse(sentinel.exists())
+
+    def test_verifier_exact_loader_works_under_isolation_and_hostile_pythonpath(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory).resolve()
+            hostile = directory / "hostile"
+            hostile.mkdir()
+            sentinel = directory / "shadow-loader-ran"
+            (hostile / "_anchored_output.py").write_text(
+                "from pathlib import Path\n"
+                f"Path({str(sentinel)!r}).write_text('shadowed', encoding='utf-8')\n"
+                "raise RuntimeError('hostile anchored output shadow loaded')\n",
+                encoding="utf-8",
+            )
+            environment = os.environ.copy()
+            environment["PYTHONPATH"] = str(hostile)
+            script = Path(verifier.__file__).resolve(strict=True)
+
+            result = subprocess.run(
+                [sys.executable, "-I", str(script), "--help"],
+                cwd=hostile,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=verifier.COMMAND_TIMEOUT_SECONDS,
+                env=environment,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Verify that a Python environment", result.stdout)
+            self.assertFalse(sentinel.exists())
 
     def test_pip_commands_ignore_checkout_and_pythonpath_shadow_modules(self) -> None:
         baseline_environment = {
@@ -1837,7 +2220,6 @@ class TestDependencyBootstrapPolicy(unittest.TestCase):
             )
             (directory / "requirements-bootstrap.txt").write_text(_bootstrap_text(), encoding="utf-8")
             output = directory / "receipt.json"
-            output.write_text("stale", encoding="utf-8")
             with chdir(directory), redirect_stdout(StringIO()), redirect_stderr(StringIO()):
                 result = verifier.bootstrap_preflight_main(
                     [
@@ -1866,6 +2248,7 @@ class TestDependencyBootstrapPolicy(unittest.TestCase):
                 self.assertRegex(cast(str, item["pin_fingerprint"]), r"[0-9a-f]{64}\Z")
             transition = cast(dict[str, object], receipt["source_transition"])
             self.assertEqual(transition["active"], True)
+            before = _file_snapshot(output)
             with chdir(directory), redirect_stdout(StringIO()), redirect_stderr(StringIO()):
                 repeated_result = verifier.bootstrap_preflight_main(
                     [
@@ -1879,100 +2262,155 @@ class TestDependencyBootstrapPolicy(unittest.TestCase):
                 )
             self.assertEqual(repeated_result, 0)
             self.assertEqual(output.read_bytes(), payload)
+            self.assertEqual(_file_snapshot(output), before)
 
-    def test_atomic_receipt_closes_raw_descriptor_when_fdopen_fails(self) -> None:
-        for close_fails in (False, True):
-            with self.subTest(close_fails=close_fails):
-                with tempfile.TemporaryDirectory() as raw_directory:
-                    directory = Path(raw_directory).resolve()
-                    output = directory / "receipt.json"
-                    real_mkstemp = tempfile.mkstemp
-                    real_close = os.close
-                    created_descriptor = -1
-                    primary_error = RuntimeError("injected fdopen failure")
+    def test_preflight_rejects_different_existing_receipt_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory).resolve()
+            source = directory / "requirements-bootstrap.txt"
+            constraint = directory / "constraint.lock"
+            output = directory / "receipt.json"
+            source.write_text(_bootstrap_text(), encoding="utf-8")
+            constraint.write_text(_constraint_text(BASE_PINS), encoding="utf-8")
+            output.write_bytes(b"different existing bootstrap receipt\n")
+            output.chmod(0o600)
+            before = _file_snapshot(output)
+            stderr = StringIO()
 
-                    def recording_mkstemp(
-                        suffix: str | None = None,
-                        prefix: str | None = None,
-                        directory: str | os.PathLike[str] | None = None,
-                        text: bool = False,
-                        **kwargs: str | os.PathLike[str] | bool | None,
-                    ) -> tuple[int, str]:
-                        nonlocal created_descriptor
-                        selected_directory = cast(
-                            str | os.PathLike[str] | None,
-                            kwargs.get("dir", directory),
-                        )
-                        created_descriptor, temporary_name = real_mkstemp(
-                            suffix=suffix,
-                            prefix=prefix,
-                            dir=selected_directory,
-                            text=text,
-                        )
-                        return created_descriptor, temporary_name
+            with redirect_stdout(StringIO()), redirect_stderr(stderr):
+                result = verifier.bootstrap_preflight_main(
+                    [
+                        "--source",
+                        str(source),
+                        "--policy",
+                        "stable",
+                        "--constraint",
+                        str(constraint),
+                        "--output",
+                        str(output),
+                    ]
+                )
 
-                    def close_descriptor(descriptor: int) -> None:
-                        real_close(descriptor)
-                        if close_fails:
-                            raise OSError("injected descriptor close failure")
+            self.assertEqual(result, 2)
+            self.assertEqual(_file_snapshot(output), before)
+            diagnostic = stderr.getvalue()
+            self.assertEqual(len(diagnostic.splitlines()), 1)
+            self.assertIn("Cannot write bootstrap verification receipt", diagnostic)
+            self.assertIn("[output-different]", diagnostic)
+            self.assertIn("Refusing to replace different existing receipt output", diagnostic)
 
-                    with (
-                        mock.patch.object(
-                            verifier.tempfile,
-                            "mkstemp",
-                            side_effect=recording_mkstemp,
-                        ),
-                        mock.patch.object(verifier.os, "fdopen", side_effect=primary_error),
-                        mock.patch.object(verifier.os, "close", side_effect=close_descriptor),
-                        self.assertRaises(RuntimeError) as raised,
-                    ):
-                        verifier.atomic_write_receipt(output, {"status": "verified"})
+    def test_preflight_receipt_diagnostic_includes_stable_code_and_cleanup_notes(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory).resolve()
+            source = directory / "requirements-bootstrap.txt"
+            constraint = directory / "constraint.lock"
+            output = directory / "receipt\n\t\x1b.json"
+            source.write_text(_bootstrap_text(), encoding="utf-8")
+            constraint.write_text(_constraint_text(BASE_PINS), encoding="utf-8")
+            message = "publication\nfailed\t\x1b"
+            note = "Could not close receipt parent descriptor:\ninjected\t\x1b close failure"
+            error = verifier.ReceiptOutputError("output-parent-changed", message)
+            error.add_note(note)
+            stderr = StringIO()
 
-                    self.assertIs(raised.exception, primary_error)
-                    self.assertGreaterEqual(created_descriptor, 0)
-                    with self.assertRaises(OSError):
-                        os.fstat(created_descriptor)
-                    notes = "\n".join(getattr(raised.exception, "__notes__", ()))
-                    if close_fails:
-                        self.assertIn(
-                            "Could not close receipt temporary descriptor: "
-                            "injected descriptor close failure",
-                            notes,
-                        )
-                    else:
-                        self.assertEqual(notes, "")
-                    self.assertEqual(list(directory.glob(".receipt.json.*.tmp")), [])
+            with (
+                mock.patch.object(verifier, "atomic_write_receipt", side_effect=error),
+                redirect_stdout(StringIO()),
+                redirect_stderr(stderr),
+            ):
+                result = verifier.bootstrap_preflight_main(
+                    [
+                        "--source",
+                        str(source),
+                        "--policy",
+                        "stable",
+                        "--constraint",
+                        str(constraint),
+                        "--output",
+                        str(output),
+                    ]
+                )
 
-    def test_atomic_receipt_cleanup_does_not_mask_primary_base_exception(self) -> None:
-        primary_errors = (
-            RuntimeError("injected replace failure"),
-            KeyboardInterrupt("interrupt"),
-            SystemExit(23),
-        )
-        for primary_error in primary_errors:
-            with self.subTest(primary=type(primary_error).__name__):
-                with tempfile.TemporaryDirectory() as raw_directory:
-                    directory = Path(raw_directory).resolve()
-                    output = directory / "receipt.json"
-                    with (
-                        mock.patch.object(verifier.os, "replace", side_effect=primary_error),
-                        mock.patch.object(
-                            verifier.Path,
-                            "unlink",
-                            side_effect=OSError("injected cleanup failure"),
-                        ),
-                        self.assertRaises(type(primary_error)) as raised,
-                    ):
-                        verifier.atomic_write_receipt(output, {"status": "verified"})
+            self.assertEqual(result, 2)
+            self.assertEqual(
+                stderr.getvalue().splitlines(),
+                [
+                    "Cannot write bootstrap verification receipt [output-parent-changed]: "
+                    + json.dumps(
+                        {
+                            "code": "output-parent-changed",
+                            "message": message,
+                            "path": os.fspath(output),
+                        },
+                        ensure_ascii=True,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                    "Receipt output cleanup note: "
+                    + json.dumps(
+                        {"note": note},
+                        ensure_ascii=True,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                ],
+            )
 
-                    self.assertIs(raised.exception, primary_error)
-                    self.assertIn(
-                        "Could not remove receipt temporary file: injected cleanup failure",
-                        "\n".join(getattr(raised.exception, "__notes__", ())),
-                    )
-                    temporary_files = list(directory.glob(".receipt.json.*.tmp"))
-                    self.assertEqual(len(temporary_files), 1)
-                    os.unlink(temporary_files[0])
+    def test_preflight_raw_receipt_error_diagnostic_escapes_controls_and_notes(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory).resolve()
+            source = directory / "requirements-bootstrap.txt"
+            constraint = directory / "constraint.lock"
+            output = directory / "receipt\n\t\x1b.json"
+            source.write_text(_bootstrap_text(), encoding="utf-8")
+            constraint.write_text(_constraint_text(BASE_PINS), encoding="utf-8")
+            error = FileNotFoundError(2, "device\n\t\x1b disappeared")
+            note = "raw cleanup note\n\t\x1b"
+            error.add_note(note)
+            stderr = StringIO()
+
+            with (
+                mock.patch.object(verifier, "atomic_write_receipt", side_effect=error),
+                redirect_stdout(StringIO()),
+                redirect_stderr(stderr),
+            ):
+                result = verifier.bootstrap_preflight_main(
+                    [
+                        "--source",
+                        str(source),
+                        "--policy",
+                        "stable",
+                        "--constraint",
+                        str(constraint),
+                        "--output",
+                        str(output),
+                    ]
+                )
+
+            self.assertEqual(result, 2)
+            self.assertEqual(
+                stderr.getvalue().splitlines(),
+                [
+                    "Cannot write bootstrap verification receipt: "
+                    + json.dumps(
+                        {
+                            "message": str(error),
+                            "path": os.fspath(output),
+                            "type": "FileNotFoundError",
+                        },
+                        ensure_ascii=True,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                    "Receipt output cleanup note: "
+                    + json.dumps(
+                        {"note": note},
+                        ensure_ascii=True,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                ],
+            )
 
     def test_stable_preflight_writes_success_and_actionable_failure_receipts(self) -> None:
         with tempfile.TemporaryDirectory() as raw_directory:
@@ -2002,6 +2440,8 @@ class TestDependencyBootstrapPolicy(unittest.TestCase):
                 _constraint_text({**BASE_PINS, "pip-tools": "7.5.2"}),
                 encoding="utf-8",
             )
+            failure_output = directory / "failure-receipt.json"
+            arguments[-1] = str(failure_output)
             stderr = StringIO()
             with (
                 mock.patch.object(verifier.subprocess, "Popen") as popen_mock,
@@ -2030,7 +2470,7 @@ class TestDependencyBootstrapPolicy(unittest.TestCase):
                 diagnostic.count("Run the native Dependency Locks workflow"),
                 1,
             )
-            failure_receipt = cast(dict[str, object], json.loads(output.read_bytes()))
+            failure_receipt = cast(dict[str, object], json.loads(failure_output.read_bytes()))
             self.assertEqual((failure_receipt["status"], failure_receipt["state"]), ("failed", "invalid"))
             errors = cast(list[dict[str, object]], failure_receipt["errors"])
             self.assertEqual([error["code"] for error in errors], ["bootstrap-source-lock-mismatch"])

--- a/tests/test_dependency_snapshot.py
+++ b/tests/test_dependency_snapshot.py
@@ -1105,6 +1105,32 @@ class DependencySnapshotTests(unittest.TestCase):
         ANCHORED_OUTPUT.descriptor_relative_output_supported(),
         "Descriptor-relative output binding is unavailable on this platform.",
     )
+    def test_legacy_atomic_output_preserves_existing_parent_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_directory:
+            root = Path(raw_directory)
+            parent = root / "shared-output"
+            parent.mkdir()
+            parent.chmod(0o770)
+            output = parent / "snapshot.json"
+
+            with _working_directory(root):
+                binding = OPEN_OUTPUT_PARENT(output)
+                try:
+                    self.assertFalse(binding.receipt_parent_policy)
+                    binding.verify()
+                finally:
+                    self.assertEqual(binding.close(), ())
+                self.assertEqual(stat.S_IMODE(parent.stat().st_mode), 0o770)
+
+                ANCHORED_OUTPUT.publish_new_bytes(output, b"payload\n")
+
+            self.assertEqual(output.read_bytes(), b"payload\n")
+            self.assertEqual(stat.S_IMODE(parent.stat().st_mode), 0o770)
+
+    @unittest.skipUnless(
+        ANCHORED_OUTPUT.descriptor_relative_output_supported(),
+        "Descriptor-relative output binding is unavailable on this platform.",
+    )
     def test_atomic_output_recovers_when_initial_fstat_fails_once(
         self,
     ) -> None:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_67(self) -> None:
-        self.assertEqual(get_version(), "0.7.67")
+    def test_release_version_is_0_7_68(self) -> None:
+        self.assertEqual(get_version(), "0.7.68")
 
     def test_release_surfaces_match_source_version(self) -> None:
         version_source = (PROJECT_ROOT / "src" / "version.py").read_text(


### PR DESCRIPTION
Fixes #859.

Publishes dependency receipts through retained physical root and ancestor bindings with identical-only semantics. Existing identical receipts keep their bytes and inode; different, redirected, multiply linked, non-regular, wrong-mode, or non-canonical targets fail untouched.

Private staging, no-replace installation, durability checks, exact verification, ACL and path validation, and reverse-order resource cleanup are covered across native POSIX and modeled Windows mutation boundaries. Windows publication uses the native same-directory rename contract; the complete native NTFS adversarial matrix remains tracked by #860.

Validation:

- 243 receipt tests passed on Python 3.12.10 and Python 3.14.7
- 2,848 repository tests passed locally with 78 expected skips on exact Godot 4.7.1
- Pyright passed with 0 errors and 0 warnings
- Ruff and diff checks passed
- Exact Godot 4.7.2 PNG-import compatibility smoke passed
- Final GitHub Actions run passed all 17 applicable checks, including Windows dependency locks, builds, artifact transactions, Included Files scale, and crash recovery; 4 release-only jobs were skipped as expected
