### PR TITLE
Remove temporary import policy exception

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,12 +156,9 @@ means invalid configuration or unavailable measurement prerequisites. Review
 changes to the measurement policy separately; dependency upgrades must also
 review any change to the pinned Ruff measurement semantics.
 
-The baseline records the import layout alongside the other policy fields. R04's
-temporary transition accepts only its frozen Git parent and raw baseline hash;
-candidate baselines must contain the complete current policy. During that migration,
-use the explicit parent in the [R04 contract](docs/architecture-campaign/R04-import-contract.md),
-including for local checks. R04 removes this bridge in a separate verified change
-after integration; formatting-only reductions retain the existing size allowances.
+The baseline records the import layout alongside the other policy fields.
+Candidate baselines and baseline-bearing Git parents must match the complete
+current policy. Formatting-only reductions retain the existing size allowances.
 
 Import graphs are syntax-based and never import application code. They include
 relative/absolute imports, package initializers, re-exports, imports in functions

--- a/docs/architecture-campaign/LEDGER.md
+++ b/docs/architecture-campaign/LEDGER.md
@@ -18,9 +18,9 @@ verified, blocked. The [plan](PLAN.md) and [contracts](contracts.json) bound the
 - Latest published release is v0.7.74. Inherited 0.7.75 metadata is an unpublished
   campaign intermediate. Root will coordinate the single final v0.8.0 release.
 - No external blocker. Initial R04 is integrated and verified at `f40402c`.
-  Its separate four-file bridge retirement is implementing under the accepted
-  [cleanup contract](R04-cleanup-contract.md); cleanup review and PR/merge proof
-  remain required before the R04 task is verified.
+  Its separate four-file bridge retirement is approved at `bfe9b1f` under the
+  [cleanup contract](R04-cleanup-contract.md); exact cleanup PR/merge proof remains
+  required before the R04 task is verified.
   Other planned rows need bounded contract acceptance before implementation.
 
 ## Ownership and progress
@@ -35,7 +35,7 @@ verified, blocked. The [plan](PLAN.md) and [contracts](contracts.json) bound the
 | N01 native receipts | verified | audit_transactions_cli, `66bfcfe`; reviewed corrections through `b06c15b`; PR #879 merged `47642d8` | Independent and root code/integration reviews approved | `N01/pr-ci-final.json`, `N01/merge-push-run.json`; six zero-skip native artifacts at each exact revision |
 | R10 recursive JSON | verified | audit_gml_resources, `bd0967c`; root integration `e56a5e3`; PR #878 merged `91a33c1` | Independent and root code/integration reviews approved | `R10/pr-ci-final.json`, `R10/merge-push-run.json`; both immutable parity runs match |
 | R03 E4/E7 lint | verified | audit_transactions_cli, `356e2ae`; PR #880 merged `1240a7b` | Independent and root code/integration reviews approved | Final PR and merge CI; exact native 6/6/2 zero-skip proof at both revisions |
-| R04 import layout | implementing | Initial `ef75836` merged by PR #881 at `f40402c`; audit_policy_tests_docs owns cleanup | Initial code and cleanup contract approved independently and by root | Initial PR/merge CI and exact native proof pass; separate four-file bridge retirement remains |
+| R04 import layout | approved | Initial PR #881 at `f40402c`; cleanup `bfe9b1f` by audit_policy_tests_docs | Initial and cleanup actual code approved independently and by root | Initial PR/merge proof and cleanup local checks pass; exact cleanup PR/merge proof remains |
 | Other rows | planned | Assigned after contract acceptance | Independent reviewer, then root | `contracts.json` |
 
 Raw evidence is retained outside the worktrees at
@@ -74,6 +74,11 @@ Raw evidence is retained outside the worktrees at
    separate import pass. R05 follows R04/R26 so remaining reflective test seams
    and exception ownership are stable; W02 waits for final R05 enforcement.
    Existing I001/B debt checks continue throughout. No task or limit is removed.
+
+9. After independent review, root accepts [conditional parallel implementation entry](R04-parallel-entry-contract.md)
+   for R11/I01/G01 from approved frozen cleanup candidate C. All entry checks and
+   explicit isolated assignments remain required. Child PRs/integration wait for
+   successful cleanup merge proof. Root serializes baseline and shared metadata.
 
 ## Validation checkpoint
 
@@ -171,6 +176,13 @@ Raw evidence is retained outside the worktrees at
   mode tests passed Linux/macOS 6 each and Windows 2, all without skips. Both actual
   parent comparisons resolved `1240a7b`; the merge tree matches the reviewed PR.
   Cleanup begins from the complete new-policy `f40402c` baseline with 1,056 entries.
+
+- R04 cleanup `bfe9b1f` matches the four-file reviewed projection. Independent and
+  root actual-code reviews approve; Pyright 0/0, both Ruff paths, 61 focused tests
+  with zero skips and the 1,056-entry strict gate pass. Actual S `f40402c` accepts;
+  baseline-bearing legacy P `1240a7b` rejects. Bootstrap, baseline/debt/evidence,
+  all five R03 test bodies and the other 370 source files remain unchanged.
+  Required cleanup PR and merge CI/native proof remain outstanding.
 
 Full-suite times from concurrent validation are not performance comparisons.
 Windows and Linux claims require their actual native CI receipts.

--- a/docs/architecture-campaign/LEDGER.md
+++ b/docs/architecture-campaign/LEDGER.md
@@ -7,8 +7,8 @@ verified, blocked. The [plan](PLAN.md) and [contracts](contracts.json) bound the
 ## Current checkpoint
 
 - Campaign baseline: main `38b364855f06e971d2676b921fd300e1f40f076a`.
-- Integration branch: `dev/080-architecture-campaign`, through R03 PR #880 at
-  `1240a7b`. R03, C01, D01, R10 and N01 passed final PR and merge CI.
+- Integration branch: `dev/080-architecture-campaign`, through initial R04 PR #881 at
+  `f40402c`. Initial R04, R03, C01, D01, R10 and N01 passed final PR and merge CI.
 - Progress counts fully verified roadmap tasks: 7 of 54 (13.0%). Integration and
   pending checks do not count as verification.
 - Main's 11 dirty policy files, preserved #820 work, and unrelated worktrees
@@ -17,9 +17,10 @@ verified, blocked. The [plan](PLAN.md) and [contracts](contracts.json) bound the
   `4.7.2.stable.official.ed1daf0bf`. The primary checkout's Python 3.14 is not proof.
 - Latest published release is v0.7.74. Inherited 0.7.75 metadata is an unpublished
   campaign intermediate. Root will coordinate the single final v0.8.0 release.
-- No external blocker. R03 is verified. R04 has approved code and frozen full-suite
-  proof at `ef75836`; exact PR/merge CI and separate bridge retirement remain
-  required before R04 is verified.
+- No external blocker. Initial R04 is integrated and verified at `f40402c`.
+  Its separate four-file bridge retirement is implementing under the accepted
+  [cleanup contract](R04-cleanup-contract.md); cleanup review and PR/merge proof
+  remain required before the R04 task is verified.
   Other planned rows need bounded contract acceptance before implementation.
 
 ## Ownership and progress
@@ -34,7 +35,7 @@ verified, blocked. The [plan](PLAN.md) and [contracts](contracts.json) bound the
 | N01 native receipts | verified | audit_transactions_cli, `66bfcfe`; reviewed corrections through `b06c15b`; PR #879 merged `47642d8` | Independent and root code/integration reviews approved | `N01/pr-ci-final.json`, `N01/merge-push-run.json`; six zero-skip native artifacts at each exact revision |
 | R10 recursive JSON | verified | audit_gml_resources, `bd0967c`; root integration `e56a5e3`; PR #878 merged `91a33c1` | Independent and root code/integration reviews approved | `R10/pr-ci-final.json`, `R10/merge-push-run.json`; both immutable parity runs match |
 | R03 E4/E7 lint | verified | audit_transactions_cli, `356e2ae`; PR #880 merged `1240a7b` | Independent and root code/integration reviews approved | Final PR and merge CI; exact native 6/6/2 zero-skip proof at both revisions |
-| R04 import layout | approved | audit_policy_tests_docs, `ef75836`, fixed parent `1240a7b` | Independent and root actual-code reviews approved | 252 reviewed files; 3,064 full tests; exact PR/merge CI and separate bridge retirement required |
+| R04 import layout | implementing | Initial `ef75836` merged by PR #881 at `f40402c`; audit_policy_tests_docs owns cleanup | Initial code and cleanup contract approved independently and by root | Initial PR/merge CI and exact native proof pass; separate four-file bridge retirement remains |
 | Other rows | planned | Assigned after contract acceptance | Independent reviewer, then root | `contracts.json` |
 
 Raw evidence is retained outside the worktrees at
@@ -163,6 +164,13 @@ Raw evidence is retained outside the worktrees at
   exact-parent bridge deletion remain required; this row is not yet verified.
 - The earlier exploratory TCC/Monophobia run overlapped root source edits and is
   not immutable baseline evidence; its explicit caveat remains with the raw log.
+
+- R04 initial PR #881 at `fef28b6` and merge `f40402c` passed CI `33939639226`
+  and `33941403378`: 24 successful jobs and the sole permitted dependency submission
+  skip. Native receipt methods passed twice per platform (10/13/16), and artifact
+  mode tests passed Linux/macOS 6 each and Windows 2, all without skips. Both actual
+  parent comparisons resolved `1240a7b`; the merge tree matches the reviewed PR.
+  Cleanup begins from the complete new-policy `f40402c` baseline with 1,056 entries.
 
 Full-suite times from concurrent validation are not performance comparisons.
 Windows and Linux claims require their actual native CI receipts.

--- a/docs/architecture-campaign/R04-cleanup-contract.md
+++ b/docs/architecture-campaign/R04-cleanup-contract.md
@@ -1,0 +1,45 @@
+# R04 bridge retirement — accepted cleanup contract
+
+Status: ACCEPTED by root after independent contract review and successful initial R04 PR #881 and merge verification. Fixed cleanup parent S is `f40402cebc7f4820571f6f54febd78c7f9c17e6a`. PR CI `33939639226` and merge CI `33941403378` each passed all 24 required jobs and the sole permitted dependency-submission skip; native receipts and 6/6/2 artifact-mode proofs passed with zero skips. The four source hashes and complete new-policy baseline are frozen in the external `cleanup-entry.json`. One implementation owner: audit_policy_tests_docs in this isolated cleanup worktree. Independent actual-code reviewer: audit_transactions_cli, then root. Root owns campaign metadata and commits/integration.
+
+## Exact scope
+
+Four files change:
+
+1. scripts/check_maintainability.py: remove its unused hashlib import, the R04 transition comment and both LEGACY_IMPORT_LAYOUT_* constants. In parent_debt replace only the raw-byte/hash/legacy-policy selection with the original strict `return load_baseline(git(root, "show", f"{revision}:{BASELINE_PATH}").decode(), policy(root))`. Preserve Git ref resolution, ancestor validation, baseline existence checks and the exact missing-baseline BOOTSTRAP_REF=38b364855f06e971d2676b921fd300e1f40f076a branch. load_baseline, policy, IMPORT_LAYOUT, measurement/retention and every budget remain unchanged.
+2. tests/test_maintainability_metrics.py: remove its now-unused hashlib import. Delete TestMaintainabilityParent.test_import_layout_bridge_requires_exact_git_parent_and_raw_bytes and replace it with test_legacy_import_layout_candidates_and_git_parents_are_rejected. The permanent test builds an otherwise valid baseline omitting only import_layout, proves direct candidate loading rejects it, and proves resolved baseline-bearing Git parent loading rejects it. Keep json for this real payload. No frozen-parent/hash constant or acceptance branch remains in tests.
+3. CONTRIBUTING.md: replace its six-line R04 bridge/explicit-P guidance with normal strict candidate/baseline-bearing-parent policy guidance and retained formatting-only size accounting. The missing-baseline bootstrap is not described as rejected. Existing general HEAD examples again apply to normal new-policy development.
+4. todo-list/07-testing-codebase-improvements.md: remove only the appended temporary-bridge pending sentence from the already-completed import-sorting item. Root campaign metadata, rather than this implementation item, controls final R04 verification.
+
+The only optional fifth allowed file is maintainability-baseline.json, and only if the ordinary strict generator produces actual reductions/current evidence at the real cleanup base. The full projected measurement shows byte-equivalent debt and retained size evidence, so no baseline edit is presently expected. No policy-metadata rewrite, allowance, new owner, new test module, helper or parent fallback is permitted.
+
+Root owns all campaign contracts/ledger/status updates. docs/wiki/Contributing-and-Testing.md contains only the permanent selected-layout guidance and needs no cleanup edit. Neither tests/test_maintainability_policy.py nor the production metrics module needs an edit. No source, converter, native transaction, workflow, runtime pin, receipt inventory or release change is part of this cleanup.
+
+## Permanent controls and exact parent proof
+
+Retain the current three real-Ruff layout regressions, mutation rejection for each import-layout field, exact project/workflow settings, unknown/nonancestor rejection, missing-parent versus the one 38b bootstrap control, pinned/isolated measurement, suppression protection, packing/proportional-retention and stale-debt tests. Preserve all five R03-added test bodies.
+
+The new named test explicitly retains both legacy-candidate and legacy-baseline-parent rejection after the temporary acceptance test is deleted. It uses a resolved mock parent solely to isolate policy validation, alongside the existing normal new-policy parent-load test. There is no permissive legacy case, obsolete pinned P constant or test-only compatibility route.
+
+For executed Git proof, the external projected checker already accepts the real new-policy owner commit ef758360d91e96f2df0a72fc17769e7e5ed77c09 and rejects historical baseline-bearing P (`1240a7b16d893bc06ba3d258683c731c60dbadca`) with the policy mismatch. The existing bootstrap constant and branch are unchanged. This is current-ref preflight, not a future integration receipt.
+
+Cleanup entry is frozen at integrated new-policy S `f40402cebc7f4820571f6f54febd78c7f9c17e6a` after successful initial PR and merge proof. Before cleanup PR/push dispatch, record the actual local comparison ref, PR event merge-base and push event.before. Each baseline-bearing comparison must carry the complete current policy and satisfy normal ancestry; the ordinary strict loader applies to all of them. They need no new constants or exceptional selection. If a live event still requires legacy P, defer the cleanup until that event is complete. C02/V01 retains final main/missing-baseline bootstrap verification.
+
+## Measured projection and validation
+
+| Owner | Before physical / structural | After physical / structural | Limit |
+| --- | ---: | ---: | ---: |
+| scripts/check_maintainability.py | 277 / 775 | 266 / 760 | 800 / 800 |
+| tests/test_maintainability_metrics.py | 414 / 1460 | 399 / 1405 | 1500 / 1500 |
+
+All other Python bytes remain the frozen initial R04 candidate. The real measurement over all 372 composed source files yields exactly the same 1,056 debt entries and identical retained size evidence: new_debt=[], no baseline change required. These are removal counts, with no architecture decomposition claim.
+
+The external capsule passes native Pyright (0 errors, 0 warnings), project Ruff and all 49 existing policy/metrics tests with zero skips. The new strict rejection method runs with the unchanged permanent controls. The receipt also verifies real new-policy owner-ref acceptance and old baseline-bearing P rejection. This does not substitute for implementation checks tied to the actual later cleanup base.
+
+After implementation, run full native Pyright --warnings, normal/tracked Ruff, the existing policy/metrics/documentation tests, strict nonwriting gate against the actual S comparison (and --update only if real reductions require it), diff checks and the two actual Git acceptance/rejection controls. Root must inspect the actual small diff, obtain independent code approval and verify the required cleanup PR and integration CI receipts. Existing workflows remain authoritative for their full-suite/native/artifact/Godot checks; no skip or inventory relaxation is permitted. Freeze code before those receipts.
+
+Completion requires the initial R04 merge proof plus the separate cleanup commit's approved exact diff, all required cleanup checks and actual local/PR/push comparison evidence. No bridge constant, raw-hash guard or temporary acceptance test may remain before V01/release.
+
+## Frozen artifacts
+
+cleanup-projection.patch and cleanup-projection.json contain exactly the four projected edits and their before/after hashes. preview/ contains those files and unchanged support copies for the bounded checks. maintainability-and-parent-proof.json records all 372-source measurement and actual Git preflight. pyright.log, ruff.log and focused.log contain executed results. cleanup-review-files.json freezes this contract, the four candidate files, patch, metrics and receipts. The actual integrated cleanup base is S `f40402cebc7f4820571f6f54febd78c7f9c17e6a`; root verified the initial merge before this assignment.

--- a/docs/architecture-campaign/R04-parallel-entry-contract.md
+++ b/docs/architecture-campaign/R04-parallel-entry-contract.md
@@ -1,0 +1,23 @@
+# R04 conditional parallel implementation entry
+
+Status: root-accepted scheduling refinement after independent review. This changes only the isolated implementation start for R11, I01 and G01 once every entry condition below is satisfied. It is not an implementation assignment. Root must still approve and freeze actual cleanup candidate C, refresh each child contract/input set at C and explicitly assign its sole owner/worktree.
+
+The original contracts put R11, I01 and G01 implementation after completed R04, including bridge cleanup. This document is the explicit bounded scheduling override; permanent dependencies and integration order remain unchanged. The initial R04 source has now merged at f40402cebc7f4820571f6f54febd78c7f9c17e6a; initial merge CI 33941403378 has passed all 24 required jobs and the sole permitted dependency-submission skip, with exact native and parent proof. Root has independently refreshed R11's12, I01's15 and G01's16 frozen inputs against that immutable source. All application/test definition bodies relevant to the three tasks are unchanged beyond approved imports. The accepted cleanup changes only the checker, one policy test and two docs, with no expected baseline/debt change.
+
+Accepted finite change: after initial R04 merge CI is fully successful, implement and review the four-file cleanup normally. Only once the exact cleanup implementation and root integration metadata are independently/root approved, required local checks pass, and its immutable candidate commit C exists may root assign R11, I01 and G01 to three separate worktrees based on C while cleanup PR/merge CI runs. All three complete accepted contracts and allowed source files remain binding; the only change is when isolated implementation may start. L01, T01 and later tasks are not covered by this exception.
+
+Entry requirements:
+
+- Initial R04 PR and merge CI/native/parent proof successful and tied to exact reviewed revisions.
+- Actual cleanup source diff equals its accepted small removal scope; no app, generated code, fixture, runtime, native, workflow, dependency or metric-policy change. The new permanent legacy-policy rejection test is reviewed.
+- Cleanup local Pyright0/0, both Ruff checks, policy/metrics/docs tests, strict new-policy parent gate, old-parent rejection and diff checks pass on frozen source.
+- Independently/root approve actual cleanup code and root-only metadata before freezing C. Baseline policy, debt and retained evidence remain the accepted new-policy values; any real baseline change requires a separately inspected source/input refresh before early entry.
+- Root verifies all three task input hashes at C, validates their final import/metric projections and publishes accepted per-task contracts. Separate sole implementers/worktrees, no shared source edits. Root serializes shared policy/coverage/verification/baseline integration. CPU-intensive proof windows are coordinated.
+
+Integration requirements are unchanged: no child PR or campaign integration until R04 cleanup's exact PR and merge CI/native/current-parent proof is successful. Root then confirms each child’s source against the actual integrated cleanup ref, reconciles ancestry and any shared metadata, and reruns relevant combined checks. Every child must still obtain independent/root actual-code review and its own exact PR/merge verification. R04 counts as verified only after its own cleanup merge proof; isolated child progress does not count toward the54-task percentage.
+
+If cleanup CI fails or its reviewed code changes, stop dependent proof/implementation that relies on the changed source, inspect the actual delta, and revalidate task inputs/contracts and local/combined checks before continuing. Do not preserve stale receipts as current proof, bypass CI or silently broaden a scope. A failure in unchanged native/full tests remains a real failure to resolve, not a reason to assume cleanup success.
+
+This parallels the already-reviewed R04 isolated start while R03 merge CI ran: immutable source and ownership are known, and dependency-ordered integration remains strict. It does not waive any verification or change the permanent architecture.
+
+Root read the independent scheduling review and the actual cleanup diff. The approved cleanup implementation is `bfe9b1fffd91d2142ab134acf00b588e034eeb26`; its 61 local tests, Pyright 0/0, both Ruff checks, strict 1,056-entry gate and actual parent controls pass. Final candidate C includes only separately reviewed root metadata beyond this implementation. No child assignment precedes the actual C hash/input confirmation.

--- a/docs/architecture-campaign/contracts.json
+++ b/docs/architecture-campaign/contracts.json
@@ -278,7 +278,7 @@
       "task_id": "R04",
       "issue": 795,
       "title": "Complete I001 import sorting lint cohort",
-      "state": "approved",
+      "state": "implementing",
       "problem_and_evidence": "213 inherited I001 owner entries; fixed explicit layout detects 247 findings on the accepted R03 source. Project/isolated defaults previously disagreed; frozen source has 372 Python inputs and 41 Markdown inputs.",
       "expected_benefit": "Eliminate cohort debt and enforce selected family globally without blanket suppressions.",
       "current_owner": "Files owning exact current I001 import sorting baseline entries",
@@ -549,12 +549,34 @@
       "expected_measurable_improvement": "Zero I findings across all source and tracked lint inputs; projected debt 1056 with no new/increased allowance. Formatting is not credited as architecture decomposition.",
       "characterization_tests": "Inspect each potentially behavior-sensitive fix; full suite; verify no unrelated formatting or frozen output drift. Add focused characterization before changing behavior; compare same inputs at immutable base and candidate.",
       "runtime_platform_proof": "Approved native Python; Pyright zero errors/warnings; Ruff; focused tests after fixes; full unittest for shared changes; maintainability and diff gate. Execute exact Godot/LTS and actual affected native platforms where relevant; record every skip.",
-      "implementation_owner": "audit_policy_tests_docs in GM2Godot-080-import-layout, dev/080-import-layout",
-      "independent_reviewers": "audit_gml_resources read-only, then root actual-code/integration review",
+      "implementation_owner": "audit_policy_tests_docs in GM2Godot-080-import-layout-cleanup, dev/080-import-layout-cleanup",
+      "independent_reviewers": "Initial implementation: audit_gml_resources and root; cleanup: audit_transactions_cli read-only, then root actual-code/integration review",
       "completion_criteria": "All scoped callers migrated; obsolete duplicates removed; measured improvement; matched proof passed; independent and upper approval; integrated exact revision verified.",
       "temporary_adapter_removal_condition": "R04 owns separate post-integration deletion of both legacy constants, exact guard, unused hashlib and temporary acceptance test; strict baseline-bearing parents restored, bootstrap 38b unchanged. R04 cannot be verified before cleanup CI and removed-P rejection pass.",
       "plan_verdict": "ACCEPTED by root after independent review; R04-import-contract.md is authoritative. Exact parent 1240a7b16d893bc06ba3d258683c731c60dbadca and raw baseline SHA cea9e1b5ec2a55a05c0f720ce43de7c4e11219e2108aabb9d47b888c38e85d7e. Isolated implementation while R03 merge CI runs is approved; PR/integration waits verified R03 and exact P event identities.",
-      "review_evidence": "Immutable ef758360d91e96f2df0a72fc17769e7e5ed77c09: independent and root actual-code APPROVE; 252 allowed paths and 372 source hashes verified; all 367 import-only ASTs and both dependency graphs preserved. Full suite: 3,064 tests with 56 classified native/filesystem skips, all five pinned projects and exact Godot. Pyright 0 errors/warnings; both Ruff paths and actionlint; 398 focused tests with one Windows-only skip; 80 independent tests and 13 native macOS tests with zero skips; strict gate 1,056 against exact 1240a7b. PR/merge native CI and separate bridge removal remain required."
+      "review_evidence": "Immutable ef758360d91e96f2df0a72fc17769e7e5ed77c09: independent and root actual-code APPROVE; 252 allowed paths and 372 source hashes verified; all 367 import-only ASTs and both dependency graphs preserved. Full suite: 3,064 tests with 56 classified native/filesystem skips, all five pinned projects and exact Godot. Pyright 0 errors/warnings; both Ruff paths and actionlint; 398 focused tests with one Windows-only skip; 80 independent tests and 13 native macOS tests with zero skips; strict gate 1,056 against exact 1240a7b. Initial PR #881 and merge f40402c passed exact CI 33939639226/33941403378, with 24 successful jobs and sole allowed skip. Six native receipts and Linux/macOS 6, Windows 2 artifact-mode proofs pass at both exact revisions. Separate bridge cleanup is implementing and still required before task verification.",
+      "cleanup": {
+        "contract": "R04-cleanup-contract.md",
+        "state": "implementing",
+        "base_ref": "f40402cebc7f4820571f6f54febd78c7f9c17e6a",
+        "allowed_files": [
+          "scripts/check_maintainability.py",
+          "tests/test_maintainability_metrics.py",
+          "CONTRIBUTING.md",
+          "todo-list/07-testing-codebase-improvements.md"
+        ],
+        "optional_file": "maintainability-baseline.json only if genuine strict-generator reductions require it; none expected",
+        "frozen_input_sha256": {
+          "scripts/check_maintainability.py": "00638f0a1c73f181eae9df2c23738fb48f71fb8a96422b76944343c4355abb30",
+          "tests/test_maintainability_metrics.py": "e85f1987eeba2279f22ae9eebeff0dc342b4f2ac29b69efdc8dbb55cd428302d",
+          "CONTRIBUTING.md": "3c81a33529fdf25b419f84358d93437bb2e028a2998cc1e9d38ca3669e351976",
+          "todo-list/07-testing-codebase-improvements.md": "b4fd7bab1b834a711f872b7c3f404c82fd8cd165f263380228ac9627f78025de"
+        },
+        "baseline_sha256": "30ef0346df5cdc85c2a5c7ea66dc47907d8766ea91b7f012e3d747040d1e9e6d",
+        "debt_entries": 1056,
+        "root_contract_verdict": "ACCEPTED after independent/root contract review and exact initial merge proof",
+        "completion": "Approved actual small diff, required local checks, exact cleanup PR and merge CI, new-policy parent acceptance and old-policy parent rejection; no remaining bridge."
+      }
     },
     {
       "task_id": "R05",

--- a/docs/architecture-campaign/contracts.json
+++ b/docs/architecture-campaign/contracts.json
@@ -278,7 +278,7 @@
       "task_id": "R04",
       "issue": 795,
       "title": "Complete I001 import sorting lint cohort",
-      "state": "implementing",
+      "state": "approved",
       "problem_and_evidence": "213 inherited I001 owner entries; fixed explicit layout detects 247 findings on the accepted R03 source. Project/isolated defaults previously disagreed; frozen source has 372 Python inputs and 41 Markdown inputs.",
       "expected_benefit": "Eliminate cohort debt and enforce selected family globally without blanket suppressions.",
       "current_owner": "Files owning exact current I001 import sorting baseline entries",
@@ -554,10 +554,10 @@
       "completion_criteria": "All scoped callers migrated; obsolete duplicates removed; measured improvement; matched proof passed; independent and upper approval; integrated exact revision verified.",
       "temporary_adapter_removal_condition": "R04 owns separate post-integration deletion of both legacy constants, exact guard, unused hashlib and temporary acceptance test; strict baseline-bearing parents restored, bootstrap 38b unchanged. R04 cannot be verified before cleanup CI and removed-P rejection pass.",
       "plan_verdict": "ACCEPTED by root after independent review; R04-import-contract.md is authoritative. Exact parent 1240a7b16d893bc06ba3d258683c731c60dbadca and raw baseline SHA cea9e1b5ec2a55a05c0f720ce43de7c4e11219e2108aabb9d47b888c38e85d7e. Isolated implementation while R03 merge CI runs is approved; PR/integration waits verified R03 and exact P event identities.",
-      "review_evidence": "Immutable ef758360d91e96f2df0a72fc17769e7e5ed77c09: independent and root actual-code APPROVE; 252 allowed paths and 372 source hashes verified; all 367 import-only ASTs and both dependency graphs preserved. Full suite: 3,064 tests with 56 classified native/filesystem skips, all five pinned projects and exact Godot. Pyright 0 errors/warnings; both Ruff paths and actionlint; 398 focused tests with one Windows-only skip; 80 independent tests and 13 native macOS tests with zero skips; strict gate 1,056 against exact 1240a7b. Initial PR #881 and merge f40402c passed exact CI 33939639226/33941403378, with 24 successful jobs and sole allowed skip. Six native receipts and Linux/macOS 6, Windows 2 artifact-mode proofs pass at both exact revisions. Separate bridge cleanup is implementing and still required before task verification.",
+      "review_evidence": "Immutable ef758360d91e96f2df0a72fc17769e7e5ed77c09: independent and root actual-code APPROVE; 252 allowed paths and 372 source hashes verified; all 367 import-only ASTs and both dependency graphs preserved. Full suite: 3,064 tests with 56 classified native/filesystem skips, all five pinned projects and exact Godot. Pyright 0 errors/warnings; both Ruff paths and actionlint; 398 focused tests with one Windows-only skip; 80 independent tests and 13 native macOS tests with zero skips; strict gate 1,056 against exact 1240a7b. Initial PR #881 and merge f40402c passed exact CI 33939639226/33941403378, with 24 successful jobs and sole allowed skip. Six native receipts and Linux/macOS 6, Windows 2 artifact-mode proofs pass at both exact revisions. Separate bridge cleanup is independently/root approved at bfe9b1f with local proof complete; exact cleanup PR/merge proof remains required before task verification.",
       "cleanup": {
         "contract": "R04-cleanup-contract.md",
-        "state": "implementing",
+        "state": "approved",
         "base_ref": "f40402cebc7f4820571f6f54febd78c7f9c17e6a",
         "allowed_files": [
           "scripts/check_maintainability.py",
@@ -575,7 +575,22 @@
         "baseline_sha256": "30ef0346df5cdc85c2a5c7ea66dc47907d8766ea91b7f012e3d747040d1e9e6d",
         "debt_entries": 1056,
         "root_contract_verdict": "ACCEPTED after independent/root contract review and exact initial merge proof",
-        "completion": "Approved actual small diff, required local checks, exact cleanup PR and merge CI, new-policy parent acceptance and old-policy parent rejection; no remaining bridge."
+        "completion": "Approved actual small diff, required local checks, exact cleanup PR and merge CI, new-policy parent acceptance and old-policy parent rejection; no remaining bridge.",
+        "owner_commit": "bfe9b1fffd91d2142ab134acf00b588e034eeb26",
+        "review_verdict": "Independent audit_transactions_cli and root actual-code APPROVE; four exact files, 372 source hashes and unchanged baseline verified",
+        "local_proof": "Pyright 0 errors/warnings; project/tracked Ruff; 61 policy/metrics/docs tests with zero skips; strict gate 1056 against f40402c; actual new-policy S accepts and old baseline-bearing P rejects; diff check passes",
+        "required_before_verification": "Exact cleanup PR and merge CI/native/current-parent proof remains mandatory"
+      },
+      "conditional_parallel_entry": {
+        "contract": "R04-parallel-entry-contract.md",
+        "scope": [
+          "R11",
+          "I01",
+          "G01"
+        ],
+        "status": "Root accepted after independent review; actual approved final cleanup candidate C and child-specific source/contract refresh remain required before assignment",
+        "integration_gate": "No child PR or campaign integration until exact cleanup merge proof succeeds",
+        "baseline_owner": "root serializes every child baseline generation and combined integration; no concurrent baseline writers"
       }
     },
     {
@@ -740,7 +755,9 @@
       "independent_reviewers": "Separate read-only reviewer, then root reads actual changed code and returns APPROVE / REQUEST CHANGES / BLOCKED.",
       "completion_criteria": "All scoped callers migrated; obsolete duplicates removed; measured improvement; matched proof passed; independent and upper approval; integrated exact revision verified.",
       "temporary_adapter_removal_condition": "Remove old adapter when final scoped caller migrates, before this task is verified; any temporary adapter records this task as owner.",
-      "plan_verdict": "PLANNED; root must refresh precise caller/file inventory and accept before implementation."
+      "plan_verdict": "PLANNED; root must refresh precise caller/file inventory and accept before implementation.",
+      "implementation_entry_condition": "Original completed-R04 start is overridden only by R04-parallel-entry-contract.md: isolated work may begin from approved immutable cleanup candidate C after all local/code/source/contract entry checks. Child PR/integration still waits completed R04 cleanup merge proof.",
+      "parallel_shared_metadata_owner": "Root alone serializes baseline generation, coverage/verification registration and campaign metadata; implementation owners do not concurrently edit these paths."
     },
     {
       "task_id": "R12",
@@ -1326,7 +1343,9 @@
       "independent_reviewers": "Separate read-only reviewer, then root reads actual changed code and returns APPROVE / REQUEST CHANGES / BLOCKED.",
       "completion_criteria": "All scoped callers migrated; obsolete duplicates removed; measured improvement; matched proof passed; independent and upper approval; integrated exact revision verified.",
       "temporary_adapter_removal_condition": "Remove old adapter when final scoped caller migrates, before this task is verified; any temporary adapter records this task as owner.",
-      "plan_verdict": "PLANNED; root must refresh precise caller/file inventory and accept before implementation."
+      "plan_verdict": "PLANNED; root must refresh precise caller/file inventory and accept before implementation.",
+      "implementation_entry_condition": "Original completed-R04 start is overridden only by R04-parallel-entry-contract.md: isolated work may begin from approved immutable cleanup candidate C after all local/code/source/contract entry checks. Child PR/integration still waits completed R04 cleanup merge proof.",
+      "parallel_shared_metadata_owner": "Root alone serializes baseline generation, coverage/verification registration and campaign metadata; implementation owners do not concurrently edit these paths."
     },
     {
       "task_id": "I02",
@@ -1693,7 +1712,9 @@
       "independent_reviewers": "Separate read-only reviewer, then root reads actual changed code and returns APPROVE / REQUEST CHANGES / BLOCKED.",
       "completion_criteria": "All scoped callers migrated; obsolete duplicates removed; measured improvement; matched proof passed; independent and upper approval; integrated exact revision verified.",
       "temporary_adapter_removal_condition": "Remove old adapter when final scoped caller migrates, before this task is verified; any temporary adapter records this task as owner.",
-      "plan_verdict": "PLANNED; root must refresh precise caller/file inventory and accept before implementation."
+      "plan_verdict": "PLANNED; root must refresh precise caller/file inventory and accept before implementation.",
+      "implementation_entry_condition": "Original completed-R04 start is overridden only by R04-parallel-entry-contract.md: isolated work may begin from approved immutable cleanup candidate C after all local/code/source/contract entry checks. Child PR/integration still waits completed R04 cleanup merge proof.",
+      "parallel_shared_metadata_owner": "Root alone serializes baseline generation, coverage/verification registration and campaign metadata; implementation owners do not concurrently edit these paths."
     },
     {
       "task_id": "G02",

--- a/scripts/check_maintainability.py
+++ b/scripts/check_maintainability.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import io
 import json
 import subprocess
@@ -34,9 +33,6 @@ BASELINE_PATH = "maintainability-baseline.json"
 SCHEMA_VERSION = 2
 # The one pre-policy tree accepted at bootstrap. Later missing parents fail closed.
 BOOTSTRAP_REF = "38b364855f06e971d2676b921fd300e1f40f076a"
-# R04 removes these after integration; root freezes both identities at actual R03 entry.
-LEGACY_IMPORT_LAYOUT_PARENT = "1240a7b16d893bc06ba3d258683c731c60dbadca"
-LEGACY_IMPORT_LAYOUT_BASELINE_SHA256 = "cea9e1b5ec2a55a05c0f720ce43de7c4e11219e2108aabb9d47b888c38e85d7e"
 
 
 @dataclass(frozen=True)
@@ -196,14 +192,7 @@ def parent_debt(root: Path, base_ref: str) -> Baseline:
     git(root, "merge-base", "--is-ancestor", revision, "HEAD")
     names = git(root, "ls-tree", "--name-only", revision, "--", BASELINE_PATH).decode().splitlines()
     if BASELINE_PATH in names:
-        raw = git(root, "show", f"{revision}:{BASELINE_PATH}")
-        expected_policy = policy(root)
-        if (
-            revision == LEGACY_IMPORT_LAYOUT_PARENT
-            and hashlib.sha256(raw).hexdigest() == LEGACY_IMPORT_LAYOUT_BASELINE_SHA256
-        ):
-            expected_policy.pop("import_layout")
-        return load_baseline(raw.decode(), expected_policy)
+        return load_baseline(git(root, "show", f"{revision}:{BASELINE_PATH}").decode(), policy(root))
     if revision != BOOTSTRAP_REF:
         raise MaintainabilityError(f"parent {revision} is missing {BASELINE_PATH}; only {BOOTSTRAP_REF} may bootstrap")
     return bootstrap_debt(root, revision)

--- a/tests/test_maintainability_metrics.py
+++ b/tests/test_maintainability_metrics.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ast
-import hashlib
 import io
 import json
 import re
@@ -319,33 +318,19 @@ class TestMaintainabilityParent(unittest.TestCase):
             self.assertEqual(checker.parent_debt(root, "parent").debt, debt)
         self.assertEqual(git_call.call_args_list[-1].args, (root, "show", f"{revision}:{checker.BASELINE_PATH}"))
 
-    def test_import_layout_bridge_requires_exact_git_parent_and_raw_bytes(self) -> None:
+    def test_legacy_import_layout_candidates_and_git_parents_are_rejected(self) -> None:
         root = checker.PROJECT_ROOT
         revision = "a" * 40
-        debt = {"application|complexity|src/example.py::process": 19}
         legacy_policy = checker.policy(root)
         legacy_policy.pop("import_layout")
-        raw = json.dumps({"schema_version": 2, "policy": legacy_policy, "debt": debt, "size_evidence": {}}).encode()
-        current = checker.serialize(root, debt).encode()
-        for selected, payload, allowed in (
-            (revision, raw, True),
-            ("b" * 40, raw, False),
-            (revision, raw + b"\n", False),
-            ("b" * 40, current, True),
-        ):
-            with (
-                self.subTest(selected=selected, payload=payload),
-                patch.object(checker, "LEGACY_IMPORT_LAYOUT_PARENT", revision),
-                patch.object(checker, "LEGACY_IMPORT_LAYOUT_BASELINE_SHA256", hashlib.sha256(raw).hexdigest()),
-                patch.object(checker, "git", side_effect=[selected.encode(), b"", checker.BASELINE_PATH.encode(), payload]),
-            ):
-                if allowed:
-                    self.assertEqual(checker.parent_debt(root, "parent").debt, debt)
-                else:
-                    with self.assertRaisesRegex(metrics.MaintainabilityError, "policy/version mismatch"):
-                        checker.parent_debt(root, "parent")
+        raw = json.dumps({"schema_version": 2, "policy": legacy_policy, "debt": {}, "size_evidence": {}}).encode()
         with self.assertRaisesRegex(metrics.MaintainabilityError, "policy/version mismatch"):
             checker.load_baseline(raw.decode(), checker.policy(root))
+        with (
+            patch.object(checker, "git", side_effect=[revision.encode(), b"", checker.BASELINE_PATH.encode(), raw]),
+            self.assertRaisesRegex(metrics.MaintainabilityError, "policy/version mismatch"),
+        ):
+            checker.parent_debt(root, "parent")
 
     def test_missing_parent_baseline_only_bootstraps_one_fixed_commit(self) -> None:
         for revision in (checker.BOOTSTRAP_REF, "a" * 40):

--- a/todo-list/07-testing-codebase-improvements.md
+++ b/todo-list/07-testing-codebase-improvements.md
@@ -118,7 +118,7 @@ This file tracks engineering work that will make full transpilation safer to bui
 - [x] Add Ruff or equivalent linting.
 - [x] Enforce complete Ruff E4/E7 families and remove their legacy cohort without rule suppressions.
 - [ ] Add complexity checks for parser/emitter/runtime generation modules.
-- [x] Add import sorting with consistent project, tracked-input CI and maintainability settings. R04's separate policy-bridge removal remains required before campaign verification.
+- [x] Add import sorting with consistent project, tracked-input CI and maintainability settings.
 - [ ] Add unused code checks.
 - [ ] Add broad exception checks.
 - [ ] Add unreachable branch checks.


### PR DESCRIPTION
The import-layout migration in #881 is fully verified at f40402c. Remove its temporary exact-parent/hash exception so every baseline-bearing parent must use the complete current policy. Replace the transition test with permanent candidate and Git-parent rejection coverage, and update the contributor/task guidance. The existing missing-baseline bootstrap remains unchanged.

The four implementation files match the accepted cleanup scope; no baseline update is needed. Pyright reports zero errors/warnings, project and tracked-input Ruff pass, all 61 policy/metrics/documentation tests pass without skips, and the strict gate passes 1,056 entries against f40402c. Actual Git proof accepts that parent and rejects the old baseline-bearing 1240a7b. The other 370 source files, all five R03 test bodies, debt values and retained size evidence are unchanged.

Independent and root code/metadata reviews approve. Exact cleanup PR/merge CI remains required before R04 is verified. This completes the migration's removal condition within #795 and #867; it does not publish a release.

The campaign metadata permits isolated R11/I01/G01 implementation from the reviewed cleanup candidate after each exact input/contract check. Their PRs and integration still wait for successful cleanup merge proof; root serializes shared baseline updates.
