### PR TITLE
Publish the typed GML lexical phase API

### DIFF
--- a/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
+++ b/.github/ISSUE_TEMPLATE/unsupported_gml_api.yml
@@ -39,6 +39,6 @@ body:
     attributes:
       label: Versions
       description: GM2Godot commit or release, GameMaker version, Godot version, and target platform.
-      placeholder: "GM2Godot 0.7.71, GameMaker LTS 2026, Godot 4.7.2, Windows"
+      placeholder: "GM2Godot 0.7.72, GameMaker LTS 2026, Godot 4.7.2, Windows"
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.72 - 2026-09-04
+
+- Published the exact 15-operation typed GML lexical phase API for complete-source and expression tokenization, both preprocessing contracts, identifier operations, and the shared ordinary, verbatim, and template-string operations while keeping cursor, numeric, delimiter, newline-search, and template-expression mechanics private.
+- Migrated 15 higher-level source modules to the lexical facade and advanced the architecture baseline from 135 to 96 private edges across 32 module pairs, while keeping all 60 production imports and reducing private production import edges from 16 to 7 and tracked private-usage suppressions from 15 to 12.
+- Preserved preprocessed bytes and layout, exact token values and locations, identifier diagnostics, exception text and locations, source maps, transpiled GDScript, golden output, shared model identities, and all 74 top-level facade exports and signatures.
+
 ## 0.7.71 - 2026-09-04
 
 - Published the exact 64-name GML language-metadata surface with `Final` annotations, read-only mapping proxies, frozen sets, and immutable registry values, retaining only `_BUILTIN_VARIABLE_REGISTRY` as the private facade compatibility alias assigned to #820.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Version 0.7.70 makes every generated GML compatibility-evidence URL use one cano
 
 Version 0.7.71 publishes the exact 64-name GML language-metadata surface with static exports, `Final` annotations, read-only mapping proxies, frozen sets, and immutable registry values. Thirteen production consumers now use those public names; the architecture baseline falls from 209 to 135 private edges while all 60 production imports remain, and the sole remaining private constants edge is the frozen facade alias assigned to #820. Preprocessing, token values and locations, transpiled GDScript, source maps, diagnostics, parser errors, golden output, runtime bytes, top-level facade exports, and signatures remain unchanged.
 
+Version 0.7.72 publishes the exact 15-operation typed GML lexical phase API for tokenization, preprocessing, identifiers, and shared string/template scanning. Fifteen higher-level source modules now use that facade while the cycle-safe low-level owner cohort keeps only deliberate public direct imports; the architecture baseline falls from 135 to 96 private edges across 32 module pairs, all 60 production imports remain, private production import edges fall from 16 to 7, and tracked suppressions fall from 15 to 12. Preprocessed bytes/layout, token values and locations, identifier diagnostics, exception text/locations, source maps, transpiled GDScript, golden output, shared models, and all 74 top-level facade exports/signatures remain unchanged.
+
 ## What GM2Godot Is and Isn't
 
 **GM2Godot is:**
@@ -120,7 +122,7 @@ The full compatibility roadmap lives in [`todo-list/`](todo-list/README.md). It 
 
 ## Releases
 
-Current source version: `0.7.71`.
+Current source version: `0.7.72`.
 
 Downloadable releases include Windows (`.exe`), macOS (`.dmg` with `.app`), and Linux binaries. You can also run from source on Windows, macOS, and Linux.
 The packaged Linux artifact is validated on Ubuntu 24.04 x86_64. Its glibc 2.39 requirement is necessary but does not make other distributions a validated target; they must also supply compatible system, OpenGL/EGL, and X11 libraries. The reviewed Linux package manifest installs Ubuntu's `libegl1` and `libgl1` providers for QtGui together with the required XCB client libraries. The release job rejects unresolved-library warnings, extracts the final ZIP, and proves that its GUI reaches the event loop through the real `qxcb` platform under Xvfb before upload.

--- a/docs/wiki/Compatibility-and-Limitations.md
+++ b/docs/wiki/Compatibility-and-Limitations.md
@@ -1,6 +1,6 @@
 # Compatibility and Limitations
 
-> **Applies to:** GM2Godot 0.7.71 · GameMaker LTS 2026 · Godot 4.7.2
+> **Applies to:** GM2Godot 0.7.72 · GameMaker LTS 2026 · Godot 4.7.2
 >
 > **Last reviewed:** 2026-09-04
 

--- a/docs/wiki/Contributing-and-Testing.md
+++ b/docs/wiki/Contributing-and-Testing.md
@@ -1,6 +1,6 @@
 # Contributing and Testing
 
-> **Applies to:** GM2Godot 0.7.71 · GameMaker LTS 2026 · Godot 4.7.2
+> **Applies to:** GM2Godot 0.7.72 · GameMaker LTS 2026 · Godot 4.7.2
 >
 > **Last reviewed:** 2026-09-04
 
@@ -114,11 +114,11 @@ Before the ordered #794 phase-interface migration is complete, run:
 ./venv/bin/python -m unittest tests.test_gml_transpiler_architecture -v
 ```
 
-The baseline inventories 135 cross-module private imported-name edges across
-53 facade/phase module pairs and all 60 production imports from those surfaces,
-including 16 remaining private production import edges. It separately freezes
+The baseline inventories 96 cross-module private imported-name edges across
+32 facade/phase module pairs and all 60 production imports from those surfaces,
+including 7 remaining private production import edges. It separately freezes
 44 supported non-underscore facade exports and their signatures, 30 legacy
-private facade exports, the 14 phase-package `reportPrivateUsage=false`
+private facade exports, the 11 phase-package `reportPrivateUsage=false`
 directives, and the facade directive. It is a no-growth migration allowlist,
 not permission to publish another private name. The #816 model slice removed
 120 internal private edges, replaced four production private model imports,
@@ -126,9 +126,14 @@ and established `shared_models`, `expression_models`, and `result_models` as
 dependency-only typed owners. The #861 language-metadata slice removed another
 74 internal private edges, reduced private production import edges from 22 to
 16 and private-usage suppressions from 17 to 15, and left only the frozen
-constants facade alias assigned to #820. Changes under #817 through #820 must
-remove the entries owned by that stage; unrelated changes must not edit the
-inventory.
+constants facade alias assigned to #820. The #862 lexical slice publishes an
+exact 15-operation typed phase API, removes another 39 internal private edges
+and 21 private module pairs, reduces private production import edges from 16 to
+7 and tracked suppressions from 15 to 12, and adds executable rejection of
+higher-level lexical-owner bypasses. The low-level owner cohort retains only
+the exact public direct imports needed to keep preprocessing acyclic. Changes
+under #818 through #820 must remove the entries owned by that stage; unrelated
+changes must not edit the inventory.
 
 The policy follows Python's
 [`__all__` package guidance](https://docs.python.org/3.12/tutorial/modules.html#importing-from-a-package),

--- a/docs/wiki/Diagnostics-and-Troubleshooting.md
+++ b/docs/wiki/Diagnostics-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Diagnostics and Troubleshooting
 
-> **Applies to:** GM2Godot 0.7.71 · GameMaker LTS 2026 · Godot 4.7.2
+> **Applies to:** GM2Godot 0.7.72 · GameMaker LTS 2026 · Godot 4.7.2
 >
 > **Last reviewed:** 2026-09-04
 

--- a/docs/wiki/Generated-Project-and-Runtime.md
+++ b/docs/wiki/Generated-Project-and-Runtime.md
@@ -1,6 +1,6 @@
 # Generated Project and Runtime
 
-> **Applies to:** GM2Godot 0.7.71 · GameMaker LTS 2026 · Godot 4.7.2
+> **Applies to:** GM2Godot 0.7.72 · GameMaker LTS 2026 · Godot 4.7.2
 >
 > **Last reviewed:** 2026-09-04
 

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,6 +1,6 @@
 # GM2Godot Documentation
 
-> **Applies to:** GM2Godot 0.7.71 · GameMaker LTS 2026 · Godot 4.7.2
+> **Applies to:** GM2Godot 0.7.72 · GameMaker LTS 2026 · Godot 4.7.2
 >
 > **Last reviewed:** 2026-09-04
 
@@ -21,7 +21,7 @@ Maintainers should also read [Release and Wiki Maintenance](Maintainer-Release-a
 
 This documentation set describes:
 
-- GM2Godot 0.7.71;
+- GM2Godot 0.7.72;
 - GameMaker LTS 2026 source projects in the GMS2 runtime family; and
 - Godot 4.7.2 output and validation, pinned in CI as `4.7.2.stable.official.ed1daf0bf`.
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-> **Applies to:** GM2Godot 0.7.71 · GameMaker LTS 2026 · Godot 4.7.2
+> **Applies to:** GM2Godot 0.7.72 · GameMaker LTS 2026 · Godot 4.7.2
 >
 > **Last reviewed:** 2026-09-04
 
@@ -46,7 +46,7 @@ On Windows, run `Get-FileHash -Algorithm SHA256 .\GM2Godot-windows.zip` in Power
 
 The packaged builds are produced as windowed applications. For the CLI commands in this Wiki, use a source installation.
 
-After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.71`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
+After launch, confirm that the title bar or **Help → About GM2Godot** shows version `0.7.72`. Click the version in the bottom information bar to browse the ten newest release changelogs; **Show more** appends the next ten.
 
 ## Run from source
 
@@ -148,6 +148,6 @@ python main.py --version
 python main.py list-converters
 ```
 
-The first command should print `GM2Godot 0.7.71`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
+The first command should print `GM2Godot 0.7.72`; the second should list the conversion groups and the exact converter keys accepted by `--only`. The same CLI is also available through `python -m src.cli`.
 
 Continue with [Quick Start Conversion](Quick-Start-Conversion). If launch or dependency setup fails, see [Diagnostics and Troubleshooting](Diagnostics-and-Troubleshooting).

--- a/docs/wiki/Maintainer-Release-and-Wiki.md
+++ b/docs/wiki/Maintainer-Release-and-Wiki.md
@@ -1,6 +1,6 @@
 # Release and Wiki Maintenance
 
-> **Applies to:** GM2Godot 0.7.71 · GameMaker LTS 2026 · Godot 4.7.2
+> **Applies to:** GM2Godot 0.7.72 · GameMaker LTS 2026 · Godot 4.7.2
 >
 > **Last reviewed:** 2026-09-04
 

--- a/docs/wiki/Quick-Start-Conversion.md
+++ b/docs/wiki/Quick-Start-Conversion.md
@@ -1,6 +1,6 @@
 # Quick Start Conversion
 
-> **Applies to:** GM2Godot 0.7.71 · GameMaker LTS 2026 · Godot 4.7.2
+> **Applies to:** GM2Godot 0.7.72 · GameMaker LTS 2026 · Godot 4.7.2
 >
 > **Last reviewed:** 2026-09-04
 

--- a/src/conversion/conversion_architecture.md
+++ b/src/conversion/conversion_architecture.md
@@ -47,6 +47,19 @@ These modules depend only on the standard library or another model module.
 `gml_transpiler_parts.model` is now only the frozen private-alias compatibility
 shim consumed by the top-level facade until #820.
 
+`gml_transpiler_parts.lexical_api` is the typed package-internal entry point for
+the lexical phase. Its exact 15-operation surface covers complete-source and
+expression tokenization, normal and layout-preserving preprocessing, identifier
+validation/sanitization/predicates, and the ordinary, verbatim, and template
+string operations shared with source analysis. It returns the canonical
+`shared_models.Token` and `result_models.GMLPreprocessResult` types rather than
+parallel lexical models. Higher-level phases and production collectors import
+those operations through `lexical_api`; the lexical owner cohort imports public
+owner definitions directly, including the exact cycle-safe `utils` dependencies
+needed by `preprocessor`. Cursor loops, numeric and character readers, delimiter
+mechanics, directive matching, newline-search helpers, and template-expression
+internals remain module-private.
+
 The GML transpiler has three explicit phase families:
 
 - Parser phase: `gml_transpiler_parts.tokens`,
@@ -65,19 +78,19 @@ expression emitter does not own the GameMaker API argument tables.
 ### Frozen transpiler boundary baseline
 
 `tests/test_gml_transpiler_architecture.py` is the machine-checked migration
-baseline for #794. It records 135 private imported-name edges across 53
+baseline for #794. It records 96 private imported-name edges across 32
 facade/phase module pairs and all 60 production imports from the facade or
-phase package, including the 16 remaining private production import edges.
+phase package, including the 7 remaining private production import edges.
 Every entry records its owner and consumer and is classified as the supported
 public facade, an intended package-internal phase API, or a module-private
 implementation that must move behind its owner.
 
 The same test freezes the 44 supported non-underscore facade exports and their
 signatures separately from the 30 underscore-prefixed legacy exports. It also
-permits exactly the current 14 phase-package `reportPrivateUsage=false`
+permits exactly the current 11 phase-package `reportPrivateUsage=false`
 directives plus the facade directive. New, missing, or unclassified imports,
-new private facade exports, signature drift, and added or broadened
-private-usage suppressions fail the test.
+new private facade exports, signature drift, lexical-owner bypasses, and added
+or broadened private-usage suppressions fail the test.
 
 The #816 model extraction removed exactly 120 internal private model edges and
 replaced four production private model imports with explicit typed exports.
@@ -85,9 +98,13 @@ The #861 language-metadata slice removed another 74 internal private edges,
 kept all 60 production imports while reducing their private import edges from
 22 to 16, and reduced private-usage suppressions from 17 to 15. Its sole
 remaining private constants edge is the frozen facade compatibility alias
-assigned to #820. The baseline is a migration allowlist, not a public-API
-declaration for private names. #817 continues the lexical/token boundary, #818
-owns expression parsing/lowering/emission, #819 the statement phase, and #820
-the legacy facade shim and final zero-private-edge assertion. Until those
-ordered children land, do not add an exception or expose an underscore name
-merely to make the baseline pass.
+assigned to #820. The #862 lexical slice removed another 39 internal private
+edges and 21 private owner/consumer pairs, routed the higher-level lexical
+consumers through the exact typed facade, kept all 60 production imports while
+reducing private production import edges from 16 to 7, and reduced tracked
+suppressions from 15 to 12. The baseline is a migration allowlist, not a
+public-API declaration for private names. #818 owns expression
+parsing/lowering/emission, #819 the statement phase, and #820 the legacy facade
+shim and final zero-private-edge assertion. Until those ordered children land,
+do not add an exception or expose an underscore name merely to make the
+baseline pass.

--- a/src/conversion/gml_transpiler.py
+++ b/src/conversion/gml_transpiler.py
@@ -72,7 +72,11 @@ from src.conversion.gml_transpiler_parts.model import (
     _Token,
     _Unary,
 )
-from src.conversion.gml_transpiler_parts.preprocessor import preprocess_gml_source
+from src.conversion.gml_transpiler_parts.lexical_api import (
+    preprocess_gml_source,
+    tokenize_gml_expression as _tokenize_gml_expression,
+    tokenize_gml_source as _tokenize_gml_source,
+)
 from src.conversion.gml_transpiler_parts.result_models import (
     GMLPreprocessResult,
     GMLPreprocessorDiagnostic,
@@ -93,7 +97,15 @@ from src.conversion.gml_transpiler_parts.source_map import (
     render_gml_source_header,
     write_gml_source_map,
 )
-from src.conversion.gml_transpiler_parts.tokens import _expression_tokens, _tokenize
+
+
+def _expression_tokens(source: str) -> list[_Token]:
+    return _tokenize_gml_expression(source)
+
+
+def _tokenize(source: str) -> list[_Token]:
+    return _tokenize_gml_source(source)
+
 
 __all__ = [
     "GMLTranspileError",

--- a/src/conversion/gml_transpiler_parts/api.py
+++ b/src/conversion/gml_transpiler_parts/api.py
@@ -10,7 +10,7 @@ from .extension_functions import (
     normalize_extension_functions,
 )
 from .function_helpers import _emit_static_initialization_lines
-from .preprocessor import preprocess_gml_source
+from .lexical_api import preprocess_gml_source, tokenize_gml_source
 from .result_models import GMLTranspileResult
 from .shared_models import ScopeContext as _ScopeContext
 from .source_map import (
@@ -19,7 +19,6 @@ from .source_map import (
 )
 from .statement_parser import _StatementParser
 from .static_declarations import _collect_static_declarations, _static_scope_id
-from .tokens import _tokenize
 from .utils import _prefix_multiline
 
 
@@ -113,7 +112,7 @@ def transpile_gml_code_with_source_map(
         macro_configuration=macro_configuration,
         active_symbols=active_preprocessor_symbols,
     )
-    tokens = _tokenize(preprocessed.source)
+    tokens = tokenize_gml_source(preprocessed.source)
     known_enum_values = {
         name: dict(members)
         for name, members in (enum_values or {}).items()

--- a/src/conversion/gml_transpiler_parts/emitter.py
+++ b/src/conversion/gml_transpiler_parts/emitter.py
@@ -66,7 +66,7 @@ from .expression_models import (
     Ternary as _Ternary,
     Unary as _Unary,
 )
-from .identifiers import _is_plain_identifier, _sanitize_gdscript_identifier
+from .lexical_api import is_plain_identifier, sanitize_gdscript_identifier
 from .shared_models import (
     GMLTranspileError,
     ScopeContext as _ScopeContext,
@@ -136,9 +136,9 @@ def _emit_name(
         legacy_argument = _legacy_argument_replacement(value)
         if legacy_argument is not None:
             return legacy_argument, POSTFIX_PRECEDENCE
-        if value.startswith("audiogroup_") and _is_plain_identifier(value):
+        if value.startswith("audiogroup_") and is_plain_identifier(value):
             return json.dumps(value), PRIMARY_PRECEDENCE
-        if value in scope_context.asset_names and _is_plain_identifier(value):
+        if value in scope_context.asset_names and is_plain_identifier(value):
             if value in scope_context.global_names:
                 raise GMLTranspileError(
                     f"Unscoped identifier '{value}' collides with a global and asset name; "
@@ -154,22 +154,22 @@ def _emit_name(
         if value in INSTANCE_NAME_REPLACEMENTS and _uses_direct_builtin_instance_members(scope_context):
             return INSTANCE_NAME_REPLACEMENTS[value], POSTFIX_PRECEDENCE
         if value in BUILTIN_INSTANCE_VARIABLES and _uses_direct_builtin_instance_members(scope_context):
-            return _sanitize_gdscript_identifier(value), PRIMARY_PRECEDENCE
+            return sanitize_gdscript_identifier(value), PRIMARY_PRECEDENCE
         if _is_gdscript_constant_identifier(value):
             return value, PRIMARY_PRECEDENCE
         if value in scope_context.direct_instance_names:
-            return _sanitize_gdscript_identifier(value), PRIMARY_PRECEDENCE
-        if value in scope_context.dynamic_instance_names and _is_plain_identifier(value):
+            return sanitize_gdscript_identifier(value), PRIMARY_PRECEDENCE
+        if value in scope_context.dynamic_instance_names and is_plain_identifier(value):
             return (
                 "GMRuntime.gml_variable_instance_get("
                 f"{scope_context.self_expression}, {json.dumps(value)})"
             ), POSTFIX_PRECEDENCE
-        if scope_context.instance_target is not None and _is_plain_identifier(value):
+        if scope_context.instance_target is not None and is_plain_identifier(value):
             return (
                 "GMRuntime.gml_variable_instance_get("
                 f"{scope_context.instance_target}, {json.dumps(value)})"
             ), POSTFIX_PRECEDENCE
-    value = _sanitize_gdscript_identifier(value)
+    value = sanitize_gdscript_identifier(value)
     return value, PRIMARY_PRECEDENCE
 
 
@@ -194,7 +194,7 @@ def _name_resolves_to_global(
     local_names: Iterable[str],
     scope_context: _ScopeContext,
 ) -> bool:
-    if name in local_names or not _is_plain_identifier(name):
+    if name in local_names or not is_plain_identifier(name):
         return False
     if name in GML_LITERAL_IDENTIFIERS:
         return False
@@ -446,7 +446,7 @@ def _emit_expression(
             local_names=local_names,
             scope_context=scope_context,
         )
-        return f"{target}.{_sanitize_gdscript_identifier(expr.member)}", POSTFIX_PRECEDENCE
+        return f"{target}.{sanitize_gdscript_identifier(expr.member)}", POSTFIX_PRECEDENCE
     target = _emit_instance_keyword_argument(
         expr.target,
         local_names,
@@ -514,10 +514,10 @@ def _emit_function_literal(
     scope_context: _ScopeContext | None = None,
 ) -> str:
     scope_context = _normalize_scope_context(scope_context)
-    name = f" {_sanitize_gdscript_identifier(expr.name)}" if expr.name is not None else ""
+    name = f" {sanitize_gdscript_identifier(expr.name)}" if expr.name is not None else ""
     parameter_names = [parameter.name for parameter in expr.parameters]
     emitted_parameters = [
-        f"{_sanitize_gdscript_identifier(parameter.name)} = null"
+        f"{sanitize_gdscript_identifier(parameter.name)} = null"
         for parameter in expr.parameters
     ]
     if expr.is_constructor:
@@ -601,7 +601,7 @@ def _emit_function_parameter_default_lines(
 ) -> list[str]:
     default_lines: list[str] = []
     for parameter in parameters:
-        parameter_name = _sanitize_gdscript_identifier(parameter.name)
+        parameter_name = sanitize_gdscript_identifier(parameter.name)
         if parameter.default is None:
             default_lines.append(f"if {parameter_name} == null: {parameter_name} = GMRuntime.gml_undefined()")
             continue

--- a/src/conversion/gml_transpiler_parts/enum_helpers.py
+++ b/src/conversion/gml_transpiler_parts/enum_helpers.py
@@ -24,11 +24,11 @@ from .expression_models import (
     Ternary as _Ternary,
     Unary as _Unary,
 )
+from .lexical_api import tokenize_gml_expression
 from .shared_models import (
     GMLTranspileError,
     Token as _Token,
 )
-from .tokens import _expression_tokens
 from .utils import _normalize_local_names, _tokens_to_source, _unwrap_grouped_expression
 
 def _evaluate_enum_value_tokens(
@@ -201,7 +201,7 @@ def _reject_constant_declaration_name(
 
 
 def _raw_identifier_target_name(target_source: str) -> str | None:
-    tokens = _expression_tokens(target_source)
+    tokens = tokenize_gml_expression(target_source)
     if len(tokens) == 2 and tokens[0].kind == "IDENT" and tokens[1].kind == "EOF":
         return tokens[0].value
     return None

--- a/src/conversion/gml_transpiler_parts/expression_parser.py
+++ b/src/conversion/gml_transpiler_parts/expression_parser.py
@@ -12,8 +12,6 @@ from .constants import (
     RIGHT_ASSOCIATIVE,
     TERNARY_PRECEDENCE,
 )
-from .identifiers import _reject_asset_identifier_name, _validate_gml_identifier
-from .lexical import _decode_gml_verbatim_string_literal
 from .expression_models import (
     ArrayLiteral as _ArrayLiteral,
     ArrayRefAccess as _ArrayRefAccess,
@@ -40,19 +38,26 @@ from .expression_models import (
     Ternary as _Ternary,
     Unary as _Unary,
 )
+from .lexical_api import (
+    decode_gml_string_literal,
+    decode_gml_verbatim_string_literal,
+    reject_asset_identifier_name,
+    split_template_string,
+    tokenize_gml_expression,
+    validate_gml_identifier,
+)
 from .shared_models import (
     GMLTranspileError,
     ScopeContext as _ScopeContext,
     Token as _Token,
 )
 from .static_declarations import _collect_static_declarations, _static_scope_id
-from .tokens import (
-    _decode_gml_string_literal,
-    _expression_tokens,
-    _is_float_like_number,
-    _split_template_string,
-)
 from .utils import _normalize_scope_context, _strip_comments
+
+
+def _is_float_like_number(value: str) -> bool:
+    return "." in value
+
 
 class _ExpressionParser:
     def __init__(
@@ -193,14 +198,14 @@ class _ExpressionParser:
         if token.kind == "NUMBER":
             return _NumberLiteral(token.value, _is_float_like_number(token.value))
         if token.kind == "STRING":
-            decoded = _decode_gml_string_literal(token.value)
+            decoded = decode_gml_string_literal(token.value)
             emitted = json.dumps(decoded)
             if token.value.startswith("'"):
                 emitted = "'" + emitted[1:-1].replace('\\"', '"').replace("'", "\\'") + "'"
             return _StringLiteral(emitted)
         if token.kind == "VERBATIM_STRING":
             return _StringLiteral(
-                json.dumps(_decode_gml_verbatim_string_literal(token.value))
+                json.dumps(decode_gml_verbatim_string_literal(token.value))
             )
         if token.kind == "TEMPLATE_STRING":
             return self._parse_template_string(token.value)
@@ -239,7 +244,7 @@ class _ExpressionParser:
                                 line=field_token.line,
                                 column=field_token.column,
                             )
-                        field_name = _decode_gml_string_literal(field_token.value)
+                        field_name = decode_gml_string_literal(field_token.value)
                         if not field_name:
                             raise GMLTranspileError(
                                 "Struct field names cannot be empty",
@@ -275,7 +280,7 @@ class _ExpressionParser:
 
     def _parse_template_string(self, source: str) -> _TemplateStringLiteral:
         parts: list[str | _Expression] = []
-        for part_kind, part_source in _split_template_string(source):
+        for part_kind, part_source in split_template_string(source):
             if part_kind == "text":
                 parts.append(part_source)
                 continue
@@ -370,8 +375,8 @@ class _ExpressionParser:
         static_declarations = _collect_static_declarations(body_tokens)
         parameter_names = [parameter.name for parameter in parameters]
         for parameter_name in parameter_names:
-            _validate_gml_identifier(parameter_name)
-            _reject_asset_identifier_name(parameter_name, self.scope_context)
+            validate_gml_identifier(parameter_name)
+            reject_asset_identifier_name(parameter_name, self.scope_context)
         scope_context = self.scope_context
         static_scope_id = None
         static_scope_name = scope_context.static_scope
@@ -516,7 +521,7 @@ class _ExpressionParser:
                 column=token.column,
             )
         try:
-            _validate_gml_identifier(token.value)
+            validate_gml_identifier(token.value)
         except GMLTranspileError as exc:
             raise exc.with_location(token.line, token.column) from exc
         return token.value
@@ -567,7 +572,7 @@ def _parse_gml_expression(
     scope_context: _ScopeContext | None = None,
 ) -> _Expression:
     parser = _ExpressionParser(
-        _expression_tokens(source),
+        tokenize_gml_expression(source),
         enum_values=enum_values,
         enum_names=enum_names,
         scope_context=scope_context,

--- a/src/conversion/gml_transpiler_parts/identifiers.py
+++ b/src/conversion/gml_transpiler_parts/identifiers.py
@@ -6,10 +6,11 @@ from .constants import (
     GENERATED_IDENTIFIER_PREFIX,
     GML_IDENTIFIER_MAX_LENGTH,
 )
-from .shared_models import GMLTranspileError, ScopeContext as _ScopeContext
+from .shared_models import GMLTranspileError, ScopeContext
 
-def _sanitize_gdscript_identifier(name: str) -> str:
-    if not _is_plain_identifier(name):
+
+def sanitize_gdscript_identifier(name: str) -> str:
+    if not is_plain_identifier(name):
         return name
     if name in GDSCRIPT_RESERVED_IDENTIFIERS:
         return f"{name}_"
@@ -18,7 +19,7 @@ def _sanitize_gdscript_identifier(name: str) -> str:
     return name
 
 
-def _is_plain_identifier(name: str) -> bool:
+def is_plain_identifier(name: str) -> bool:
     if not name:
         return False
     return (name[0].isalpha() or name[0] == "_") and all(
@@ -26,7 +27,7 @@ def _is_plain_identifier(name: str) -> bool:
     )
 
 
-def _validate_gml_identifier(name: str) -> None:
+def validate_gml_identifier(name: str) -> None:
     if not name:
         raise GMLTranspileError("Expected identifier name")
     if len(name) > GML_IDENTIFIER_MAX_LENGTH:
@@ -37,6 +38,6 @@ def _validate_gml_identifier(name: str) -> None:
         raise GMLTranspileError("GML identifier can only contain letters, numbers, and underscores")
 
 
-def _reject_asset_identifier_name(name: str, scope_context: _ScopeContext) -> None:
+def reject_asset_identifier_name(name: str, scope_context: ScopeContext) -> None:
     if name in scope_context.asset_names:
         raise GMLTranspileError(f"Unscoped identifier '{name}' collides with an asset name")

--- a/src/conversion/gml_transpiler_parts/lexical.py
+++ b/src/conversion/gml_transpiler_parts/lexical.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from .shared_models import GMLTranspileError
 
 
-def _is_verbatim_string_start(source: str, index: int) -> bool:
+def is_verbatim_string_start(source: str, index: int) -> bool:
     return (
         0 <= index < len(source)
         and source[index] == "@"
@@ -12,7 +12,7 @@ def _is_verbatim_string_start(source: str, index: int) -> bool:
     )
 
 
-def _read_verbatim_string(source: str, start: int) -> str:
+def read_verbatim_string(source: str, start: int) -> str:
     """Read one documented GML @-prefixed string literal.
 
     Verbatim strings require a contiguous ``@`` and quote, can span lines, and
@@ -20,7 +20,7 @@ def _read_verbatim_string(source: str, start: int) -> str:
     always terminates the literal.
     """
 
-    if not _is_verbatim_string_start(source, start):
+    if not is_verbatim_string_start(source, start):
         raise GMLTranspileError(
             "Verbatim string literal must start with @ followed by a quote"
         )
@@ -32,14 +32,14 @@ def _read_verbatim_string(source: str, start: int) -> str:
     return source[start : end + 1]
 
 
-def _decode_gml_verbatim_string_literal(source: str) -> str:
-    literal = _read_verbatim_string(source, 0)
+def decode_gml_verbatim_string_literal(source: str) -> str:
+    literal = read_verbatim_string(source, 0)
     if len(literal) != len(source):
         raise GMLTranspileError("Unexpected text after verbatim string literal")
     return source[2:-1]
 
 
-def _read_ordinary_string(source: str, start: int) -> str:
+def read_ordinary_string(source: str, start: int) -> str:
     if start < 0 or start >= len(source) or source[start] not in "\"'":
         raise GMLTranspileError("String literal must start with a quote")
 
@@ -59,8 +59,8 @@ def _read_ordinary_string(source: str, start: int) -> str:
 
 
 __all__ = [
-    "_decode_gml_verbatim_string_literal",
-    "_is_verbatim_string_start",
-    "_read_ordinary_string",
-    "_read_verbatim_string",
+    "decode_gml_verbatim_string_literal",
+    "is_verbatim_string_start",
+    "read_ordinary_string",
+    "read_verbatim_string",
 ]

--- a/src/conversion/gml_transpiler_parts/lexical_api.py
+++ b/src/conversion/gml_transpiler_parts/lexical_api.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Final
+
+from .identifiers import (
+    is_plain_identifier,
+    reject_asset_identifier_name,
+    sanitize_gdscript_identifier,
+    validate_gml_identifier,
+)
+from .lexical import (
+    decode_gml_verbatim_string_literal,
+    is_verbatim_string_start,
+    read_ordinary_string,
+    read_verbatim_string,
+)
+from .preprocessor import (
+    preprocess_gml_source,
+    preprocess_gml_source_preserving_layout,
+)
+from .tokens import (
+    decode_gml_string_literal,
+    read_template_string,
+    split_template_string,
+    tokenize_gml_expression,
+    tokenize_gml_source,
+)
+
+
+__all__: Final[tuple[str, ...]] = (
+    "decode_gml_string_literal",
+    "decode_gml_verbatim_string_literal",
+    "is_plain_identifier",
+    "is_verbatim_string_start",
+    "preprocess_gml_source",
+    "preprocess_gml_source_preserving_layout",
+    "read_ordinary_string",
+    "read_template_string",
+    "read_verbatim_string",
+    "reject_asset_identifier_name",
+    "sanitize_gdscript_identifier",
+    "split_template_string",
+    "tokenize_gml_expression",
+    "tokenize_gml_source",
+    "validate_gml_identifier",
+)

--- a/src/conversion/gml_transpiler_parts/preprocessor.py
+++ b/src/conversion/gml_transpiler_parts/preprocessor.py
@@ -5,11 +5,11 @@ import re
 from dataclasses import dataclass
 from typing import Iterable, TypeAlias
 
-from .identifiers import _validate_gml_identifier
-from .lexical import _is_verbatim_string_start, _read_verbatim_string
+from .identifiers import validate_gml_identifier
+from .lexical import is_verbatim_string_start, read_verbatim_string
 from .result_models import GMLPreprocessResult, GMLPreprocessorDiagnostic
 from .shared_models import GMLTranspileError
-from .tokens import _read_template_string
+from .tokens import read_template_string
 from .utils import _join_macro_continuation_lines, _macro_configuration_matches, _strip_comments
 
 
@@ -78,15 +78,15 @@ def _preprocessor_source_views(source: str) -> tuple[str, str]:
             index += 1
             continue
 
-        if _is_verbatim_string_start(source, index):
-            literal = _read_verbatim_string(source, index)
+        if is_verbatim_string_start(source, index):
+            literal = read_verbatim_string(source, index)
             end = index + len(literal)
             _blank_layout_span(code_only, index, end)
             index = end
             continue
 
         if source.startswith('$"', index):
-            literal = _read_template_string(source, index)
+            literal = read_template_string(source, index)
             end = index + len(literal)
             _blank_layout_span(code_only, index, end)
             index = end
@@ -560,7 +560,7 @@ def _preprocess_define(
     name = match.group(1)
     value = (match.group(2) or "").strip()
     try:
-        _validate_gml_identifier(name)
+        validate_gml_identifier(name)
     except GMLTranspileError as exc:
         _add_diagnostic(diagnostics, line_number, "#define", str(exc), line)
         return ""

--- a/src/conversion/gml_transpiler_parts/source_map.py
+++ b/src/conversion/gml_transpiler_parts/source_map.py
@@ -1,4 +1,3 @@
-# pyright: reportPrivateUsage=false
 from __future__ import annotations
 
 import json
@@ -8,18 +7,18 @@ from dataclasses import dataclass
 from typing import Iterable
 
 from .constants import GDSCRIPT_RESERVED_IDENTIFIERS
-from .identifiers import _sanitize_gdscript_identifier
-from .lexical import (
-    _is_verbatim_string_start,
-    _read_ordinary_string,
-    _read_verbatim_string,
+from .lexical_api import (
+    is_verbatim_string_start,
+    read_ordinary_string,
+    read_template_string,
+    read_verbatim_string,
+    sanitize_gdscript_identifier,
 )
 from .result_models import (
     GMLSourceDiagnostic,
     GMLSourceMap,
     GMLSourceMapEntry,
 )
-from .tokens import _read_template_string
 
 _IDENTIFIER_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\b")
 _DECLARATION_RE = re.compile(r"\b(?:var|globalvar|static)\s+([^;\n]+)")
@@ -181,7 +180,7 @@ def analyze_gml_source_identifiers(source: str) -> tuple[GMLSourceDiagnostic, ..
     diagnostics: list[GMLSourceDiagnostic] = []
     declarations = _declared_identifier_locations(source)
     for identifier, line, column in declarations:
-        suggested_name = _sanitize_gdscript_identifier(identifier)
+        suggested_name = sanitize_gdscript_identifier(identifier)
         if suggested_name != identifier and identifier in GDSCRIPT_RESERVED_IDENTIFIERS:
             diagnostics.append(
                 GMLSourceDiagnostic(
@@ -249,8 +248,8 @@ def _source_lexical_views(source: str) -> tuple[str, str, str]:
     strings_masked = list(source)
     index = 0
     while index < len(source):
-        if _is_verbatim_string_start(source, index):
-            literal = _read_verbatim_string(source, index)
+        if is_verbatim_string_start(source, index):
+            literal = read_verbatim_string(source, index)
             end = index + len(literal)
             _blank_source_span(code_only, index, end)
             _blank_source_span(strings_masked, index, end)
@@ -258,7 +257,7 @@ def _source_lexical_views(source: str) -> tuple[str, str, str]:
             continue
 
         if source.startswith('$"', index):
-            literal = _read_template_string(source, index)
+            literal = read_template_string(source, index)
             end = index + len(literal)
             _blank_source_span(code_only, index, end)
             _blank_source_span(strings_masked, index, end)
@@ -267,7 +266,7 @@ def _source_lexical_views(source: str) -> tuple[str, str, str]:
 
         char = source[index]
         if char in ("'", '"'):
-            literal = _read_ordinary_string(source, index)
+            literal = read_ordinary_string(source, index)
             end = index + len(literal)
             _blank_source_span(code_only, index, end)
             _blank_source_span(strings_masked, index, end)
@@ -423,4 +422,4 @@ def _identifier_locations(source: str) -> tuple[tuple[str, int, int], ...]:
 
 def _case_collision_suggestion(name: str, names: list[str]) -> str:
     suffix = names.index(name) + 1
-    return f"{_sanitize_gdscript_identifier(name)}_{suffix}"
+    return f"{sanitize_gdscript_identifier(name)}_{suffix}"

--- a/src/conversion/gml_transpiler_parts/statement_parser.py
+++ b/src/conversion/gml_transpiler_parts/statement_parser.py
@@ -9,10 +9,10 @@ from .emitter import _emit_instance_keyword_argument
 from .enum_helpers import _evaluate_enum_value_tokens
 from .expression_parser import _parse_gml_expression
 from .expression_service import transpile_gml_condition, transpile_gml_expression
-from .identifiers import (
-    _reject_asset_identifier_name,
-    _sanitize_gdscript_identifier,
-    _validate_gml_identifier,
+from .lexical_api import (
+    reject_asset_identifier_name,
+    sanitize_gdscript_identifier,
+    validate_gml_identifier,
 )
 from .shared_models import (
     GMLExtensionFunction,
@@ -74,7 +74,7 @@ class _StatementParser:
         )
         self.hoisted_local_names = _collect_hoisted_local_names(tokens)
         self._hoisted_local_declaration_lines = [
-            f"var {_sanitize_gdscript_identifier(name)} = GMRuntime.gml_undefined()"
+            f"var {sanitize_gdscript_identifier(name)} = GMRuntime.gml_undefined()"
             for name in self.hoisted_local_names
             if name not in initial_local_names
         ]
@@ -207,8 +207,8 @@ class _StatementParser:
         self._consume_identifier("globalvar")
         while not self._at_end() and not self._check(";") and not self._check("\n"):
             name = self._consume_identifier_name()
-            _validate_gml_identifier(name)
-            _reject_asset_identifier_name(name, self.scope_context)
+            validate_gml_identifier(name)
+            reject_asset_identifier_name(name, self.scope_context)
             self.global_names.add(name)
             if not self._match(","):
                 break
@@ -230,7 +230,7 @@ class _StatementParser:
     def _parse_enum_statement(self) -> list[str]:
         self._consume_identifier("enum")
         enum_name = self._consume_identifier_name()
-        gdscript_enum_name = _sanitize_gdscript_identifier(enum_name)
+        gdscript_enum_name = sanitize_gdscript_identifier(enum_name)
         self._skip_newlines()
         self._consume("{")
 
@@ -734,7 +734,7 @@ class _StatementParser:
         ]
 
         if catch_lines is not None and catch_name is not None:
-            gdscript_catch_name = _sanitize_gdscript_identifier(catch_name)
+            gdscript_catch_name = sanitize_gdscript_identifier(catch_name)
             lines.extend([
                 f"if not GMRuntime.is_undefined({control_name}) and {control_name}[\"kind\"] == \"throw\":",
                 f"\tvar {gdscript_catch_name} = GMRuntime.gml_exception_struct({control_name}[\"value\"])",
@@ -762,7 +762,7 @@ class _StatementParser:
         if len(catch_tokens) != 1 or catch_tokens[0].kind != "IDENT":
             raise GMLTranspileError("catch requires a variable name")
         catch_name = catch_tokens[0].value
-        _validate_gml_identifier(catch_name)
+        validate_gml_identifier(catch_name)
         return catch_name
 
     def _read_switch_label_tokens(self) -> list[_Token]:
@@ -996,7 +996,7 @@ class _StatementParser:
                 column=token.column,
             )
         try:
-            _validate_gml_identifier(token.value)
+            validate_gml_identifier(token.value)
         except GMLTranspileError as exc:
             raise exc.with_location(token.line, token.column) from exc
         return token.value

--- a/src/conversion/gml_transpiler_parts/statements.py
+++ b/src/conversion/gml_transpiler_parts/statements.py
@@ -28,11 +28,12 @@ from .enum_helpers import (
 )
 from .expression_parser import _parse_gml_expression
 from .expression_service import transpile_gml_expression
-from .identifiers import (
-    _is_plain_identifier,
-    _reject_asset_identifier_name,
-    _sanitize_gdscript_identifier,
-    _validate_gml_identifier,
+from .lexical_api import (
+    is_plain_identifier,
+    reject_asset_identifier_name,
+    sanitize_gdscript_identifier,
+    tokenize_gml_expression,
+    validate_gml_identifier,
 )
 from .expression_models import (
     ArrayRefAccess as _ArrayRefAccess,
@@ -53,7 +54,6 @@ from .shared_models import (
     ScopeContext as _ScopeContext,
     Token as _Token,
 )
-from .tokens import _expression_tokens
 from .utils import (
     _cache_assignment_part,
     _indent_lines,
@@ -243,7 +243,7 @@ def _transpile_statement(
         _reject_enum_assignment_target(target_expr, enum_names)
         _reject_readonly_builtin_assignment_target(target_expr, local_names)
         if isinstance(target_expr, _Name):
-            _reject_asset_identifier_name(target_expr.value, scope_context)
+            reject_asset_identifier_name(target_expr.value, scope_context)
         static_target = _static_scope_assignment_parts(target_expr, scope_context)
         if static_target is not None:
             static_scope, member_name = static_target
@@ -316,7 +316,7 @@ def _transpile_statement(
             raise GMLTranspileError("Increment target must be assignable")
         _reject_readonly_builtin_assignment_target(target_expr, local_names)
         if isinstance(target_expr, _Name):
-            _reject_asset_identifier_name(target_expr.value, scope_context)
+            reject_asset_identifier_name(target_expr.value, scope_context)
         static_target = _static_scope_assignment_parts(target_expr, scope_context)
         if static_target is not None:
             static_scope, member_name = static_target
@@ -712,7 +712,7 @@ def _transpile_statement(
         _reject_enum_assignment_target(target_expr, enum_names)
         _reject_readonly_builtin_assignment_target(target_expr, local_names)
         if isinstance(target_expr, _Name):
-            _reject_asset_identifier_name(target_expr.value, scope_context)
+            reject_asset_identifier_name(target_expr.value, scope_context)
         static_target = _static_scope_assignment_parts(target_expr, scope_context)
         global_target = _global_scope_assignment_parts(
             target_expr,
@@ -1566,7 +1566,7 @@ def _scoped_instance_assignment_parts(
             name in BUILTIN_INSTANCE_VARIABLES
             and _uses_direct_builtin_instance_members(scope_context)
         )
-        or not _is_plain_identifier(name)
+        or not is_plain_identifier(name)
     ):
         return None
     return scope_context.instance_target, json.dumps(name)
@@ -1593,7 +1593,7 @@ def _dynamic_instance_assignment_parts(
             name in BUILTIN_INSTANCE_VARIABLES
             and _uses_direct_builtin_instance_members(scope_context)
         )
-        or not _is_plain_identifier(name)
+        or not is_plain_identifier(name)
     ):
         return None
     return scope_context.self_expression, json.dumps(name)
@@ -1622,7 +1622,7 @@ def _motion_current_value(
     scope_context = _normalize_scope_context(scope_context)
     if scope_context.instance_target is not None:
         return f"GMRuntime.gml_variable_instance_get({instance_target}, {json.dumps(member_name)})"
-    return _sanitize_gdscript_identifier(member_name)
+    return sanitize_gdscript_identifier(member_name)
 
 
 def _motion_assignment_lines(
@@ -1686,7 +1686,7 @@ def _record_instance_assignment(
     if instance_variables is None:
         return
 
-    tokens = _expression_tokens(target.strip())
+    tokens = tokenize_gml_expression(target.strip())
     if len(tokens) >= 4 and tokens[0].kind == "IDENT" and tokens[1].value == "[":
         name = tokens[0].value
         if name not in local_names and name not in BUILTIN_INSTANCE_VARIABLES:
@@ -1729,13 +1729,13 @@ def _transpile_var_statement(
         assignment = _split_assignment(declaration)
         if assignment is None:
             name = declaration.strip()
-            _validate_gml_identifier(name)
-            _reject_asset_identifier_name(name, scope_context)
+            validate_gml_identifier(name)
+            reject_asset_identifier_name(name, scope_context)
             _reject_constant_declaration_name(name, macro_values.keys())
             if name in enum_name_set:
                 raise GMLTranspileError("Cannot redeclare enum")
             declaration_prefix = "" if name in declared_local_names else "var "
-            lines.append(f"{declaration_prefix}{_sanitize_gdscript_identifier(name)} = GMRuntime.gml_undefined()")
+            lines.append(f"{declaration_prefix}{sanitize_gdscript_identifier(name)} = GMRuntime.gml_undefined()")
             local_names.add(name)
             declared_local_names.add(name)
             continue
@@ -1743,8 +1743,8 @@ def _transpile_var_statement(
         if operator not in ("=", ":="):
             raise GMLTranspileError("Variable declarations only support simple assignments")
         name = name.strip()
-        _validate_gml_identifier(name)
-        _reject_asset_identifier_name(name, scope_context)
+        validate_gml_identifier(name)
+        reject_asset_identifier_name(name, scope_context)
         _reject_constant_declaration_name(name, macro_values.keys())
         if name in enum_name_set:
             raise GMLTranspileError("Cannot redeclare enum")
@@ -1782,7 +1782,7 @@ def _transpile_var_statement(
             )
             lines.extend(prelude_lines)
         declaration_prefix = "" if name in declared_local_names else "var "
-        lines.append(f"{declaration_prefix}{_sanitize_gdscript_identifier(name)} = {initial_value}")
+        lines.append(f"{declaration_prefix}{sanitize_gdscript_identifier(name)} = {initial_value}")
         local_names.add(name)
         declared_local_names.add(name)
     return lines
@@ -1901,7 +1901,7 @@ def _lower_simple_array_index_postincrement_target(
     macro_values: Mapping[str, str] | None = None,
     generated_counter: list[int] | None = None,
 ) -> tuple[list[str], str]:
-    tokens = [token for token in _expression_tokens(target) if token.kind != "EOF"]
+    tokens = [token for token in tokenize_gml_expression(target) if token.kind != "EOF"]
     if len(tokens) == 5:
         base, opener, index, increment, closer = tokens
     elif len(tokens) == 6 and tokens[2].value == "@":
@@ -1931,7 +1931,7 @@ def _lower_simple_array_index_postincrement_target(
 def _find_next_mutation_expression(
     source: str,
 ) -> tuple[int, int, str, _IncrementDelta, _IncrementMode] | None:
-    tokens = [token for token in _expression_tokens(source) if token.kind != "EOF"]
+    tokens = [token for token in tokenize_gml_expression(source) if token.kind != "EOF"]
     for index, token in enumerate(tokens):
         if token.value not in ("++", "--"):
             continue
@@ -2122,7 +2122,7 @@ def _parse_assignment_target(
     _reject_enum_assignment_target(target_expr, enum_names)
     _reject_readonly_builtin_assignment_target(target_expr, local_names)
     if isinstance(target_expr, _Name):
-        _reject_asset_identifier_name(target_expr.value, scope_context)
+        reject_asset_identifier_name(target_expr.value, scope_context)
     return target_expr
 
 
@@ -2626,7 +2626,7 @@ def _transpile_assignment_to_emitted_value(
     _reject_enum_assignment_target(target_expr, enum_names)
     _reject_readonly_builtin_assignment_target(target_expr, local_names)
     if isinstance(target_expr, _Name):
-        _reject_asset_identifier_name(target_expr.value, scope_context)
+        reject_asset_identifier_name(target_expr.value, scope_context)
     static_target = _static_scope_assignment_parts(target_expr, scope_context)
     if static_target is not None:
         static_scope, member_name = static_target

--- a/src/conversion/gml_transpiler_parts/static_declarations.py
+++ b/src/conversion/gml_transpiler_parts/static_declarations.py
@@ -5,7 +5,7 @@ import hashlib
 
 from typing import Iterable
 
-from .identifiers import _validate_gml_identifier
+from .lexical_api import validate_gml_identifier
 from .shared_models import (
     GMLTranspileError,
     StaticDeclaration as _StaticDeclaration,
@@ -160,6 +160,6 @@ def _parse_static_declarations(source: str) -> list[_StaticDeclaration]:
                 raise GMLTranspileError("Static declarations only support simple assignments")
             name = name.strip()
             value_source = value_source.strip()
-        _validate_gml_identifier(name)
+        validate_gml_identifier(name)
         declarations.append(_StaticDeclaration(name, value_source))
     return declarations

--- a/src/conversion/gml_transpiler_parts/tokens.py
+++ b/src/conversion/gml_transpiler_parts/tokens.py
@@ -1,17 +1,17 @@
-# pyright: reportPrivateUsage=false, reportUnusedFunction=false, reportUnusedClass=false
+# pyright: reportUnusedFunction=false, reportUnusedClass=false
 from __future__ import annotations
 
 from bisect import bisect_left
 from collections.abc import Sequence
 
 from .constants import BLOCK_DELIMITER_REPLACEMENTS, MULTI_CHAR_OPERATORS
-from .identifiers import _validate_gml_identifier
+from .identifiers import validate_gml_identifier
 from .lexical import (
-    _is_verbatim_string_start,
-    _read_ordinary_string,
-    _read_verbatim_string,
+    is_verbatim_string_start,
+    read_ordinary_string,
+    read_verbatim_string,
 )
-from .shared_models import GMLTranspileError, Token as _Token
+from .shared_models import GMLTranspileError, Token
 
 
 _GML_SIMPLE_ESCAPES = {
@@ -31,8 +31,8 @@ _HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
 _OCTAL_DIGITS = frozenset("01234567")
 
 
-def _tokenize(source: str) -> list[_Token]:
-    tokens: list[_Token] = []
+def tokenize_gml_source(source: str) -> list[Token]:
+    tokens: list[Token] = []
     newline_positions = [
         position for position, char in enumerate(source) if char == "\n"
     ]
@@ -47,7 +47,7 @@ def _tokenize(source: str) -> list[_Token]:
         if char in "\r\n":
             if char == "\r" and index + 1 < len(source) and source[index + 1] == "\n":
                 index += 1
-            tokens.append(_Token("NEWLINE", "\n", line=line, column=column, index=index))
+            tokens.append(Token("NEWLINE", "\n", line=line, column=column, index=index))
             index += 1
             continue
 
@@ -55,13 +55,13 @@ def _tokenize(source: str) -> list[_Token]:
             index += 1
             continue
 
-        if _is_verbatim_string_start(source, index):
+        if is_verbatim_string_start(source, index):
             try:
-                verbatim = _read_verbatim_string(source, index)
+                verbatim = read_verbatim_string(source, index)
             except GMLTranspileError as exc:
                 raise exc.with_location(line, column) from exc
             tokens.append(
-                _Token(
+                Token(
                     "VERBATIM_STRING",
                     verbatim,
                     line=line,
@@ -77,13 +77,13 @@ def _tokenize(source: str) -> list[_Token]:
                 number_end = _read_number(source, index)
             except GMLTranspileError as exc:
                 raise exc.with_location(line, column) from exc
-            tokens.append(_Token("NUMBER", source[index:number_end].replace("_", ""), line=line, column=column, index=index))
+            tokens.append(Token("NUMBER", source[index:number_end].replace("_", ""), line=line, column=column, index=index))
             index = number_end
             continue
 
         if char == '"' or char == "'":
             try:
-                tokens.append(_Token("STRING", _read_string(source, index), line=line, column=column, index=index))
+                tokens.append(Token("STRING", _read_string(source, index), line=line, column=column, index=index))
             except GMLTranspileError as exc:
                 raise exc.with_location(line, column) from exc
             index += len(tokens[-1].value)
@@ -92,11 +92,11 @@ def _tokenize(source: str) -> list[_Token]:
         if char == "$":
             if source.startswith('$"', index):
                 try:
-                    template = _read_template_string(source, index)
+                    template = read_template_string(source, index)
                 except GMLTranspileError as exc:
                     raise exc.with_location(line, column) from exc
                 tokens.append(
-                    _Token(
+                    Token(
                         "TEMPLATE_STRING",
                         template,
                         line=line,
@@ -112,30 +112,30 @@ def _tokenize(source: str) -> list[_Token]:
                     hex_end = _read_hex_number(source, index + 1)
                 except GMLTranspileError as exc:
                     raise exc.with_location(line, column) from exc
-                tokens.append(_Token("NUMBER", f"0x{source[index + 1:hex_end].replace('_', '')}", line=line, column=column, index=index))
+                tokens.append(Token("NUMBER", f"0x{source[index + 1:hex_end].replace('_', '')}", line=line, column=column, index=index))
                 index = hex_end
             else:
-                tokens.append(_Token("OP", char, line=line, column=column, index=index))
+                tokens.append(Token("OP", char, line=line, column=column, index=index))
                 index += 1
             continue
 
         if char == "#":
             if _source_startswith_directive(source, index, "#macro"):
-                tokens.append(_Token("DIRECTIVE", "#macro", line=line, column=column, index=index))
+                tokens.append(Token("DIRECTIVE", "#macro", line=line, column=column, index=index))
                 index += len("#macro")
                 continue
             previous_index = index - 1
             while previous_index >= 0 and source[previous_index].isspace():
                 previous_index -= 1
             if previous_index >= 0 and source[previous_index] == "[":
-                tokens.append(_Token("OP", char, line=line, column=column, index=index))
+                tokens.append(Token("OP", char, line=line, column=column, index=index))
                 index += 1
                 continue
             try:
                 color_literal, color_end = _read_hash_color_literal(source, index)
             except GMLTranspileError as exc:
                 raise exc.with_location(line, column) from exc
-            tokens.append(_Token("NUMBER", color_literal, line=line, column=column, index=index))
+            tokens.append(Token("NUMBER", color_literal, line=line, column=column, index=index))
             index = color_end
             continue
 
@@ -146,14 +146,14 @@ def _tokenize(source: str) -> list[_Token]:
                 index += 1
             identifier = source[start:index]
             try:
-                _validate_gml_identifier(identifier)
+                validate_gml_identifier(identifier)
             except GMLTranspileError as exc:
                 raise exc.with_location(line, column) from exc
             block_delimiter = BLOCK_DELIMITER_REPLACEMENTS.get(identifier)
             if block_delimiter is not None:
-                tokens.append(_Token("OP", block_delimiter, line=line, column=column, index=start))
+                tokens.append(Token("OP", block_delimiter, line=line, column=column, index=start))
             else:
-                tokens.append(_Token("IDENT", identifier, line=line, column=column, index=start))
+                tokens.append(Token("IDENT", identifier, line=line, column=column, index=start))
             continue
 
         matched_operator = None
@@ -162,12 +162,12 @@ def _tokenize(source: str) -> list[_Token]:
                 matched_operator = operator
                 break
         if matched_operator is not None:
-            tokens.append(_Token("OP", matched_operator, line=line, column=column, index=index))
+            tokens.append(Token("OP", matched_operator, line=line, column=column, index=index))
             index += len(matched_operator)
             continue
 
         if char in "+-*/%&|^~!=<>()[]{}?:,.;.@":
-            tokens.append(_Token("OP", char, line=line, column=column, index=index))
+            tokens.append(Token("OP", char, line=line, column=column, index=index))
             index += 1
             continue
 
@@ -177,16 +177,8 @@ def _tokenize(source: str) -> list[_Token]:
         newline_positions,
         len(source),
     )
-    tokens.append(_Token("EOF", "", line=eof_line, column=eof_column, index=len(source)))
+    tokens.append(Token("EOF", "", line=eof_line, column=eof_column, index=len(source)))
     return tokens
-
-
-def _line_column(source: str, index: int) -> tuple[int, int]:
-    line = source.count("\n", 0, index) + 1
-    line_start = source.rfind("\n", 0, index)
-    if line_start == -1:
-        return line, index + 1
-    return line, index - line_start
 
 
 def _line_column_from_newline_positions(
@@ -209,8 +201,10 @@ def _source_startswith_directive(source: str, index: int, directive: str) -> boo
     return not (next_char.isalnum() or next_char == "_")
 
 
-def _expression_tokens(source: str) -> list[_Token]:
-    return [token for token in _tokenize(source) if token.kind != "NEWLINE"]
+def tokenize_gml_expression(source: str) -> list[Token]:
+    return [
+        token for token in tokenize_gml_source(source) if token.kind != "NEWLINE"
+    ]
 
 
 def _read_number(source: str, start: int) -> int:
@@ -345,15 +339,11 @@ def _read_separated_digits(
     return index, saw_digit
 
 
-def _is_float_like_number(value: str) -> bool:
-    return "." in value
-
-
 def _read_string(source: str, start: int) -> str:
-    return _read_ordinary_string(source, start)
+    return read_ordinary_string(source, start)
 
 
-def _decode_gml_string_literal(source: str) -> str:
+def decode_gml_string_literal(source: str) -> str:
     if len(source) < 2 or source[0] not in "\"'" or source[-1] != source[0]:
         raise GMLTranspileError("Invalid string literal")
 
@@ -371,12 +361,12 @@ def _decode_gml_string_literal(source: str) -> str:
     return "".join(decoded)
 
 
-def _read_template_string(source: str, start: int) -> str:
+def read_template_string(source: str, start: int) -> str:
     end, _parts = _scan_template_string(source, start)
     return source[start:end]
 
 
-def _split_template_string(source: str) -> tuple[tuple[str, str], ...]:
+def split_template_string(source: str) -> tuple[tuple[str, str], ...]:
     end, parts = _scan_template_string(source, 0)
     if end != len(source):
         raise GMLTranspileError("Unexpected text after template string literal")
@@ -491,13 +481,13 @@ def _read_template_expression(source: str, start: int) -> int:
     index = start
     while index < len(source):
         if source.startswith('$"', index):
-            nested_template = _read_template_string(source, index)
+            nested_template = read_template_string(source, index)
             index += len(nested_template)
             continue
 
-        if _is_verbatim_string_start(source, index):
+        if is_verbatim_string_start(source, index):
             try:
-                nested_verbatim = _read_verbatim_string(source, index)
+                nested_verbatim = read_verbatim_string(source, index)
             except GMLTranspileError as exc:
                 raise GMLTranspileError(
                     "Unterminated template string interpolation"

--- a/src/conversion/gml_transpiler_parts/utils.py
+++ b/src/conversion/gml_transpiler_parts/utils.py
@@ -1,4 +1,4 @@
-# pyright: reportPrivateUsage=false, reportUnusedFunction=false, reportUnusedClass=false
+# pyright: reportUnusedFunction=false, reportUnusedClass=false
 from __future__ import annotations
 
 from typing import Iterable, Mapping
@@ -23,7 +23,7 @@ from .expression_models import (
     Ternary as _Ternary,
     Unary as _Unary,
 )
-from .lexical import _is_verbatim_string_start, _read_verbatim_string
+from .lexical import is_verbatim_string_start, read_verbatim_string
 from .shared_models import (
     AssignmentOperator as _AssignmentOperator,
     DEFAULT_SCOPE_CONTEXT as _DEFAULT_SCOPE_CONTEXT,
@@ -33,7 +33,16 @@ from .shared_models import (
     ScopeContext as _ScopeContext,
     Token as _Token,
 )
-from .tokens import _line_column, _read_template_string
+from .tokens import read_template_string
+
+
+def _line_column(source: str, index: int) -> tuple[int, int]:
+    line = source.count("\n", 0, index) + 1
+    line_start = source.rfind("\n", 0, index)
+    if line_start == -1:
+        return line, index + 1
+    return line, index - line_start
+
 
 def _normalize_local_names(local_names: Iterable[str] | None) -> frozenset[str]:
     return frozenset(local_names or [])
@@ -238,9 +247,9 @@ def _strip_comments(source: str) -> str:
             index += 1
             continue
 
-        if _is_verbatim_string_start(source, index):
+        if is_verbatim_string_start(source, index):
             try:
-                verbatim = _read_verbatim_string(source, index)
+                verbatim = read_verbatim_string(source, index)
             except GMLTranspileError as exc:
                 line, column = _line_column(source, index)
                 raise exc.with_location(line, column) from exc
@@ -250,7 +259,7 @@ def _strip_comments(source: str) -> str:
 
         if source.startswith('$"', index):
             try:
-                template = _read_template_string(source, index)
+                template = read_template_string(source, index)
             except GMLTranspileError as exc:
                 line, column = _line_column(source, index)
                 raise exc.with_location(line, column) from exc
@@ -319,12 +328,12 @@ def _split_statements(source: str) -> list[str]:  # pyright: ignore[reportUnused
             index += 1
             continue
 
-        if _is_verbatim_string_start(source, index):
-            index += len(_read_verbatim_string(source, index))
+        if is_verbatim_string_start(source, index):
+            index += len(read_verbatim_string(source, index))
             continue
 
         if source.startswith('$"', index):
-            index += len(_read_template_string(source, index))
+            index += len(read_template_string(source, index))
             continue
 
         if char == '"' or char == "'":
@@ -367,12 +376,12 @@ def _split_assignment(statement: str) -> tuple[str, _AssignmentOperator, str] | 
             index += 1
             continue
 
-        if _is_verbatim_string_start(statement, index):
-            index += len(_read_verbatim_string(statement, index))
+        if is_verbatim_string_start(statement, index):
+            index += len(read_verbatim_string(statement, index))
             continue
 
         if statement.startswith('$"', index):
-            index += len(_read_template_string(statement, index))
+            index += len(read_template_string(statement, index))
             continue
 
         if char == '"' or char == "'":
@@ -427,12 +436,12 @@ def _split_top_level(source: str, separator: str) -> list[str]:
             index += 1
             continue
 
-        if _is_verbatim_string_start(source, index):
-            index += len(_read_verbatim_string(source, index))
+        if is_verbatim_string_start(source, index):
+            index += len(read_verbatim_string(source, index))
             continue
 
         if source.startswith('$"', index):
-            index += len(_read_template_string(source, index))
+            index += len(read_template_string(source, index))
             continue
 
         if char == '"' or char == "'":

--- a/src/conversion/objects.py
+++ b/src/conversion/objects.py
@@ -38,9 +38,11 @@ from src.conversion.gml_transpiler_parts.constants import (
     GDSCRIPT_NATIVE_INSTANCE_MEMBER_IDENTIFIERS,
     GML_LITERAL_IDENTIFIERS,
 )
-from src.conversion.gml_transpiler_parts.preprocessor import preprocess_gml_source
+from src.conversion.gml_transpiler_parts.lexical_api import (
+    preprocess_gml_source,
+    tokenize_gml_source,
+)
 from src.conversion.gml_transpiler_parts.shared_models import Token
-from src.conversion.gml_transpiler_parts.tokens import _tokenize
 from src.conversion.project_source_paths import (
     is_safe_project_source_component,
     ProjectSourcePathError,
@@ -178,7 +180,7 @@ def _script_assigned_instance_variable_names(
     macro_configuration: str | None = None,
 ) -> set[str]:
     try:
-        tokens = _tokenize(
+        tokens = tokenize_gml_source(
             preprocess_gml_source(
                 source,
                 macro_configuration=macro_configuration,

--- a/src/conversion/project_enums.py
+++ b/src/conversion/project_enums.py
@@ -7,9 +7,11 @@ from typing import Mapping, Sequence
 from src.conversion.gml_transpiler_parts.enum_helpers import (
     _evaluate_enum_value_tokens,
 )
-from src.conversion.gml_transpiler_parts.preprocessor import preprocess_gml_source
+from src.conversion.gml_transpiler_parts.lexical_api import (
+    preprocess_gml_source,
+    tokenize_gml_source,
+)
 from src.conversion.gml_transpiler_parts.shared_models import GMLTranspileError, Token
-from src.conversion.gml_transpiler_parts.tokens import _tokenize
 from src.conversion.project_macros import collect_project_macro_values
 from src.conversion.project_source_paths import project_gml_source_paths
 from src.conversion.type_defs import StrPath
@@ -42,7 +44,7 @@ def collect_project_enum_values(
                 source,
                 macro_configuration=macro_configuration,
             )
-            token_streams.append(_tokenize(preprocessed.source))
+            token_streams.append(tokenize_gml_source(preprocessed.source))
         except (OSError, GMLTranspileError):
             # The owning converter will report malformed/unsupported source with
             # its normal resource-level diagnostic. Enum discovery must not make

--- a/src/conversion/project_macros.py
+++ b/src/conversion/project_macros.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 
-from src.conversion.gml_transpiler_parts.preprocessor import preprocess_gml_source
+from src.conversion.gml_transpiler_parts.lexical_api import (
+    preprocess_gml_source,
+    tokenize_gml_source,
+)
 from src.conversion.gml_transpiler_parts.shared_models import GMLTranspileError, Token
-from src.conversion.gml_transpiler_parts.tokens import _tokenize
 from src.conversion.gml_transpiler_parts.utils import (
     _macro_configuration_matches,
     _tokens_to_source,
@@ -34,7 +36,7 @@ def collect_project_macro_values(
                 source,
                 macro_configuration=macro_configuration,
             )
-            token_streams.append(_tokenize(preprocessed.source))
+            token_streams.append(tokenize_gml_source(preprocessed.source))
         except (OSError, GMLTranspileError):
             # The owning resource converter reports malformed/unsupported GML.
             # Discovery should not prevent unrelated resources from converting.

--- a/src/conversion/script_functions.py
+++ b/src/conversion/script_functions.py
@@ -6,15 +6,13 @@ from dataclasses import dataclass
 from typing import Literal
 
 from src.conversion.gml_transpiler import GMLTranspileError
-from src.conversion.gml_transpiler_parts.identifiers import _validate_gml_identifier
-from src.conversion.gml_transpiler_parts.lexical import (
-    _is_verbatim_string_start,
-    _read_verbatim_string,
-)
-from src.conversion.gml_transpiler_parts.preprocessor import (
+from src.conversion.gml_transpiler_parts.lexical_api import (
+    is_verbatim_string_start,
     preprocess_gml_source_preserving_layout,
+    read_template_string,
+    read_verbatim_string,
+    validate_gml_identifier,
 )
-from src.conversion.gml_transpiler_parts.tokens import _read_template_string
 from src.conversion.gml_transpiler_parts.utils import (
     _split_assignment,
     _split_top_level,
@@ -69,8 +67,8 @@ def find_matching_delimiter(source: str, start: int, opener: str, closer: str) -
                 quote = None
             index += 1
             continue
-        if _is_verbatim_string_start(source, index):
-            index += len(_read_verbatim_string(source, index))
+        if is_verbatim_string_start(source, index):
+            index += len(read_verbatim_string(source, index))
             continue
         if char in ("'", '"'):
             quote = char
@@ -101,7 +99,7 @@ def parse_script_function_parameters(params_text: str) -> tuple[ScriptFunctionPa
             if operator != "=":
                 raise GMLTranspileError("Script function parameters only support simple defaults")
         name = name.strip()
-        _validate_gml_identifier(name)
+        validate_gml_identifier(name)
         parameters.append(
             ScriptFunctionParameter(
                 name=name,
@@ -179,8 +177,8 @@ def _find_function_body_start(source: str, start: int) -> int | None:
                 quote = None
             index += 1
             continue
-        if _is_verbatim_string_start(source, index):
-            index += len(_read_verbatim_string(source, index))
+        if is_verbatim_string_start(source, index):
+            index += len(read_verbatim_string(source, index))
             continue
         if char in ("'", '"'):
             quote = char
@@ -240,11 +238,11 @@ def _mask_comments_preserving_layout(source: str) -> str:
                 quote = None
             index += 1
             continue
-        if _is_verbatim_string_start(source, index):
-            index += len(_read_verbatim_string(source, index))
+        if is_verbatim_string_start(source, index):
+            index += len(read_verbatim_string(source, index))
             continue
         if source.startswith('$"', index):
-            index += len(_read_template_string(source, index))
+            index += len(read_template_string(source, index))
             continue
         if char in ("'", '"'):
             quote = char

--- a/src/conversion/script_generator.py
+++ b/src/conversion/script_generator.py
@@ -1,4 +1,3 @@
-# pyright: reportPrivateUsage=false
 import json
 import re
 from collections.abc import Iterable, Mapping, Sequence
@@ -10,7 +9,7 @@ from src.conversion.events.base import EventMapping
 from src.conversion.events.features import get_script_features
 from src.conversion.gml_runtime import GML_RUNTIME_RESOURCE_PATH
 from src.conversion.gml_transpiler_parts.constants import GDSCRIPT_NATIVE_INSTANCE_MEMBER_IDENTIFIERS
-from src.conversion.gml_transpiler_parts.identifiers import _sanitize_gdscript_identifier
+from src.conversion.gml_transpiler_parts.lexical_api import sanitize_gdscript_identifier
 from src.conversion.type_defs import JsonDict
 
 
@@ -718,7 +717,7 @@ def generate_script_content(
             declare_members=base_script_path is None,
         )
     for variable_name in _valid_instance_variables(instance_variables):
-        lines.append(f"\n\nvar {_sanitize_gdscript_identifier(variable_name)}\n")
+        lines.append(f"\n\nvar {sanitize_gdscript_identifier(variable_name)}\n")
 
     for func in unique_functions:
         body = _get_function_body(func, effective_code_bodies)

--- a/src/conversion/scripts.py
+++ b/src/conversion/scripts.py
@@ -45,15 +45,13 @@ from src.conversion.script_functions import (
     modern_script_structure,
     render_script_top_level_source,
 )
-from src.conversion.gml_transpiler_parts.identifiers import (
-    _sanitize_gdscript_identifier,
-)
 from src.conversion.gml_transpiler_parts.expression_parser import (
     _parse_gml_expression,
 )
 from src.conversion.gml_transpiler_parts.function_helpers import (
     _emit_constructor_inheritance_line,
 )
+from src.conversion.gml_transpiler_parts.lexical_api import sanitize_gdscript_identifier
 from src.conversion.gml_transpiler_parts.shared_models import ScopeContext
 from src.conversion.type_defs import ConversionRunning, LogCallback, ProgressCallback, StrPath
 
@@ -127,7 +125,7 @@ def _script_forward_call(*, declaration: ScriptFunctionDeclaration, scoped_call_
     args = [
         "self",
         "self",
-        *(_sanitize_gdscript_identifier(parameter.name) for parameter in declaration.parameters),
+        *(sanitize_gdscript_identifier(parameter.name) for parameter in declaration.parameters),
     ]
     return f"\treturn {scoped_call_method}({', '.join(args)})\n"
 
@@ -140,7 +138,7 @@ def _script_callable_names(declaration_name: str, *, use_default_names: bool) ->
             callable_accessor="gm2godot_callable",
             scoped_callable_accessor="gm2godot_scoped_callable",
         )
-    suffix = _sanitize_gdscript_identifier(declaration_name)
+    suffix = sanitize_gdscript_identifier(declaration_name)
     return _ScriptCallableNames(
         call_method=f"_gm_script_call_{suffix}",
         scoped_call_method=f"_gm_script_call_scoped_{suffix}",
@@ -527,7 +525,7 @@ class ScriptConverter(BaseConverter):
         )
         lines: list[str] = [] if declaration.is_constructor else _script_scope_lines()
         for parameter in declaration.parameters:
-            parameter_name = _sanitize_gdscript_identifier(parameter.name)
+            parameter_name = sanitize_gdscript_identifier(parameter.name)
             if parameter.default is None:
                 lines.append(f"\tif {parameter_name} == null: {parameter_name} = GMRuntime.gml_undefined()")
                 continue
@@ -656,12 +654,12 @@ class ScriptConverter(BaseConverter):
                     use_default_names=use_default_names,
                 )
                 parameter_declarations = [
-                    f"{_sanitize_gdscript_identifier(parameter.name)} = null"
+                    f"{sanitize_gdscript_identifier(parameter.name)} = null"
                     for parameter in declaration.parameters
                 ]
                 constructor_value: str | None = None
                 if declaration.is_constructor:
-                    constructor_suffix = _sanitize_gdscript_identifier(declaration.name)
+                    constructor_suffix = sanitize_gdscript_identifier(declaration.name)
                     constructor_value = f"_gm_constructor_{constructor_suffix}"
                     constructor_params = ", ".join(
                         [

--- a/src/version.py
+++ b/src/version.py
@@ -1,4 +1,4 @@
-VERSION = "0.7.71"
+VERSION = "0.7.72"
 
 
 def get_version():

--- a/tests/test_gml_lexical_api.py
+++ b/tests/test_gml_lexical_api.py
@@ -1,0 +1,540 @@
+from __future__ import annotations
+
+import ast
+from collections.abc import Callable
+import inspect
+from pathlib import Path
+from typing import Final, Iterable, get_args, get_origin, get_type_hints
+import unittest
+
+import src.conversion.gml_transpiler as gml_transpiler
+from src.conversion.gml_transpiler_parts import lexical_api
+from src.conversion.gml_transpiler_parts.result_models import GMLPreprocessResult
+from src.conversion.gml_transpiler_parts.shared_models import (
+    GMLTranspileError,
+    ScopeContext,
+    Token,
+)
+
+
+PUBLIC_NAMES = (
+    "decode_gml_string_literal",
+    "decode_gml_verbatim_string_literal",
+    "is_plain_identifier",
+    "is_verbatim_string_start",
+    "preprocess_gml_source",
+    "preprocess_gml_source_preserving_layout",
+    "read_ordinary_string",
+    "read_template_string",
+    "read_verbatim_string",
+    "reject_asset_identifier_name",
+    "sanitize_gdscript_identifier",
+    "split_template_string",
+    "tokenize_gml_expression",
+    "tokenize_gml_source",
+    "validate_gml_identifier",
+)
+
+
+def _token_fields(tokens: list[Token]) -> list[tuple[str, str, int, int, int]]:
+    return [
+        (token.kind, token.value, token.index, token.line, token.column)
+        for token in tokens
+    ]
+
+
+def _parameter_shape(
+    function: Callable[..., object],
+) -> tuple[tuple[str, str, object], ...]:
+    signature = inspect.signature(function)
+    return tuple(
+        (
+            parameter.name,
+            parameter.kind.name,
+            parameter.default,
+        )
+        for parameter in signature.parameters.values()
+    )
+
+
+class GMLLexicalAPISurfaceTests(unittest.TestCase):
+    def test_exact_static_alphabetized_public_surface(self) -> None:
+        self.assertEqual(tuple(lexical_api.__all__), PUBLIC_NAMES)
+        self.assertEqual(len(lexical_api.__all__), 15)
+        self.assertEqual(tuple(sorted(lexical_api.__all__)), PUBLIC_NAMES)
+        self.assertTrue(all(not name.startswith("_") for name in lexical_api.__all__))
+        self.assertNotIn("is_float_like_number", vars(lexical_api))
+
+        module_path = Path(lexical_api.__file__)
+        tree = ast.parse(module_path.read_text(encoding="utf-8"), filename=str(module_path))
+        declarations = [
+            node
+            for node in tree.body
+            if (
+                isinstance(node, ast.Assign)
+                and any(
+                    isinstance(target, ast.Name) and target.id == "__all__"
+                    for target in node.targets
+                )
+            )
+            or (
+                isinstance(node, ast.AnnAssign)
+                and isinstance(node.target, ast.Name)
+                and node.target.id == "__all__"
+            )
+        ]
+        self.assertEqual(len(declarations), 1)
+        declaration = declarations[0]
+        self.assertIsInstance(declaration, ast.AnnAssign)
+        assert isinstance(declaration, ast.AnnAssign)
+        value = declaration.value
+        self.assertIsInstance(value, (ast.List, ast.Tuple))
+        assert isinstance(value, (ast.List, ast.Tuple))
+        self.assertEqual(
+            tuple(
+                element.value
+                for element in value.elts
+                if isinstance(element, ast.Constant)
+                and isinstance(element.value, str)
+            ),
+            PUBLIC_NAMES,
+        )
+        self.assertEqual(len(value.elts), len(PUBLIC_NAMES))
+
+        hints = get_type_hints(lexical_api, include_extras=True)
+        self.assertIs(get_origin(hints["__all__"]), Final)
+        self.assertEqual(get_args(hints["__all__"]), (tuple[str, ...],))
+
+    def test_resolved_signatures_and_model_types_are_exact(self) -> None:
+        one_argument = {
+            "decode_gml_string_literal": "source",
+            "decode_gml_verbatim_string_literal": "source",
+            "is_plain_identifier": "name",
+            "sanitize_gdscript_identifier": "name",
+            "split_template_string": "source",
+            "tokenize_gml_expression": "source",
+            "tokenize_gml_source": "source",
+            "validate_gml_identifier": "name",
+        }
+        for name, parameter_name in one_argument.items():
+            with self.subTest(name=name):
+                self.assertEqual(
+                    _parameter_shape(getattr(lexical_api, name)),
+                    (
+                        (
+                            parameter_name,
+                            "POSITIONAL_OR_KEYWORD",
+                            inspect.Parameter.empty,
+                        ),
+                    ),
+                )
+
+        for name in (
+            "is_verbatim_string_start",
+            "read_ordinary_string",
+            "read_template_string",
+            "read_verbatim_string",
+        ):
+            with self.subTest(name=name):
+                self.assertEqual(
+                    _parameter_shape(getattr(lexical_api, name)),
+                    (
+                        ("source", "POSITIONAL_OR_KEYWORD", inspect.Parameter.empty),
+                        (
+                            "index" if name == "is_verbatim_string_start" else "start",
+                            "POSITIONAL_OR_KEYWORD",
+                            inspect.Parameter.empty,
+                        ),
+                    ),
+                )
+
+        self.assertEqual(
+            _parameter_shape(lexical_api.reject_asset_identifier_name),
+            (
+                ("name", "POSITIONAL_OR_KEYWORD", inspect.Parameter.empty),
+                ("scope_context", "POSITIONAL_OR_KEYWORD", inspect.Parameter.empty),
+            ),
+        )
+        preprocess_shape = (
+            ("source", "POSITIONAL_OR_KEYWORD", inspect.Parameter.empty),
+            ("macro_configuration", "KEYWORD_ONLY", None),
+            ("active_symbols", "KEYWORD_ONLY", None),
+        )
+        self.assertEqual(
+            _parameter_shape(lexical_api.preprocess_gml_source),
+            preprocess_shape,
+        )
+        self.assertEqual(
+            _parameter_shape(lexical_api.preprocess_gml_source_preserving_layout),
+            preprocess_shape,
+        )
+
+        expected_returns: dict[str, object] = {
+            "decode_gml_string_literal": str,
+            "decode_gml_verbatim_string_literal": str,
+            "is_plain_identifier": bool,
+            "is_verbatim_string_start": bool,
+            "preprocess_gml_source": GMLPreprocessResult,
+            "preprocess_gml_source_preserving_layout": GMLPreprocessResult,
+            "read_ordinary_string": str,
+            "read_template_string": str,
+            "read_verbatim_string": str,
+            "reject_asset_identifier_name": type(None),
+            "sanitize_gdscript_identifier": str,
+            "split_template_string": tuple[tuple[str, str], ...],
+            "tokenize_gml_expression": list[Token],
+            "tokenize_gml_source": list[Token],
+            "validate_gml_identifier": type(None),
+        }
+        expected_parameters: dict[str, dict[str, object]] = {
+            "decode_gml_string_literal": {"source": str},
+            "decode_gml_verbatim_string_literal": {"source": str},
+            "is_plain_identifier": {"name": str},
+            "is_verbatim_string_start": {"source": str, "index": int},
+            "preprocess_gml_source": {
+                "source": str,
+                "macro_configuration": str | None,
+                "active_symbols": Iterable[str] | None,
+            },
+            "preprocess_gml_source_preserving_layout": {
+                "source": str,
+                "macro_configuration": str | None,
+                "active_symbols": Iterable[str] | None,
+            },
+            "read_ordinary_string": {"source": str, "start": int},
+            "read_template_string": {"source": str, "start": int},
+            "read_verbatim_string": {"source": str, "start": int},
+            "reject_asset_identifier_name": {
+                "name": str,
+                "scope_context": ScopeContext,
+            },
+            "sanitize_gdscript_identifier": {"name": str},
+            "split_template_string": {"source": str},
+            "tokenize_gml_expression": {"source": str},
+            "tokenize_gml_source": {"source": str},
+            "validate_gml_identifier": {"name": str},
+        }
+        self.assertEqual(set(expected_parameters), set(PUBLIC_NAMES))
+        for name, expected_return in expected_returns.items():
+            with self.subTest(return_type=name):
+                hints = get_type_hints(getattr(lexical_api, name))
+                self.assertEqual(hints["return"], expected_return)
+                self.assertEqual(
+                    {key: value for key, value in hints.items() if key != "return"},
+                    expected_parameters[name],
+                )
+
+    def test_legacy_facade_aliases_keep_signatures_behavior_and_surface(self) -> None:
+        self.assertEqual(
+            str(inspect.signature(gml_transpiler._tokenize, eval_str=False)),
+            "(source: 'str') -> 'list[_Token]'",
+        )
+        self.assertEqual(
+            str(
+                inspect.signature(
+                    gml_transpiler._expression_tokens,
+                    eval_str=False,
+                )
+            ),
+            "(source: 'str') -> 'list[_Token]'",
+        )
+        source = "alpha\n+ beta"
+        facade_source_tokens = gml_transpiler._tokenize(source)
+        facade_expression_tokens = gml_transpiler._expression_tokens(source)
+        self.assertEqual(
+            facade_source_tokens,
+            lexical_api.tokenize_gml_source(source),
+        )
+        self.assertEqual(
+            facade_expression_tokens,
+            lexical_api.tokenize_gml_expression(source),
+        )
+        self.assertTrue(all(type(token) is Token for token in facade_source_tokens))
+        self.assertTrue(
+            all(type(token) is Token for token in facade_expression_tokens)
+        )
+        self.assertIs(
+            gml_transpiler.preprocess_gml_source,
+            lexical_api.preprocess_gml_source,
+        )
+        self.assertEqual(len(gml_transpiler.__all__), 74)
+        self.assertEqual(
+            sum(not name.startswith("_") for name in gml_transpiler.__all__),
+            44,
+        )
+        self.assertEqual(
+            sum(name.startswith("_") for name in gml_transpiler.__all__),
+            30,
+        )
+        newly_internal = set(PUBLIC_NAMES) - {"preprocess_gml_source"}
+        self.assertTrue(newly_internal.isdisjoint(gml_transpiler.__all__))
+
+
+class GMLLexicalAPIBehaviorTests(unittest.TestCase):
+    def test_source_and_expression_tokens_differ_only_by_newline_filtering(self) -> None:
+        source = "alpha\r\n+\nbeta"
+
+        source_tokens = lexical_api.tokenize_gml_source(source)
+        expression_tokens = lexical_api.tokenize_gml_expression(source)
+
+        self.assertTrue(all(type(token) is Token for token in source_tokens))
+        self.assertTrue(all(type(token) is Token for token in expression_tokens))
+        self.assertEqual(
+            _token_fields(source_tokens),
+            [
+                ("IDENT", "alpha", 0, 1, 1),
+                ("NEWLINE", "\n", 6, 1, 6),
+                ("OP", "+", 7, 2, 1),
+                ("NEWLINE", "\n", 8, 2, 2),
+                ("IDENT", "beta", 9, 3, 1),
+                ("EOF", "", 13, 3, 5),
+            ],
+        )
+        self.assertEqual(
+            expression_tokens,
+            [token for token in source_tokens if token.kind != "NEWLINE"],
+        )
+        self.assertEqual(expression_tokens[-1].kind, "EOF")
+
+    def test_ordinary_string_read_decode_and_failures(self) -> None:
+        self.assertEqual(
+            lexical_api.read_ordinary_string('xx"a\\"b"tail', 2),
+            '"a\\"b"',
+        )
+        self.assertEqual(
+            lexical_api.decode_gml_string_literal('"line\\n\\u0041\\x42\\101"'),
+            "line\nABA",
+        )
+        self.assertEqual(
+            lexical_api.decode_gml_string_literal("'single\\tquote'"),
+            "single\tquote",
+        )
+
+        failure_cases = (
+            (
+                lambda: lexical_api.read_ordinary_string("plain", 0),
+                "String literal must start with a quote",
+            ),
+            (
+                lambda: lexical_api.read_ordinary_string('"unterminated', 0),
+                "Unterminated string literal",
+            ),
+            (
+                lambda: lexical_api.decode_gml_string_literal('"mismatch\''),
+                "Invalid string literal",
+            ),
+        )
+        for operation, message in failure_cases:
+            with self.subTest(message=message):
+                with self.assertRaises(GMLTranspileError) as raised:
+                    operation()
+                self.assertIs(type(raised.exception), GMLTranspileError)
+                self.assertEqual(str(raised.exception), message)
+
+    def test_verbatim_string_read_decode_predicate_and_failures(self) -> None:
+        source = 'xx@"first\\\r\nsecond"tail'
+        self.assertTrue(lexical_api.is_verbatim_string_start(source, 2))
+        self.assertFalse(lexical_api.is_verbatim_string_start(source, -1))
+        self.assertFalse(lexical_api.is_verbatim_string_start(source, len(source)))
+        self.assertFalse(lexical_api.is_verbatim_string_start("@ x", 0))
+        self.assertEqual(
+            lexical_api.read_verbatim_string(source, 2),
+            '@"first\\\r\nsecond"',
+        )
+        self.assertEqual(
+            lexical_api.decode_gml_verbatim_string_literal('@"first\\\r\nsecond"'),
+            "first\\\r\nsecond",
+        )
+        self.assertEqual(
+            lexical_api.read_verbatim_string(r'@"a\" + suffix', 0),
+            r'@"a\"',
+        )
+
+        failure_cases = (
+            (
+                lambda: lexical_api.read_verbatim_string('"plain"', 0),
+                "Verbatim string literal must start with @ followed by a quote",
+            ),
+            (
+                lambda: lexical_api.read_verbatim_string('@"unterminated', 0),
+                "Unterminated verbatim string literal",
+            ),
+            (
+                lambda: lexical_api.decode_gml_verbatim_string_literal('@"ok"tail'),
+                "Unexpected text after verbatim string literal",
+            ),
+        )
+        for operation, message in failure_cases:
+            with self.subTest(message=message):
+                with self.assertRaises(GMLTranspileError) as raised:
+                    operation()
+                self.assertIs(type(raised.exception), GMLTranspileError)
+                self.assertEqual(str(raised.exception), message)
+
+    def test_template_string_read_split_and_failures(self) -> None:
+        self.assertEqual(
+            lexical_api.read_template_string('xx$"hello {name}"tail', 2),
+            '$"hello {name}"',
+        )
+        self.assertEqual(
+            lexical_api.split_template_string('$"a\\n{name + " + "1}b"'),
+            (
+                ("text", "a\n"),
+                ("expression", 'name + " + "1'),
+                ("text", "b"),
+            ),
+        )
+        self.assertEqual(
+            lexical_api.split_template_string('$"{ {x: 1} }"'),
+            (("expression", " {x: 1} "),),
+        )
+
+        failure_cases = (
+            (
+                lambda: lexical_api.read_template_string('"plain"', 0),
+                'Template string literal must start with $"',
+            ),
+            (
+                lambda: lexical_api.split_template_string('$"{   }"'),
+                "Template string interpolation cannot be empty",
+            ),
+            (
+                lambda: lexical_api.split_template_string('$"line\nbreak"'),
+                "Template string literal text cannot contain a newline",
+            ),
+            (
+                lambda: lexical_api.split_template_string('$"unterminated'),
+                "Unterminated template string literal",
+            ),
+            (
+                lambda: lexical_api.split_template_string('$"ok"tail'),
+                "Unexpected text after template string literal",
+            ),
+        )
+        for operation, message in failure_cases:
+            with self.subTest(message=message):
+                with self.assertRaises(GMLTranspileError) as raised:
+                    operation()
+                self.assertIs(type(raised.exception), GMLTranspileError)
+                self.assertEqual(str(raised.exception), message)
+
+    def test_identifier_validation_sanitization_and_asset_rejection(self) -> None:
+        valid_64 = "a" * 64
+        self.assertIsNone(lexical_api.validate_gml_identifier(valid_64))
+        self.assertTrue(lexical_api.is_plain_identifier(valid_64))
+        self.assertTrue(lexical_api.is_plain_identifier("naïve_2"))
+        self.assertFalse(lexical_api.is_plain_identifier(""))
+        self.assertFalse(lexical_api.is_plain_identifier("2bad"))
+        self.assertFalse(lexical_api.is_plain_identifier("bad-name"))
+
+        invalid_identifiers = (
+            ("", "Expected identifier name"),
+            ("a" * 65, "GML identifier exceeds 64 characters"),
+            ("2bad", "GML identifier must start with a letter or underscore"),
+            (
+                "bad-name",
+                "GML identifier can only contain letters, numbers, and underscores",
+            ),
+        )
+        for name, message in invalid_identifiers:
+            with self.subTest(name=name):
+                with self.assertRaises(GMLTranspileError) as raised:
+                    lexical_api.validate_gml_identifier(name)
+                self.assertEqual(str(raised.exception), message)
+
+        self.assertEqual(lexical_api.sanitize_gdscript_identifier("class"), "class_")
+        self.assertEqual(
+            lexical_api.sanitize_gdscript_identifier("_gml_internal"),
+            "gml_user_gml_internal",
+        )
+        self.assertEqual(
+            lexical_api.sanitize_gdscript_identifier("bad-name"),
+            "bad-name",
+        )
+        self.assertEqual(lexical_api.sanitize_gdscript_identifier("player"), "player")
+
+        scope_context = ScopeContext(asset_names=frozenset({"spr_player"}))
+        self.assertIsNone(
+            lexical_api.reject_asset_identifier_name("ordinary", scope_context)
+        )
+        with self.assertRaises(GMLTranspileError) as raised:
+            lexical_api.reject_asset_identifier_name("spr_player", scope_context)
+        self.assertEqual(
+            str(raised.exception),
+            "Unscoped identifier 'spr_player' collides with an asset name",
+        )
+
+        with self.assertRaises(GMLTranspileError) as raised:
+            lexical_api.tokenize_gml_source("ok\n" + "b" * 65)
+        self.assertEqual(raised.exception.line, 2)
+        self.assertEqual(raised.exception.column, 1)
+        self.assertEqual(
+            str(raised.exception),
+            "GML identifier exceeds 64 characters at line 2, column 1",
+        )
+
+    def test_preprocessing_models_layout_bytes_positions_and_failures(self) -> None:
+        ordinary = lexical_api.preprocess_gml_source(
+            "#ifdef FEATURE\nactive = 1;\n#else\ninactive = 2;\n#endif\n",
+            active_symbols={"FEATURE"},
+        )
+        self.assertIs(type(ordinary), GMLPreprocessResult)
+        self.assertEqual(ordinary.source, "\nactive = 1;\n\n\n")
+        self.assertEqual(ordinary.diagnostics, ())
+
+        source = (
+            "#if FEATURE\r\n"
+            "active = 1;\r\n"
+            "#else\r"
+            "inactive = 2;\n"
+            "#endif\r\n"
+            "tail = 3;"
+        )
+        result = lexical_api.preprocess_gml_source_preserving_layout(
+            source,
+            active_symbols={"FEATURE"},
+        )
+        expected = (
+            "           \r\n"
+            "active = 1;\r\n"
+            "     \r"
+            "             \n"
+            "      \r\n"
+            "tail = 3;"
+        )
+        self.assertIs(type(result), GMLPreprocessResult)
+        self.assertEqual(result.source, expected)
+        self.assertEqual(result.diagnostics, ())
+        self.assertEqual(len(result.source), len(source))
+        self.assertEqual(result.source.index("active"), source.index("active"))
+        self.assertEqual(result.source.index("tail"), source.index("tail"))
+        self.assertNotIn("inactive", result.source)
+        self.assertEqual(
+            [
+                (index, char)
+                for index, char in enumerate(result.source)
+                if char in "\r\n"
+            ],
+            [
+                (index, char)
+                for index, char in enumerate(source)
+                if char in "\r\n"
+            ],
+        )
+
+        for operation in (
+            lexical_api.preprocess_gml_source,
+            lexical_api.preprocess_gml_source_preserving_layout,
+        ):
+            with self.subTest(operation=operation.__name__):
+                with self.assertRaises(GMLTranspileError) as raised:
+                    operation("#else\nx = 1;")
+                self.assertIs(type(raised.exception), GMLTranspileError)
+                self.assertEqual(
+                    str(raised.exception),
+                    "Unmatched preprocessor directive #else at line 1: #else",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gml_tokenizer.py
+++ b/tests/test_gml_tokenizer.py
@@ -1,59 +1,75 @@
-# pyright: reportPrivateUsage=false
 from __future__ import annotations
 
 import unittest
 
-from src.conversion.gml_transpiler_parts.tokens import (
-    _line_column,
-    _line_column_from_newline_positions,
-    _tokenize,
-)
+from src.conversion.gml_transpiler_parts.lexical_api import tokenize_gml_source
 from src.conversion.gml_transpiler_parts.shared_models import GMLTranspileError
 
 
-def _legacy_line_column(source: str, index: int) -> tuple[int, int]:
-    line = source.count("\n", 0, index) + 1
-    line_start = source.rfind("\n", 0, index)
-    if line_start == -1:
-        return line, index + 1
-    return line, index - line_start
+def _token_fields(
+    source: str,
+) -> list[tuple[str, str, int, int, int]]:
+    return [
+        (token.kind, token.value, token.index, token.line, token.column)
+        for token in tokenize_gml_source(source)
+    ]
 
 
 class TestGMLTokenizerLineColumns(unittest.TestCase):
-    def test_precomputed_line_columns_match_legacy_semantics_at_every_position(
-        self,
-    ) -> None:
+    def test_public_tokens_preserve_exact_lf_crlf_cr_and_mixed_positions(self) -> None:
         cases = {
-            "empty": "",
-            "lf": "\nalpha\n\nomega\n",
-            "crlf": "\r\nalpha\r\n\r\nomega\r\n",
-            "cr_only": "\ralpha\r\romega\r",
-            "mixed": "first\r\nsecond\nthird\rfourth",
-            "unicode": "naïve 🙂\n漢字\r\n👩‍💻 é\n",
+            "lf": (
+                "a\nb",
+                [
+                    ("IDENT", "a", 0, 1, 1),
+                    ("NEWLINE", "\n", 1, 1, 2),
+                    ("IDENT", "b", 2, 2, 1),
+                    ("EOF", "", 3, 2, 2),
+                ],
+            ),
+            "crlf": (
+                "a\r\nb",
+                [
+                    ("IDENT", "a", 0, 1, 1),
+                    ("NEWLINE", "\n", 2, 1, 2),
+                    ("IDENT", "b", 3, 2, 1),
+                    ("EOF", "", 4, 2, 2),
+                ],
+            ),
+            "cr_only": (
+                "a\rb",
+                [
+                    ("IDENT", "a", 0, 1, 1),
+                    ("NEWLINE", "\n", 1, 1, 2),
+                    ("IDENT", "b", 2, 1, 3),
+                    ("EOF", "", 3, 1, 4),
+                ],
+            ),
+            "mixed": (
+                "a\r\nb\nc\rd",
+                [
+                    ("IDENT", "a", 0, 1, 1),
+                    ("NEWLINE", "\n", 2, 1, 2),
+                    ("IDENT", "b", 3, 2, 1),
+                    ("NEWLINE", "\n", 4, 2, 2),
+                    ("IDENT", "c", 5, 3, 1),
+                    ("NEWLINE", "\n", 6, 3, 2),
+                    ("IDENT", "d", 7, 3, 3),
+                    ("EOF", "", 8, 3, 4),
+                ],
+            ),
         }
 
-        for case_name, source in cases.items():
-            newline_positions = tuple(
-                index for index, char in enumerate(source) if char == "\n"
-            )
-            for index in range(len(source) + 1):
-                with self.subTest(case=case_name, index=index):
-                    expected = _legacy_line_column(source, index)
-                    self.assertEqual(_line_column(source, index), expected)
-                    self.assertEqual(
-                        _line_column_from_newline_positions(
-                            newline_positions,
-                            index,
-                        ),
-                        expected,
-                    )
+        for case_name, (source, expected) in cases.items():
+            with self.subTest(case=case_name):
+                self.assertEqual(_token_fields(source), expected)
 
     def test_tokenizes_both_verbatim_delimiters_as_single_multiline_tokens(
         self,
     ) -> None:
         source = '@"first\r\nsecond"\r\n+ @\'double " quote\''
 
-        tokens = _tokenize(source)
+        tokens = tokenize_gml_source(source)
 
         self.assertEqual(tokens[0].kind, "VERBATIM_STRING")
         self.assertEqual(tokens[0].value, '@"first\r\nsecond"')
@@ -66,7 +82,7 @@ class TestGMLTokenizerLineColumns(unittest.TestCase):
         self.assertEqual(tokens[3].value, '@\'double " quote\'')
 
     def test_verbatim_backslash_does_not_escape_the_closing_delimiter(self) -> None:
-        tokens = _tokenize(r'@"a\" + suffix')
+        tokens = tokenize_gml_source(r'@"a\" + suffix')
 
         self.assertEqual(tokens[0].kind, "VERBATIM_STRING")
         self.assertEqual(tokens[0].value, r'@"a\"')
@@ -75,7 +91,7 @@ class TestGMLTokenizerLineColumns(unittest.TestCase):
 
     def test_rejects_unterminated_verbatim_string_at_prefix_location(self) -> None:
         with self.assertRaises(GMLTranspileError) as raised:
-            _tokenize('value + @"unterminated')
+            tokenize_gml_source('value + @"unterminated')
 
         self.assertEqual(raised.exception.line, 1)
         self.assertEqual(raised.exception.column, 9)

--- a/tests/test_gml_transpiler.py
+++ b/tests/test_gml_transpiler.py
@@ -13,12 +13,14 @@ from src.conversion.gml_transpiler import (
     _BUILTIN_VARIABLE_REGISTRY,
     GMLTranspileError,
     _ExpressionParser,
-    _expression_tokens,
-    _tokenize,
     load_gml_extension_function_mappings,
     preprocess_gml_source,
     transpile_gml_code,
     transpile_gml_expression,
+)
+from src.conversion.gml_transpiler_parts.lexical_api import (
+    tokenize_gml_expression,
+    tokenize_gml_source,
 )
 from src.conversion.gml_transpiler_parts.expression_models import (
     ArrayLiteral,
@@ -97,8 +99,8 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
                 )
 
     def test_preserves_numeric_literal_float_metadata(self):
-        integer_literal = _ExpressionParser(_expression_tokens("42")).parse()
-        decimal_literal = _ExpressionParser(_expression_tokens("3.5")).parse()
+        integer_literal = _ExpressionParser(tokenize_gml_expression("42")).parse()
+        decimal_literal = _ExpressionParser(tokenize_gml_expression("3.5")).parse()
 
         self.assertIsInstance(integer_literal, NumberLiteral)
         self.assertIsInstance(decimal_literal, NumberLiteral)
@@ -238,7 +240,7 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
                     transpile_gml_expression(source)
 
     def test_preserves_string_literal_metadata(self):
-        literal = _ExpressionParser(_expression_tokens('"hello"')).parse()
+        literal = _ExpressionParser(tokenize_gml_expression('"hello"')).parse()
 
         self.assertIsInstance(literal, StringLiteral)
         assert isinstance(literal, StringLiteral)
@@ -295,7 +297,7 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
 
     def test_tokenizes_template_string_as_one_literal(self):
         source = '$"Hello {name}!" + 1'
-        tokens = _tokenize(source)
+        tokens = tokenize_gml_source(source)
 
         self.assertEqual(tokens[0].kind, "TEMPLATE_STRING")
         self.assertEqual(tokens[0].value, '$"Hello {name}!"')
@@ -303,7 +305,7 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
         self.assertEqual(tokens[0].column, 1)
         self.assertEqual(tokens[1].value, "+")
 
-        literal = _ExpressionParser(_expression_tokens('$"Hello {name}!"')).parse()
+        literal = _ExpressionParser(tokenize_gml_expression('$"Hello {name}!"')).parse()
         self.assertIsInstance(literal, TemplateStringLiteral)
         assert isinstance(literal, TemplateStringLiteral)
         self.assertEqual(literal.parts[0], "Hello ")
@@ -1507,7 +1509,7 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
         )
 
     def test_preserves_array_literal_metadata(self):
-        literal = _ExpressionParser(_expression_tokens("[1, [2]]")).parse()
+        literal = _ExpressionParser(tokenize_gml_expression("[1, [2]]")).parse()
 
         self.assertIsInstance(literal, ArrayLiteral)
         assert isinstance(literal, ArrayLiteral)
@@ -1541,7 +1543,7 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
         )
 
         literal = _ExpressionParser(
-            _expression_tokens(r'{"line\nname": 1, "Unicode 鍵": 2}')
+            tokenize_gml_expression(r'{"line\nname": 1, "Unicode 鍵": 2}')
         ).parse()
         self.assertIsInstance(literal, StructLiteral)
         assert isinstance(literal, StructLiteral)
@@ -1584,7 +1586,9 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
         )
 
     def test_preserves_struct_literal_metadata(self):
-        literal = _ExpressionParser(_expression_tokens("{a: 1, child: {b: 2}, shorthand}")).parse()
+        literal = _ExpressionParser(
+            tokenize_gml_expression("{a: 1, child: {b: 2}, shorthand}")
+        ).parse()
 
         self.assertIsInstance(literal, StructLiteral)
         assert isinstance(literal, StructLiteral)
@@ -2307,7 +2311,7 @@ class TestGMLExpressionTranspiler(unittest.TestCase):
 
 class TestGMLStatementTranspiler(unittest.TestCase):
     def test_tokenizes_begin_end_as_block_delimiters(self):
-        tokens = _tokenize("if ready begin score = 1; end")
+        tokens = tokenize_gml_source("if ready begin score = 1; end")
         values = [token.value for token in tokens]
         kinds = [token.kind for token in tokens]
 

--- a/tests/test_gml_transpiler_architecture.py
+++ b/tests/test_gml_transpiler_architecture.py
@@ -11,6 +11,7 @@ import unittest
 
 import src.conversion.gml_transpiler as gml_transpiler
 from src.conversion.gml_transpiler_parts import constants as language_metadata
+from src.conversion.gml_transpiler_parts import lexical_api as lexical_phase_api
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -19,6 +20,28 @@ PARTS_PACKAGE = "src.conversion.gml_transpiler_parts"
 FACADE_PATH = PROJECT_ROOT / "src" / "conversion" / "gml_transpiler.py"
 PARTS_PATH = PROJECT_ROOT / "src" / "conversion" / "gml_transpiler_parts"
 MODULE_IMPORT_NAME = "<module>"
+LEXICAL_API_MODULE = f"{PARTS_PACKAGE}.lexical_api"
+LEXICAL_IMPLEMENTATION_MODULES = frozenset(
+    {
+        f"{PARTS_PACKAGE}.identifiers",
+        f"{PARTS_PACKAGE}.lexical",
+        f"{PARTS_PACKAGE}.preprocessor",
+        f"{PARTS_PACKAGE}.tokens",
+    }
+)
+LEGACY_LEXICAL_FACADE_NAMES = frozenset({"_expression_tokens", "_tokenize"})
+LEGACY_LEXICAL_FACADE_ACCESS_BY_CONSUMER = {
+    "tests.test_gml_lexical_api": LEGACY_LEXICAL_FACADE_NAMES,
+}
+LOW_LEVEL_LEXICAL_IMPORTS_BY_CONSUMER = {
+    f"{PARTS_PACKAGE}.utils": frozenset(
+        {
+            (f"{PARTS_PACKAGE}.lexical", "is_verbatim_string_start"),
+            (f"{PARTS_PACKAGE}.lexical", "read_verbatim_string"),
+            (f"{PARTS_PACKAGE}.tokens", "read_template_string"),
+        }
+    )
+}
 
 
 class BoundaryClassification(str, Enum):
@@ -266,23 +289,16 @@ EXPECTED_INTERNAL_PRIVATE_IMPORT_GROUPS = """
 src.conversion.gml_transpiler|src.conversion.gml_transpiler_parts.constants|_BUILTIN_VARIABLE_REGISTRY
 src.conversion.gml_transpiler|src.conversion.gml_transpiler_parts.expression_parser|_ExpressionParser,_parse_gml_expression
 src.conversion.gml_transpiler|src.conversion.gml_transpiler_parts.model|_ArrayLiteral,_Binary,_BuiltinVariableMetadata,_Call,_DSMapAccess,_Expression,_FunctionLiteral,_FunctionParameter,_Grouped,_Index,_Literal,_Member,_Name,_NameOf,_NewCall,_NumberLiteral,_ScopeContext,_StaticDeclaration,_StringLiteral,_StructAccess,_StructLiteral,_TemplateStringLiteral,_Ternary,_Token,_Unary
-src.conversion.gml_transpiler|src.conversion.gml_transpiler_parts.tokens|_expression_tokens,_tokenize
 src.conversion.gml_transpiler_parts.api|src.conversion.gml_transpiler_parts.function_helpers|_emit_static_initialization_lines
 src.conversion.gml_transpiler_parts.api|src.conversion.gml_transpiler_parts.statement_parser|_StatementParser
 src.conversion.gml_transpiler_parts.api|src.conversion.gml_transpiler_parts.static_declarations|_collect_static_declarations,_static_scope_id
-src.conversion.gml_transpiler_parts.api|src.conversion.gml_transpiler_parts.tokens|_tokenize
 src.conversion.gml_transpiler_parts.api|src.conversion.gml_transpiler_parts.utils|_prefix_multiline
-src.conversion.gml_transpiler_parts.emitter|src.conversion.gml_transpiler_parts.identifiers|_is_plain_identifier,_sanitize_gdscript_identifier
 src.conversion.gml_transpiler_parts.emitter|src.conversion.gml_transpiler_parts.utils|_normalize_local_names,_normalize_scope_context,_prefix_multiline,_unwrap_grouped_expression
 src.conversion.gml_transpiler_parts.enum_helpers|src.conversion.gml_transpiler_parts.expression_parser|_parse_gml_expression
-src.conversion.gml_transpiler_parts.enum_helpers|src.conversion.gml_transpiler_parts.tokens|_expression_tokens
 src.conversion.gml_transpiler_parts.enum_helpers|src.conversion.gml_transpiler_parts.utils|_normalize_local_names,_tokens_to_source,_unwrap_grouped_expression
 src.conversion.gml_transpiler_parts.expression_parser|src.conversion.gml_transpiler_parts.function_helpers|_emit_constructor_inheritance_line,_emit_static_initialization_lines
-src.conversion.gml_transpiler_parts.expression_parser|src.conversion.gml_transpiler_parts.identifiers|_reject_asset_identifier_name,_validate_gml_identifier
-src.conversion.gml_transpiler_parts.expression_parser|src.conversion.gml_transpiler_parts.lexical|_decode_gml_verbatim_string_literal
 src.conversion.gml_transpiler_parts.expression_parser|src.conversion.gml_transpiler_parts.statement_parser|_StatementParser
 src.conversion.gml_transpiler_parts.expression_parser|src.conversion.gml_transpiler_parts.static_declarations|_collect_static_declarations,_static_scope_id
-src.conversion.gml_transpiler_parts.expression_parser|src.conversion.gml_transpiler_parts.tokens|_decode_gml_string_literal,_expression_tokens,_is_float_like_number,_split_template_string
 src.conversion.gml_transpiler_parts.expression_parser|src.conversion.gml_transpiler_parts.utils|_normalize_scope_context,_strip_comments
 src.conversion.gml_transpiler_parts.expression_service|src.conversion.gml_transpiler_parts.emitter|_emit_expression,_emit_truthy_expression
 src.conversion.gml_transpiler_parts.expression_service|src.conversion.gml_transpiler_parts.enum_helpers|_reject_enum_mutation_expression
@@ -290,32 +306,18 @@ src.conversion.gml_transpiler_parts.expression_service|src.conversion.gml_transp
 src.conversion.gml_transpiler_parts.expression_service|src.conversion.gml_transpiler_parts.utils|_normalize_local_names,_normalize_scope_context,_scope_context_with_global_names
 src.conversion.gml_transpiler_parts.function_helpers|src.conversion.gml_transpiler_parts.emitter|_emit_expression
 src.conversion.gml_transpiler_parts.function_helpers|src.conversion.gml_transpiler_parts.expression_parser|_parse_gml_expression
-src.conversion.gml_transpiler_parts.preprocessor|src.conversion.gml_transpiler_parts.identifiers|_validate_gml_identifier
-src.conversion.gml_transpiler_parts.preprocessor|src.conversion.gml_transpiler_parts.lexical|_is_verbatim_string_start,_read_verbatim_string
-src.conversion.gml_transpiler_parts.preprocessor|src.conversion.gml_transpiler_parts.tokens|_read_template_string
 src.conversion.gml_transpiler_parts.preprocessor|src.conversion.gml_transpiler_parts.utils|_join_macro_continuation_lines,_macro_configuration_matches,_strip_comments
-src.conversion.gml_transpiler_parts.source_map|src.conversion.gml_transpiler_parts.identifiers|_sanitize_gdscript_identifier
-src.conversion.gml_transpiler_parts.source_map|src.conversion.gml_transpiler_parts.lexical|_is_verbatim_string_start,_read_ordinary_string,_read_verbatim_string
-src.conversion.gml_transpiler_parts.source_map|src.conversion.gml_transpiler_parts.tokens|_read_template_string
 src.conversion.gml_transpiler_parts.statement_parser|src.conversion.gml_transpiler_parts.emitter|_emit_instance_keyword_argument
 src.conversion.gml_transpiler_parts.statement_parser|src.conversion.gml_transpiler_parts.enum_helpers|_evaluate_enum_value_tokens
 src.conversion.gml_transpiler_parts.statement_parser|src.conversion.gml_transpiler_parts.expression_parser|_parse_gml_expression
-src.conversion.gml_transpiler_parts.statement_parser|src.conversion.gml_transpiler_parts.identifiers|_reject_asset_identifier_name,_sanitize_gdscript_identifier,_validate_gml_identifier
 src.conversion.gml_transpiler_parts.statement_parser|src.conversion.gml_transpiler_parts.statements|_ControlFlowCapture,_control_flow_dispatch_lines,_transpile_statement
 src.conversion.gml_transpiler_parts.statement_parser|src.conversion.gml_transpiler_parts.static_declarations|_read_static_declaration_tokens
 src.conversion.gml_transpiler_parts.statement_parser|src.conversion.gml_transpiler_parts.utils|_indent_lines,_insert_lines_before_continue,_insert_until_check_before_continue,_macro_configuration_matches,_normalize_scope_context,_scope_context_with_global_names,_split_top_level_tokens,_tokens_to_source
 src.conversion.gml_transpiler_parts.statements|src.conversion.gml_transpiler_parts.emitter|_emit_expression,_emit_instance_keyword_argument,_is_alarm_array_access,_name_resolves_to_global,_uses_direct_builtin_instance_members,_uses_direct_member_access
 src.conversion.gml_transpiler_parts.statements|src.conversion.gml_transpiler_parts.enum_helpers|_reject_constant_assignment_target_name,_reject_constant_declaration_name,_reject_enum_assignment_target,_reject_readonly_builtin_assignment_target
 src.conversion.gml_transpiler_parts.statements|src.conversion.gml_transpiler_parts.expression_parser|_parse_gml_expression
-src.conversion.gml_transpiler_parts.statements|src.conversion.gml_transpiler_parts.identifiers|_is_plain_identifier,_reject_asset_identifier_name,_sanitize_gdscript_identifier,_validate_gml_identifier
-src.conversion.gml_transpiler_parts.statements|src.conversion.gml_transpiler_parts.tokens|_expression_tokens
 src.conversion.gml_transpiler_parts.statements|src.conversion.gml_transpiler_parts.utils|_cache_assignment_part,_indent_lines,_next_generated_name_from_counter,_normalize_scope_context,_split_assignment,_split_top_level,_unwrap_grouped_expression
-src.conversion.gml_transpiler_parts.static_declarations|src.conversion.gml_transpiler_parts.identifiers|_validate_gml_identifier
 src.conversion.gml_transpiler_parts.static_declarations|src.conversion.gml_transpiler_parts.utils|_split_assignment,_split_top_level,_tokens_to_source
-src.conversion.gml_transpiler_parts.tokens|src.conversion.gml_transpiler_parts.identifiers|_validate_gml_identifier
-src.conversion.gml_transpiler_parts.tokens|src.conversion.gml_transpiler_parts.lexical|_is_verbatim_string_start,_read_ordinary_string,_read_verbatim_string
-src.conversion.gml_transpiler_parts.utils|src.conversion.gml_transpiler_parts.lexical|_is_verbatim_string_start,_read_verbatim_string
-src.conversion.gml_transpiler_parts.utils|src.conversion.gml_transpiler_parts.tokens|_line_column,_read_template_string
 """
 
 EXPECTED_PRODUCTION_IMPORT_GROUPS = """
@@ -325,30 +327,24 @@ src.conversion.extension_registry|src.conversion.gml_transpiler_parts.extension_
 src.conversion.gml_runtime_parts.manifest|src.conversion.gml_transpiler_parts.gml_api_manifest|iter_gml_api_entries
 src.conversion.objects|src.conversion.gml_transpiler|GMLSourceMap,GMLTranspileError,analyze_gml_source_identifiers,merge_gml_source_maps,transpile_gml_code_with_source_map,write_gml_source_map
 src.conversion.objects|src.conversion.gml_transpiler_parts.constants|ASSIGNMENT_OPERATORS,BUILTIN_GLOBAL_VARIABLES,BUILTIN_INSTANCE_VARIABLES,GDSCRIPT_NATIVE_INSTANCE_MEMBER_IDENTIFIERS,GML_LITERAL_IDENTIFIERS
+src.conversion.objects|src.conversion.gml_transpiler_parts.lexical_api|preprocess_gml_source,tokenize_gml_source
 src.conversion.objects|src.conversion.gml_transpiler_parts.shared_models|Token
-src.conversion.objects|src.conversion.gml_transpiler_parts.preprocessor|preprocess_gml_source
-src.conversion.objects|src.conversion.gml_transpiler_parts.tokens|_tokenize
 src.conversion.project_enums|src.conversion.gml_transpiler_parts.enum_helpers|_evaluate_enum_value_tokens
+src.conversion.project_enums|src.conversion.gml_transpiler_parts.lexical_api|preprocess_gml_source,tokenize_gml_source
 src.conversion.project_enums|src.conversion.gml_transpiler_parts.shared_models|GMLTranspileError,Token
-src.conversion.project_enums|src.conversion.gml_transpiler_parts.preprocessor|preprocess_gml_source
-src.conversion.project_enums|src.conversion.gml_transpiler_parts.tokens|_tokenize
+src.conversion.project_macros|src.conversion.gml_transpiler_parts.lexical_api|preprocess_gml_source,tokenize_gml_source
 src.conversion.project_macros|src.conversion.gml_transpiler_parts.shared_models|GMLTranspileError,Token
-src.conversion.project_macros|src.conversion.gml_transpiler_parts.preprocessor|preprocess_gml_source
-src.conversion.project_macros|src.conversion.gml_transpiler_parts.tokens|_tokenize
 src.conversion.project_macros|src.conversion.gml_transpiler_parts.utils|_macro_configuration_matches,_tokens_to_source
 src.conversion.rooms|src.conversion.gml_transpiler|GMLTranspileError,transpile_gml_code
 src.conversion.script_functions|src.conversion.gml_transpiler|GMLTranspileError
-src.conversion.script_functions|src.conversion.gml_transpiler_parts.identifiers|_validate_gml_identifier
-src.conversion.script_functions|src.conversion.gml_transpiler_parts.lexical|_is_verbatim_string_start,_read_verbatim_string
-src.conversion.script_functions|src.conversion.gml_transpiler_parts.preprocessor|preprocess_gml_source_preserving_layout
-src.conversion.script_functions|src.conversion.gml_transpiler_parts.tokens|_read_template_string
+src.conversion.script_functions|src.conversion.gml_transpiler_parts.lexical_api|is_verbatim_string_start,preprocess_gml_source_preserving_layout,read_template_string,read_verbatim_string,validate_gml_identifier
 src.conversion.script_functions|src.conversion.gml_transpiler_parts.utils|_split_assignment,_split_top_level
-src.conversion.script_generator|src.conversion.gml_transpiler_parts.identifiers|_sanitize_gdscript_identifier
 src.conversion.script_generator|src.conversion.gml_transpiler_parts.constants|GDSCRIPT_NATIVE_INSTANCE_MEMBER_IDENTIFIERS
+src.conversion.script_generator|src.conversion.gml_transpiler_parts.lexical_api|sanitize_gdscript_identifier
 src.conversion.scripts|src.conversion.gml_transpiler|EXTENSION_FUNCTION_MAPPING_FILENAME,GMLExtensionFunction,GMLExtensionFunctionMapping,GMLSourceMap,GMLTranspileError,analyze_gml_source_identifiers,load_gml_extension_function_mappings,merge_gml_source_maps,render_gml_source_header,transpile_gml_code_with_source_map,transpile_gml_expression,write_gml_source_map
 src.conversion.scripts|src.conversion.gml_transpiler_parts.expression_parser|_parse_gml_expression
 src.conversion.scripts|src.conversion.gml_transpiler_parts.function_helpers|_emit_constructor_inheritance_line
-src.conversion.scripts|src.conversion.gml_transpiler_parts.identifiers|_sanitize_gdscript_identifier
+src.conversion.scripts|src.conversion.gml_transpiler_parts.lexical_api|sanitize_gdscript_identifier
 src.conversion.scripts|src.conversion.gml_transpiler_parts.shared_models|ScopeContext
 """
 
@@ -370,15 +366,13 @@ EXPECTED_PRODUCTION_IMPORTS = _parse_import_groups(EXPECTED_PRODUCTION_IMPORT_GR
 EXPECTED_ALL_IMPORTS = EXPECTED_INTERNAL_PRIVATE_IMPORTS | EXPECTED_PRODUCTION_IMPORTS
 
 
-# The six owner modules below contain shared data, language metadata, lexical
-# operations, or semantic operations that the named child issue makes explicit.
+# The four owner modules below contain shared data, language metadata, or
+# semantic operations that the named child issue makes explicit.
 ALL_PRIVATE_NAMES_ARE_INTENDED_INTERNAL = frozenset(
     {
         f"{PARTS_PACKAGE}.constants",
         f"{PARTS_PACKAGE}.enum_helpers",
         f"{PARTS_PACKAGE}.function_helpers",
-        f"{PARTS_PACKAGE}.identifiers",
-        f"{PARTS_PACKAGE}.lexical",
         f"{PARTS_PACKAGE}.model",
     }
 )
@@ -396,13 +390,6 @@ INTENDED_INTERNAL_NAMES_BY_MIXED_OWNER: dict[str, frozenset[str]] = {
     ),
     f"{PARTS_PACKAGE}.expression_parser": frozenset({"_parse_gml_expression"}),
     f"{PARTS_PACKAGE}.statements": frozenset({"_ControlFlowCapture"}),
-    f"{PARTS_PACKAGE}.tokens": frozenset(
-        {
-            "_expression_tokens",
-            "_read_template_string",
-            "_tokenize",
-        }
-    ),
     f"{PARTS_PACKAGE}.utils": frozenset(
         {
             "_macro_configuration_matches",
@@ -435,14 +422,6 @@ MODULE_PRIVATE_NAMES_BY_MIXED_OWNER: dict[str, frozenset[str]] = {
             "_static_scope_id",
         }
     ),
-    f"{PARTS_PACKAGE}.tokens": frozenset(
-        {
-            "_decode_gml_string_literal",
-            "_is_float_like_number",
-            "_line_column",
-            "_split_template_string",
-        }
-    ),
     f"{PARTS_PACKAGE}.utils": frozenset(
         {
             "_cache_assignment_part",
@@ -466,10 +445,6 @@ RETAINED_PACKAGE_INTERNAL_EXPORTS = frozenset(
 )
 
 MIGRATION_STAGE_BY_OWNER: dict[str, int] = {
-    f"{PARTS_PACKAGE}.constants": 817,
-    f"{PARTS_PACKAGE}.identifiers": 817,
-    f"{PARTS_PACKAGE}.lexical": 817,
-    f"{PARTS_PACKAGE}.tokens": 817,
     f"{PARTS_PACKAGE}.emitter": 818,
     f"{PARTS_PACKAGE}.enum_helpers": 818,
     f"{PARTS_PACKAGE}.expression_parser": 818,
@@ -498,6 +473,8 @@ def _disposition_for(edge: ImportEdge) -> BoundaryDisposition:
     if edge.name in EXPECTED_PUBLIC_FACADE_EXPORTS:
         return BoundaryDisposition(BoundaryClassification.SUPPORTED_PUBLIC_FACADE, None)
     if edge.owner == f"{PARTS_PACKAGE}.constants" and edge.name in language_metadata.__all__:
+        return BoundaryDisposition(BoundaryClassification.INTENDED_PACKAGE_INTERNAL, None)
+    if edge.owner == LEXICAL_API_MODULE and edge.name in lexical_phase_api.__all__:
         return BoundaryDisposition(BoundaryClassification.INTENDED_PACKAGE_INTERNAL, None)
     if (edge.owner, edge.name) in RETAINED_PACKAGE_INTERNAL_EXPORTS:
         return BoundaryDisposition(BoundaryClassification.INTENDED_PACKAGE_INTERNAL, None)
@@ -572,11 +549,6 @@ EXPECTED_PRIVATE_USAGE_SUPPRESSIONS = frozenset(
             "# pyright: reportPrivateUsage=false",
         ),
         (
-            "src/conversion/gml_transpiler_parts/source_map.py",
-            1,
-            "# pyright: reportPrivateUsage=false",
-        ),
-        (
             "src/conversion/gml_transpiler_parts/statement_parser.py",
             1,
             "# pyright: reportPrivateUsage=false, reportUnusedFunction=false, reportUnusedClass=false",
@@ -588,16 +560,6 @@ EXPECTED_PRIVATE_USAGE_SUPPRESSIONS = frozenset(
         ),
         (
             "src/conversion/gml_transpiler_parts/static_declarations.py",
-            1,
-            "# pyright: reportPrivateUsage=false, reportUnusedFunction=false, reportUnusedClass=false",
-        ),
-        (
-            "src/conversion/gml_transpiler_parts/tokens.py",
-            1,
-            "# pyright: reportPrivateUsage=false, reportUnusedFunction=false, reportUnusedClass=false",
-        ),
-        (
-            "src/conversion/gml_transpiler_parts/utils.py",
             1,
             "# pyright: reportPrivateUsage=false, reportUnusedFunction=false, reportUnusedClass=false",
         ),
@@ -667,6 +629,131 @@ def _imports_from_path(path: Path) -> frozenset[ImportEdge]:
         _module_name(path),
         package_module=path.name == "__init__.py",
     )
+
+
+def _lexical_boundary_bypasses_from_source(
+    source: str,
+    consumer: str,
+    *,
+    package_module: bool = False,
+) -> frozenset[ImportEdge]:
+    bypasses: set[ImportEdge] = set()
+    for edge in _imports_from_source(
+        source,
+        consumer,
+        package_module=package_module,
+    ):
+        if edge.owner in LEXICAL_IMPLEMENTATION_MODULES:
+            bypasses.add(edge)
+            continue
+
+        imported_module = f"{edge.owner}.{edge.name}"
+        if imported_module in LEXICAL_IMPLEMENTATION_MODULES:
+            bypasses.add(
+                ImportEdge(
+                    consumer=consumer,
+                    owner=imported_module,
+                    name=MODULE_IMPORT_NAME,
+                )
+            )
+            continue
+
+        if edge.owner == FACADE_MODULE and (
+            edge.name in LEGACY_LEXICAL_FACADE_NAMES or edge.name == "*"
+        ):
+            bypasses.add(edge)
+
+    tree = ast.parse(source)
+    facade_bindings: set[tuple[str, ...]] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for imported_module in node.names:
+                if imported_module.name != FACADE_MODULE:
+                    continue
+                if imported_module.asname is not None:
+                    facade_bindings.add((imported_module.asname,))
+                else:
+                    facade_bindings.add(tuple(FACADE_MODULE.split(".")))
+        elif isinstance(node, ast.ImportFrom):
+            owner = _resolve_import_owner(
+                consumer,
+                node,
+                package_module=package_module,
+            )
+            for imported_name in node.names:
+                if f"{owner}.{imported_name.name}" != FACADE_MODULE:
+                    continue
+                facade_bindings.add((imported_name.asname or imported_name.name,))
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Attribute):
+            continue
+        name_parts = _attribute_name_parts(node)
+        if name_parts is None:
+            continue
+        for binding in facade_bindings:
+            if name_parts[: len(binding)] != binding or len(name_parts) <= len(binding):
+                continue
+            accessed_name = name_parts[len(binding)]
+            if accessed_name in LEGACY_LEXICAL_FACADE_NAMES:
+                bypasses.add(
+                    ImportEdge(
+                        consumer=consumer,
+                        owner=FACADE_MODULE,
+                        name=accessed_name,
+                    )
+                )
+    return frozenset(bypasses)
+
+
+def _attribute_name_parts(node: ast.expr) -> tuple[str, ...] | None:
+    if isinstance(node, ast.Name):
+        return (node.id,)
+    if not isinstance(node, ast.Attribute):
+        return None
+    parent = _attribute_name_parts(node.value)
+    if parent is None:
+        return None
+    return (*parent, node.attr)
+
+
+def _lexical_boundary_import_is_allowed(
+    consumer: str,
+    edge: ImportEdge,
+) -> bool:
+    if consumer in LEXICAL_IMPLEMENTATION_MODULES or consumer == LEXICAL_API_MODULE:
+        return (
+            edge.owner in LEXICAL_IMPLEMENTATION_MODULES
+            and edge.name != MODULE_IMPORT_NAME
+            and not edge.name.startswith("_")
+        )
+    if (edge.owner, edge.name) in LOW_LEVEL_LEXICAL_IMPORTS_BY_CONSUMER.get(
+        consumer,
+        frozenset(),
+    ):
+        return True
+    return (
+        edge.owner == FACADE_MODULE
+        and edge.name
+        in LEGACY_LEXICAL_FACADE_ACCESS_BY_CONSUMER.get(consumer, frozenset())
+    )
+
+
+def _actual_lexical_boundary_bypasses() -> frozenset[ImportEdge]:
+    bypasses: set[ImportEdge] = set()
+    for source_root in (PROJECT_ROOT / "src", PROJECT_ROOT / "tests"):
+        for path in sorted(source_root.rglob("*.py")):
+            consumer = _module_name(path)
+            bypasses.update(
+                edge
+                for edge in _lexical_boundary_bypasses_from_source(
+                    path.read_text(encoding="utf-8"),
+                    consumer,
+                    package_module=path.name == "__init__.py",
+                )
+                if not _lexical_boundary_import_is_allowed(consumer, edge)
+            )
+    return frozenset(bypasses)
 
 
 def _internal_module_paths() -> tuple[Path, ...]:
@@ -768,6 +855,134 @@ import src.conversion.gml_transpiler_parts.api as phase_api
             ),
         )
 
+    def test_lexical_boundary_scanner_rejects_private_and_module_bypasses(
+        self,
+    ) -> None:
+        consumer = f"{PARTS_PACKAGE}.synthetic_consumer"
+        source = """
+from .tokens import (
+    _read_number as relative_parenthesized_alias,
+)
+from src.conversion.gml_transpiler_parts.identifiers import (
+    _validate_gml_identifier as absolute_parenthesized_alias,
+)
+from .lexical import _read_verbatim_string as relative_alias
+from src.conversion.gml_transpiler_parts.preprocessor import _source_line_spans
+from . import tokens as token_module
+from src.conversion.gml_transpiler_parts import identifiers as identifier_module
+import src.conversion.gml_transpiler_parts.lexical as lexical_module
+from src.conversion.gml_transpiler import _tokenize as legacy_facade_bypass
+from src.conversion.gml_transpiler import *
+import src.conversion.gml_transpiler as facade_module
+from src.conversion import gml_transpiler as package_facade
+
+facade_module._expression_tokens("value")
+package_facade._tokenize("value")
+"""
+
+        self.assertEqual(
+            _lexical_boundary_bypasses_from_source(source, consumer),
+            frozenset(
+                {
+                    ImportEdge(
+                        consumer,
+                        f"{PARTS_PACKAGE}.tokens",
+                        "_read_number",
+                    ),
+                    ImportEdge(
+                        consumer,
+                        f"{PARTS_PACKAGE}.identifiers",
+                        "_validate_gml_identifier",
+                    ),
+                    ImportEdge(
+                        consumer,
+                        f"{PARTS_PACKAGE}.lexical",
+                        "_read_verbatim_string",
+                    ),
+                    ImportEdge(
+                        consumer,
+                        f"{PARTS_PACKAGE}.preprocessor",
+                        "_source_line_spans",
+                    ),
+                    ImportEdge(
+                        consumer,
+                        f"{PARTS_PACKAGE}.tokens",
+                        MODULE_IMPORT_NAME,
+                    ),
+                    ImportEdge(
+                        consumer,
+                        f"{PARTS_PACKAGE}.identifiers",
+                        MODULE_IMPORT_NAME,
+                    ),
+                    ImportEdge(
+                        consumer,
+                        f"{PARTS_PACKAGE}.lexical",
+                        MODULE_IMPORT_NAME,
+                    ),
+                    ImportEdge(
+                        consumer,
+                        FACADE_MODULE,
+                        "_tokenize",
+                    ),
+                    ImportEdge(
+                        consumer,
+                        FACADE_MODULE,
+                        "_expression_tokens",
+                    ),
+                    ImportEdge(
+                        consumer,
+                        FACADE_MODULE,
+                        "*",
+                    ),
+                }
+            ),
+        )
+        owner_consumer = f"{PARTS_PACKAGE}.tokens"
+        self.assertTrue(
+            _lexical_boundary_import_is_allowed(
+                owner_consumer,
+                ImportEdge(
+                    owner_consumer,
+                    f"{PARTS_PACKAGE}.lexical",
+                    "read_verbatim_string",
+                ),
+            )
+        )
+        self.assertFalse(
+            _lexical_boundary_import_is_allowed(
+                owner_consumer,
+                ImportEdge(
+                    owner_consumer,
+                    f"{PARTS_PACKAGE}.lexical",
+                    "_read_verbatim_string",
+                ),
+            )
+        )
+        compatibility_consumer = "tests.test_gml_lexical_api"
+        self.assertTrue(
+            _lexical_boundary_import_is_allowed(
+                compatibility_consumer,
+                ImportEdge(
+                    compatibility_consumer,
+                    FACADE_MODULE,
+                    "_tokenize",
+                ),
+            )
+        )
+        self.assertFalse(
+            _lexical_boundary_import_is_allowed(
+                owner_consumer,
+                ImportEdge(
+                    owner_consumer,
+                    f"{PARTS_PACKAGE}.lexical",
+                    MODULE_IMPORT_NAME,
+                ),
+            )
+        )
+
+    def test_lexical_implementation_modules_have_no_external_bypasses(self) -> None:
+        self.assertEqual(_actual_lexical_boundary_bypasses(), frozenset())
+
     def test_private_phase_and_production_import_inventory_is_exact(self) -> None:
         actual_internal = _actual_internal_private_imports()
         actual_production = _actual_production_imports()
@@ -776,11 +991,11 @@ import src.conversion.gml_transpiler_parts.api as phase_api
             actual_internal | actual_production,
         )
 
-        self.assertEqual(len(EXPECTED_INTERNAL_PRIVATE_IMPORTS), 135)
+        self.assertEqual(len(EXPECTED_INTERNAL_PRIVATE_IMPORTS), 96)
         self.assertEqual(len(EXPECTED_PRODUCTION_IMPORTS), 60)
         self.assertEqual(
             sum(edge.name.startswith("_") for edge in EXPECTED_PRODUCTION_IMPORTS),
-            16,
+            7,
         )
         self.assertEqual(
             actual_internal,
@@ -891,7 +1106,7 @@ import src.conversion.gml_transpiler_parts.api as phase_api
 
     def test_transitional_private_usage_suppressions_are_exact(self) -> None:
         actual = _actual_private_usage_suppressions()
-        self.assertEqual(len(EXPECTED_PRIVATE_USAGE_SUPPRESSIONS), 15)
+        self.assertEqual(len(EXPECTED_PRIVATE_USAGE_SUPPRESSIONS), 12)
         self.assertEqual(actual, EXPECTED_PRIVATE_USAGE_SUPPRESSIONS)
 
 

--- a/tests/test_gml_transpiler_models.py
+++ b/tests/test_gml_transpiler_models.py
@@ -7,7 +7,6 @@ import unittest
 
 import src.conversion.gml_transpiler as gml_transpiler
 import src.conversion.gml_transpiler_parts.extension_functions as extension_functions
-import src.conversion.gml_transpiler_parts.preprocessor as preprocessor
 import src.conversion.gml_transpiler_parts.source_map as source_map
 from src.conversion.gml_transpiler_parts.expression_models import (
     ArrayLiteral,
@@ -347,8 +346,6 @@ class TestGMLTranspilerModels(unittest.TestCase):
         )
         self.assertIs(gml_transpiler.GMLPreprocessResult, GMLPreprocessResult)
         self.assertIs(gml_transpiler.GMLPreprocessorDiagnostic, GMLPreprocessorDiagnostic)
-        self.assertIs(preprocessor.GMLPreprocessResult, GMLPreprocessResult)
-        self.assertIs(preprocessor.GMLPreprocessorDiagnostic, GMLPreprocessorDiagnostic)
         self.assertIs(gml_transpiler.GMLSourceDiagnostic, GMLSourceDiagnostic)
         self.assertIs(gml_transpiler.GMLSourceMap, GMLSourceMap)
         self.assertIs(gml_transpiler.GMLSourceMapEntry, GMLSourceMapEntry)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -11,8 +11,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class TestVersion(unittest.TestCase):
-    def test_release_version_is_0_7_71(self) -> None:
-        self.assertEqual(get_version(), "0.7.71")
+    def test_release_version_is_0_7_72(self) -> None:
+        self.assertEqual(get_version(), "0.7.72")
 
     def test_release_surfaces_match_source_version(self) -> None:
         version_source = (PROJECT_ROOT / "src" / "version.py").read_text(


### PR DESCRIPTION
Closes #862

Publishes the exact 15-operation typed package-internal lexical API for source/expression tokenization, both preprocessing contracts, identifier handling, and shared ordinary/verbatim/template string operations. Fifteen higher-level consumers now use the facade while the acyclic owner cohort keeps only three explicit public direct imports.

The architecture gate now scans source and tests, rejects direct, relative, absolute, aliased, parenthesized, wildcard, module-qualified, and legacy-facade bypasses, and retains one narrow compatibility-test allowance until #820. The frozen graph moves from 135 to 96 private edges across 32 pairs, keeps all 60 production imports, reduces private production edges from 16 to 7, and reduces tracked suppressions from 15 to 12.

Behavior evidence is unchanged: a 29,721-byte differential token/preprocess/identifier/source-map/transpile snapshot matches v0.7.71 exactly, including all 74 facade exports and signatures. No golden expectation changed.

Verification:
- focused suite: 596 tests run; OK (19 fixture-environment skips)
- full suite: 2,872 tests run; OK (82 skipped)
- Pyright: 0 errors and 0 warnings
- configured Ruff and isolated E9/F Pyflakes policy: clean
- exact Godot `4.7.2.stable.official.ed1daf0bf`: 83 discovery tests and 66 explicit integration tests passed
- pinned GameMaker LTS 2026 SNAP/Adding gate: 3 passed at `b4191e195c7c84359f995d568d8906c452b83e50` / `1bf032618be258242f78505de7cd151242452776`
- two independent code reviews and one documentation/version review: no remaining findings

#817 and #794 intentionally remain open for #818 through #820.
